### PR TITLE
fix(chezmoi): op 認証診断にアプリ再起動ヒントを追加

### DIFF
--- a/scripts/powershell/handlers/Handler.Chezmoi.ps1
+++ b/scripts/powershell/handlers/Handler.Chezmoi.ps1
@@ -323,13 +323,29 @@ class ChezmoiHandler : SetupHandlerBase {
     #>
     hidden [string] DiagnoseOpAuthFailure([string]$opExe) {
         $accountResult = Invoke-OpAccountList -OpExe $opExe
-        $hasAccounts = $false
-        if ($accountResult.ExitCode -eq 0 -and $accountResult.Output) {
-            $outputStr = ($accountResult.Output | Out-String).Trim()
-            # JSON 配列が空でないか確認
-            $hasAccounts = $outputStr -and $outputStr -ne '[]' -and $outputStr -ne ''
+        $outputStr = if ($accountResult.Output) { ($accountResult.Output | Out-String).Trim() } else { '' }
+
+        # op account list 自体が失敗 → デスクトップアプリに接続できない
+        if ($accountResult.ExitCode -ne 0) {
+            $isConnectError = $outputStr -match 'cannot connect|make sure it is running'
+            if ($isConnectError) {
+                return @(
+                    "1Password デスクトップアプリに接続できません。"
+                    "CLI 連携を有効にした後、アプリの再起動が必要な場合があります:"
+                    "  1. タスクトレイの 1Password を右クリック → 「Quit 1Password」で完全終了"
+                    "  2. 1Password デスクトップアプリを再起動"
+                    "  3. アプリでロック解除（パスワード or 生体認証）"
+                    "  4. install.cmd を再実行する"
+                ) -join "`n"
+            }
+            return @(
+                "1Password CLI がデスクトップアプリと通信できません。"
+                "1Password デスクトップアプリが起動・ロック解除されていることを確認してください。"
+            ) -join "`n"
         }
 
+        # account list は成功したがアカウントが空 → CLI連携が無効
+        $hasAccounts = $outputStr -and $outputStr -ne '[]' -and $outputStr -ne ''
         if (-not $hasAccounts) {
             return @(
                 "1Password CLI にアカウントが登録されていません。"
@@ -337,15 +353,17 @@ class ChezmoiHandler : SetupHandlerBase {
                 "  1. 1Password デスクトップアプリを開く"
                 "  2. Settings > Developer を開く"
                 "  3. 「Biometric unlock for 1Password CLI」をオンにする"
-                "  4. install.cmd を再実行する"
+                "  4. 1Password デスクトップアプリを再起動する"
+                "  5. install.cmd を再実行する"
                 ""
                 "  参考: https://developer.1password.com/docs/cli/app-integration/"
             ) -join "`n"
         }
 
+        # アカウントはあるが未認証
         return @(
             "1Password CLI が未認証です。"
-            "1Password デスクトップアプリでサインインしてから再実行してください。"
+            "1Password デスクトップアプリでロック解除してから再実行してください。"
         ) -join "`n"
     }
 

--- a/scripts/powershell/tests/handlers/Handler.Chezmoi.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Chezmoi.Tests.ps1
@@ -904,6 +904,25 @@ Describe 'ChezmoiHandler' {
 
             $result.Success | Should -Be $false
             $result.Message | Should -Match '1Password CLI が未認証です'
+            $result.Message | Should -Match 'ロック解除'
+        }
+
+        It 'should show restart hint when desktop app connection fails' {
+            Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
+            Mock Invoke-OpWhoAmI {
+                return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
+            }
+            Mock Invoke-OpAccountList {
+                return [PSCustomObject]@{ Output = 'cannot connect to 1Password app, make sure it is running'; ExitCode = 1 }
+            }
+            Mock Test-InteractiveEnvironment { return $false }
+            $handler.CanApply($ctx)
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $false
+            $result.Message | Should -Match '接続できません'
+            $result.Message | Should -Match '再起動'
         }
     }
 


### PR DESCRIPTION
## Summary
`DiagnoseOpAuthFailure` で3パターンを診断:

| 状態 | 診断メッセージ |
|------|---------------|
| デスクトップアプリに接続不可 | 「再起動が必要な場合があります」+ 手順 |
| CLI にアカウント未登録 | 「CLI 連携を有効にしてください」+ 再起動含む手順 |
| アカウントはあるが未認証 | 「ロック解除してから再実行」 |

## Test plan
- [x] Chezmoi テスト 55件合格（接続エラーテスト1件追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)