### PR TITLE
fix(wsl): wsl --install 失敗時に dism.exe フォールバックを追加

### DIFF
--- a/scripts/powershell/handlers/Handler.WslInstall.ps1
+++ b/scripts/powershell/handlers/Handler.WslInstall.ps1
@@ -51,23 +51,67 @@ class WslInstallHandler : SetupHandlerBase {
     [SetupResult] Apply([SetupContext]$ctx) {
         try {
             $this.Log("WSL コンポーネントをインストールしています...")
-            $this.Log("wsl --install --no-distribution を実行中...")
 
-            # wsl --install は stderr に進捗を出力するため 2>&1 でマージ
+            # 方法1: wsl --install --no-distribution
+            $this.Log("wsl --install --no-distribution を実行中...")
             $output = & wsl --install --no-distribution 2>&1
             $output | ForEach-Object { $this.Log("  $_", "Gray") }
 
-            if ($LASTEXITCODE -ne 0) {
-                return $this.CreateFailureResult("wsl --install が失敗しました (exit=$LASTEXITCODE)")
+            if ($LASTEXITCODE -eq 0) {
+                return $this.CreateRebootRequiredResult()
             }
 
-            $this.Log("WSL コンポーネントのインストールが完了しました", "Green")
-            $this.Log("WSL を有効にするには PC の再起動が必要です", "Yellow")
-            $this.Log("再起動後に install.cmd を再実行してください", "Yellow")
+            # 方法2: wsl --install が失敗した場合、dism.exe で Optional Feature を直接有効化
+            $this.LogWarning("wsl --install が失敗しました。dism.exe で Windows Optional Feature を有効化します...")
+            $dismSuccess = $this.EnableWslFeatures()
 
-            return $this.CreateSuccessResult("WSL をインストールしました（再起動が必要）")
+            if ($dismSuccess) {
+                return $this.CreateRebootRequiredResult()
+            }
+
+            return $this.CreateFailureResult(
+                "WSL のインストールに失敗しました。手動で以下を管理者 PowerShell で実行してください:`n" +
+                "  dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart`n" +
+                "  dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart"
+            )
         } catch {
             return $this.CreateFailureResult($_.Exception.Message, $_.Exception)
         }
+    }
+
+    <#
+    .SYNOPSIS
+        dism.exe で WSL 関連の Windows Optional Feature を有効化する
+    .OUTPUTS
+        全て成功なら $true
+    #>
+    hidden [bool] EnableWslFeatures() {
+        $features = @(
+            "Microsoft-Windows-Subsystem-Linux",
+            "VirtualMachinePlatform"
+        )
+        $allSuccess = $true
+
+        foreach ($feature in $features) {
+            $this.Log("dism.exe: $feature を有効化中...")
+            $output = & dism.exe /online /enable-feature /featurename:$feature /all /norestart 2>&1
+            $output | ForEach-Object { $this.Log("  $_", "Gray") }
+
+            if ($LASTEXITCODE -ne 0) {
+                $this.LogWarning("$feature の有効化に失敗しました (exit=$LASTEXITCODE)")
+                $allSuccess = $false
+            } else {
+                $this.Log("$feature を有効化しました", "Green")
+            }
+        }
+
+        return $allSuccess
+    }
+
+    hidden [SetupResult] CreateRebootRequiredResult() {
+        $this.Log("WSL コンポーネントのインストールが完了しました", "Green")
+        $this.Log("WSL を有効にするには PC の再起動が必要です", "Yellow")
+        $this.Log("再起動後に install.cmd を再実行してください", "Yellow")
+        return $this.CreateSuccessResult("WSL をインストールしました（再起動が必要）")
     }
 }

--- a/scripts/powershell/tests/handlers/Handler.WslInstall.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.WslInstall.Tests.ps1
@@ -79,15 +79,39 @@ Describe 'WslInstallHandler' {
             $script:wslInstallCalled | Should -Be $true
         }
 
-        It 'should return failure when wsl --install fails' {
+        It 'should fallback to dism when wsl --install fails' {
             Mock wsl {
                 $global:LASTEXITCODE = 1
                 return "Installation failed"
+            }
+            $script:dismCalls = @()
+            Mock dism.exe {
+                $script:dismCalls += ($args -join " ")
+                $global:LASTEXITCODE = 0
+                return "The operation completed successfully."
+            }
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $result.Message | Should -Match '再起動が必要'
+            $script:dismCalls.Count | Should -Be 2
+        }
+
+        It 'should return failure when both wsl --install and dism fail' {
+            Mock wsl {
+                $global:LASTEXITCODE = 1
+                return "Installation failed"
+            }
+            Mock dism.exe {
+                $global:LASTEXITCODE = 1
+                return "Error"
             }
 
             $result = $handler.Apply($ctx)
 
             $result.Success | Should -Be $false
+            $result.Message | Should -Match 'dism.exe'
         }
     }
 }


### PR DESCRIPTION
## Summary
`wsl --install --no-distribution` が `REGDB_E_CLASSNOTREG` で失敗する環境向けに、`dism.exe` で Windows Optional Feature を直接有効化するフォールバックを追加。

### 実行順序
1. `wsl --install --no-distribution` を試行
2. 失敗した場合、`dism.exe` で以下を有効化:
   - `Microsoft-Windows-Subsystem-Linux`
   - `VirtualMachinePlatform`
3. 両方失敗した場合、手動コマンドを案内

## Test plan
- [x] WslInstall テスト 9件合格（dism フォールバックテスト2件追加）

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)