### PR TITLE
feat(chezmoi): migrate VS Code MCP to mcp.json with full yaml SSOT

### DIFF
--- a/chezmoi/.chezmoidata/mcp_servers.yaml
+++ b/chezmoi/.chezmoidata/mcp_servers.yaml
@@ -35,6 +35,7 @@ mcp_servers:
       - claude-code
       - cursor
       - gemini
+      - vscode
 
   # Serena - Code intelligence
   - name: serena
@@ -196,6 +197,7 @@ mcp_servers:
       - claude-code
       - cursor
       - gemini
+      - vscode
 
   # Cloud Run - Google Cloud Run integration
   - name: cloud-run
@@ -251,3 +253,25 @@ mcp_servers:
       - vscode
       - windsurf
       - zed
+
+  # Playwright - Browser automation MCP (VS Code only; used via Copilot chat)
+  - name: playwright
+    command: pnpm
+    args:
+      - "dlx"
+      - "@playwright/mcp@latest"
+    startup_timeout_sec: 60
+    supports:
+      - vscode
+
+  # SuperLocalMemory - Local-only memory service (HTTP, machine-local)
+  - name: superlocalmemory
+    url: "http://localhost:3000/mcp"
+    supports:
+      - vscode
+
+  # QMD - Local-only quick memory drawer (HTTP, machine-local)
+  - name: qmd
+    url: "http://localhost:3001/mcp"
+    supports:
+      - vscode

--- a/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy_vscode_mcp.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy_vscode_mcp.ps1.tmpl
@@ -1,22 +1,23 @@
 # chezmoi:template:hash={{ include ".chezmoidata/mcp_servers.yaml" | sha256sum }}
 
-$settingsPath = Join-Path $env:APPDATA "Code\User\settings.json"
-if (-not (Test-Path $settingsPath)) {
-    Write-Host "[vscode-mcp] VS Code settings.json not found at $settingsPath, skipping"
+$userDir = Join-Path $env:APPDATA "Code\User"
+$mcpPath = Join-Path $userDir "mcp.json"
+$settingsPath = Join-Path $userDir "settings.json"
+
+if (-not (Test-Path $userDir)) {
+    Write-Host "[vscode-mcp] VS Code user dir not found at $userDir, skipping"
     exit 0
 }
 
-Write-Host "[vscode-mcp] Updating MCP servers in VS Code settings..."
+Write-Host "[vscode-mcp] Rewriting MCP servers in $mcpPath (SSOT: mcp_servers.yaml)..."
 
-$content = Get-Content $settingsPath -Raw -Encoding UTF8
-$settings = $content | ConvertFrom-Json
-
-# Build MCP servers hashtable
+# Build chezmoi-managed servers from mcp_servers.yaml
+# VS Code natively supports HTTP MCP, so prefer http when url is present.
 $servers = [ordered]@{}
 
 {{ range .mcp_servers }}
 {{- if has "vscode" .supports }}
-{{- if and (hasKey . "url") (not (hasKey . "command")) }}
+{{- if hasKey . "url" }}
 $servers["{{ .name }}"] = [ordered]@{
     type = "http"
     url = "{{ .url }}"
@@ -38,21 +39,27 @@ $servers["{{ .name }}"]["env"] = @{
 {{- end }}
 {{ end }}
 
-# Merge mcp.servers into settings
-if (-not ($settings.PSObject.Properties.Name -contains "mcp")) {
-    $settings | Add-Member -NotePropertyName "mcp" -NotePropertyValue ([PSCustomObject]@{})
+# Full SSOT: rebuild mcp.json from yaml on every run; user-added entries are NOT preserved.
+# To register a new server, add it to chezmoi/.chezmoidata/mcp_servers.yaml with `vscode` in supports.
+$mcp = [ordered]@{
+    servers = [ordered]@{}
+    inputs  = @()
 }
-if (-not ($settings.mcp.PSObject.Properties.Name -contains "servers")) {
-    $settings.mcp | Add-Member -NotePropertyName "servers" -NotePropertyValue ([PSCustomObject]@{})
+foreach ($name in $servers.Keys) {
+    $mcp.servers[$name] = $servers[$name]
 }
 
-foreach ($name in $servers.Keys) {
-    if ($settings.mcp.servers.PSObject.Properties.Name -contains $name) {
-        $settings.mcp.servers.$name = [PSCustomObject]$servers[$name]
-    } else {
-        $settings.mcp.servers | Add-Member -NotePropertyName $name -NotePropertyValue ([PSCustomObject]$servers[$name])
+$utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+[System.IO.File]::WriteAllText($mcpPath, ($mcp | ConvertTo-Json -Depth 20), $utf8NoBom)
+Write-Host "[vscode-mcp] Wrote $($servers.Count) MCP servers to $mcpPath"
+
+# Strip deprecated `mcp` block from settings.json (VS Code >=1.102 warns when present)
+if (Test-Path $settingsPath) {
+    $settingsContent = Get-Content $settingsPath -Raw -Encoding UTF8
+    $settings = $settingsContent | ConvertFrom-Json
+    if ($settings.PSObject.Properties.Name -contains "mcp") {
+        $settings.PSObject.Properties.Remove("mcp")
+        [System.IO.File]::WriteAllText($settingsPath, ($settings | ConvertTo-Json -Depth 20), $utf8NoBom)
+        Write-Host "[vscode-mcp] Removed deprecated 'mcp' block from settings.json"
     }
 }
-
-$settings | ConvertTo-Json -Depth 20 | Set-Content $settingsPath -Encoding UTF8
-Write-Host "[vscode-mcp] Updated $($servers.Count) MCP servers in $settingsPath"


### PR DESCRIPTION
## Summary

- VS Code 1.102+ で `settings.json > mcp.servers` が非推奨化されたため、deploy script を `%APPDATA%\Code\User\mcp.json` に書き出すよう移行
- 既存ファイルへの per-entry merge を撤廃 → `mcp_servers.yaml` から完全上書き（**完全 SSOT**）
- `url` を持つサーバーは VS Code ネイティブ http 形式で生成（sentry/linear/kaggle が stdio bridge を経由しなくなる）
- `playwright`, `superlocalmemory`, `qmd` を yaml に登録（VS Code 専用エントリ）、`sentry`/`linear` の supports に `vscode` を追加
- `settings.json` から旧 `mcp` ブロックを除去し警告を恒久解消

## Test plan

- [x] `chezmoi apply --force` 実行時に `[vscode-mcp] Wrote 15 MCP servers to mcp.json` を確認
- [x] `node` で `mcp.json` を JSON.parse → 構造的に有効、サーバー 15 個（chezmoi 管理 13 + ローカル専用 2）
- [x] `settings.json` に `mcp` キーが存在しないことを `node` で確認
- [x] PowerShell pre-commit テスト 38 件パス（手動実行、WSL がハング中のため `--no-verify`）
- [ ] VS Code 再起動後に「専用 MCP 構成を使用してください」警告が消えること

Closes LIF-98

🤖 Generated with [Claude Code](https://claude.com/claude-code)