### PR TITLE
fix(wsl): re-register WSLInterop binfmt entry on NixOS boot

### DIFF
--- a/nix/hosts/wsl/configuration.nix
+++ b/nix/hosts/wsl/configuration.nix
@@ -15,10 +15,6 @@
   wsl.enable = true;
   wsl.defaultUser = "nixos";
 
-  # Re-register WSLInterop binfmt entry after systemd clears it on boot.
-  # Without this, Windows .exe files (e.g. VS Code) cannot be executed from WSL.
-  wsl.interop.register = true;
-
   # Enable Docker Desktop WSL integration
   # Required for kind to use Docker Desktop as container runtime
   mySettings.wsl.dockerDesktopIntegration = true;

--- a/nix/hosts/wsl/configuration.nix
+++ b/nix/hosts/wsl/configuration.nix
@@ -15,6 +15,10 @@
   wsl.enable = true;
   wsl.defaultUser = "nixos";
 
+  # Re-register WSLInterop binfmt entry after systemd clears it on boot.
+  # Without this, Windows .exe files (e.g. VS Code) cannot be executed from WSL.
+  wsl.interop.register = true;
+
   # Enable Docker Desktop WSL integration
   # Required for kind to use Docker Desktop as container runtime
   mySettings.wsl.dockerDesktopIntegration = true;

--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -21,6 +21,10 @@
     ];
   };
 
+  # Re-register WSLInterop binfmt entry after systemd clears it on boot.
+  # Without this, Windows .exe files (e.g. VS Code) cannot be executed from WSL.
+  wsl.interop.register = true;
+
   # WSL のデフォルトでは /etc/hosts を毎回上書きするため generateHosts = false で無効化し、
   # NixOS が networking.extraHosts 経由で /etc/hosts を管理できるようにする。
   wsl.wslConf.network.generateHosts = false;


### PR DESCRIPTION
## Summary

- NixOS-WSL + systemd 環境で `code` などの Windows コマンドが `Exec format error` で起動できない問題を修正
- 根本原因: systemd の binfmt.d が起動時に WSL カーネルの `WSLInterop` binfmt エントリを消去する
- `wsl.interop.register = true` を追加し、NixOS activation 時に WSLInterop エントリを再登録するよう設定

## Test plan

- [ ] `sudo nixos-rebuild switch --flake . --impure` を実行
- [ ] WSL 再起動後に `/proc/sys/fs/binfmt_misc/WSLInterop` が存在することを確認
- [ ] `code .` が正常に VS Code を起動することを確認

Closes LIF-118

🤖 Generated with [Claude Code](https://claude.com/claude-code)