### PR TITLE
fix(chezmoi): cursor CLI の stderr warning がエラー判定される問題を修正

### DIFF
--- a/chezmoi/.chezmoiscripts/sync/editors/run_onchange_sync.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/sync/editors/run_onchange_sync.ps1.tmpl
@@ -34,7 +34,9 @@ function Sync-Extensions {
     }
 
     # Get currently installed extensions
-    $installed = & $EditorCommand --list-extensions | ForEach-Object { $_.ToLower() }
+    # 一部エディタ CLI (cursor 等) は deprecation warning を stderr に出力するため
+    # 2>$null で抑制し、stdout のみ取得する
+    $installed = & $EditorCommand --list-extensions 2>$null | ForEach-Object { $_.ToLower() }
 
     # Remove unlisted extensions (retry loop for dependency resolution)
     $toRemove = @($installed | Where-Object { $_ -notin $managed })


### PR DESCRIPTION
## Summary
`cursor --list-extensions` が Node.js の `punycode` deprecation warning を stderr に出力し、chezmoi がスクリプト失敗と判定していた。

`--list-extensions` の stderr を `2>$null` で抑制し、stdout のみ取得するよう修正。

## Test plan
- [x] `install.ps1` で Chezmoi の editor sync が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)