### PR TITLE
fix(chezmoi): deploy_claude_code_mcp.sh に Windows スキップガードを追加

### DIFF
--- a/chezmoi/.chezmoiscripts/deploy/llms/run_onchange_deploy_claude_code_mcp.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/llms/run_onchange_deploy_claude_code_mcp.sh.tmpl
@@ -1,3 +1,4 @@
+{{ if ne .chezmoi.os "windows" -}}
 #!/bin/bash
 # chezmoi:template:hash={{ include ".chezmoidata/mcp_servers.yaml" | sha256sum }}
 
@@ -19,3 +20,4 @@ claude mcp add "{{ .name }}" -s user -- {{ .command }} {{ range .args }}"{{ . }}
 {{ end }}
 
 echo "[claude-code-mcp] Done"
+{{ end -}}


### PR DESCRIPTION
## Summary
`deploy_claude_code_mcp.sh.tmpl` に `{{ if ne .chezmoi.os "windows" }}` ガードがなく、Windows で `chezmoi apply` 時に `.sh` を直接実行して `%1 is not a valid Win32 application` エラーで失敗していた。

他の `.sh.tmpl` と同様の OS ガードを追加。`.ps1` 版が Windows 用として正常動作する。

## Test plan
- [x] Windows 上で `chezmoi apply` を実行し、`.sh` スクリプトがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)