### PR TITLE
fix(windows): align chezmoi config with native Claude Code and pnpm migration

### DIFF
--- a/chezmoi/.chezmoiscripts/run_after_ensure-gemini-shim_windows.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/run_after_ensure-gemini-shim_windows.ps1.tmpl
@@ -1,7 +1,19 @@
 {{ if eq .chezmoi.os "windows" -}}
 $ErrorActionPreference = "Stop"
 
-$entrypoint = Join-Path $env:USERPROFILE ".bun\install\global\node_modules\@google\gemini-cli\dist\index.js"
+# Resolve pnpm global root to find gemini-cli entrypoint
+$pnpmRoot = $null
+try {
+  $pnpmRoot = (& pnpm root -g 2>$null)
+  if ($pnpmRoot) { $pnpmRoot = $pnpmRoot.Trim() }
+} catch {}
+
+if (-not $pnpmRoot -or -not (Test-Path $pnpmRoot)) {
+  Write-Host "[gemini-shim] Skip: pnpm global root not found."
+  return
+}
+
+$entrypoint = Join-Path $pnpmRoot "@google\gemini-cli\dist\index.js"
 if (-not (Test-Path -LiteralPath $entrypoint -PathType Leaf)) {
   Write-Host "[gemini-shim] Skip: Gemini CLI entrypoint not found."
   return
@@ -29,12 +41,13 @@ $shimPath = Join-Path $localBin "gemini.cmd"
 $shimContent = @(
   "@echo off"
   "setlocal"
-  "set ""GEMINI_JS=%USERPROFILE%\.bun\install\global\node_modules\@google\gemini-cli\dist\index.js"""
+  "for /f ""delims="" %%R in ('pnpm root -g 2^>nul') do set ""PNPM_ROOT=%%R"""
+  "set ""GEMINI_JS=%PNPM_ROOT%\@google\gemini-cli\dist\index.js"""
   "if not exist ""%GEMINI_JS%"" ("
   "  echo [ERROR] Gemini CLI entrypoint not found: %GEMINI_JS%"
   "  exit /b 1"
   ")"
-  "bun ""%GEMINI_JS%"" %*"
+  "node ""%GEMINI_JS%"" %*"
   "exit /b %ERRORLEVEL%"
   ""
 ) -join "`r`n"

--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -133,31 +133,6 @@ if (-not $env:CLAUDE_CODE_GIT_BASH_PATH) {
     Remove-Variable _candidate -ErrorAction SilentlyContinue
 }
 
-# pnpm global CLI shims
-# pnpm's global bin may not be in PATH yet, or Windows shims may not pass env vars.
-# Define PowerShell functions that call node + entrypoint directly.
-$_pnpmGlobalRoot = $null
-try {
-    $_pnpmGlobalRoot = (& pnpm root -g 2>$null)
-    if ($_pnpmGlobalRoot) { $_pnpmGlobalRoot = $_pnpmGlobalRoot.Trim() }
-} catch {}
-if ($_pnpmGlobalRoot -and (Test-Path $_pnpmGlobalRoot)) {
-    $_pnpmCliShims = @{
-        claude = "@anthropic-ai\claude-code\cli.js"
-        gemini = "@google\gemini-cli\dist\index.js"
-    }
-    foreach ($_entry in $_pnpmCliShims.GetEnumerator()) {
-        $_entrypoint = Join-Path $_pnpmGlobalRoot $_entry.Value
-        if (Test-Path -LiteralPath $_entrypoint -PathType Leaf) {
-            $__ep = $_entrypoint
-            New-Item -Path "Function:\Global:$($_entry.Key)" -Value (
-                [scriptblock]::Create("& node `"$__ep`" @args")
-            ) -Force | Out-Null
-        }
-    }
-}
-Remove-Variable _pnpmGlobalRoot, _pnpmCliShims, _entry, _entrypoint, __ep -ErrorAction SilentlyContinue
-
 # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)
 $_secretPs1 = Join-Path $HOME ".config\shell\secret.ps1"
 if (Test-Path $_secretPs1) { . $_secretPs1 }

--- a/scripts/powershell/handlers/Handler.ClaudeCode.ps1
+++ b/scripts/powershell/handlers/Handler.ClaudeCode.ps1
@@ -49,7 +49,7 @@ class ClaudeCodeHandler : SetupHandlerBase {
             # Trust: cli.claude.ai は Anthropic が管理する HTTPS エンドポイント。
             # TLS で配信元の正当性を担保する（curl | sh 相当の信頼モデル）。
             $this.Log("Claude Code をインストールしています...")
-            $installerUrl = "https://cli.claude.ai/install.ps1"
+            $installerUrl = "https://claude.ai/install.ps1"
             $installerScript = Invoke-RestMethodSafe -Uri $installerUrl
             $this.Log("インストーラースクリプトをダウンロードしました")
 


### PR DESCRIPTION
## Summary
- Update Claude Code installer URL to `claude.ai/install.ps1`
- Remove pnpm global CLI shims from PowerShell profile (eliminates slow `pnpm root -g` on every shell start)
- Update gemini shim script from bun to pnpm/node paths

## Test plan
- [ ] 新しいターミナルで `claude --version` が native 版 (v2.1.121+) を返すこと
- [ ] `gemini` コマンドが pnpm 経由で正しく起動すること
- [ ] PowerShell プロファイル読み込み時間が改善されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)