### PR TITLE
feat(nix): add platform guards via meta.platforms filtering

### DIFF
--- a/docs/superpowers/specs/2026-04-24-nix-platform-guards-design.md
+++ b/docs/superpowers/specs/2026-04-24-nix-platform-guards-design.md
@@ -13,11 +13,13 @@ Modify the `resolve` helper in `sets.nix` to filter packages based on `meta.plat
 ### Change: `nix/packages/sets.nix` — `resolve` helper only
 
 Before:
+
 ```nix
 resolve = names: map (n: catalog.${n}.pkg) names;
 ```
 
 After:
+
 ```nix
 resolve =
   names:

--- a/docs/superpowers/specs/2026-04-24-nix-platform-guards-design.md
+++ b/docs/superpowers/specs/2026-04-24-nix-platform-guards-design.md
@@ -1,0 +1,55 @@
+# Nix Platform Guards Design
+
+## Problem
+
+`inputs.systems` defines 4 platforms (x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin), but some packages in the catalog (e.g., `slack` on aarch64-linux) are not available on all platforms. `nix flake check --all-systems` will fail when evaluating these packages.
+
+## Solution
+
+Modify the `resolve` helper in `sets.nix` to filter packages based on `meta.platforms` from nixpkgs. Packages whose `meta.platforms` does not include the current `pkgs.system` are excluded automatically.
+
+## Design
+
+### Change: `nix/packages/sets.nix` — `resolve` helper only
+
+Before:
+```nix
+resolve = names: map (n: catalog.${n}.pkg) names;
+```
+
+After:
+```nix
+resolve =
+  names:
+  builtins.filter (p: p != null) (
+    map (
+      n:
+      let
+        p = catalog.${n}.pkg;
+      in
+      if builtins.elem pkgs.system (p.meta.platforms or lib.platforms.all) then p else null
+    ) names
+  );
+```
+
+### Behavior
+
+- `meta.platforms` defined and includes current system → package included
+- `meta.platforms` defined but does NOT include current system → package excluded
+- `meta.platforms` undefined → falls back to `lib.platforms.all` (included on all platforms)
+
+### What is NOT changed
+
+- Catalog entries — no `platforms` field added
+- Consumers (`home/packages.nix`, `winget.nix`, `flakes/packages.nix`) — no changes
+- `wingetMap` derivation — unaffected (derived from `catalog.*.winget`, not `resolve`)
+
+### Verification
+
+- `nix flake check --all-systems` must pass (currently only x86_64-linux is verified)
+- winget-export consistency must be maintained
+
+## Out of scope
+
+- Windows package manager strategy (winget vs pnpm vs npm) — separate issue
+- `windowsOnly` section restructuring — separate issue

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -223,8 +223,18 @@ let
   # Group package names by category
   grouped = lib.groupBy (name: catalog.${name}.category) (lib.attrNames catalog);
 
-  # Resolve attr names to derivations
-  resolve = names: map (n: catalog.${n}.pkg) names;
+  # Resolve attr names to derivations, filtering by platform availability
+  resolve =
+    names:
+    builtins.filter (p: p != null) (
+      map (
+        n:
+        let
+          p = catalog.${n}.pkg;
+        in
+        if builtins.elem pkgs.system (p.meta.platforms or lib.platforms.all) then p else null
+      ) names
+    );
 
   # Extract winget mappings (non-null only)
   wingetMap = lib.filterAttrs (_: v: v != null) (lib.mapAttrs (_: v: v.winget) catalog);


### PR DESCRIPTION
## Summary

- `sets.nix` の `resolve` ヘルパーに `meta.platforms` ベースのフィルタを追加
- 現在の `pkgs.system` で利用不可なパッケージを自動除外（例: `slack` on aarch64-linux）
- catalog エントリの変更なし、消費者の変更なし — `resolve` 1箇所の変更のみ

## Test plan

- [x] `nix flake check --no-build` 通過 (x86_64-linux)
- [x] `nix flake check --all-systems --no-build` 全4プラットフォーム通過
  - aarch64-darwin, aarch64-linux, x86_64-darwin, x86_64-linux
- [ ] CI 通過を確認

Refs: LIF-91

🤖 Generated with [Claude Code](https://claude.com/claude-code)