### PR TITLE
fix(nvim): oil.nvim のキーマップを `-` に変更

### DIFF
--- a/chezmoi/editors/nvim/lua/config/keymaps.lua
+++ b/chezmoi/editors/nvim/lua/config/keymaps.lua
@@ -41,7 +41,7 @@ map("n", "<leader>q", "<cmd>q<cr>", { desc = "Quit" })
 map("n", "<leader>Q", "<cmd>qa!<cr>", { desc = "Quit all" })
 
 -- File explorer
-map("n", "<leader>e", "<cmd>Oil<cr>", { desc = "File explorer" })
+map("n", "-", "<cmd>Oil<cr>", { desc = "Open parent directory" })
 
 -- Telescope
 map("n", "<leader>ff", "<cmd>Telescope find_files<cr>", { desc = "Find files" })

--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -15,7 +15,7 @@ return {
     {
         "stevearc/oil.nvim",
         cmd = "Oil",
-        keys = { { "<leader>e", "<cmd>Oil<cr>", desc = "File explorer" } },
+        keys = { { "-", "<cmd>Oil<cr>", desc = "Open parent directory" } },
         opts = {
             view_options = { show_hidden = true },
         },


### PR DESCRIPTION
## Summary

- `<leader>e` から `-` へ oil.nvim のキーマップを変更
- `plugins/init.lua` と `keymaps.lua` の2箇所を更新

## 背景

`-` は oil.nvim 推奨のデフォルトキーであり、Vim 標準の netrw と同じ挙動（親ディレクトリを開く）に一致する。`<leader>e` はサイドバー型ファイラーで一般的なキーであり、バッファ型の oil.nvim には `-` の方がフィット感がある。

## Test plan

- [x] nvim を起動して `-` でファイルエクスプローラーが開くことを確認
- [x] oil バッファ内で `-` で親ディレクトリへ遡れることを確認
- [x] `<leader>e` が未割り当てになっていることを確認

Closes LIF-112

🤖 Generated with [Claude Code](https://claude.com/claude-code)