### PR TITLE
feat(nix): add devShell with treefmt formatters and Nix linters

### DIFF
--- a/nix/flakes/treefmt.nix
+++ b/nix/flakes/treefmt.nix
@@ -5,10 +5,21 @@
 # References:
 # - treefmt config: https://treefmt.com/v2.1/getting-started/configure/
 # - treefmt-nix examples: https://github.com/numtide/treefmt-nix/tree/main/examples
-_: {
+{ config, ... }:
+{
   perSystem =
-    { pkgs, ... }:
+    { pkgs, config, ... }:
     {
+      # devShell with treefmt formatters + Nix linters
+      devShells.default = pkgs.mkShell {
+        packages =
+          config.treefmt.build.devShell.nativeBuildInputs
+          ++ (with pkgs; [
+            statix
+            deadnix
+          ]);
+      };
+
       treefmt = {
         projectRootFile = "flake.nix";
 


### PR DESCRIPTION
## Summary

- `nix develop` で treefmt の全フォーマッター（nixfmt, shfmt, taplo, stylua, oxfmt）+ Nix linter（statix, deadnix）が使えるようになった
- treefmt-nix の `config.treefmt.build.devShell` を活用して重複なく定義

## Usage

```bash
nix develop
# nixfmt, statix, deadnix, treefmt, shfmt, taplo, stylua, oxfmt が利用可能
```

## Test plan

- [x] `nix flake check --no-build` 通過
- [x] `nix develop` で nixfmt, statix, deadnix, treefmt, shfmt が利用可能
- [ ] CI 通過を確認

Refs: LIF-94

🤖 Generated with [Claude Code](https://claude.com/claude-code)