### PR TITLE
fix(chezmoi): op 認証チェックを op vault list に変更

### DIFF
--- a/scripts/powershell/handlers/Handler.Chezmoi.ps1
+++ b/scripts/powershell/handlers/Handler.Chezmoi.ps1
@@ -248,9 +248,11 @@ class ChezmoiHandler : SetupHandlerBase {
             return
         }
 
-        # サインイン済みか確認（op whoami で実際の認証状態をチェック）
-        # op account list はアカウント情報を返すだけで認証状態を確認できないため使わない
-        $result = Invoke-OpWhoAmI -OpExe $opExe
+        # サインイン済みか確認
+        # op whoami はデスクトップアプリ連携環境（特に -File モード）で
+        # "account is not signed in" を返す場合がある。
+        # op vault list は認証済みなら exit 0 を返し、より信頼性が高い。
+        $result = Invoke-OpVaultList -OpExe $opExe
         if ($result.ExitCode -eq 0) {
             $this.Log("1Password CLI: サインイン済み", "Gray")
             return
@@ -288,7 +290,7 @@ class ChezmoiHandler : SetupHandlerBase {
             Invoke-OpSignIn -OpExe $opExe | Out-Null
 
             # signin 後に whoami で確認
-            $result = Invoke-OpWhoAmI -OpExe $opExe
+            $result = Invoke-OpVaultList -OpExe $opExe
             if ($result.ExitCode -eq 0) {
                 $this.Log("1Password CLI: サインイン完了", "Green")
                 return
@@ -301,7 +303,7 @@ class ChezmoiHandler : SetupHandlerBase {
                 Read-Host | Out-Null
 
                 # デスクトップアプリ連携が有効になった可能性があるため whoami で再確認
-                $result = Invoke-OpWhoAmI -OpExe $opExe
+                $result = Invoke-OpVaultList -OpExe $opExe
                 if ($result.ExitCode -eq 0) {
                     $this.Log("1Password CLI: サインイン完了（デスクトップアプリ連携）", "Green")
                     return

--- a/scripts/powershell/lib/Invoke-ExternalCommand.ps1
+++ b/scripts/powershell/lib/Invoke-ExternalCommand.ps1
@@ -656,6 +656,28 @@ function Invoke-OpWhoAmI {
 
 <#
 .SYNOPSIS
+    1Password CLI の vault list を実行する
+.DESCRIPTION
+    op whoami はデスクトップアプリ連携環境（特に PowerShell -File モード）で
+    "account is not signed in" を返す場合がある。
+    op vault list は認証済みなら exit 0 を返し、認証チェックとしてより信頼性が高い。
+.PARAMETER OpExe
+    op.exe のパス
+.OUTPUTS
+    [PSCustomObject]@{ Output=[string]; ExitCode=[int] }
+#>
+function Invoke-OpVaultList {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$OpExe
+    )
+    $output = & $OpExe vault list --format=json 2>&1
+    return [PSCustomObject]@{ Output = $output; ExitCode = $LASTEXITCODE }
+}
+
+<#
+.SYNOPSIS
     1Password CLI の signin を実行する
 .DESCRIPTION
     UAC 昇格プロセスなどデスクトップアプリ連携が使えない環境で

--- a/scripts/powershell/tests/handlers/Handler.Chezmoi.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Chezmoi.Tests.ps1
@@ -682,7 +682,7 @@ Describe 'ChezmoiHandler' {
         It 'should proceed silently when op whoami succeeds' {
             Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
             Mock Invoke-OpVaultList {
-                return [PSCustomObject]@{ Output = 'my@example.com'; ExitCode = 0 }
+                return [PSCustomObject]@{ Output = '[{"id":"vault1"}]'; ExitCode = 0 }
             }
             Mock Read-Host { return '' }
             $script:signedInLogged = $false
@@ -729,12 +729,12 @@ Describe 'ChezmoiHandler' {
 
         It 'should sign in and log success after op signin succeeds' {
             Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
-            $script:whoamiCallCount = 0
+            $script:vaultListCallCount = 0
             Mock Invoke-OpVaultList {
-                $script:whoamiCallCount++
+                $script:vaultListCallCount++
                 # 2回目で成功（op signin 後）
-                if ($script:whoamiCallCount -ge 2) {
-                    return [PSCustomObject]@{ Output = 'my@example.com'; ExitCode = 0 }
+                if ($script:vaultListCallCount -ge 2) {
+                    return [PSCustomObject]@{ Output = '[{"id":"vault1"}]'; ExitCode = 0 }
                 }
                 return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
             }
@@ -829,12 +829,12 @@ Describe 'ChezmoiHandler' {
 
         It 'should succeed when user signs in via desktop app after Read-Host wait' {
             Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
-            $script:whoamiCount = 0
+            $script:vaultListCount = 0
             Mock Invoke-OpVaultList {
-                $script:whoamiCount++
+                $script:vaultListCount++
                 # 1: 初回チェック=失敗, 2: signin後=失敗, 3: ReadHost後デスクトップアプリ連携=成功
-                if ($script:whoamiCount -ge 3) {
-                    return [PSCustomObject]@{ Output = 'user@example.com'; ExitCode = 0 }
+                if ($script:vaultListCount -ge 3) {
+                    return [PSCustomObject]@{ Output = '[{"id":"vault1"}]'; ExitCode = 0 }
                 }
                 return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
             }
@@ -939,7 +939,7 @@ Describe 'ChezmoiHandler' {
             Mock New-DirectorySafe { }
             Mock Write-Host { }
             Mock Invoke-OpVaultList {
-                return [PSCustomObject]@{ Output = 'my@example.com'; ExitCode = 0 }
+                return [PSCustomObject]@{ Output = '[{"id":"vault1"}]'; ExitCode = 0 }
             }
             # 非管理者セッションでは DeployProfileToOtherUsers はスキップされる
             Mock Test-IsAdminSession { return $false }

--- a/scripts/powershell/tests/handlers/Handler.Chezmoi.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Chezmoi.Tests.ps1
@@ -681,7 +681,7 @@ Describe 'ChezmoiHandler' {
 
         It 'should proceed silently when op whoami succeeds' {
             Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
-            Mock Invoke-OpWhoAmI {
+            Mock Invoke-OpVaultList {
                 return [PSCustomObject]@{ Output = 'my@example.com'; ExitCode = 0 }
             }
             Mock Read-Host { return '' }
@@ -704,7 +704,7 @@ Describe 'ChezmoiHandler' {
 
         It 'should attempt op signin when op whoami fails and throw after max retries' {
             Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
-            Mock Invoke-OpWhoAmI {
+            Mock Invoke-OpVaultList {
                 return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
             }
             Mock Invoke-OpSignIn {
@@ -730,7 +730,7 @@ Describe 'ChezmoiHandler' {
         It 'should sign in and log success after op signin succeeds' {
             Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
             $script:whoamiCallCount = 0
-            Mock Invoke-OpWhoAmI {
+            Mock Invoke-OpVaultList {
                 $script:whoamiCallCount++
                 # 2回目で成功（op signin 後）
                 if ($script:whoamiCallCount -ge 2) {
@@ -757,7 +757,7 @@ Describe 'ChezmoiHandler' {
 
         It 'should throw and return failure after max retries exhausted' {
             Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
-            Mock Invoke-OpWhoAmI {
+            Mock Invoke-OpVaultList {
                 return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
             }
             Mock Invoke-OpSignIn {
@@ -777,7 +777,7 @@ Describe 'ChezmoiHandler' {
 
         It 'should show desktop app hint in non-admin session' {
             Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
-            Mock Invoke-OpWhoAmI {
+            Mock Invoke-OpVaultList {
                 return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
             }
             Mock Invoke-OpSignIn {
@@ -803,7 +803,7 @@ Describe 'ChezmoiHandler' {
 
         It 'should show admin-specific message in admin session' {
             Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
-            Mock Invoke-OpWhoAmI {
+            Mock Invoke-OpVaultList {
                 return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
             }
             Mock Invoke-OpSignIn {
@@ -830,7 +830,7 @@ Describe 'ChezmoiHandler' {
         It 'should succeed when user signs in via desktop app after Read-Host wait' {
             Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
             $script:whoamiCount = 0
-            Mock Invoke-OpWhoAmI {
+            Mock Invoke-OpVaultList {
                 $script:whoamiCount++
                 # 1: 初回チェック=失敗, 2: signin後=失敗, 3: ReadHost後デスクトップアプリ連携=成功
                 if ($script:whoamiCount -ge 3) {
@@ -859,7 +859,7 @@ Describe 'ChezmoiHandler' {
 
         It 'should throw in non-interactive environment when op is not authenticated' {
             Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
-            Mock Invoke-OpWhoAmI {
+            Mock Invoke-OpVaultList {
                 return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
             }
             Mock Test-InteractiveEnvironment { return $false }
@@ -873,7 +873,7 @@ Describe 'ChezmoiHandler' {
 
         It 'should show CLI integration hint when no accounts registered' {
             Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
-            Mock Invoke-OpWhoAmI {
+            Mock Invoke-OpVaultList {
                 return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
             }
             Mock Invoke-OpAccountList {
@@ -891,7 +891,7 @@ Describe 'ChezmoiHandler' {
 
         It 'should show generic auth error when accounts exist but not authenticated' {
             Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
-            Mock Invoke-OpWhoAmI {
+            Mock Invoke-OpVaultList {
                 return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
             }
             Mock Invoke-OpAccountList {
@@ -909,7 +909,7 @@ Describe 'ChezmoiHandler' {
 
         It 'should show restart hint when desktop app connection fails' {
             Mock Get-ExternalCommand { return [PSCustomObject]@{ Source = 'C:\op.exe' } } -ParameterFilter { $Name -eq 'op' }
-            Mock Invoke-OpWhoAmI {
+            Mock Invoke-OpVaultList {
                 return [PSCustomObject]@{ Output = ''; ExitCode = 1 }
             }
             Mock Invoke-OpAccountList {
@@ -938,7 +938,7 @@ Describe 'ChezmoiHandler' {
             Mock Test-PathExist { return $true }
             Mock New-DirectorySafe { }
             Mock Write-Host { }
-            Mock Invoke-OpWhoAmI {
+            Mock Invoke-OpVaultList {
                 return [PSCustomObject]@{ Output = 'my@example.com'; ExitCode = 0 }
             }
             # 非管理者セッションでは DeployProfileToOtherUsers はスキップされる
@@ -955,7 +955,7 @@ Describe 'ChezmoiHandler' {
             $handler.CanApply($ctx)
             $handler.Apply($ctx)
 
-            Should -Invoke Invoke-OpWhoAmI -ParameterFilter {
+            Should -Invoke Invoke-OpVaultList -ParameterFilter {
                 $OpExe -eq 'C:\tools\op.exe'
             } -Times 1
         }
@@ -971,7 +971,7 @@ Describe 'ChezmoiHandler' {
             $handler.CanApply($ctx)
             $handler.Apply($ctx)
 
-            Should -Invoke Invoke-OpWhoAmI -ParameterFilter {
+            Should -Invoke Invoke-OpVaultList -ParameterFilter {
                 $OpExe -eq 'C:\WinGet\Packages\AgileBits.1Password.CLI_2.32.1\op.exe'
             } -Times 1
         }
@@ -989,7 +989,7 @@ Describe 'ChezmoiHandler' {
             $handler.Apply($ctx)
 
             $script:notFoundWarned | Should -Be $true
-            Should -Invoke Invoke-OpWhoAmI -Times 0
+            Should -Invoke Invoke-OpVaultList -Times 0
         }
     }
 


### PR DESCRIPTION
## Summary
- `op whoami` はデスクトップアプリ連携環境（PowerShell `-File` モード）で `account is not signed in` を返す場合がある
- `op vault list` は認証済みなら確実に exit 0 を返すため、認証チェックとして信頼性が高い
- `Invoke-OpVaultList` ラッパー関数を追加し、全認証チェックを `op vault list` に変更

## Test plan
- [x] Chezmoi テスト 55件合格
- [x] `-File` モードで `op vault list` が exit 0 を返すことを実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)