### PR TITLE
fix(gitattributes): prevent UTF-8 BOM in PowerShell files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,10 @@
 # デフォルトの動作: すべてのテキストファイルはLFに正規化
 * text=auto
 
-# PowerShellスクリプトはCRLFを使用
-*.ps1 text eol=crlf
-*.psm1 text eol=crlf
-*.psd1 text eol=crlf
+# PowerShellスクリプトはCRLFを使用、UTF-8 BOMなし
+*.ps1 text eol=crlf working-tree-encoding=UTF-8
+*.psm1 text eol=crlf working-tree-encoding=UTF-8
+*.psd1 text eol=crlf working-tree-encoding=UTF-8
 
 # Windowsバッチファイル/コマンドファイルはCRLFを使用
 *.bat text eol=crlf


### PR DESCRIPTION
## Summary

- Add `working-tree-encoding=UTF-8` to `.ps1`, `.psm1`, `.psd1` entries in `.gitattributes`
- Prevents Windows editors from silently introducing UTF-8 BOM into PowerShell scripts
- Git will normalize checkout to UTF-8 without BOM regardless of editor settings

Closes LIF-124

## Test plan

- [ ] Verify `git check-attr working-tree-encoding scripts/powershell/handlers/Handler.ClaudeCode.ps1` returns `UTF-8`
- [ ] Confirm existing PowerShell tests still pass after re-checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)