### PR TITLE
feat: migrate Claude Code install to standalone installer

### DIFF
--- a/nix/packages/all.nix
+++ b/nix/packages/all.nix
@@ -129,7 +129,6 @@ in
       "9NT1R1C2HH7J"
     ];
     pnpm = [
-      "@anthropic-ai/claude-code"
       "@google/gemini-cli"
     ];
   };

--- a/scripts/powershell/handlers/Handler.ClaudeCode.ps1
+++ b/scripts/powershell/handlers/Handler.ClaudeCode.ps1
@@ -1,0 +1,108 @@
+<#
+.SYNOPSIS
+    Claude Code スタンドアロンインストールハンドラー（Windows）
+
+.DESCRIPTION
+    Claude Code を公式スタンドアロンインストーラーで ~/.local/bin にインストールする。
+    pnpm 経由でのインストールは .ps1 shim が .exe より優先されてしまうため、
+    直接バイナリをダウンロードする方式を採用。
+
+.NOTES
+    Order = 7 (Winget の後)
+    Phase = 1 (ユーザースコープ)
+#>
+
+$libPath = Split-Path -Parent $PSScriptRoot
+. (Join-Path $libPath "lib\Invoke-ExternalCommand.ps1")
+
+class ClaudeCodeHandler : SetupHandlerBase {
+    ClaudeCodeHandler() {
+        $this.Name = "ClaudeCode"
+        $this.Description = "Claude Code スタンドアロンインストール"
+        $this.Order = 7
+        $this.RequiresAdmin = $false
+        $this.Phase = 1
+    }
+
+    [bool] CanApply([SetupContext]$ctx) {
+        $localBin = $this.GetLocalBinPath()
+        $claudeExe = Join-Path $localBin "claude.exe"
+
+        if (Test-PathExist -Path $claudeExe) {
+            $this.Log("Claude Code は既にインストール済みです: $claudeExe", "Gray")
+            return $false
+        }
+
+        return $true
+    }
+
+    [SetupResult] Apply([SetupContext]$ctx) {
+        try {
+            $localBin = $this.GetLocalBinPath()
+
+            if (-not (Test-Path -LiteralPath $localBin)) {
+                New-Item -ItemType Directory -Path $localBin -Force | Out-Null
+                $this.Log("ディレクトリを作成しました: $localBin", "Gray")
+            }
+
+            # 公式インストーラースクリプトをダウンロードして実行
+            $this.Log("Claude Code をインストールしています...")
+            $installerUrl = "https://cli.claude.ai/install.ps1"
+            $installerScript = Invoke-RestMethodSafe -Uri $installerUrl
+            $this.Log("インストーラースクリプトをダウンロードしました")
+
+            # インストーラースクリプトを一時ファイルに保存して実行
+            $tempScript = Join-Path ([System.IO.Path]::GetTempPath()) "claude-install.ps1"
+            [System.IO.File]::WriteAllText($tempScript, $installerScript)
+
+            try {
+                $output = & $tempScript 2>&1
+                $this.Log("インストーラー出力: $output", "Gray")
+            }
+            finally {
+                if (Test-Path -LiteralPath $tempScript) {
+                    Remove-Item -LiteralPath $tempScript -Force -ErrorAction SilentlyContinue
+                }
+            }
+
+            # インストール結果を確認
+            $claudeExe = Join-Path $localBin "claude.exe"
+            if (Test-PathExist -Path $claudeExe) {
+                $this.EnsureLocalBinInPath($localBin)
+                $this.Log("Claude Code をインストールしました: $claudeExe", "Green")
+                return $this.CreateSuccessResult("Claude Code をインストールしました")
+            }
+
+            return $this.CreateFailureResult("インストール後に claude.exe が見つかりません")
+        }
+        catch {
+            return $this.CreateFailureResult($_.Exception.Message, $_.Exception)
+        }
+    }
+
+    hidden [string] GetLocalBinPath() {
+        $homeDir = if ($env:USERPROFILE) { $env:USERPROFILE } else { $env:HOME }
+        return Join-Path $homeDir ".local\bin"
+    }
+
+    hidden [void] EnsureLocalBinInPath([string]$localBin) {
+        $userPath = Get-UserEnvironmentPath
+        $pathItems = if ($userPath) { @($userPath -split ";" | Where-Object { $_ }) } else { @() }
+
+        if ($pathItems -notcontains $localBin) {
+            # .local/bin を先頭に追加して pnpm 等より優先させる
+            $newPath = (@($localBin) + $pathItems) -join ";"
+            Set-UserEnvironmentPath -Path $newPath
+            $this.Log("~/.local/bin を USER PATH の先頭に追加しました", "Green")
+        }
+        else {
+            $this.Log("~/.local/bin は既に PATH に含まれています", "Gray")
+        }
+
+        # 現プロセスの PATH にも追加
+        $processItems = if ($env:PATH) { @($env:PATH -split ";" | Where-Object { $_ }) } else { @() }
+        if ($processItems -notcontains $localBin) {
+            $env:PATH = "$localBin;$env:PATH"
+        }
+    }
+}

