### PR TITLE
fix(chezmoi): harden Linux/Darwin claude-plugins with --ff-only and strict mode

### DIFF
--- a/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_darwin.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_darwin.sh.tmpl
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # Claude Code プラグイン マーケットプレース インストールスクリプト
 # Generated from: {{ range .claude_marketplaces }}{{ .repo }} {{ end }}
 
@@ -15,7 +16,7 @@ if [ ! -d "$TARGET_DIR" ]; then
     git clone "https://github.com/{{ .repo }}.git" "$TARGET_DIR"
 else
     echo "Updating {{ .name }}..."
-    cd "$TARGET_DIR" && git pull
+    git -C "$TARGET_DIR" pull --ff-only 2>&1 || echo "Warning: git pull failed for {{ .name }}, skipping"
 fi
 
 {{ end -}}

--- a/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_darwin.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_darwin.sh.tmpl
@@ -13,7 +13,9 @@ mkdir -p "$MARKETPLACES_DIR"
 TARGET_DIR="$MARKETPLACES_DIR/{{ .name }}"
 if [ ! -d "$TARGET_DIR" ]; then
     echo "Cloning {{ .name }}..."
-    git clone "https://github.com/{{ .repo }}.git" "$TARGET_DIR"
+    if ! git clone "https://github.com/{{ .repo }}.git" "$TARGET_DIR" 2>&1; then
+        echo "Warning: git clone failed for {{ .name }}, skipping"
+    fi
 else
     echo "Updating {{ .name }}..."
     git -C "$TARGET_DIR" pull --ff-only 2>&1 || echo "Warning: git pull failed for {{ .name }}, skipping"

--- a/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_linux.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_linux.sh.tmpl
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # Claude Code プラグイン マーケットプレース インストールスクリプト
 # Generated from: {{ range .claude_marketplaces }}{{ .repo }} {{ end }}
 
@@ -15,7 +16,7 @@ if [ ! -d "$TARGET_DIR" ]; then
     git clone "https://github.com/{{ .repo }}.git" "$TARGET_DIR"
 else
     echo "Updating {{ .name }}..."
-    cd "$TARGET_DIR" && git pull
+    git -C "$TARGET_DIR" pull --ff-only 2>&1 || echo "Warning: git pull failed for {{ .name }}, skipping"
 fi
 
 {{ end -}}

--- a/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_linux.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_linux.sh.tmpl
@@ -13,7 +13,9 @@ mkdir -p "$MARKETPLACES_DIR"
 TARGET_DIR="$MARKETPLACES_DIR/{{ .name }}"
 if [ ! -d "$TARGET_DIR" ]; then
     echo "Cloning {{ .name }}..."
-    git clone "https://github.com/{{ .repo }}.git" "$TARGET_DIR"
+    if ! git clone "https://github.com/{{ .repo }}.git" "$TARGET_DIR" 2>&1; then
+        echo "Warning: git clone failed for {{ .name }}, skipping"
+    fi
 else
     echo "Updating {{ .name }}..."
     git -C "$TARGET_DIR" pull --ff-only 2>&1 || echo "Warning: git pull failed for {{ .name }}, skipping"


### PR DESCRIPTION
## Summary

- `run_always_install-claude-plugins_linux.sh.tmpl` と `_darwin.sh.tmpl` を強化
- `set -euo pipefail` を追加（サイレント失敗を早期検出）
- `cd "$TARGET_DIR" && git pull` → `git -C "$TARGET_DIR" pull --ff-only 2>&1 || echo "Warning: ..."` に変更

## Why

PR #67 で `run_onchange` → `run_always` に移行したことで毎回実行されるようになり、以下の潜在的問題が顕在化:
- 裸の `git pull` はローカル変更がある場合にマージ競合を引き起こす可能性がある
- `set -euo pipefail` がないとサイレント失敗が見えにくい

Windows 版は既に `--ff-only` + エラー握り潰しを実装済み。今回 Linux / Darwin を同水準に揃える。

Closes LIF-119

## Test plan

- [ ] Linux / Darwin で `chezmoi apply` を実行してスクリプトが正常完了することを確認
- [ ] marketplace ディレクトリが存在する状態で `chezmoi apply` を実行して `git pull --ff-only` が走ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)