### PR TITLE
feat(warp): align keybindings with WezTerm and Windows Terminal

### DIFF
--- a/chezmoi/terminals/warp/keybindings.yaml
+++ b/chezmoi/terminals/warp/keybindings.yaml
@@ -1,7 +1,21 @@
 # Warp keybindings — managed via chezmoi
 # Format: flat YAML map of action_name to key-binding (no root key)
 # Reference: https://github.com/warpdotdev/keysets/blob/main/FORMAT.md
-# Example (macOS):
-#   editor_view:add_cursor_below: cmd-shift-A
-# Example (Windows/Linux):
-#   editor_view:add_cursor_below: ctrl-shift-A
+# Aligned with WezTerm and Windows Terminal conventions.
+#
+# Not configurable here (no action name in Warp):
+#   close pane (Ctrl+Alt+X), toggle zoom (Ctrl+Alt+W)
+
+# Pane split — matches WezTerm (Ctrl+Alt+H/V) and Windows Terminal
+pane_group:add_horizontal: ctrl-alt-h
+pane_group:add_vertical: ctrl-alt-v
+
+# Pane navigation — matches WezTerm/WT vim-style (Ctrl+Shift+H/J/K/L)
+pane_group:navigate_left: ctrl-shift-H
+pane_group:navigate_down: ctrl-shift-J
+pane_group:navigate_up: ctrl-shift-K
+pane_group:navigate_right: ctrl-shift-L
+
+# Tab navigation — matches Windows Terminal (Ctrl+Tab / Ctrl+Shift+Tab)
+workspace:activate_next_tab: ctrl-tab
+workspace:activate_prev_tab: ctrl-shift-tab


### PR DESCRIPTION
## Summary

`keybindings.yaml` を WezTerm・Windows Terminal と統一。

| 操作 | キー |
|---|---|
| 右に分割 | `Ctrl+Alt+H` |
| 下に分割 | `Ctrl+Alt+V` |
| ペイン移動左/下/上/右 | `Ctrl+Shift+H/J/K/L` |
| 次タブ | `Ctrl+Tab` |
| 前タブ | `Ctrl+Shift+Tab` |

ペイン閉じる (`Ctrl+Alt+X`) とズーム (`Ctrl+Alt+W`) は Warp の keybindings.yaml に対応アクション名が存在しないため未設定。

Closes LIF-111

## Test plan

- [x] `chezmoi apply` でローカルデプロイ確認済み
- [x] `%LOCALAPPDATA%\warp\Warp\config\keybindings.yaml` に正しく展開されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)