### PR TITLE
feat(terminal): add Warp terminal cross-platform install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ chezmoi/private_dot_claude/settings.local.json
 .playwright/
 .playwright-mcp/
 .task/
+.worktrees/
 
 # Temporary files
 *.tmp

--- a/chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.ps1.tmpl
@@ -34,7 +34,10 @@ if (Test-Path -LiteralPath $WTSettingsDir) {
 }
 
 # Warp
-Deploy-File "$ChezmoiSource\terminals\warp\keybindings.yaml" "$env:LOCALAPPDATA\warp\Warp\config\keybindings.yaml"
+$WarpConfigDir = "$env:LOCALAPPDATA\warp\Warp"
+if (Test-Path -LiteralPath $WarpConfigDir) {
+  Deploy-File "$ChezmoiSource\terminals\warp\keybindings.yaml" "$WarpConfigDir\config\keybindings.yaml"
+}
 
 Write-Host "Terminal configurations deployed."
 {{ end -}}

--- a/chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.ps1.tmpl
@@ -1,6 +1,6 @@
 {{ if eq .chezmoi.os "windows" -}}
 # Deploy terminal configurations for Windows
-# hash: {{ include "terminals/wezterm/wezterm.lua" | sha256sum }}{{ include "terminals/windows-terminal/settings.json" | sha256sum }}
+# hash: {{ include "terminals/wezterm/wezterm.lua" | sha256sum }}{{ include "terminals/windows-terminal/settings.json" | sha256sum }}{{ include "terminals/warp/keybindings.yaml" | sha256sum }}
 
 $ErrorActionPreference = "Stop"
 
@@ -32,6 +32,9 @@ $WTSettingsDir = "$env:LOCALAPPDATA\Packages\Microsoft.WindowsTerminal_8wekyb3d8
 if (Test-Path -LiteralPath $WTSettingsDir) {
   Deploy-File "$ChezmoiSource\terminals\windows-terminal\settings.json" "$WTSettingsDir\settings.json"
 }
+
+# Warp
+Deploy-File "$ChezmoiSource\terminals\warp\keybindings.yaml" "$env:LOCALAPPDATA\warp\Warp\config\keybindings.yaml"
 
 Write-Host "Terminal configurations deployed."
 {{ end -}}

