### PR TITLE
fix(chezmoi): op 未ログイン時にログイン画面を表示して待機

### DIFF
--- a/scripts/powershell/handlers/Handler.Chezmoi.ps1
+++ b/scripts/powershell/handlers/Handler.Chezmoi.ps1
@@ -262,14 +262,22 @@ class ChezmoiHandler : SetupHandlerBase {
             return
         }
 
-        # UAC 昇格プロセスではデスクトップアプリ連携が使えないため op signin を試みる
+        # 1Password CLI が未認証 → ログイン画面を表示して待機
         Write-Host ""
         Write-Host "========================================"  -ForegroundColor Yellow
         Write-Host "[Chezmoi] 1Password CLI の認証が必要です" -ForegroundColor Yellow
         Write-Host "========================================"  -ForegroundColor Yellow
         Write-Host ""
-        Write-Host "  管理者昇格プロセスでは 1Password デスクトップアプリ連携が使えないため、" -ForegroundColor Cyan
-        Write-Host "  op signin による対話認証を試みます。"                                     -ForegroundColor Cyan
+        if (Test-IsAdminSession) {
+            Write-Host "  管理者昇格プロセスでは 1Password デスクトップアプリ連携が使えないため、" -ForegroundColor Cyan
+            Write-Host "  op signin による対話認証を試みます。"                                     -ForegroundColor Cyan
+        } else {
+            Write-Host "  chezmoi テンプレートが 1Password の秘密情報を参照するため、"              -ForegroundColor Cyan
+            Write-Host "  1Password CLI へのサインインが必要です。"                                 -ForegroundColor Cyan
+            Write-Host ""
+            Write-Host "  ヒント: 1Password デスクトップアプリが起動・サインイン済みなら"           -ForegroundColor Gray
+            Write-Host "  自動的に認証される場合があります。アプリを確認してください。"             -ForegroundColor Gray
+        }
         Write-Host ""
 
         $maxRetries = 3
@@ -285,14 +293,22 @@ class ChezmoiHandler : SetupHandlerBase {
             }
 
             if ($i -lt $maxRetries) {
-                $this.LogWarning("1Password CLI のサインインを確認できませんでした。再試行します")
+                $this.LogWarning("1Password CLI のサインインを確認できませんでした")
                 Write-Host ""
-                Write-Host "  Enter を押して再試行してください ($i/$maxRetries)..." -ForegroundColor Yellow -NoNewline
+                Write-Host "  1Password デスクトップアプリでサインインしてから Enter を押してください ($i/$maxRetries)..." -ForegroundColor Yellow -NoNewline
                 Read-Host | Out-Null
+
+                # デスクトップアプリ連携が有効になった可能性があるため whoami で再確認
+                $result = Invoke-OpWhoAmI -OpExe $opExe
+                if ($result.ExitCode -eq 0) {
+                    $this.Log("1Password CLI: サインイン完了（デスクトップアプリ連携）", "Green")
+                    return
+                }
             }
         }
 
-        $this.LogWarning("1Password CLI のサインインに失敗しました。chezmoi apply でテンプレートエラーが発生する可能性があります")
+        # 全リトライ失敗 → chezmoi apply に進んでも確実に失敗するため例外で停止
+        throw "1Password CLI のサインインに失敗しました。1Password デスクトップアプリでサインインしてから再実行してください。"
     }
 
     <#

--- a/scripts/powershell/tests/handlers/Handler.Chezmoi.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Chezmoi.Tests.ps1
@@ -770,6 +770,88 @@ Describe 'ChezmoiHandler' {
             $result.Message | Should -Match 'サインインに失敗'
             Should -Invoke Read-Host -Times 2
         }
