### PR TITLE
ci: update GitHub Actions versions and harden workflow configs

### DIFF
--- a/.github/workflows/test-consistency.yml
+++ b/.github/workflows/test-consistency.yml
@@ -1,6 +1,7 @@
 name: Package Consistency
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths:
@@ -10,18 +11,23 @@ on:
       - "windows/pnpm/packages.json"
       - ".github/workflows/test-consistency.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Nix
-        uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           extra_nix_config: |
             accept-flake-config = true

--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -1,6 +1,7 @@
 name: Nix Checks
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths:
@@ -9,18 +10,23 @@ on:
       - "flake.lock"
       - ".github/workflows/test-nix.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Nix
-        uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           extra_nix_config: |
             accept-flake-config = true

--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -1,12 +1,16 @@
 name: PowerShell Tests
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths:
       - "scripts/powershell/**"
-      - "install.ps1"
       - ".github/workflows/test-powershell.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -14,9 +18,10 @@ permissions:
 jobs:
   test:
     runs-on: windows-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Pester
         shell: pwsh
         run: |
@@ -40,7 +45,8 @@ jobs:
             "./handlers/Handler.WslConfig.ps1",
             "./handlers/Handler.Docker.ps1",
             "./handlers/Handler.VscodeServer.ps1",
-            "./handlers/Handler.Chezmoi.ps1"
+            "./handlers/Handler.Chezmoi.ps1",
+            "./handlers/Handler.ClaudeCode.ps1"
           ) | Where-Object { Test-Path $_ }
 
           if ($sourceFiles.Count -gt 0) {
@@ -75,7 +81,7 @@ jobs:
           }
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         if: always()
         with:
           files: scripts/powershell/coverage.xml
@@ -85,7 +91,7 @@ jobs:
           verbose: true
 
       - name: Upload test results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: test-results


### PR DESCRIPTION
## Summary

Closes LIF-123

GitHub Actions ワークフロー3本のアクションバージョン更新と設定強化。

- **`actions/upload-artifact` v4.4.3 → v7.0.1** (3メジャー遅れを解消)
- **`codecov/codecov-action` v5.5.3 → v6.0.0**
- **`actions/checkout` → v6.0.2** (SHA更新)
- **`cachix/install-nix-action` → v31.10.6** (SHA更新)
- `concurrency` グループ追加 — PR への連続 push で旧ランを自動キャンセル
- `timeout-minutes` 追加 — powershell: 20分、nix系: 30分
- `workflow_dispatch` トリガー追加 — 手動再実行が可能に
- `Handler.ClaudeCode.ps1` をカバレッジ対象に追加
- 存在しない `install.ps1` を path トリガーから削除

## Test plan

- [ ] PR CI (PowerShell Tests / Nix Checks / Package Consistency) がすべてグリーン
- [ ] `workflow_dispatch` で手動トリガーが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)