### PR TITLE
feat(warp): add Gemini CLI and Opencode Warp plugins

### DIFF
--- a/chezmoi/.chezmoiscripts/run_onchange_install-gemini-warp_linux.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_install-gemini-warp_linux.sh.tmpl
@@ -1,0 +1,16 @@
+{{ if eq .chezmoi.os "linux" -}}
+#!/usr/bin/env bash
+set -euo pipefail
+
+# gemini CLI が利用可能か確認
+if ! command -v gemini &>/dev/null; then
+  echo "[gemini-warp] Skip: gemini CLI not found."
+  exit 0
+fi
+
+echo "[gemini-warp] Installing Warp extension..."
+gemini extensions install https://github.com/warpdotdev/gemini-cli-warp || {
+  echo "[gemini-warp] Warning: extension install returned non-zero (may already be installed)"
+}
+echo "[gemini-warp] Done. Restart Gemini CLI for the extension to activate."
+{{ end -}}

--- a/chezmoi/.chezmoiscripts/run_onchange_install-gemini-warp_windows.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_install-gemini-warp_windows.ps1.tmpl
@@ -1,0 +1,17 @@
+{{ if eq .chezmoi.os "windows" -}}
+$ErrorActionPreference = "Stop"
+
+# gemini CLI が利用可能か確認
+$geminiCmd = Get-Command gemini -ErrorAction SilentlyContinue
+if (-not $geminiCmd) {
+  Write-Host "[gemini-warp] Skip: gemini CLI not found."
+  return
+}
+
+Write-Host "[gemini-warp] Installing Warp extension..."
+& gemini extensions install https://github.com/warpdotdev/gemini-cli-warp 2>&1 | ForEach-Object { Write-Host $_ }
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "[gemini-warp] Warning: extension install returned non-zero (may already be installed)"
+}
+Write-Host "[gemini-warp] Done. Restart Gemini CLI for the extension to activate."
+{{ end -}}

--- a/chezmoi/dot_config/opencode/opencode.json
+++ b/chezmoi/dot_config/opencode/opencode.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@warp-dot-dev/opencode-warp"]
+}


### PR DESCRIPTION
## Summary

- Gemini CLI Warp extension を chezmoi run_onchange スクリプトで自動インストール（Windows / Linux）
- Opencode Warp plugin を `~/.config/opencode/opencode.json` で管理

## 調査結果

| ツール | Warp plugin |
|--------|------------|
| Claude Code | `warpdotdev/claude-code-warp`（既存） |
| Gemini CLI | `warpdotdev/gemini-cli-warp` ✅ |
| Opencode | `warpdotdev/opencode-warp` ✅ |
| Codex CLI | 存在しない ❌ |

## 変更ファイル

- `chezmoi/.chezmoiscripts/run_onchange_install-gemini-warp_windows.ps1.tmpl`
- `chezmoi/.chezmoiscripts/run_onchange_install-gemini-warp_linux.sh.tmpl`
- `chezmoi/dot_config/opencode/opencode.json`

## Test plan

- [ ] `chezmoi apply` を実行して Gemini Warp extension がインストールされることを確認
- [ ] `~/.config/opencode/opencode.json` が正しく展開されることを確認
- [ ] Warp terminal で Gemini CLI / Opencode を起動してノーティフィケーションが動作することを確認

Closes LIF-115

🤖 Generated with [Claude Code](https://claude.com/claude-code)