### PR TITLE
refactor(secret): batch op fetches to cut 1Password prompts on shell startup

### DIFF
--- a/chezmoi/secret/env.ps1
+++ b/chezmoi/secret/env.ps1
@@ -5,8 +5,30 @@
 # Set actual item paths in 1Password before using:
 #   op item create --category login --title "GitHub CLI" ...
 #   op item create --category login --title "Tavily" ...
+#
+# Each `op` invocation triggers a 1Password biometric/desktop approval, so
+# we (1) skip when env is already populated by a parent process and
+# (2) use a single `op inject` call to resolve all secrets at once,
+# instead of one `op read` per secret.
 
-if (Get-Command op -ErrorAction SilentlyContinue) {
-  try { $env:GH_TOKEN       = & op read "op://Personal/GitHubUsedUserPAT/credential" 2>$null } catch {}
-  try { $env:TAVILY_API_KEY = & op read "op://Personal/TavilyUsedUserPAT/credential" 2>$null } catch {}
+if ($env:GH_TOKEN -and $env:TAVILY_API_KEY) { return }
+if (-not (Get-Command op -ErrorAction SilentlyContinue)) { return }
+
+$_secretTmpl = @"
+GH_TOKEN={{ op://Personal/GitHubUsedUserPAT/credential }}
+TAVILY_API_KEY={{ op://Personal/TavilyUsedUserPAT/credential }}
+"@
+
+try {
+    $_resolved = $_secretTmpl | & op inject 2>$null
+    if ($LASTEXITCODE -eq 0 -and $_resolved) {
+        foreach ($_line in ($_resolved -split "`r?`n")) {
+            if ($_line -match '^([A-Z_][A-Z0-9_]*)=(.*)$') {
+                Set-Item -Path "env:$($Matches[1])" -Value $Matches[2]
+            }
+        }
+    }
+} catch {}
+finally {
+    Remove-Variable _secretTmpl, _resolved, _line -ErrorAction SilentlyContinue
 }

--- a/chezmoi/secret/env.sh
+++ b/chezmoi/secret/env.sh
@@ -5,8 +5,24 @@
 # Set actual item paths in 1Password before using:
 #   op item create --category login --title "GitHub CLI" ...
 #   op item create --category login --title "Tavily" ...
+#
+# Each `op` invocation triggers a 1Password biometric/desktop approval, so
+# we (1) skip when env is already populated by a parent process and
+# (2) use a single `op inject` call to resolve all secrets at once,
+# instead of one `op read` per secret.
 
-if command -v op &>/dev/null 2>&1; then
-  export GH_TOKEN=$(op read "op://Personal/GitHubUsedUserPAT/credential" 2>/dev/null)
-  export TAVILY_API_KEY=$(op read "op://Personal/TavilyUsedUserPAT/credential" 2>/dev/null)
+[ -n "$GH_TOKEN" ] && [ -n "$TAVILY_API_KEY" ] && return 0
+command -v op >/dev/null 2>&1 || return 0
+
+_secret_tmpl='GH_TOKEN={{ op://Personal/GitHubUsedUserPAT/credential }}
+TAVILY_API_KEY={{ op://Personal/TavilyUsedUserPAT/credential }}'
+
+# `op inject` reads the template on stdin and emits KEY=value lines on stdout
+# with secrets substituted. `set -a` exports every assignment that follows.
+_resolved=$(printf '%s\n' "$_secret_tmpl" | op inject 2>/dev/null) || _resolved=''
+if [ -n "$_resolved" ]; then
+  set -a
+  eval "$_resolved"
+  set +a
 fi
+unset _secret_tmpl _resolved


### PR DESCRIPTION
## Summary
PowerShell / bash の secret loader (`chezmoi/secret/env.{ps1,sh}`) は secret 個数分 `op read` を呼んでおり、シェル起動の度に 1Password 承認 prompt が secret 数だけ出ていた。Zed の LSP / claude / codex などが pwsh 子プロセスを連鎖的に立ち上げるため、1 セッションで 6〜10 回承認を求められる UX 問題。

## Changes
両 loader (PS と bash) に同じ 2 つの改善:

1. **既に env 設定済なら early-return** — 親プロセスから継承した子 pwsh は再フェッチ不要
2. **`op inject` で 1 回にまとめる** — secret 数 → 1 invocation。今後 secret を追加しても prompt は 1 回のまま

```powershell
# Before: secret ごとに op read (= prompt)
$env:GH_TOKEN       = & op read "op://..."
$env:TAVILY_API_KEY = & op read "op://..."

# After: 全部まとめて op inject (= 1 prompt)
if ($env:GH_TOKEN -and $env:TAVILY_API_KEY) { return }
$_secretTmpl = @"
GH_TOKEN={{ op://Personal/GitHubUsedUserPAT/credential }}
TAVILY_API_KEY={{ op://Personal/TavilyUsedUserPAT/credential }}
"@
$_secretTmpl | & op inject | ForEach-Object { ... Set-Item env:... }
```

## Verified locally
- [x] `pwsh -NoProfile -Command "[scriptblock]::Create((Get-Content -Raw env.ps1))"` で構文 OK
- [x] `bash -n env.sh` で構文 OK
- [ ] `chezmoi apply` 後の新規 pwsh 起動で 1Password 承認 prompt が **1 回**であること
- [ ] 既存 pwsh から `pwsh` を呼んで env 継承された子で **0 回**であること
- [ ] WSL bash でも同様であること

## Notes
- `op inject` は 1Password CLI v2 の機能。stdin に template、stdout に key=value を出力
- Secret 追加時は両 file の here-doc に 1 行足すだけ。prompt 増えない

Closes LIF-103

🤖 Generated with [Claude Code](https://claude.com/claude-code)