### PR TITLE
ci: run workflows on pull_request only

### DIFF
--- a/.github/workflows/test-consistency.yml
+++ b/.github/workflows/test-consistency.yml
@@ -1,14 +1,6 @@
 name: Package Consistency
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "nix/packages/**"
-      - "nix/home/**"
-      - "windows/winget/packages.json"
-      - "windows/pnpm/packages.json"
-      - ".github/workflows/test-consistency.yml"
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -1,13 +1,6 @@
 name: Nix Checks
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "nix/**"
-      - "flake.nix"
-      - "flake.lock"
-      - ".github/workflows/test-nix.yml"
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -1,12 +1,6 @@
 name: PowerShell Tests
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "scripts/powershell/**"
-      - "install.ps1"
-      - ".github/workflows/test-powershell.yml"
   pull_request:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary

- Remove `on.push` trigger from all 3 workflows (test-nix, test-consistency, test-powershell)
- Workflows now only run on `pull_request` to `main`
- Avoids redundant CI runs on merge push since PRs already validate the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)