### PR TITLE
feat(nix): wire linux host configuration

### DIFF
--- a/nix/flakes/hosts.nix
+++ b/nix/flakes/hosts.nix
@@ -30,6 +30,25 @@ in
             ];
           }
         );
+
+      linux =
+        let
+          system = "x86_64-linux";
+        in
+        withSystem system (
+          { pkgs, ... }:
+          let
+            siteLib = import ../lib {
+              inherit pkgs system;
+              inherit (pkgs) lib;
+            };
+          in
+          Hosts.mkNixos {
+            inherit system siteLib;
+            hostPath = ../hosts/linux;
+            homeModulePath = ../home/linux/users.nix;
+          }
+        );
     };
   };
 }

--- a/nix/home/linux/users.nix
+++ b/nix/home/linux/users.nix
@@ -1,0 +1,9 @@
+# User → Home Manager module mapping for native Linux host.
+# Imported by nix/flakes/hosts.nix as home-manager.users.
+{
+  nixos =
+    { ... }:
+    {
+      imports = [ ../common.nix ];
+    };
+}

--- a/nix/hosts/linux/configuration.nix
+++ b/nix/hosts/linux/configuration.nix
@@ -1,5 +1,24 @@
 { ... }:
 {
+  system.stateVersion = "25.05";
+
+  # Boot — override per machine
+  boot.loader.grub.devices = [ "/dev/sda" ];
+  fileSystems."/" = {
+    device = "/dev/sda1";
+    fsType = "ext4";
+  };
+
+  # User
+  users.users.nixos = {
+    isNormalUser = true;
+    extraGroups = [
+      "wheel"
+      "docker"
+    ];
+  };
+  users.groups.nixos = { };
+
   virtualisation.docker = {
     enable = true;
     rootless = {


### PR DESCRIPTION
## Summary

- `nix/hosts/linux/` のデッドコードを解消 — `nixosConfigurations.linux` として wiring
- `nix/home/linux/users.nix` を新規作成（`common.nix` を import）
- `configuration.nix` に最小限のブート・ファイルシステム・ユーザー設定を追加（実機で上書き前提）

## Usage

```bash
sudo nixos-rebuild switch --flake .#linux
```

## Test plan

- [x] `nix flake check --no-build` 通過（`nixosConfigurations.linux` が eval 成功）
- [ ] CI 通過を確認

Refs: LIF-93

🤖 Generated with [Claude Code](https://claude.com/claude-code)