### PR TITLE
fix: WSL を wsl --install で正しくセットアップする

### DIFF
--- a/scripts/powershell/handlers/Handler.WslInstall.ps1
+++ b/scripts/powershell/handlers/Handler.WslInstall.ps1
@@ -1,0 +1,73 @@
+<#
+.SYNOPSIS
+    WSL コンポーネントのインストールを管理するハンドラー
+
+.DESCRIPTION
+    - wsl --install --no-distribution で WSL 基盤を有効化
+    - winget install Microsoft.WSL では Optional Feature が有効化されないため、
+      wsl --install を使用する
+
+.NOTES
+    Order = 5 (WSL 依存ハンドラより先に実行)
+    RequiresAdmin = $true (Windows Optional Feature の有効化に管理者権限が必要)
+#>
+
+$libPath = Split-Path -Parent $PSScriptRoot
+. (Join-Path $libPath "lib\Invoke-ExternalCommand.ps1")
+
+class WslInstallHandler : SetupHandlerBase {
+    WslInstallHandler() {
+        $this.Name = "WslInstall"
+        $this.Description = "WSL コンポーネントのインストール"
+        $this.Order = 5
+        $this.RequiresAdmin = $true
+    }
+
+    <#
+    .SYNOPSIS
+        実行可否を判定する
+    .DESCRIPTION
+        WSL が既に利用可能なら実行不要
+    #>
+    [bool] CanApply([SetupContext]$ctx) {
+        if ($ctx.GetOption("SkipWslInstall", $false)) {
+            $this.Log("SkipWslInstall が設定されているためスキップします", "Gray")
+            return $false
+        }
+
+        # WSL が既に利用可能なら不要
+        if (Test-WslAvailable) {
+            $this.Log("WSL は既にインストール済みです", "Gray")
+            return $false
+        }
+
+        return $true
+    }
+
+    <#
+    .SYNOPSIS
+        WSL をインストールする
+    #>
+    [SetupResult] Apply([SetupContext]$ctx) {
+        try {
+            $this.Log("WSL コンポーネントをインストールしています...")
+            $this.Log("wsl --install --no-distribution を実行中...")
+
+            # wsl --install は stderr に進捗を出力するため 2>&1 でマージ
+            $output = & wsl --install --no-distribution 2>&1
+            $output | ForEach-Object { $this.Log("  $_", "Gray") }
+
+            if ($LASTEXITCODE -ne 0) {
+                return $this.CreateFailureResult("wsl --install が失敗しました (exit=$LASTEXITCODE)")
+            }
+
+            $this.Log("WSL コンポーネントのインストールが完了しました", "Green")
+            $this.Log("WSL を有効にするには PC の再起動が必要です", "Yellow")
+            $this.Log("再起動後に install.cmd を再実行してください", "Yellow")
+
+            return $this.CreateSuccessResult("WSL をインストールしました（再起動が必要）")
+        } catch {
+            return $this.CreateFailureResult($_.Exception.Message, $_.Exception)
+        }
+    }
+}

--- a/scripts/powershell/tests/handlers/Handler.WslInstall.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.WslInstall.Tests.ps1
@@ -1,0 +1,93 @@
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Handler.WslInstall.ps1 のユニットテスト
+#>
+
+BeforeAll {
+    . $PSScriptRoot/../../lib/SetupHandler.ps1
+    . $PSScriptRoot/../../lib/Invoke-ExternalCommand.ps1
+    . $PSScriptRoot/../../handlers/Handler.WslInstall.ps1
+}
+
+Describe 'WslInstallHandler' {
+    BeforeEach {
+        $script:handler = [WslInstallHandler]::new()
+        $script:ctx = [SetupContext]::new('D:\dotfiles')
+    }
+
+    Context 'Constructor' {
+        It 'should set Name to WslInstall' {
+            $handler.Name | Should -Be 'WslInstall'
+        }
+
+        It 'should set Order to 5' {
+            $handler.Order | Should -Be 5
+        }
+
+        It 'should require admin' {
+            $handler.RequiresAdmin | Should -Be $true
+        }
+    }
+
+    Context 'CanApply' {
+        It 'should return false when WSL is already available' {
+            Mock Test-WslAvailable { return $true }
+            Mock Write-Host { }
+
+            $result = $handler.CanApply($ctx)
+
+            $result | Should -Be $false
+        }
+
+        It 'should return true when WSL is not available' {
+            Mock Test-WslAvailable { return $false }
+
+            $result = $handler.CanApply($ctx)
+
+            $result | Should -Be $true
+        }
+
+        It 'should return false when SkipWslInstall is set' {
+            Mock Write-Host { }
+            $ctx.Options["SkipWslInstall"] = $true
+
+            $result = $handler.CanApply($ctx)
+
+            $result | Should -Be $false
+        }
+    }
+
+    Context 'Apply' {
+        BeforeEach {
+            Mock Write-Host { }
+        }
+
+        It 'should run wsl --install --no-distribution' {
+            $script:wslInstallCalled = $false
+            Mock wsl {
+                $script:wslInstallCalled = $true
+                $global:LASTEXITCODE = 0
+                return "Installing WSL..."
+            }
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $result.Message | Should -Match '再起動が必要'
+            $script:wslInstallCalled | Should -Be $true
+        }
+
+        It 'should return failure when wsl --install fails' {
+            Mock wsl {
+                $global:LASTEXITCODE = 1
+                return "Installation failed"
+            }
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $false
+        }
+    }
+}

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -71,9 +71,6 @@
           "PackageIdentifier": "Microsoft.WindowsTerminal"
         },
         {
-          "PackageIdentifier": "Microsoft.WSL"
-        },
-        {
           "PackageIdentifier": "OpenAI.Codex"
         },
         {


### PR DESCRIPTION
## Summary
`winget install Microsoft.WSL` ではストア版パッケージのみインストールされ、Windows Optional Feature が有効化されない。

- `packages.json` から `Microsoft.WSL` を削除
- `WslInstall` ハンドラを新規作成（Phase 2b, `RequiresAdmin=true`, Order=5）
  - `wsl --install --no-distribution` を管理者権限で実行
  - 再起動が必要な旨をユーザーに通知

## Test plan
- [x] WslInstall テスト 8件合格

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)