### PR TITLE
feat(nix): add standalone homeConfigurations for all platforms

### DIFF
--- a/docs/superpowers/specs/2026-04-24-standalone-home-configurations-design.md
+++ b/docs/superpowers/specs/2026-04-24-standalone-home-configurations-design.md
@@ -1,0 +1,108 @@
+# Standalone homeConfigurations Design
+
+## Problem
+
+Home Manager is only integrated as a NixOS module, so it cannot be used on non-NixOS Linux or macOS. The WSL user config has hardcoded username/home directory, and there are no `homeConfigurations` flake outputs.
+
+## Solution
+
+1. Extract a shared `common.nix` that uses `builtins.getEnv` for user info (no hardcoded usernames)
+2. Add `homeConfigurations` flake outputs for all 4 platforms
+3. Refactor WSL `users.nix` to reuse `common.nix`
+
+## Design
+
+### `nix/home/common.nix` (new)
+
+Shared Home Manager module. Uses `builtins.getEnv` to get username and home directory at build time, so no user-specific data is committed to the repo.
+
+```nix
+{ pkgs, lib, ... }:
+let
+  sets = import ../packages/sets.nix { inherit pkgs lib; };
+  user = builtins.getEnv "USER";
+  home = builtins.getEnv "HOME";
+in
+{
+  home.username = if user != "" then user else "unknown";
+  home.homeDirectory = if home != "" then home else "/home/unknown";
+  home.stateVersion = "25.05";
+  home.packages = sets.all;
+  programs.home-manager.enable = true;
+}
+```
+
+### `nix/home/wsl/users.nix` (modified)
+
+Simplified to import `common.nix`:
+
+```nix
+{
+  nixos = { ... }: {
+    imports = [ ../common.nix ];
+  };
+}
+```
+
+Note: The key `nixos` refers to the NixOS system user, not a username in common.nix. This mapping is used by `home-manager.users` in the NixOS module integration.
+
+### `nix/home/packages.nix` (deleted)
+
+Functionality moved into `common.nix`. No longer needed as a separate file.
+
+### `nix/flakes/home.nix` (new)
+
+```nix
+{ inputs, ... }:
+let
+  mkHome =
+    system:
+    inputs.home-manager.lib.homeManagerConfiguration {
+      pkgs = import inputs.nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+      };
+      modules = [ ../home/common.nix ];
+    };
+in
+{
+  flake.homeConfigurations = {
+    "aarch64-darwin" = mkHome "aarch64-darwin";
+    "x86_64-darwin" = mkHome "x86_64-darwin";
+    "x86_64-linux" = mkHome "x86_64-linux";
+    "aarch64-linux" = mkHome "aarch64-linux";
+  };
+}
+```
+
+### `nix/flakes/default.nix` (modified)
+
+Add `./home.nix` to imports.
+
+### Usage
+
+```bash
+# macOS (Apple Silicon)
+home-manager switch --flake .#aarch64-darwin
+
+# macOS (Intel)
+home-manager switch --flake .#x86_64-darwin
+
+# Non-NixOS Linux
+home-manager switch --flake .#x86_64-linux
+
+# WSL (existing NixOS module path still works)
+sudo nixos-rebuild switch --flake .#nixos
+```
+
+## Invariants
+
+1. No usernames or home directories hardcoded in the repository
+2. `common.nix` is the single module shared by both NixOS integration and standalone
+3. `builtins.getEnv` returns empty string in pure eval (`nix flake check`), but `homeConfigurations` are not checked by `nix flake check`
+4. Platform guards from LIF-91 (`meta.platforms` filter) automatically apply
+
+## Out of scope
+
+- nix-darwin integration (LIF-92 is standalone Home Manager only)
+- Windows package manager strategy (separate issue)

--- a/nix/flakes/default.nix
+++ b/nix/flakes/default.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     inputs.treefmt-nix.flakeModule
+    ./home.nix
     ./hosts.nix
     ./packages.nix
     ./systems.nix

