### PR TITLE
feat(packages): add jq cross-platform install and warp claude-code-warp plugin

### DIFF
--- a/chezmoi/dot_claude/settings.json.tmpl
+++ b/chezmoi/dot_claude/settings.json.tmpl
@@ -40,6 +40,8 @@
     ],
     "ask": ["Bash(git checkout:*)", "Bash(git commit:*)"]
   },
+  "model": "sonnet",
+  "theme": "light-daltonized",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },

--- a/chezmoi/dot_claude/settings.json.tmpl
+++ b/chezmoi/dot_claude/settings.json.tmpl
@@ -56,7 +56,16 @@
     "serena@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
-    "linear@claude-plugins-official": true
+    "linear@claude-plugins-official": true,
+    "warp@claude-code-warp": true
+  },
+  "extraKnownMarketplaces": {
+    "claude-code-warp": {
+      "source": {
+        "source": "github",
+        "repo": "warpdotdev/claude-code-warp"
+      }
+    }
   },
   "hooks": {
     "PostToolUse": [

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -39,6 +39,11 @@ let
       winget = null;
       category = "core";
     };
+    jq = {
+      pkg = pkgs.jq;
+      winget = "jqlang.jq";
+      category = "core";
+    };
     eza = {
       pkg = pkgs.eza;
       winget = "eza-community.eza";

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -24,6 +24,9 @@
           "Version": "0.72.0"
         },
         {
+          "PackageIdentifier": "jqlang.jq"
+        },
+        {
           "PackageIdentifier": "GitHub.cli",
           "Version": "2.92.0"
         },

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -24,7 +24,8 @@
           "Version": "0.72.0"
         },
         {
-          "PackageIdentifier": "jqlang.jq"
+          "PackageIdentifier": "jqlang.jq",
+          "Version": "1.7.1"
         },
         {
           "PackageIdentifier": "GitHub.cli",


### PR DESCRIPTION
## Summary

- `nix/packages/sets.nix` に `jq` を追加（nix: `pkgs.jq` / winget: `jqlang.jq`、category: `core`）
- `windows/winget/packages.json` に `jqlang.jq` エントリを追加
- `chezmoi/dot_claude/settings.json.tmpl` に `warp@claude-code-warp` プラグインと `extraKnownMarketplaces` を追加

## 背景

Claude Code の SessionStart フックで以下のエラーが発生していた:
```
🚨 Warp notifications require jq! Install it with your system package manager
```

`warp@claude-code-warp` プラグインが jq を必要とするが、dotfiles に未登録だった。また chezmoi の `settings.json.tmpl` にも warp プラグイン設定が反映されていなかった。

Closes LIF-113

## Test plan

- [ ] WSL で `nix build .#winget-export` を実行して packages.json が正しく生成されることを確認
- [ ] chezmoi apply 後に `~/.claude/settings.json` に warp プラグイン設定が反映されていることを確認
- [ ] WSL で `nix rebuild` 後に `jq --version` が動作することを確認
- [ ] Windows で `winget install jqlang.jq` が成功することを確認
- [ ] Claude Code 再起動後に SessionStart エラーが出なくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)