### PR TITLE
feat(claude): add SLM conversation observer hook

### DIFF
--- a/chezmoi/.chezmoidata/claude_plugins.yaml
+++ b/chezmoi/.chezmoidata/claude_plugins.yaml
@@ -1,0 +1,61 @@
+# Claude Code プラグイン設定
+# type: plugins (マーケットプレイス内蔵) / external_plugins (外部リポジトリ)
+claude_plugins:
+  # claude-plugins-official: 内蔵プラグイン
+  - name: code-simplifier
+    marketplace: claude-plugins-official
+    type: plugins
+  - name: code-review
+    marketplace: claude-plugins-official
+    type: plugins
+  - name: commit-commands
+    marketplace: claude-plugins-official
+    type: plugins
+  - name: pr-review-toolkit
+    marketplace: claude-plugins-official
+    type: plugins
+  - name: pyright-lsp
+    marketplace: claude-plugins-official
+    type: plugins
+  - name: ralph-loop
+    marketplace: claude-plugins-official
+    type: plugins
+  - name: security-guidance
+    marketplace: claude-plugins-official
+    type: plugins
+  - name: superpowers
+    marketplace: claude-plugins-official
+    type: plugins
+  # claude-plugins-official: 外部プラグイン
+  - name: context7
+    marketplace: claude-plugins-official
+    type: external_plugins
+  - name: github
+    marketplace: claude-plugins-official
+    type: external_plugins
+  - name: linear
+    marketplace: claude-plugins-official
+    type: external_plugins
+  - name: playwright
+    marketplace: claude-plugins-official
+    type: external_plugins
+  - name: serena
+    marketplace: claude-plugins-official
+    type: external_plugins
+  # claude-plugins-official: 外部プラグイン (MCP サーバー付き)
+  - name: chrome-devtools-mcp
+    marketplace: claude-plugins-official
+    type: external_plugins
+  - name: coderabbit
+    marketplace: claude-plugins-official
+    type: external_plugins
+  - name: notion
+    marketplace: claude-plugins-official
+    type: external_plugins
+  - name: sentry
+    marketplace: claude-plugins-official
+    type: external_plugins
+  # openai-codex
+  - name: codex
+    marketplace: openai-codex
+    type: plugins

--- a/chezmoi/dot_claude/hooks/slm-observe.js
+++ b/chezmoi/dot_claude/hooks/slm-observe.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse hook: observe conversation turns in SuperLocalMemory.
+ *
+ * Reads tool interaction from CLAUDE_TOOL_* env vars and sends to SLM's
+ * observe_conversation MCP tool. If the user message contains explicit
+ * memory keywords ("覚えて", "remember this", etc.), also calls remember.
+ *
+ * SLM_MCP_URL env var controls the endpoint:
+ *   - Local tools: http://localhost:3000/mcp (default, Kind NodePort 30300 → host 3000)
+ *   - OpenClaw Gateway: http://superlocalmemory:3000/mcp
+ */
+
+const SLM_MCP_URL = process.env.SLM_MCP_URL || "http://localhost:3000/mcp";
+const TIMEOUT_MS = 5000;
+
+const REMEMBER_PATTERNS = [
+  /覚えて/,
+  /記憶して/,
+  /保存して/,
+  /メモして/,
+  /remember this/i,
+  /save this/i,
+  /note this/i,
+  /keep this in mind/i,
+];
+
+async function callMcp(method, args) {
+  const payload = {
+    jsonrpc: "2.0",
+    id: Date.now(),
+    method: "tools/call",
+    params: { name: method, arguments: args },
+  };
+  const resp = await fetch(SLM_MCP_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "Accept": "application/json, text/event-stream" },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (!resp.ok) {
+    console.error(`[slm-observe] HTTP ${resp.status}: ${await resp.text()}`);
+  }
+}
+
+async function main() {
+  const toolName = process.env.CLAUDE_TOOL_NAME || "";
+  const toolInput = process.env.CLAUDE_TOOL_INPUT || "";
+  const toolResult = process.env.CLAUDE_TOOL_RESULT || "";
+
+  // Skip if no meaningful content
+  if (!toolName && !toolInput && !toolResult) return;
+
+  // Build conversation text from available context
+  const parts = [];
+  if (toolName) parts.push(`[Tool: ${toolName}]`);
+  if (toolInput) parts.push(`Input: ${toolInput}`);
+  if (toolResult) parts.push(`Result: ${toolResult.slice(0, 2000)}`);
+  const conversation = parts.join("\n");
+
+  // Determine source
+  const source = process.env.SLM_SOURCE || "claude-code";
+
+  // Send to observe_conversation
+  await callMcp("observe_conversation", { conversation, source });
+
+  // Check for explicit remember keywords in input
+  if (toolInput && REMEMBER_PATTERNS.some((p) => p.test(toolInput))) {
+    await callMcp("remember", { content: toolInput });
+  }
+}
+
+main().catch((err) => console.error(`[slm-observe] ${err.message}`));

--- a/chezmoi/dot_claude/plugins/create_installed_plugins.json.tmpl
+++ b/chezmoi/dot_claude/plugins/create_installed_plugins.json.tmpl
@@ -1,0 +1,22 @@
+{{- $sep := "/" -}}
+{{- if eq .chezmoi.os "windows" -}}{{- $sep = "\\\\" -}}{{- end -}}
+{{- $home := .chezmoi.homeDir | replace "/" $sep -}}
+{
+  "version": 2,
+  "plugins": {
+{{- $first := true }}
+{{- range .claude_plugins }}
+{{- if not $first }},{{ end }}
+{{- $first = false }}
+    "{{ .name }}@{{ .marketplace }}": [
+      {
+        "scope": "user",
+        "installPath": "{{ $home }}{{ $sep }}.claude{{ $sep }}plugins{{ $sep }}cache{{ $sep }}{{ .marketplace }}{{ $sep }}{{ .name }}{{ $sep }}unknown",
+        "version": "unknown",
+        "installedAt": "2026-01-01T00:00:00.000Z",
+        "lastUpdated": "2026-01-01T00:00:00.000Z"
+      }
+    ]
+{{- end }}
+  }
+}

--- a/chezmoi/dot_claude/settings.json.tmpl
+++ b/chezmoi/dot_claude/settings.json.tmpl
@@ -58,5 +58,18 @@
     "pr-review-toolkit@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
     "linear@claude-plugins-official": true
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node {{ .chezmoi.homeDir }}/.claude/hooks/slm-observe.js"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Add `slm-observe.js` to `~/.claude/hooks/` (chezmoi managed)
- Wire PostToolUse hook in `settings.json.tmpl`
- Auto-saves all conversation turns to SuperLocalMemory via `observe_conversation`
- Detects "覚えて"/"remember this" keywords for explicit memory via `remember`

## Context

Part of the SLM conversation sync feature (openclaw-k8s#feat/slm-conversation-sync). All local AI tool conversations are now auto-saved to SLM for knowledge retention.

## Test plan

- [ ] `chezmoi apply` deploys hook to `~/.claude/hooks/slm-observe.js`
- [ ] `settings.json` contains PostToolUse hook entry
- [ ] Claude Code conversation triggers SLM observe_conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)