### PR TITLE
fix(zed): replace removed soft_wrap value with bounded for Python

### DIFF
--- a/chezmoi/editors/zed/settings.json
+++ b/chezmoi/editors/zed/settings.json
@@ -182,7 +182,7 @@
       "format_on_save": "on",
       "formatter": "language_server",
       "language_servers": ["ty", "ruff", "!basedpyright", "!pyright"],
-      "soft_wrap": "preferred_line_length",
+      "soft_wrap": "bounded",
       "preferred_line_length": 88
     },
     "Dockerfile": {


### PR DESCRIPTION
## Summary
Zed v1.0.0 で削除された `"soft_wrap": "preferred_line_length"` を `"bounded"` に置換。Python 言語設定の 1 行修正。

## Background
[Zed v1.0.0 release notes](https://zed.dev/releases/stable/1.0.0) より:
> Removed `"soft_wrap": "preferred_line_length"` in favor of `"soft_wrap": "bounded"`. Soft wrap now always respects editor width when it's enabled.

`chezmoi/editors/zed/settings.json:185` の Python 設定がこの古い値を使用しており、v1.0.0 以降は無効値として silently 無視されていた。

## Changes
```diff
 "Python": {
   "format_on_save": "on",
   "formatter": "language_server",
   "language_servers": ["ty", "ruff", "!basedpyright", "!pyright"],
-  "soft_wrap": "preferred_line_length",
+  "soft_wrap": "bounded",
   "preferred_line_length": 88
 }
```

`preferred_line_length: 88` は残す — `bounded` モードが wrap 上限と column ruler の参照値として読む。

## Verified locally
- [x] node で JSONC parse 成功 (`Python.soft_wrap = bounded`)
- [ ] `chezmoi apply` 後 Zed 再起動で Python ファイルの wrap が機能

## Out of scope (follow-up issues created)
- [LIF-105](https://linear.app/life-style-base/issue/LIF-105): Pin winget package versions
- [LIF-106](https://linear.app/life-style-base/issue/LIF-106): Replace @latest with pinned versions in mcp_servers.yaml
- [LIF-107](https://linear.app/life-style-base/issue/LIF-107): Audit Zed v0.x→v1.0.0 release notes for missed settings changes

Closes LIF-104

🤖 Generated with [Claude Code](https://claude.com/claude-code)