### PR TITLE
fix(chezmoi): support multiple 1Password accounts

### DIFF
--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -2,6 +2,10 @@
 
 sourceDir = {{ .chezmoi.sourceDir | quote }}
 
+[onepassword]
+    command = "op"
+    args = ["--account", "my.1password.com"]
+
 [interpreters.ps1]
     command = "powershell"
     args = ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File"]

--- a/scripts/powershell/handlers/Handler.Chezmoi.ps1
+++ b/scripts/powershell/handlers/Handler.Chezmoi.ps1
@@ -20,6 +20,8 @@ $libPath = Split-Path -Parent $PSScriptRoot
 class ChezmoiHandler : SetupHandlerBase {
     # 検出された chezmoi 実行ファイルのパス
     hidden [string]$ChezmoiExePath
+    # 1Password アカウント（複数アカウント環境での --account 指定用）
+    hidden [string]$OpAccount = "my.1password.com"
 
     ChezmoiHandler() {
         $this.Name = "Chezmoi"
@@ -252,7 +254,7 @@ class ChezmoiHandler : SetupHandlerBase {
         # op whoami はデスクトップアプリ連携環境（特に -File モード）で
         # "account is not signed in" を返す場合がある。
         # op vault list は認証済みなら exit 0 を返し、より信頼性が高い。
-        $result = Invoke-OpVaultList -OpExe $opExe
+        $result = Invoke-OpVaultList -OpExe $opExe -Account $this.OpAccount
         if ($result.ExitCode -eq 0) {
             $this.Log("1Password CLI: サインイン済み", "Gray")
             return
@@ -287,10 +289,10 @@ class ChezmoiHandler : SetupHandlerBase {
         $maxRetries = 3
         for ($i = 1; $i -le $maxRetries; $i++) {
             $this.Log("1Password CLI: サインインを試行中 ($i/$maxRetries)...")
-            Invoke-OpSignIn -OpExe $opExe | Out-Null
+            Invoke-OpSignIn -OpExe $opExe -Account $this.OpAccount | Out-Null
 
             # signin 後に whoami で確認
-            $result = Invoke-OpVaultList -OpExe $opExe
+            $result = Invoke-OpVaultList -OpExe $opExe -Account $this.OpAccount
             if ($result.ExitCode -eq 0) {
                 $this.Log("1Password CLI: サインイン完了", "Green")
                 return
@@ -303,7 +305,7 @@ class ChezmoiHandler : SetupHandlerBase {
                 Read-Host | Out-Null
 
                 # デスクトップアプリ連携が有効になった可能性があるため whoami で再確認
-                $result = Invoke-OpVaultList -OpExe $opExe
+                $result = Invoke-OpVaultList -OpExe $opExe -Account $this.OpAccount
                 if ($result.ExitCode -eq 0) {
                     $this.Log("1Password CLI: サインイン完了（デスクトップアプリ連携）", "Green")
                     return
@@ -324,7 +326,7 @@ class ChezmoiHandler : SetupHandlerBase {
         2. それ以外 → 一般的な認証エラー
     #>
     hidden [string] DiagnoseOpAuthFailure([string]$opExe) {
-        $accountResult = Invoke-OpAccountList -OpExe $opExe
+        $accountResult = Invoke-OpAccountList -OpExe $opExe -Account $this.OpAccount
         $outputStr = if ($accountResult.Output) { ($accountResult.Output | Out-String).Trim() } else { '' }
 
         # op account list 自体が失敗 → デスクトップアプリに接続できない

--- a/scripts/powershell/lib/Invoke-ExternalCommand.ps1
+++ b/scripts/powershell/lib/Invoke-ExternalCommand.ps1
@@ -623,9 +623,13 @@ function Invoke-OpAccountList {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$OpExe
+        [string]$OpExe,
+
+        [string]$Account
     )
-    $output = & $OpExe account list 2>&1
+    $args = @("account", "list")
+    if ($Account) { $args += @("--account", $Account) }
+    $output = & $OpExe @args 2>&1
     return [PSCustomObject]@{ Output = $output; ExitCode = $LASTEXITCODE }
 }
 
@@ -670,9 +674,13 @@ function Invoke-OpVaultList {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$OpExe
+        [string]$OpExe,
+
+        [string]$Account
     )
-    $output = & $OpExe vault list --format=json 2>&1
+    $args = @("vault", "list", "--format=json")
+    if ($Account) { $args += @("--account", $Account) }
+    $output = & $OpExe @args 2>&1
     return [PSCustomObject]@{ Output = $output; ExitCode = $LASTEXITCODE }
 }
 
@@ -691,9 +699,13 @@ function Invoke-OpSignIn {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$OpExe
+        [string]$OpExe,
+
+        [string]$Account
     )
-    $output = & $OpExe signin 2>&1
+    $args = @("signin")
+    if ($Account) { $args += @("--account", $Account) }
+    $output = & $OpExe @args 2>&1
     return [PSCustomObject]@{ Output = $output; ExitCode = $LASTEXITCODE }
 }
 

--- a/scripts/powershell/lib/Invoke-ExternalCommand.ps1
+++ b/scripts/powershell/lib/Invoke-ExternalCommand.ps1
@@ -627,9 +627,9 @@ function Invoke-OpAccountList {
 
         [string]$Account
     )
-    $args = @("account", "list")
-    if ($Account) { $args += @("--account", $Account) }
-    $output = & $OpExe @args 2>&1
+    $opArgs = @("account", "list")
+    if ($Account) { $opArgs += @("--account", $Account) }
+    $output = & $OpExe @opArgs 2>&1
     return [PSCustomObject]@{ Output = $output; ExitCode = $LASTEXITCODE }
 }
 
@@ -678,9 +678,9 @@ function Invoke-OpVaultList {
 
         [string]$Account
     )
-    $args = @("vault", "list", "--format=json")
-    if ($Account) { $args += @("--account", $Account) }
-    $output = & $OpExe @args 2>&1
+    $opArgs = @("vault", "list", "--format=json")
+    if ($Account) { $opArgs += @("--account", $Account) }
+    $output = & $OpExe @opArgs 2>&1
     return [PSCustomObject]@{ Output = $output; ExitCode = $LASTEXITCODE }
 }
 
@@ -703,9 +703,9 @@ function Invoke-OpSignIn {
 
         [string]$Account
     )
-    $args = @("signin")
-    if ($Account) { $args += @("--account", $Account) }
-    $output = & $OpExe @args 2>&1
+    $opArgs = @("signin")
+    if ($Account) { $opArgs += @("--account", $Account) }
+    $output = & $OpExe @opArgs 2>&1
     return [PSCustomObject]@{ Output = $output; ExitCode = $LASTEXITCODE }
 }
 

--- a/scripts/powershell/tests/handlers/Handler.Chezmoi.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Chezmoi.Tests.ps1
@@ -659,6 +659,8 @@ Describe 'ChezmoiHandler' {
             Mock Invoke-OpAccountList {
                 return [PSCustomObject]@{ Output = '[]'; ExitCode = 0 }
             }
+            # OpAccount のデフォルト値を検証用変数に保存
+            $script:expectedOpAccount = "my.1password.com"
         }
 
         It 'should log warning and continue when op is not found' {
@@ -700,6 +702,10 @@ Describe 'ChezmoiHandler' {
             # サインイン済みなのでセットアップ案内は表示されない
             $script:instructionsShown | Should -Be $false
             Should -Invoke Read-Host -Times 0
+            # --account パラメータが正しく渡されていること
+            Should -Invoke Invoke-OpVaultList -ParameterFilter {
+                $Account -eq $script:expectedOpAccount
+            }
         }
 
         It 'should attempt op signin when op whoami fails and throw after max retries' {
@@ -723,6 +729,13 @@ Describe 'ChezmoiHandler' {
 
             $script:instructionsShown | Should -Be $true
             Should -Invoke Invoke-OpSignIn -Times 3
+            # --account パラメータが正しく渡されていること
+            Should -Invoke Invoke-OpSignIn -ParameterFilter {
+                $Account -eq $script:expectedOpAccount
+            }
+            Should -Invoke Invoke-OpVaultList -ParameterFilter {
+                $Account -eq $script:expectedOpAccount
+            }
             # 全リトライ失敗時は例外で停止し、失敗結果を返す
             $result.Success | Should -Be $false
         }
@@ -887,6 +900,10 @@ Describe 'ChezmoiHandler' {
             $result.Success | Should -Be $false
             $result.Message | Should -Match 'アカウントが登録されていません'
             $result.Message | Should -Match 'Biometric unlock for 1Password CLI'
+            # DiagnoseOpAuthFailure 内でも --account が渡されていること
+            Should -Invoke Invoke-OpAccountList -ParameterFilter {
+                $Account -eq $script:expectedOpAccount
+            }
         }
 
         It 'should show generic auth error when accounts exist but not authenticated' {
@@ -956,7 +973,7 @@ Describe 'ChezmoiHandler' {
             $handler.Apply($ctx)
 
             Should -Invoke Invoke-OpVaultList -ParameterFilter {
-                $OpExe -eq 'C:\tools\op.exe'
+                $OpExe -eq 'C:\tools\op.exe' -and $Account -eq 'my.1password.com'
             } -Times 1
         }
 
@@ -972,7 +989,7 @@ Describe 'ChezmoiHandler' {
             $handler.Apply($ctx)
 
             Should -Invoke Invoke-OpVaultList -ParameterFilter {
-                $OpExe -eq 'C:\WinGet\Packages\AgileBits.1Password.CLI_2.32.1\op.exe'
+                $OpExe -eq 'C:\WinGet\Packages\AgileBits.1Password.CLI_2.32.1\op.exe' -and $Account -eq 'my.1password.com'
             } -Times 1
         }
 


### PR DESCRIPTION
## Summary

- 1Password CLI に複数アカウントが登録されている環境で `op vault list` が `multiple accounts found` エラーで失敗する問題を修正
- `Invoke-OpVaultList`, `Invoke-OpSignIn`, `Invoke-OpAccountList` に `-Account` パラメータを追加
- `ChezmoiHandler` から `--account my.1password.com` を指定
- chezmoi テンプレートにも `[onepassword]` セクションを追加し `--account` を設定

## Test plan

- [ ] `op vault list --account my.1password.com` が成功することを確認済み
- [ ] `install.cmd` で Chezmoi ハンドラーが 1Password 認証を通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)