--- a/nix/flakes/home.nix
+++ b/nix/flakes/home.nix
@@ -1,0 +1,26 @@
+# Standalone Home Manager configurations for non-NixOS systems.
+# Usage:
+#   home-manager switch --flake .#aarch64-darwin
+#   home-manager switch --flake .#x86_64-darwin
+#   home-manager switch --flake .#x86_64-linux
+#   home-manager switch --flake .#aarch64-linux
+{ inputs, ... }:
+let
+  mkHome =
+    system:
+    inputs.home-manager.lib.homeManagerConfiguration {
+      pkgs = import inputs.nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+      };
+      modules = [ ../home/common.nix ];
+    };
+in
+{
+  flake.homeConfigurations = {
+    "aarch64-darwin" = mkHome "aarch64-darwin";
+    "x86_64-darwin" = mkHome "x86_64-darwin";
+    "x86_64-linux" = mkHome "x86_64-linux";
+    "aarch64-linux" = mkHome "aarch64-linux";
+  };
+}

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -1,0 +1,23 @@
+# Shared Home Manager module for all platforms.
+# Uses builtins.getEnv to avoid hardcoding usernames in the repository.
+#
+# Used by:
+#   - nix/home/wsl/users.nix   → NixOS module integration
+#   - nix/flakes/home.nix      → standalone homeConfigurations
+{
+  pkgs,
+  lib,
+  ...
+}:
+let
+  sets = import ../packages/sets.nix { inherit pkgs lib; };
+  user = builtins.getEnv "USER";
+  home = builtins.getEnv "HOME";
+in
+{
+  home.username = lib.mkDefault (if user != "" then user else "unknown");
+  home.homeDirectory = lib.mkDefault (if home != "" then home else "/home/unknown");
+  home.stateVersion = "25.05";
+  home.packages = sets.all;
+  programs.home-manager.enable = true;
+}

--- a/nix/home/packages.nix
+++ b/nix/home/packages.nix
@@ -1,8 +1,0 @@
-# Home Manager module — installs all CLI tools from the SSOT.
-{ pkgs, lib, ... }:
-let
-  sets = import ../packages/sets.nix { inherit pkgs lib; };
-in
-{
-  home.packages = sets.all;
-}

--- a/nix/home/wsl/users.nix
+++ b/nix/home/wsl/users.nix
@@ -2,14 +2,8 @@
 # Imported by nix/flakes/lib/hosts.nix as home-manager.users.
 {
   nixos =
-    { pkgs, ... }:
+    { ... }:
     {
-      imports = [ ../packages.nix ];
-
-      home.username = "nixos";
-      home.homeDirectory = "/home/nixos";
-      home.stateVersion = "25.05";
-
-      programs.home-manager.enable = true;
+      imports = [ ../common.nix ];
     };
 }


### PR DESCRIPTION
## Summary

- `nix/home/common.nix` を共通 Home Manager モジュールとして新規作成（`builtins.getEnv` でユーザー情報を実行時取得、リポジトリにユーザー名ハードコードなし）
- `homeConfigurations` を flake output に追加（aarch64-darwin, x86_64-darwin, x86_64-linux, aarch64-linux）
- WSL の `users.nix` を `common.nix` を使うようリファクタ
- `packages.nix` を `common.nix` に統合して削除

## Usage

```bash
# macOS (Apple Silicon)
home-manager switch --flake .#aarch64-darwin

# macOS (Intel)
home-manager switch --flake .#x86_64-darwin

# Non-NixOS Linux
home-manager switch --flake .#x86_64-linux
```

## Test plan

- [x] `nix flake check --no-build` 通過
- [x] `homeConfigurations` が flake output に含まれることを確認
- [x] NixOS 構成（WSL）との互換性確認（`lib.mkDefault` で競合回避）
- [ ] CI 通過を確認

Refs: LIF-92

🤖 Generated with [Claude Code](https://claude.com/claude-code)