### PR TITLE
fix(docker): Docker Desktop 起動後にディストリビューション初期化完了を待機

### DIFF
--- a/scripts/powershell/handlers/Handler.Docker.ps1
+++ b/scripts/powershell/handlers/Handler.Docker.ps1
@@ -368,12 +368,40 @@ class DockerHandler : SetupHandlerBase {
 
         $this.Log("Docker Desktop を起動します")
         Start-ProcessSafe -FilePath $dockerExe
-        Start-SleepSafe -Seconds 5
+
+        # Docker Desktop 起動後、docker-desktop WSL ディストリビューションが
+        # 利用可能になるまで待機する（最大60秒）
+        $this.WaitForDockerDesktopDistro()
 
         # StopLingeringDockerProcesses による強制終了後、Docker Desktop が
         # WSL cross-distro 共有の docker-desktop-user-distro を 0 バイトで
         # 残すことがある。修復しないと NixOS WSL integration が永続的に失敗する。
         $this.RepairWslProxyBinary()
+    }
+
+    <#
+    .SYNOPSIS
+        Docker Desktop 起動後に docker-desktop ディストリビューションが利用可能になるまで待機する
+    .DESCRIPTION
+        Docker Desktop はプロセス起動後に WSL ディストリビューション (docker-desktop) を
+        初期化する。初期化完了前に docker-desktop ディストリビューションにアクセスすると
+        "/bin/sh: docker-desktop: not found" エラーが発生する。
+    #>
+    hidden [void] WaitForDockerDesktopDistro() {
+        $maxAttempts = 12
+        $delaySec = 5
+        for ($i = 1; $i -le $maxAttempts; $i++) {
+            Start-SleepSafe -Seconds $delaySec
+            $testResult = Invoke-Wsl -d "docker-desktop" "--" "sh" "-c" "echo ok" 2>$null
+            if ($LASTEXITCODE -eq 0 -and $testResult -match "ok") {
+                $this.Log("Docker Desktop ディストリビューションが利用可能です", "Gray")
+                return
+            }
+            if ($i -lt $maxAttempts) {
+                $this.Log("Docker Desktop 初期化待機中... ($i/$maxAttempts)", "Gray")
+            }
+        }
+        $this.LogWarning("Docker Desktop ディストリビューションの初期化がタイムアウトしました（${maxAttempts}回試行）")
     }
 
     <#

--- a/scripts/powershell/tests/handlers/Handler.Docker.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Docker.Tests.ps1
@@ -809,6 +809,67 @@ Describe 'DockerHandler' {
 
             Should -Invoke Start-ProcessSafe -Times 0
         }
+
+        It 'should wait for docker-desktop distro to be ready after startup' {
+            Mock Get-ProcessSafe { return $null }
+            Mock Start-ProcessSafe { }
+            $script:wslEchoAttempts = 0
+            Mock Invoke-Wsl {
+                param($Arguments)
+                $argStr = $Arguments -join " "
+                if ($argStr -match "echo ok") {
+                    $script:wslEchoAttempts++
+                    if ($script:wslEchoAttempts -ge 3) {
+                        $global:LASTEXITCODE = 0
+                        return "ok"
+                    }
+                    $global:LASTEXITCODE = 1
+                    return ""
+                }
+                if ($argStr -match "-l -q") {
+                    return @("docker-desktop", "docker-desktop-data", "NixOS")
+                }
+                if ($argStr -match "componentsVersion.json") { $global:LASTEXITCODE = 0 }
+                if ($argStr -match "docker-desktop-user-distro") { $global:LASTEXITCODE = 0 }
+                if ($argStr -match "proxy") { $global:LASTEXITCODE = 0 }
+                if ($argStr -match "groupadd|whoami") { return "nixos" }
+                if ($argStr -match "wsl-write-test") { $global:LASTEXITCODE = 0; return "" }
+                if ($argStr -match "df -Pk") { return "50000" }
+                $global:LASTEXITCODE = 0
+                return ""
+            }
+
+            $handler.Apply($ctx)
+
+            $script:wslEchoAttempts | Should -BeGreaterOrEqual 3
+        }
+
+        It 'should continue even if docker-desktop distro initialization times out' {
+            Mock Get-ProcessSafe { return $null }
+            Mock Start-ProcessSafe { }
+            Mock Invoke-Wsl {
+                param($Arguments)
+                $argStr = $Arguments -join " "
+                if ($argStr -match "echo ok") {
+                    $global:LASTEXITCODE = 1
+                    return ""
+                }
+                if ($argStr -match "-l -q") {
+                    return @("docker-desktop", "docker-desktop-data", "NixOS")
+                }
+                if ($argStr -match "componentsVersion.json") { $global:LASTEXITCODE = 1 }
+                if ($argStr -match "docker-desktop-user-distro") { $global:LASTEXITCODE = 1 }
+                if ($argStr -match "proxy") { $global:LASTEXITCODE = 1 }
+                if ($argStr -match "groupadd|whoami") { return "nixos" }
+                if ($argStr -match "wsl-write-test") { $global:LASTEXITCODE = 0; return "" }
+                if ($argStr -match "df -Pk") { return "50000" }
+                $global:LASTEXITCODE = 0
+                return ""
+            }
+
+            # タイムアウトしても例外は投げずに続行する
+            { $handler.Apply($ctx) } | Should -Not -Throw
+        }
     }
 
     Context 'GetWslDefaultUser' {


### PR DESCRIPTION
## Summary
Docker Desktop プロセス起動後、`docker-desktop` WSL ディストリビューションが初期化されるまでに時間がかかる。初期化完了前にアクセスすると `/bin/sh: docker-desktop: not found` エラーが発生していた。

`WaitForDockerDesktopDistro` メソッドを追加し、`docker-desktop` ディストリビューション内で `echo ok` が成功するまで最大60秒（5秒×12回）リトライ待機。

## Test plan
- [x] Docker テスト 52件合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)