### PR TITLE
fix(pnpm): PNPM_HOME をレジストリから復元して PATH エラーを解消

### DIFF
--- a/scripts/powershell/handlers/Handler.Pnpm.ps1
+++ b/scripts/powershell/handlers/Handler.Pnpm.ps1
@@ -187,6 +187,16 @@ class PnpmHandler : SetupHandlerBase {
     }
 
     hidden [string] EnsurePnpmSetup() {
+        # PNPM_HOME がプロセスに未設定の場合、レジストリから復元
+        # （前回の pnpm setup で登録済みだが新規シェルにしか反映されないため）
+        if (-not $env:PNPM_HOME) {
+            $registryPnpmHome = [System.Environment]::GetEnvironmentVariable('PNPM_HOME', 'User')
+            if ($registryPnpmHome) {
+                $env:PNPM_HOME = $registryPnpmHome
+                $this.Log("PNPM_HOME をレジストリから復元しました: $registryPnpmHome", "Gray")
+            }
+        }
+
         $rawBinPath = Invoke-Pnpm -Arguments @("bin", "-g")
         if ($LASTEXITCODE -eq 0 -and $rawBinPath -and $rawBinPath.Trim()) {
             return $rawBinPath.Trim()

--- a/scripts/powershell/tests/handlers/Handler.Pnpm.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Pnpm.Tests.ps1
@@ -270,6 +270,44 @@ Describe 'PnpmHandler' {
         }
     }
 
+    Context 'EnsurePnpmSetup - PNPM_HOME restored from registry' {
+        BeforeEach {
+            $script:origPnpmHome = $env:PNPM_HOME
+            $env:PNPM_HOME = ""
+            $script:pnpmBin = Join-Path $TestDrive "pnpm-restored"
+            Mock Invoke-Pnpm {
+                param($Arguments)
+                if ($Arguments -contains "bin") {
+                    $global:LASTEXITCODE = 0
+                    return $script:pnpmBin
+                }
+                $global:LASTEXITCODE = 0
+                return ""
+            }
+            Mock Write-Host { }
+            # [System.Environment]::GetEnvironmentVariable をモック不可のため、
+            # 実際のレジストリ値を一時的にセットしてテスト
+            [System.Environment]::SetEnvironmentVariable('PNPM_HOME', $script:pnpmBin, 'User')
+        }
+        AfterEach {
+            $env:PNPM_HOME = $script:origPnpmHome
+            # レジストリを元に戻す
+            if ($script:origPnpmHome) {
+                [System.Environment]::SetEnvironmentVariable('PNPM_HOME', $script:origPnpmHome, 'User')
+            }
+        }
+
+        It 'should restore PNPM_HOME from registry when env is empty' {
+            $handler.EnsurePnpmSetup()
+            $env:PNPM_HOME | Should -Be $script:pnpmBin
+        }
+
+        It 'should not call pnpm setup when bin path is available after restore' {
+            $handler.EnsurePnpmSetup()
+            Should -Invoke Invoke-Pnpm -ParameterFilter { $Arguments -contains "setup" } -Times 0
+        }
+    }
+
     Context 'AddPnpmBinToPath - empty bin path' {
         BeforeEach {
             Mock Set-UserEnvironmentPath { }


### PR DESCRIPTION
## Summary
`pnpm setup` 完了後の新規シェルでは `PNPM_HOME` 環境変数がプロセスにセットされないため、`pnpm bin -g` が空を返し `pnpm add -g` が `"global bin directory is not in PATH"` で失敗していた。

`EnsurePnpmSetup` の冒頭でレジストリから `PNPM_HOME` を復元するよう修正。

## Test plan
- [x] Pnpm テスト 54件合格（レジストリ復元テスト2件追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)