### PR TITLE
fix: Test-WslAvailable の例外処理と Chezmoi 非対話環境での停止

### DIFF
--- a/scripts/powershell/handlers/Handler.Chezmoi.ps1
+++ b/scripts/powershell/handlers/Handler.Chezmoi.ps1
@@ -256,10 +256,10 @@ class ChezmoiHandler : SetupHandlerBase {
             return
         }
 
-        # 非対話環境では Read-Host がハングするためスキップ
+        # 非対話環境では Read-Host がハングするため対話的サインインをスキップ
+        # ただし chezmoi apply は確実に失敗するため、例外で停止する
         if (-not (Test-InteractiveEnvironment)) {
-            $this.LogWarning("1Password CLI が未認証ですが、非対話環境のためセットアップ案内をスキップします")
-            return
+            throw "1Password CLI が未認証です。1Password デスクトップアプリでサインインしてから再実行してください。（非対話環境のため対話的サインインは実行できません）"
         }
 
         # 1Password CLI が未認証 → ログイン画面を表示して待機

--- a/scripts/powershell/lib/Invoke-ExternalCommand.ps1
+++ b/scripts/powershell/lib/Invoke-ExternalCommand.ps1
@@ -725,8 +725,12 @@ function Test-WslAvailable {
     [OutputType([bool])]
     param()
 
-    $null = Invoke-Wsl "--status" 2>&1
-    return $LASTEXITCODE -eq 0
+    try {
+        $null = Invoke-Wsl "--status" 2>&1
+        return $LASTEXITCODE -eq 0
+    } catch {
+        return $false
+    }
 }
 
 <#

--- a/scripts/powershell/tests/handlers/Handler.Chezmoi.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Chezmoi.Tests.ps1
@@ -852,6 +852,20 @@ Describe 'ChezmoiHandler' {
             $script:desktopAppSuccess | Should -Be $true -Because 'デスクトップアプリ連携での成功メッセージが出るべき'
             $result.Success | Should -Be $true
         }
+
+        It 'should throw in non-interactive environment when op is not authenticated' {
+            Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
+            Mock Invoke-OpWhoAmI {
+                return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
+            }
+            Mock Test-InteractiveEnvironment { return $false }
+            $handler.CanApply($ctx)
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $false
+            $result.Message | Should -Match '1Password CLI が未認証'
+        }
     }
 
     Context 'FindOpExe' {

--- a/scripts/powershell/tests/lib/Invoke-ExternalCommand.Tests.ps1
+++ b/scripts/powershell/tests/lib/Invoke-ExternalCommand.Tests.ps1
@@ -441,4 +441,12 @@ Describe 'Test-WslAvailable' {
 
         $result | Should -Be $false
     }
+
+    It 'should return false when Invoke-Wsl throws an exception' {
+        Mock Invoke-Wsl { throw "wsl: WSL component not installed" }
+
+        $result = Test-WslAvailable
+
+        $result | Should -Be $false
+    }
 }


### PR DESCRIPTION
## Summary
- `Test-WslAvailable` に try/catch を追加し、WSL 未インストール時の例外で `CanApply()` がクラッシュする問題を修正
- Chezmoi: 非対話環境（`install.cmd` → `powershell -File` 経由で `IsInputRedirected=true`）で op 未認証時に Warning で続行せず `throw` で停止するよう修正

## Background
`install.cmd` から `powershell.exe -File` で起動すると `Console.IsInputRedirected` が `true` になり、`Test-InteractiveEnvironment` が `false` を返す。従来は Warning を出して `chezmoi apply` に進み `no account found for filter` で失敗していた。

## Test plan
- [x] Chezmoi テスト 52件合格（非対話環境テスト1件追加）
- [x] Invoke-ExternalCommand テスト 40件合格（WSL例外テスト1件追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)