### PR TITLE
fix(nixoswsl): wslpath パス変換のバックスラッシュ消失を修正

### DIFF
--- a/scripts/powershell/handlers/Handler.NixOSWSL.ps1
+++ b/scripts/powershell/handlers/Handler.NixOSWSL.ps1
@@ -432,7 +432,10 @@ class NixOSWSLHandler : SetupHandlerBase {
 
         $this.Log("Post-install セットアップを実行します...")
         $resolved = (Resolve-Path -LiteralPath $scriptPath).Path
-        $wslPath = Invoke-Wsl -Arguments @("-d", $ctx.DistroName, "--", "wslpath", "-a", $resolved)
+        # wslpath にバックスラッシュを渡すと WSL がエスケープシーケンスとして解釈して消失する
+        # フォワードスラッシュに変換してから渡す
+        $resolvedForWsl = $resolved.Replace('\', '/')
+        $wslPath = Invoke-Wsl -Arguments @("-d", $ctx.DistroName, "--", "wslpath", "-a", $resolvedForWsl)
         if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($wslPath)) {
             $drive = [IO.Path]::GetPathRoot($resolved).TrimEnd(":\")
             $rest = $resolved.Substring(2) -replace "\\", "/"


### PR DESCRIPTION
## Summary
`wsl -- wslpath -a D:\path` と渡すと WSL がバックスラッシュをエスケープシーケンスとして解釈し消失する（`D:dotfilesscripts...` になる）。

`.Replace('\', '/')` で変換してから渡すよう修正。

## Test plan
- [x] NixOSWSL テスト 46件合格
- [x] 実機で `wslpath -a D:/dotfiles/...` が正しく `/mnt/d/dotfiles/...` を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)