--- a/chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.sh.tmpl
@@ -22,7 +22,9 @@ deploy_file() {
 echo "Deploying terminal configurations..."
 
 deploy_file "$CHEZMOI_SOURCE/terminals/wezterm/wezterm.lua" "$HOME_DIR/.config/wezterm/wezterm.lua"
-if [[ -d "$HOME_DIR/.warp" ]] || command -v warp-terminal &>/dev/null; then
+
+# Warp
+if command -v warp-terminal &>/dev/null; then
   deploy_file "$CHEZMOI_SOURCE/terminals/warp/keybindings.yaml" "$HOME_DIR/.warp/keybindings.yaml"
 fi
 

--- a/chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.sh.tmpl
@@ -1,7 +1,7 @@
 {{ if ne .chezmoi.os "windows" -}}
 #!/bin/bash
 # Deploy terminal configurations for Linux/macOS
-# hash: {{ include "terminals/wezterm/wezterm.lua" | sha256sum }}
+# hash: {{ include "terminals/wezterm/wezterm.lua" | sha256sum }}{{ include "terminals/warp/keybindings.yaml" | sha256sum }}
 
 set -euo pipefail
 
@@ -22,6 +22,7 @@ deploy_file() {
 echo "Deploying terminal configurations..."
 
 deploy_file "$CHEZMOI_SOURCE/terminals/wezterm/wezterm.lua" "$HOME_DIR/.config/wezterm/wezterm.lua"
+deploy_file "$CHEZMOI_SOURCE/terminals/warp/keybindings.yaml" "$HOME_DIR/.warp/keybindings.yaml"
 
 echo "Terminal configurations deployed."
 {{ end -}}

--- a/chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.sh.tmpl
@@ -22,7 +22,9 @@ deploy_file() {
 echo "Deploying terminal configurations..."
 
 deploy_file "$CHEZMOI_SOURCE/terminals/wezterm/wezterm.lua" "$HOME_DIR/.config/wezterm/wezterm.lua"
-deploy_file "$CHEZMOI_SOURCE/terminals/warp/keybindings.yaml" "$HOME_DIR/.warp/keybindings.yaml"
+if [[ -d "$HOME_DIR/.warp" ]] || command -v warp-terminal &>/dev/null; then
+  deploy_file "$CHEZMOI_SOURCE/terminals/warp/keybindings.yaml" "$HOME_DIR/.warp/keybindings.yaml"
+fi
 
 echo "Terminal configurations deployed."
 {{ end -}}

--- a/chezmoi/terminals/warp/keybindings.yaml
+++ b/chezmoi/terminals/warp/keybindings.yaml
@@ -1,0 +1,5 @@
+# Warp keybindings — managed via chezmoi
+# Format: action_name: key-binding
+# Reference: https://github.com/warpdotdev/keysets/blob/main/FORMAT.md
+# Example:
+#   editor_view:add_cursor_below: cmd-shift-a

--- a/chezmoi/terminals/warp/keybindings.yaml
+++ b/chezmoi/terminals/warp/keybindings.yaml
@@ -1,5 +1,7 @@
 # Warp keybindings — managed via chezmoi
-# Format: action_name: key-binding
+# Format: flat YAML map of action_name to key-binding (no root key)
 # Reference: https://github.com/warpdotdev/keysets/blob/main/FORMAT.md
-# Example:
-#   editor_view:add_cursor_below: cmd-shift-a
+# Example (macOS):
+#   editor_view:add_cursor_below: cmd-shift-A
+# Example (Windows/Linux):
+#   editor_view:add_cursor_below: ctrl-shift-A

--- a/docs/superpowers/specs/2026-05-01-warp-terminal-crossplatform-design.md
+++ b/docs/superpowers/specs/2026-05-01-warp-terminal-crossplatform-design.md
@@ -1,0 +1,55 @@
+# Warp Terminal クロスプラットフォームインストール設計
+
+## 概要
+
+Warp Terminal を Windows（winget）と Linux/WSL（Nix home-manager）の両方でインストール・設定管理できるようにする。既存の wezterm と同じパターンを踏襲する。
+
+## アーキテクチャ
+
+### パッケージ管理
+
+`nix/packages/sets.nix` の catalog に `warp-terminal` エントリを追加する。
+
+```nix
+warp-terminal = {
+  pkg = pkgs.warp-terminal;
+  winget = "Warp.Warp";
+  category = "terminal";
+};
+```
+
+- **Nix（Linux/WSL）**: `pkgs.warp-terminal` が home-manager 経由でインストールされる
+- **Windows**: `winget.nix` が `Warp.Warp` を `packages.json` に自動生成し、`task install` で反映される
+
+### 設定管理
+
+`chezmoi/terminals/warp/keybindings.yaml` を scaffold として新規作成する（コメントのみ）。フォーマットは `action_name: key-binding` マップ形式（例: `editor_view:add_cursor_below: cmd-shift-a`）。空の scaffold はコメント行のみとし、Warp にカスタムキーバインドなしとして扱わせる。
+
+デプロイ先：
+
+| OS | デプロイ先 |
+|---|---|
+| Linux/WSL | `~/.warp/keybindings.yaml` |
+| Windows | `%LOCALAPPDATA%\warp\Warp\config\keybindings.yaml` |
+
+### デプロイスクリプト変更
+
+`chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.ps1.tmpl`（Windows）と `run_onchange_deploy.sh.tmpl`（Linux）を更新する：
+
+1. ハッシュ行に `terminals/warp/keybindings.yaml` を追加（ファイル変更時に自動再デプロイ）
+2. `Deploy-File` / `deploy_file` 呼び出しを追加
+
+## 変更ファイル一覧
+
+| ファイル | 変更種別 |
+|---|---|
+| `nix/packages/sets.nix` | 編集（warp-terminal エントリ追加） |
+| `chezmoi/terminals/warp/keybindings.yaml` | 新規作成（scaffold） |
+| `chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.ps1.tmpl` | 編集（Warp デプロイ追加） |
+| `chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.sh.tmpl` | 編集（Warp デプロイ追加） |
+
+## スコープ外
+
+- Warp の themes ディレクトリ管理（必要になった時点で追加）
+- Windows の `packages.json` 直接編集（`sets.nix` から自動生成）
+- macOS 対応（現リポジトリは未対応）

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -128,6 +128,11 @@ let
       winget = "Starship.Starship";
       category = "terminal";
     };
+    warp-terminal = {
+      pkg = pkgs.warp-terminal;
+      winget = "Warp.Warp";
+      category = "terminal";
+    };
 
     # ── editors ───────────────────────────────────────────
     neovim = {

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -80,6 +80,10 @@
           "Version": "20240203-110809-5046fc22"
         },
         {
+          "PackageIdentifier": "Warp.Warp",
+          "Version": "v0.2026.04.15.08.45.stable_03"
+        },
+        {
           "PackageIdentifier": "ajeetdsouza.zoxide",
           "Version": "0.9.9"
         },

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -76,12 +76,12 @@
           "Version": "0.11.7"
         },
         {
-          "PackageIdentifier": "wez.wezterm",
-          "Version": "20240203-110809-5046fc22"
-        },
-        {
           "PackageIdentifier": "Warp.Warp",
           "Version": "v0.2026.04.15.08.45.stable_03"
+        },
+        {
+          "PackageIdentifier": "wez.wezterm",
+          "Version": "20240203-110809-5046fc22"
         },
         {
           "PackageIdentifier": "ajeetdsouza.zoxide",


### PR DESCRIPTION
## Summary

- `nix/packages/sets.nix` に `warp-terminal` エントリ追加（`pkgs.warp-terminal` + `winget = "Warp.Warp"`）
- `chezmoi/terminals/warp/keybindings.yaml` を scaffold として新規作成
- `chezmoi/.chezmoiscripts/deploy/terminals/` の両スクリプトに Warp デプロイ処理を追加

## 設定パス

| OS | パス |
|---|---|
| Linux/WSL | `~/.warp/keybindings.yaml` |
| Windows | `%LOCALAPPDATA%\warp\Warp\config\keybindings.yaml` |

## Test plan

- [ ] `nix build .#default` がエラーなしで完了する（`pkgs.warp-terminal` が解決される）
- [ ] Windows: `chezmoi apply` 後に `%LOCALAPPDATA%\warp\Warp\config\keybindings.yaml` が作成される
- [ ] Linux/WSL: `chezmoi apply` 後に `~/.warp/keybindings.yaml` が作成される
- [ ] `windows/winget/packages.json` を再生成すると `Warp.Warp` が含まれる

Closes LIF-108

🤖 Generated with [Claude Code](https://claude.com/claude-code)