### PR TITLE
feat(zed): wire Agent Panel to Claude/Codex/Gemini/OpenCode/Cursor via ACP

### DIFF
--- a/chezmoi/editors/zed/settings.json
+++ b/chezmoi/editors/zed/settings.json
@@ -257,5 +257,39 @@
       "provider": "anthropic",
       "model": "claude-sonnet-4-20250514"
     }
+  },
+  // External agents via ACP (Agent Client Protocol).
+  //
+  // Each registry-typed adapter is auto-installed by Zed on first use and
+  // spawns the corresponding native CLI, which reads its own config files
+  // (~/.claude.json, ~/.codex/config.toml, ~/.gemini/settings.json, etc.).
+  // That means MCP servers and other settings declared in the chezmoi
+  // mcp_servers.yaml chain (and per-CLI native configs) flow through to
+  // Zed's Agent Panel automatically — no duplicate wiring here.
+  //
+  // Notes:
+  // - claude-acp / codex-acp support MCP servers; the gemini adapter does
+  //   not currently expose MCP (per Zed docs).
+  // - opencode is in Zed's ACP registry directly (no -acp suffix).
+  // - Cursor is not in Zed's registry; we bridge cursor-agent through the
+  //   community npm adapter `cursor-acp`. Requires the cursor-agent CLI.
+  "agent_servers": {
+    "claude-acp": {
+      "type": "registry"
+    },
+    "codex-acp": {
+      "type": "registry"
+    },
+    "gemini": {
+      "type": "registry"
+    },
+    "opencode": {
+      "type": "registry"
+    },
+    "Cursor": {
+      "type": "custom",
+      "command": "pnpm",
+      "args": ["dlx", "cursor-acp"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
Zed の Agent Panel から **Claude Code / Codex / Gemini / OpenCode / Cursor** を呼べるように `chezmoi/editors/zed/settings.json` に `agent_servers` を宣言的に追加。

## Approach
4 つは Zed の ACP registry にあるため `type: registry` で auto-install。Cursor だけ registry 未登録なので community npm adapter (`cursor-acp`) 経由で stdio bridge する。

```jsonc
"agent_servers": {
  "claude-acp": { "type": "registry" },
  "codex-acp":  { "type": "registry" },
  "gemini":     { "type": "registry" },
  "opencode":   { "type": "registry" },
  "Cursor": {
    "type": "custom",
    "command": "pnpm",
    "args": ["dlx", "cursor-acp"]
  }
}
```

## Why this is thin
各 ACP adapter は対応する native CLI を spawn するだけで、CLI 側が自分の設定ファイル (`~/.claude.json`, `~/.codex/config.toml`, `~/.gemini/settings.json`, `~/.cursor/cli-config.json`, `~/.opencode/...`) を読み込む。chezmoi 側で MCP サーバ等を二重に書かなくて済む — `mcp_servers.yaml` SSOT がそのまま流れる。

## Caveats
- **Gemini CLI は MCP サーバ未対応** (Zed docs: "Claude Agent and Codex support MCP servers, while Gemini CLI does not currently") のため、Kaggle 等の MCP は Gemini からは使えない
- **Cursor は `cursor-agent` ローカル CLI が必要**。未インストール環境では adapter が起動失敗する
- registry adapter は npm 経由で初回 auto-install するため、Zed 初回起動時に少し待ち時間あり

## Verified locally
- [x] JSONC が valid (5 agents + 既存 31 キー保持を node でパース確認)
- [x] `chezmoi apply --source D:\dotfiles\.claude\worktrees\lif-102\chezmoi --force` で `%APPDATA%/Zed/settings.json` に書き込み (verifyは別途、まだ未実施)
- [ ] Zed 再起動後、Agent Panel から各 CLI を選択できる
- [ ] Claude Code 起動時に `~/.claude.json` の MCP (kaggle 等) が継承される
- [ ] Codex 起動時に `~/.codex/config.toml` の MCP が継承される
- [ ] OpenCode 起動時に native config が読まれる
- [ ] Cursor adapter (cursor-acp) が動作する (cursor-agent 必要)

Closes LIF-102

## References
- [Zed External Agents](https://zed.dev/docs/ai/external-agents)
- [Zed ACP Registry](https://zed.dev/acp)
- [OpenCode ACP Support](https://opencode.ai/docs/acp/)
- [cursor-acp (community adapter)](https://github.com/roshan-c/cursor-acp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)