### PR TITLE
chore: harden GitHub Actions security

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -14,13 +14,15 @@ on:
       - "install.ps1"
       - ".github/workflows/test-powershell.yml"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Install Pester
         shell: pwsh
         run: |
@@ -79,8 +81,7 @@ jobs:
           }
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        if: always()
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad        if: always()
         with:
           files: scripts/powershell/coverage.xml
           flags: powershell
@@ -89,8 +90,7 @@ jobs:
           verbose: true
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
-        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02        if: always()
         with:
           name: test-results
           path: |


### PR DESCRIPTION
This PR hardens GitHub Actions security by:

- pinning external `uses:` references to immutable commit SHAs
- adding explicit top-level `permissions` where missing (`contents: read`)

Please review any workflow that requires write scopes and elevate per-job only when needed.