### PR TITLE
feat(warp): manage settings.toml via chezmoi

### DIFF
--- a/chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.ps1.tmpl
@@ -1,6 +1,6 @@
 {{ if eq .chezmoi.os "windows" -}}
 # Deploy terminal configurations for Windows
-# hash: {{ include "terminals/wezterm/wezterm.lua" | sha256sum }}{{ include "terminals/windows-terminal/settings.json" | sha256sum }}{{ include "terminals/warp/keybindings.yaml" | sha256sum }}
+# hash: {{ include "terminals/wezterm/wezterm.lua" | sha256sum }}{{ include "terminals/windows-terminal/settings.json" | sha256sum }}{{ include "terminals/warp/keybindings.yaml" | sha256sum }}{{ include "terminals/warp/settings.toml" | sha256sum }}
 
 $ErrorActionPreference = "Stop"
 
@@ -37,6 +37,7 @@ if (Test-Path -LiteralPath $WTSettingsDir) {
 $WarpConfigDir = "$env:LOCALAPPDATA\warp\Warp"
 if (Test-Path -LiteralPath $WarpConfigDir) {
   Deploy-File "$ChezmoiSource\terminals\warp\keybindings.yaml" "$WarpConfigDir\config\keybindings.yaml"
+  Deploy-File "$ChezmoiSource\terminals\warp\settings.toml" "$WarpConfigDir\config\settings.toml"
 } else {
   Write-Host "Warp config dir not found ($WarpConfigDir), skipping. Launch Warp once to create it, then re-run chezmoi apply."
 }

--- a/chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.sh.tmpl
@@ -1,7 +1,7 @@
 {{ if ne .chezmoi.os "windows" -}}
 #!/bin/bash
 # Deploy terminal configurations for Linux/macOS
-# hash: {{ include "terminals/wezterm/wezterm.lua" | sha256sum }}{{ include "terminals/warp/keybindings.yaml" | sha256sum }}
+# hash: {{ include "terminals/wezterm/wezterm.lua" | sha256sum }}{{ include "terminals/warp/keybindings.yaml" | sha256sum }}{{ include "terminals/warp/settings.toml" | sha256sum }}
 
 set -euo pipefail
 
@@ -26,6 +26,7 @@ deploy_file "$CHEZMOI_SOURCE/terminals/wezterm/wezterm.lua" "$HOME_DIR/.config/w
 # Warp (Linux only — macOS out of scope; pkgs.warp-terminal is linux-only in nixpkgs)
 if command -v warp-terminal &>/dev/null; then
   deploy_file "$CHEZMOI_SOURCE/terminals/warp/keybindings.yaml" "$HOME_DIR/.warp/keybindings.yaml"
+  deploy_file "$CHEZMOI_SOURCE/terminals/warp/settings.toml" "$HOME_DIR/.config/warp-terminal/settings.toml"
 fi
 
 echo "Terminal configurations deployed."

--- a/chezmoi/terminals/AGENTS.md
+++ b/chezmoi/terminals/AGENTS.md
@@ -5,6 +5,7 @@
 - `wezterm/wezterm.lua`
 - `windows-terminal/settings.json`
 - `warp/keybindings.yaml`
+- `warp/settings.toml`
 
 ## ルール
 

--- a/chezmoi/terminals/warp/settings.toml
+++ b/chezmoi/terminals/warp/settings.toml
@@ -1,0 +1,26 @@
+[agents]
+cloud_conversation_storage_enabled = true
+
+[agents.warp_agent]
+
+[agents.warp_agent.input]
+nld_in_terminal_enabled = true
+
+[agents.warp_agent.other]
+cloud_agent_computer_use_enabled = true
+
+[privacy]
+telemetry_enabled = true
+crash_reporting_enabled = true
+
+[account]
+is_settings_sync_enabled = true
+
+[appearance]
+
+[appearance.text]
+notebook_font_size = 14.0
+font_size = 13.0
+
+[appearance.themes]
+system_theme = true


### PR DESCRIPTION
## Summary

- `chezmoi/terminals/warp/settings.toml` 新規作成（現在の設定を scaffold として使用）
- デプロイスクリプト更新: Windows (`%LOCALAPPDATA%\warp\Warp\config\settings.toml`) + Linux (`~/.config/warp-terminal/settings.toml`)
- ハッシュ行に `settings.toml` を追加（変更時に自動再デプロイ）

Closes LIF-110

## Test plan

- [x] `chezmoi apply` でローカル動作確認済み（`Deployed: ...warp\Warp\config\settings.toml`）
- [x] ファイル内容が既存設定と一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)