### PR TITLE
fix(warp): correct pane split action names (add_right/add_down)

### DIFF
--- a/chezmoi/terminals/warp/keybindings.yaml
+++ b/chezmoi/terminals/warp/keybindings.yaml
@@ -7,8 +7,9 @@
 #   close pane (Ctrl+Alt+X), toggle zoom (Ctrl+Alt+W)
 
 # Pane split — matches WezTerm (Ctrl+Alt+H/V) and Windows Terminal
-pane_group:add_horizontal: ctrl-alt-h
-pane_group:add_vertical: ctrl-alt-v
+# Warp uses add_right (split right) / add_down (split down)
+pane_group:add_right: ctrl-alt-h
+pane_group:add_down: ctrl-alt-v
 
 # Pane navigation — matches WezTerm/WT vim-style (Ctrl+Shift+H/J/K/L)
 pane_group:navigate_left: ctrl-shift-H


### PR DESCRIPTION
## Summary
- `pane_group:add_horizontal`/`add_vertical` are not valid Warp actions, so `Ctrl+Alt+H/V` were silently no-ops
- Replaced with the documented actions `pane_group:add_right` / `pane_group:add_down` (per [warpdotdev/keysets default-warp-keybindings.yaml](https://github.com/warpdotdev/keysets/blob/main/default-warp-keybindings.yaml))
- Direction is preserved: `Ctrl+Alt+H` splits right, `Ctrl+Alt+V` splits down — matches WezTerm

## Test plan
- [x] `chezmoi apply` deploys updated `keybindings.yaml`
- [ ] Restart Warp, press `Ctrl+Alt+H` → pane splits right
- [ ] Press `Ctrl+Alt+V` → pane splits down

🤖 Generated with [Claude Code](https://claude.com/claude-code)