--- a/scripts/powershell/handlers/Handler.ClaudeCode.ps1
+++ b/scripts/powershell/handlers/Handler.ClaudeCode.ps1
@@ -46,6 +46,8 @@ class ClaudeCodeHandler : SetupHandlerBase {
             }
 
             # 公式インストーラースクリプトをダウンロードして実行
+            # Trust: cli.claude.ai は Anthropic が管理する HTTPS エンドポイント。
+            # TLS で配信元の正当性を担保する（curl | sh 相当の信頼モデル）。
             $this.Log("Claude Code をインストールしています...")
             $installerUrl = "https://cli.claude.ai/install.ps1"
             $installerScript = Invoke-RestMethodSafe -Uri $installerUrl
@@ -57,6 +59,9 @@ class ClaudeCodeHandler : SetupHandlerBase {
 
             try {
                 $output = & $tempScript 2>&1
+                if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+                    return $this.CreateFailureResult("インストーラーが失敗しました (exit code: $LASTEXITCODE): $output")
+                }
                 $this.Log("インストーラー出力: $output", "Gray")
             }
             finally {
@@ -89,7 +94,8 @@ class ClaudeCodeHandler : SetupHandlerBase {
         $userPath = Get-UserEnvironmentPath
         $pathItems = if ($userPath) { @($userPath -split ";" | Where-Object { $_ }) } else { @() }
 
-        if ($pathItems -notcontains $localBin) {
+        $normalizedBin = $localBin.ToLower()
+        if (-not ($pathItems | Where-Object { $_.ToLower() -eq $normalizedBin })) {
             # .local/bin を先頭に追加して pnpm 等より優先させる
             $newPath = (@($localBin) + $pathItems) -join ";"
             Set-UserEnvironmentPath -Path $newPath
@@ -101,7 +107,7 @@ class ClaudeCodeHandler : SetupHandlerBase {
 
         # 現プロセスの PATH にも追加
         $processItems = if ($env:PATH) { @($env:PATH -split ";" | Where-Object { $_ }) } else { @() }
-        if ($processItems -notcontains $localBin) {
+        if (-not ($processItems | Where-Object { $_.ToLower() -eq $normalizedBin })) {
             $env:PATH = "$localBin;$env:PATH"
         }
     }

--- a/scripts/powershell/tests/handlers/Handler.ClaudeCode.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.ClaudeCode.Tests.ps1
@@ -1,0 +1,166 @@
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Handler.ClaudeCode.ps1 のユニットテスト
+
+.DESCRIPTION
+    ClaudeCodeHandler クラスのテスト
+#>
+
+BeforeAll {
+    . $PSScriptRoot/../../lib/SetupHandler.ps1
+    . $PSScriptRoot/../../lib/Invoke-ExternalCommand.ps1
+    . $PSScriptRoot/../../handlers/Handler.ClaudeCode.ps1
+    $script:projectRoot = (Resolve-Path -LiteralPath "$PSScriptRoot/../../../..").Path
+}
+
+Describe 'ClaudeCodeHandler' {
+    BeforeEach {
+        $script:handler = [ClaudeCodeHandler]::new()
+        $script:ctx = [SetupContext]::new($script:projectRoot)
+    }
+
+    Context 'Constructor' {
+        It 'should set <property> correctly' -ForEach @(
+            @{ property = "Name"; expected = "ClaudeCode"; checkType = "Be" }
+            @{ property = "Description"; expected = $null; checkType = "Not -BeNullOrEmpty" }
+            @{ property = "Order"; expected = 7; checkType = "Be" }
+            @{ property = "RequiresAdmin"; expected = $false; checkType = "Be" }
+            @{ property = "Phase"; expected = 1; checkType = "Be" }
+        ) {
+            if ($checkType -eq "Be") {
+                $handler.$property | Should -Be $expected
+            }
+            else {
+                $handler.$property | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'CanApply - claude.exe already exists' {
+        BeforeEach {
+            Mock Test-PathExist { return $true }
+            Mock Write-Host { }
+        }
+
+        It 'should return false' {
+            $result = $handler.CanApply($ctx)
+            $result | Should -Be $false
+        }
+    }
+
+    Context 'CanApply - claude.exe not found' {
+        BeforeEach {
+            Mock Test-PathExist { return $false }
+            Mock Write-Host { }
+        }
+
+        It 'should return true' {
+            $result = $handler.CanApply($ctx)
+            $result | Should -Be $true
+        }
+    }
+
+    Context 'Apply - successful install' {
+        BeforeEach {
+            Mock Write-Host { }
+            Mock Test-Path { return $true }
+            Mock Test-PathExist { return $true }
+            Mock New-Item { }
+            Mock Invoke-RestMethodSafe { return '# mock installer script' }
+            Mock Get-UserEnvironmentPath { return "C:\existing\path" }
+            Mock Set-UserEnvironmentPath { }
+
+            # Mock the installer script execution by creating a ScriptBlock mock
+            # The handler writes a temp file and executes it, so we mock at the file level
+            $localBin = Join-Path $env:USERPROFILE ".local\bin"
+            $claudeExe = Join-Path $localBin "claude.exe"
+        }
+
+        It 'should download and run the installer' {
+            $result = $handler.Apply($ctx)
+            $result.Success | Should -Be $true
+            Should -Invoke Invoke-RestMethodSafe -Times 1
+        }
+    }
+
+    Context 'Apply - installer download fails' {
+        BeforeEach {
+            Mock Write-Host { }
+            Mock Test-Path { return $false }
+            Mock Test-PathExist { return $false }
+            Mock Invoke-RestMethodSafe { throw "Network error" }
+        }
+
+        It 'should return failure' {
+            $result = $handler.Apply($ctx)
+            $result.Success | Should -Be $false
+            $result.Message | Should -Match "Network error"
+        }
+    }
+
+    Context 'Apply - claude.exe not found after install' {
+        BeforeEach {
+            Mock Write-Host { }
+            Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -notlike "*claude.exe" }
+            Mock Test-PathExist { return $false }
+            Mock New-Item { }
+            Mock Invoke-RestMethodSafe { return '# mock installer' }
+        }
+
+        It 'should return failure when exe missing after install' {
+            $result = $handler.Apply($ctx)
+            $result.Success | Should -Be $false
+            $result.Message | Should -Match "claude.exe が見つかりません"
+        }
+    }
+
+    Context 'EnsureLocalBinInPath - adds to PATH when missing' {
+        BeforeEach {
+            Mock Write-Host { }
+            Mock Test-Path { return $true }
+            Mock Test-PathExist { return $true }
+            Mock New-Item { }
+            Mock Invoke-RestMethodSafe { return '# mock installer' }
+
+            $script:capturedPath = $null
+            Mock Get-UserEnvironmentPath { return "C:\other\path" }
+            Mock Set-UserEnvironmentPath {
+                param($Path)
+                $script:capturedPath = $Path
+            }
+        }
+
+        It 'should prepend .local\bin to PATH' {
+            $result = $handler.Apply($ctx)
+            $result.Success | Should -Be $true
+
+            $localBin = Join-Path $env:USERPROFILE ".local\bin"
+            $escaped = [regex]::Escape($localBin)
+            $script:capturedPath | Should -Match $escaped
+            # .local\bin should be at the beginning
+            $script:capturedPath | Should -Match "^$escaped"
+        }
+    }
+
+    Context 'EnsureLocalBinInPath - skips when already in PATH' {
+        BeforeEach {
+            Mock Write-Host { }
+            Mock Test-Path { return $true }
+            Mock Test-PathExist { return $true }
+            Mock New-Item { }
+            Mock Invoke-RestMethodSafe { return '# mock installer' }
+
+            $localBin = Join-Path $env:USERPROFILE ".local\bin"
+            Mock Get-UserEnvironmentPath { return "$localBin;C:\other\path" }
+            Mock Set-UserEnvironmentPath { }
+        }
+
+        It 'should not modify PATH' {
+            $result = $handler.Apply($ctx)
+            $result.Success | Should -Be $true
+            Should -Invoke Set-UserEnvironmentPath -Times 0
+        }
+    }
+}

--- a/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
@@ -136,7 +136,7 @@ if ($argStr -match "nixos-rebuild") { $global:LASTEXITCODE = 1; return @("error:
         It 'should install pnpm global packages after nixos-rebuild' {
             $script:pnpmArgs = ""
             Mock Get-JsonContent {
-                return @{ globalPackages = @("@google/gemini-cli", "@anthropic-ai/claude-code") }
+                return @{ globalPackages = @("@tobilu/qmd", "@google/gemini-cli") }
             }
             Mock Invoke-Wsl {
                 param($Arguments)
@@ -172,7 +172,7 @@ if ($argStr -match "nixos-rebuild") { $global:LASTEXITCODE = 0; return "" }
                 if ($argStr -match "command -v pnpm") { $global:LASTEXITCODE = 0; return "/nix/store/bin/pnpm" }
                 if ($argStr -match "pnpm ls -g") {
                     $global:LASTEXITCODE = 0
-                    return @("@tobilu/qmd@1.0.0", "@google/gemini-cli@0.32.1", "@anthropic-ai/claude-code@2.1.70")
+                    return @("@tobilu/qmd@1.0.0", "@google/gemini-cli@0.32.1")
                 }
                 if ($argStr -match "pnpm add") {
                     $script:pnpmAddCalled = $true

--- a/windows/pnpm/packages.json
+++ b/windows/pnpm/packages.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "description": "pnpm global packages to install on Windows",
-  "globalPackages": ["@tobilu/qmd", "@anthropic-ai/claude-code", "@google/gemini-cli"]
+  "globalPackages": ["@tobilu/qmd", "@google/gemini-cli"]
 }


### PR DESCRIPTION
## Summary
- Claude Code のインストールを pnpm グローバルから公式スタンドアロンインストーラーに移行
- pnpm の .ps1 shim が .exe より優先される問題を回避
- ~/.local/bin に直接バイナリを配置し、PATH の先頭に追加

## Changes
- 新規 `Handler.ClaudeCode.ps1`: 公式インストーラー (`cli.claude.ai/install.ps1`) を使用
- 新規 `Handler.ClaudeCode.Tests.ps1`: ユニットテスト
- `windows/pnpm/packages.json`: `@anthropic-ai/claude-code` 削除
- `nix/packages/all.nix`: `@anthropic-ai/claude-code` 削除
- `Handler.NixRebuild.Tests.ps1`: モックデータ更新

## Test plan
- [ ] Handler.ClaudeCode.Tests.ps1 が全て PASS する
- [ ] pnpm global に claude-code が含まれていないこと
- [ ] ~/.local/bin/claude.exe が存在すること

Resolves LIF-83

🤖 Generated with [Claude Code](https://claude.com/claude-code)