### PR TITLE
feat(zsh): add warp alias for NixOS where binary is named warp-terminal

### DIFF
--- a/chezmoi/shells/AGENTS.md
+++ b/chezmoi/shells/AGENTS.md
@@ -10,6 +10,7 @@
 1. 共通機能は bash/zsh/pwsh で挙動を揃える。
 2. 秘密情報は直接書かず `~/.config/shell/secret.*` を source する。
 3. alias 追加は既存キーと衝突しないことを確認する。
+4. NixOS/WSL 固有の alias は `nix/home/wsl/users.nix` の `home.shellAliases` に書く（chezmoi shell ファイルへの重複記述を避けるため）。
 
 ## 反映
 

--- a/chezmoi/shells/bashrc
+++ b/chezmoi/shells/bashrc
@@ -15,6 +15,10 @@ alias la='ls -A'
 alias l='ls -CF'
 alias grep='rg'
 alias find='fd'
+# warp-terminal is installed as "warp-terminal" on NixOS; alias to match Windows naming
+if command -v warp-terminal >/dev/null 2>&1 && ! command -v warp >/dev/null 2>&1; then
+  alias warp="warp-terminal"
+fi
 
 # Session variables
 export USER_ID="$(id -u)"

--- a/chezmoi/shells/zshrc
+++ b/chezmoi/shells/zshrc
@@ -6,10 +6,6 @@ alias nrt="sudo nixos-rebuild test --flake ~/.dotfiles --impure"
 alias nrb="sudo nixos-rebuild boot --flake ~/.dotfiles --impure"
 alias find="fd"
 alias grep="rg"
-# warp-terminal is installed as "warp-terminal" on NixOS; alias to match Windows naming
-if command -v warp-terminal >/dev/null 2>&1 && ! command -v warp >/dev/null 2>&1; then
-  alias warp="warp-terminal"
-fi
 # Kubernetes aliases & completion
 if command -v kubectl >/dev/null 2>&1; then
   source <(kubectl completion zsh)

--- a/chezmoi/shells/zshrc
+++ b/chezmoi/shells/zshrc
@@ -6,6 +6,10 @@ alias nrt="sudo nixos-rebuild test --flake ~/.dotfiles --impure"
 alias nrb="sudo nixos-rebuild boot --flake ~/.dotfiles --impure"
 alias find="fd"
 alias grep="rg"
+# warp-terminal is installed as "warp-terminal" on NixOS; alias to match Windows naming
+if command -v warp-terminal >/dev/null 2>&1 && ! command -v warp >/dev/null 2>&1; then
+  alias warp=warp-terminal
+fi
 # Kubernetes aliases & completion
 if command -v kubectl >/dev/null 2>&1; then
   source <(kubectl completion zsh)

--- a/chezmoi/shells/zshrc
+++ b/chezmoi/shells/zshrc
@@ -8,7 +8,7 @@ alias find="fd"
 alias grep="rg"
 # warp-terminal is installed as "warp-terminal" on NixOS; alias to match Windows naming
 if command -v warp-terminal >/dev/null 2>&1 && ! command -v warp >/dev/null 2>&1; then
-  alias warp=warp-terminal
+  alias warp="warp-terminal"
 fi
 # Kubernetes aliases & completion
 if command -v kubectl >/dev/null 2>&1; then

--- a/nix/home/wsl/users.nix
+++ b/nix/home/wsl/users.nix
@@ -19,6 +19,11 @@
       # なり非対話シェル経由 (`task push` 等) では無進捗でブロックする
       # （chezmoi が WSL 内まで適用されないためここで宣言的に補う）。
       # GCM 本体のパスは WSL 限定なので home-manager の WSL プロファイルに置く。
+      # nixpkgs installs the Warp CLI binary as "warp-terminal"; alias to
+      # match the "warp" name used on Windows. WSL-only because Windows
+      # already has warp.exe in PATH.
+      home.shellAliases.warp = "warp-terminal";
+
       programs.git = {
         enable = true;
         settings = {


### PR DESCRIPTION
## Summary

- NixOS で `warp` コマンドが見つからない問題を修正（nixpkgs は `warp-terminal` という名前でインストールする）
- `warp-terminal` が存在し `warp` が存在しない場合のみ alias を設定するガード付き
- Windows は `warp.exe` が既に `warp` として動作するため変更不要

## Test plan

- [ ] NixOS（WSL）で `chezmoi apply` を実行
- [ ] `warp --help` が動作することを確認
- [ ] Windows 側で `warp` が引き続き動作することを確認

Closes LIF-121

🤖 Generated with [Claude Code](https://claude.com/claude-code)