### PR TITLE
fix(chezmoi): write Zed/VS Code MCP settings without UTF-8 BOM

### DIFF
--- a/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy_vscode_mcp.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy_vscode_mcp.ps1.tmpl
@@ -54,5 +54,9 @@ foreach ($name in $servers.Keys) {
     }
 }
 
-$settings | ConvertTo-Json -Depth 20 | Set-Content $settingsPath -Encoding UTF8
+# Set-Content -Encoding UTF8 prepends a BOM on PowerShell 5.1; some
+# strict JSON consumers (and editors that re-parse the file) reject it.
+# Write BOM-less UTF8 so the output stays portable across PS 5.1 and 7.
+$json = $settings | ConvertTo-Json -Depth 20
+[System.IO.File]::WriteAllText($settingsPath, $json, [System.Text.UTF8Encoding]::new($false))
 Write-Host "[vscode-mcp] Updated $($servers.Count) MCP servers in $settingsPath"

--- a/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy_zed_mcp.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy_zed_mcp.ps1.tmpl
@@ -64,6 +64,11 @@ foreach ($name in $servers.Keys) {
 }
 
 # Write back as JSON (comments will be lost - this is a known limitation)
-$settings | ConvertTo-Json -Depth 20 | Set-Content $settingsPath -Encoding UTF8
+# Set-Content -Encoding UTF8 prepends a BOM on PowerShell 5.1, which Zed's
+# serde_json parser rejects ("expected value at line 1 column 1") so all
+# user settings stop loading. Use WriteAllText with a BOM-less UTF8Encoding
+# to stay compatible with both PowerShell 5.1 and 7.
+$json = $settings | ConvertTo-Json -Depth 20
+[System.IO.File]::WriteAllText($settingsPath, $json, [System.Text.UTF8Encoding]::new($false))
 Write-Host "[zed-mcp] Updated $($servers.Count) context servers in $settingsPath"
 Write-Host "[zed-mcp] Note: JSONC comments were removed during merge"


### PR DESCRIPTION
## Summary
`Set-Content -Encoding UTF8` は Windows PowerShell 5.1 で **UTF-8 BOM を付与**する。Zed の `serde_json` パーサが BOM を拒否し `expected value at line 1 column 1` を出して**全ユーザー設定の読み込みに失敗**していた (テーマ・拡張機能・`context_servers` の MCP 設定を含む)。

両 deploy script を `[System.IO.File]::WriteAllText` + `UTF8Encoding($false)` に置き換え、PowerShell 5.1 / 7 の両方で BOM 無しの UTF-8 を出力するようにした。

## Background
PR #49 で Kaggle MCP を 8 LLM に展開した際、Zed 側の動作確認で発覚。実機の `%LOCALAPPDATA%/Zed/logs/Zed.log` に以下のエラーが繰り返し記録されていた:

```
2026-04-30T00:45:05+09:00 ERROR [zed::zed] Failed to load user settings: expected value at line 1 column 1
2026-04-29T21:32:18+09:00 ERROR [crates/settings/src/settings_store.rs:321] Settings file could not be parsed.
```

`%APPDATA%/Zed/settings.json` の先頭バイトが `EF BB BF` (UTF-8 BOM) であることを `od -An -tx1` で確認。

## Verified locally
PowerShell で WriteAllText の出力バイト列を直接確認:

```
First 6 bytes: 123 34 116 101 115 116    # `{"test`
Has BOM: False
```

`{` (0x7B = 123) で始まり、BOM (`EF BB BF`) は付いていない。

## Test plan
- [x] PowerShell で `WriteAllText + UTF8Encoding($false)` が BOM 無しを出力することを実機確認
- [ ] `chezmoi apply` 実行後、`%APPDATA%/Zed/settings.json` の先頭が `{` (0x7B) になる
- [ ] Zed 再起動後、`Failed to load user settings` エラーがログに出ない
- [ ] Zed の `context_servers` (MCP) が動作する
- [ ] VS Code の `mcp.servers` 経由でも同様に MCP が動作する

## Out of scope (follow-up)
deploy script の env 行 `"{{ \$key }}" = "{{ \$value }}"` が PowerShell 変数展開を起こし、`\${GH_TOKEN}` 等が空文字になる問題は残っている。github / tavily / exa / firecrawl の API キーが空のまま deploy されているので runtime エラー要因。本 PR では BOM 修正だけにスコープを絞り、env 問題は別途対処する。

Closes LIF-97

🤖 Generated with [Claude Code](https://claude.com/claude-code)