### PR TITLE
refactor(mcp): pin pnpm dlx versions in mcp_servers.yaml

### DIFF
--- a/chezmoi/.chezmoidata/mcp_servers.yaml
+++ b/chezmoi/.chezmoidata/mcp_servers.yaml
@@ -9,7 +9,7 @@ mcp_servers:
     command: pnpm
     args:
       - "dlx"
-      - "@upstash/context7-mcp@latest"
+      - "@upstash/context7-mcp@2.2.3"
     startup_timeout_sec: 30
     # Supported by: codex, claude-code
     supports:
@@ -28,7 +28,7 @@ mcp_servers:
     command: pnpm
     args:
       - "dlx"
-      - "mcp-remote"
+      - "mcp-remote@0.1.38"
       - "https://mcp.linear.app/mcp"
     supports:
       - codex
@@ -61,7 +61,7 @@ mcp_servers:
     command: pnpm
     args:
       - "dlx"
-      - "@modelcontextprotocol/server-github"
+      - "@modelcontextprotocol/server-github@2025.4.8"
     env:
       GITHUB_PERSONAL_ACCESS_TOKEN: "${GH_TOKEN}"
     supports:
@@ -80,7 +80,7 @@ mcp_servers:
     command: pnpm
     args:
       - "dlx"
-      - "mcp-remote"
+      - "mcp-remote@0.1.38"
       - "https://mcp.deepwiki.com/mcp"
     startup_timeout_sec: 30
     supports:
@@ -169,7 +169,7 @@ mcp_servers:
     command: pnpm
     args:
       - "dlx"
-      - "@drawio/mcp"
+      - "@drawio/mcp@1.2.6"
     startup_timeout_sec: 30
     supports:
       - codex
@@ -189,7 +189,7 @@ mcp_servers:
     command: pnpm
     args:
       - "dlx"
-      - "mcp-remote"
+      - "mcp-remote@0.1.38"
       - "https://mcp.sentry.dev/mcp"
     startup_timeout_sec: 30
     supports:
@@ -204,7 +204,7 @@ mcp_servers:
     command: pnpm
     args:
       - "dlx"
-      - "@google-cloud/cloud-run-mcp"
+      - "@google-cloud/cloud-run-mcp@1.10.0"
     startup_timeout_sec: 120
     supports:
       - codex
@@ -241,7 +241,7 @@ mcp_servers:
     command: pnpm
     args:
       - "dlx"
-      - "mcp-remote"
+      - "mcp-remote@0.1.38"
       - "https://www.kaggle.com/mcp"
     startup_timeout_sec: 30
     supports:
@@ -259,7 +259,7 @@ mcp_servers:
     command: pnpm
     args:
       - "dlx"
-      - "@playwright/mcp@latest"
+      - "@playwright/mcp@0.0.71"
     startup_timeout_sec: 60
     supports:
       - vscode

--- a/chezmoi/.chezmoiscripts/deploy/llms/run_onchange_deploy_claude_code_mcp.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/llms/run_onchange_deploy_claude_code_mcp.ps1.tmpl
@@ -7,8 +7,13 @@ if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
 
 Write-Host "[claude-code-mcp] Syncing MCP servers to ~/.claude.json..."
 
+# `claude mcp add` is a strict insert and refuses to update an existing
+# entry, so re-running this script after a yaml change (e.g. pinning a
+# version) leaves the old args in ~/.claude.json. Remove first, then add,
+# to keep this script idempotent against arg drift.
 {{ range .mcp_servers }}
 {{- if has "claude-code" .supports }}
+claude mcp remove "{{ .name }}" -s user 2>$null | Out-Null
 {{- if and (hasKey . "url") (not (hasKey . "command")) }}
 claude mcp add "{{ .name }}" -s user -- npx -y mcp-remote "{{ .url }}" 2>$null
 Write-Host "[claude-code-mcp] Added/updated {{ .name }} (mcp-remote)"

--- a/chezmoi/.chezmoiscripts/deploy/llms/run_onchange_deploy_claude_code_mcp.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/llms/run_onchange_deploy_claude_code_mcp.sh.tmpl
@@ -9,8 +9,13 @@ fi
 
 echo "[claude-code-mcp] Syncing MCP servers to ~/.claude.json..."
 
+# `claude mcp add` is a strict insert and refuses to update an existing
+# entry, so re-running this script after a yaml change (e.g. pinning a
+# version) leaves the old args in ~/.claude.json. Remove first, then add,
+# to keep this script idempotent against arg drift.
 {{ range .mcp_servers }}
 {{- if has "claude-code" .supports }}
+claude mcp remove "{{ .name }}" -s user >/dev/null 2>&1 || true
 {{- if and (hasKey . "url") (not (hasKey . "command")) }}
 claude mcp add "{{ .name }}" -s user -- npx -y mcp-remote "{{ .url }}" 2>/dev/null || true
 {{- else }}


### PR DESCRIPTION
## Summary
`mcp_servers.yaml` の 9 エントリ (6 unique package) を **`@x.y.z` で固定**。これまで `pnpm dlx` がコールドスタートの度に npm registry から latest を引いていたため、上流の破壊的変更を予期せず取り込むリスクがあった。

## Pinned versions
| Package | Version |
|---|---|
| `@upstash/context7-mcp` | 2.2.3 |
| `mcp-remote` (linear/deepwiki/sentry/kaggle) | 0.1.38 |
| `@modelcontextprotocol/server-github` | 2025.4.8 |
| `@drawio/mcp` | 1.2.6 |
| `@google-cloud/cloud-run-mcp` | 1.10.0 |
| `@playwright/mcp` | 0.0.71 |

## Update workflow
1. `pnpm view <pkg> version` で latest 確認
2. yaml 編集 → PR
3. `chezmoi apply` → 該当 LLM 再起動 → MCP 応答確認

## Verified locally
- [x] `@latest` が yaml から完全に消滅 (`grep` で 0 件)
- [x] 全 entry に `@version` 形式の pin が入った (9 件)
- [ ] `chezmoi apply` で各 LLM 設定ファイルにも version 付き args が書き込まれる

Closes LIF-106

🤖 Generated with [Claude Code](https://claude.com/claude-code)