+
+        It 'should show desktop app hint in non-admin session' {
+            Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
+            Mock Invoke-OpWhoAmI {
+                return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
+            }
+            Mock Invoke-OpSignIn {
+                return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
+            }
+            Mock Read-Host { return '' }
+            Mock Test-InteractiveEnvironment { return $true }
+            Mock Test-IsAdminSession { return $false }
+            $script:hintShown = $false
+            $script:adminMsg = $false
+            Mock Write-Host {
+                param($Object)
+                if ($Object -match 'デスクトップアプリが起動') { $script:hintShown = $true }
+                if ($Object -match '管理者昇格プロセス') { $script:adminMsg = $true }
+            }
+            $handler.CanApply($ctx)
+
+            $handler.Apply($ctx)
+
+            $script:hintShown | Should -Be $true -Because '非管理者セッションではデスクトップアプリのヒントが表示されるべき'
+            $script:adminMsg | Should -Be $false -Because '非管理者セッションでは管理者用メッセージは出ないべき'
+        }
+
+        It 'should show admin-specific message in admin session' {
+            Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
+            Mock Invoke-OpWhoAmI {
+                return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
+            }
+            Mock Invoke-OpSignIn {
+                return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
+            }
+            Mock Read-Host { return '' }
+            Mock Test-InteractiveEnvironment { return $true }
+            Mock Test-IsAdminSession { return $true }
+            $script:adminMsg = $false
+            $script:nonAdminHint = $false
+            Mock Write-Host {
+                param($Object)
+                if ($Object -match '管理者昇格プロセス') { $script:adminMsg = $true }
+                if ($Object -match 'デスクトップアプリが起動') { $script:nonAdminHint = $true }
+            }
+            $handler.CanApply($ctx)
+
+            $handler.Apply($ctx)
+
+            $script:adminMsg | Should -Be $true -Because '管理者セッションでは管理者用メッセージが出るべき'
+            $script:nonAdminHint | Should -Be $false -Because '管理者セッションでは非管理者ヒントは出ないべき'
+        }
+
+        It 'should succeed when user signs in via desktop app after Read-Host wait' {
+            Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
+            $script:whoamiCount = 0
+            Mock Invoke-OpWhoAmI {
+                $script:whoamiCount++
+                # 1: 初回チェック=失敗, 2: signin後=失敗, 3: ReadHost後デスクトップアプリ連携=成功
+                if ($script:whoamiCount -ge 3) {
+                    return [PSCustomObject]@{ Output = 'user@example.com'; ExitCode = 0 }
+                }
+                return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
+            }
+            Mock Invoke-OpSignIn {
+                return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
+            }
+            Mock Read-Host { return '' }
+            Mock Test-InteractiveEnvironment { return $true }
+            $script:desktopAppSuccess = $false
+            Mock Write-Host {
+                param($Object)
+                if ($Object -match 'デスクトップアプリ連携') { $script:desktopAppSuccess = $true }
+            }
+            Mock Invoke-Chezmoi { $global:LASTEXITCODE = 0 }
+
+            $handler.CanApply($ctx)
+            $result = $handler.Apply($ctx)
+
+            $script:desktopAppSuccess | Should -Be $true -Because 'デスクトップアプリ連携での成功メッセージが出るべき'
+            $result.Success | Should -Be $true
+        }
     }
 
     Context 'FindOpExe' {

--- a/scripts/powershell/tests/handlers/Handler.Chezmoi.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Chezmoi.Tests.ps1
@@ -698,7 +698,7 @@ Describe 'ChezmoiHandler' {
             Should -Invoke Read-Host -Times 0
         }
 
-        It 'should attempt op signin when op whoami fails' {
+        It 'should attempt op signin when op whoami fails and throw after max retries' {
             Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
             Mock Invoke-OpWhoAmI {
                 return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
@@ -715,10 +715,12 @@ Describe 'ChezmoiHandler' {
             }
             $handler.CanApply($ctx)
 
-            $handler.Apply($ctx)
+            $result = $handler.Apply($ctx)
 
             $script:instructionsShown | Should -Be $true
             Should -Invoke Invoke-OpSignIn -Times 3
+            # 全リトライ失敗時は例外で停止し、失敗結果を返す
+            $result.Success | Should -Be $false
         }
 
         It 'should sign in and log success after op signin succeeds' {
@@ -749,7 +751,7 @@ Describe 'ChezmoiHandler' {
             $script:signedInLogged | Should -Be $true
         }
 
-        It 'should log warning after max retries exhausted' {
+        It 'should throw and return failure after max retries exhausted' {
             Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
             Mock Invoke-OpWhoAmI {
                 return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
@@ -759,16 +761,13 @@ Describe 'ChezmoiHandler' {
             }
             Mock Read-Host { return '' }
             Mock Test-InteractiveEnvironment { return $true }
-            $script:failureWarningLogged = $false
-            Mock Write-Host {
-                param($Object)
-                if ($Object -match 'サインインに失敗') { $script:failureWarningLogged = $true }
-            }
             $handler.CanApply($ctx)
 
-            $handler.Apply($ctx)
+            $result = $handler.Apply($ctx)
 
-            $script:failureWarningLogged | Should -Be $true
+            # 全リトライ失敗時は throw → catch で CreateFailureResult が返る
+            $result.Success | Should -Be $false
+            $result.Message | Should -Match 'サインインに失敗'
             Should -Invoke Read-Host -Times 2
         }
     }


### PR DESCRIPTION
## Summary
- op 未ログイン時にセッション種別に応じた案内メッセージを表示し、ログイン完了を待機
- Read-Host 待機後に `op whoami` を再チェック（デスクトップアプ���連携対応）
- 全リトライ失敗時は `throw` で停止し、無駄な `chezmoi apply` を防止

## Test plan
- [x] Pester テスト全48件合格
- [x] 新規PC環境で 1Password 未サインイン状態から `install.cmd` を実行し、ログイン案内が表示されることを確認
- [x] 1Password デスクトップアプリでサインイン後に Enter を押すと認証が通ることを確認

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)