### PR TITLE
fix(chezmoi): git clone の stderr がエラー判定される問題を修正

### DIFF
--- a/chezmoi/.chezmoiscripts/run_onchange_install-claude-plugins_windows.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_install-claude-plugins_windows.ps1.tmpl
@@ -19,12 +19,16 @@ if (-not (Test-Path -Path $marketplacesDir)) {
 $targetDir = Join-Path $marketplacesDir "{{ .name }}"
 if (-not (Test-Path -Path $targetDir)) {
     Write-Host "Cloning {{ .name }}..."
-    & $gitCmd @gitNonInteractive clone "https://github.com/{{ .repo }}.git" $targetDir
+    # git clone は進捗メッセージを stderr に出力するため、PowerShell が
+    # NativeCommandError として扱わないよう stderr をリダイレクト
+    & $gitCmd @gitNonInteractive clone "https://github.com/{{ .repo }}.git" $targetDir 2>&1 | ForEach-Object { Write-Host $_ }
+    if ($LASTEXITCODE -ne 0) { throw "git clone failed for {{ .name }}" }
 }
 else {
     Write-Host "Updating {{ .name }}..."
     Push-Location $targetDir
-    try { & $gitCmd @gitNonInteractive pull --ff-only } finally { Pop-Location }
+    try { & $gitCmd @gitNonInteractive pull --ff-only 2>&1 | ForEach-Object { Write-Host $_ } } finally { Pop-Location }
+    if ($LASTEXITCODE -ne 0) { Write-Host "Warning: git pull failed for {{ .name }}, skipping" }
 }
 
 {{ end -}}


### PR DESCRIPTION
## Summary
`install-claude-plugins_windows.ps1` で `git clone` の進捗メッセージ（stderr）が PowerShell の `NativeCommandError` として扱われ、chezmoi がスクリプト失敗と判定していた。

- `2>&1 | ForEach-Object { Write-Host $_ }` で stderr をマージして表示
- `$LASTEXITCODE` で実際の成否を判定

## Test plan
- [x] `install.ps1` で Chezmoi の前段階（deploy スクリプト群）が全て成功することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)