### PR TITLE
feat(warp): align AI natural language search to Ctrl+Space leader convention

### DIFF
--- a/chezmoi/terminals/warp/keybindings.yaml
+++ b/chezmoi/terminals/warp/keybindings.yaml
@@ -20,3 +20,6 @@ pane_group:navigate_right: ctrl-shift-L
 # Tab navigation — matches Windows Terminal (Ctrl+Tab / Ctrl+Shift+Tab)
 workspace:activate_next_tab: ctrl-tab
 workspace:activate_prev_tab: ctrl-shift-tab
+
+# AI natural language search — matches WezTerm/nvim leader (Ctrl+Space / Space)
+input:toggle_natural_language_command_search: ctrl-space

--- a/docs/chezmoi/keybindings.md
+++ b/docs/chezmoi/keybindings.md
@@ -29,6 +29,12 @@
 - Windows Terminal
   - `Ctrl+Shift+H/J/K/L`: ペイン移動
   - `Ctrl+Alt+H/V/X/W`: 分割/close/ズーム
+- Warp
+  - `Ctrl+Shift+H/J/K/L`: ペイン移動
+  - `Ctrl+Alt+H/V`: 分割
+  - `Ctrl+Space`: AI natural language search（nvim/WezTerm leader に合わせた統一キー）
+  - `Ctrl+Enter`: AI agent へ送信（Warp ハードコード、変更不可）
+  - `Ctrl+Y`: AI agent 会話を継続（Warp ハードコード、変更不可）
 
 ### Editors
 


### PR DESCRIPTION
## Summary

- `keybindings.yaml` に `input:toggle_natural_language_command_search: ctrl-space` を追加
- `docs/chezmoi/keybindings.md` に Warp セクションを追加

## Why

| ツール | Leader |
|--------|--------|
| nvim | `Space` |
| WezTerm | `Ctrl+Space` (leader prefix) |
| Warp AI NL search | `Ctrl+Space` ← **今回追加** |

Warp の AI agent 操作（`Ctrl+Enter` send / `Ctrl+Y` continue）はハードコードで変更不可。唯一 keybindings.yaml で変更できる `input:toggle_natural_language_command_search` を `Ctrl+Space` に割り当てて統一感を出す。

Closes LIF-120

## Test plan

- [ ] Warp で `Ctrl+Space` を押して AI natural language search が開くことを確認
- [ ] `chezmoi apply` で keybindings.yaml が正しく展開されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)