### PR TITLE
ci: add cross-platform environment smoke tests

### DIFF
--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -34,10 +34,28 @@ jobs:
       - name: Check flake evaluation
         run: nix flake check --no-build
 
-      - name: Build package sets (dry-run)
+      - name: Build package sets
         run: |
-          nix build .#minimal --dry-run
-          nix build .#default --dry-run
+          nix build .#minimal
+          nix build .#default
+
+      - name: Smoke test core tools
+        run: |
+          nix shell .#default --command bash -c '
+            set -euo pipefail
+            echo "=== Smoke testing core tools ==="
+            chezmoi --version
+            git --version
+            gh --version
+            fd --version
+            rg --version
+            bat --version
+            jq --version
+            eza --version
+            zoxide --version
+            fzf --version
+            echo "=== All core tools OK ==="
+          '
 
       - name: Check formatting
         run: nix fmt -- --fail-on-change

--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -43,17 +43,24 @@ jobs:
         run: |
           nix shell .#default --command bash -c '
             set -euo pipefail
+            check() {
+              local name=$1; shift
+              local out
+              out=$("$name" "$@" 2>&1) || { echo "FAIL $name (exit $?)"; exit 1; }
+              echo "OK  $name: $out"
+            }
             echo "=== Smoke testing core tools ==="
-            chezmoi --version
-            git --version
-            gh --version
-            fd --version
-            rg --version
-            bat --version
-            jq --version
-            eza --version
-            zoxide --version
-            fzf --version
+            check chezmoi --version
+            check git --version
+            check gh --version
+            check fd --version
+            check rg --version
+            check bat --version
+            check jq --version
+            check eza --version
+            check zoxide --version
+            check fzf --version
+            check unzip -v
             echo "=== All core tools OK ==="
           '
 

--- a/.github/workflows/test-winget.yml
+++ b/.github/workflows/test-winget.yml
@@ -1,0 +1,84 @@
+name: Windows Environment Smoke Test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - "windows/winget/packages.json"
+      - "nix/packages/sets.nix"
+      - ".github/workflows/test-winget.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Bootstrap winget
+        shell: pwsh
+        run: |
+          # Ensure winget is available on the runner
+          if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+            Write-Host "Installing Microsoft.WinGet.Client..."
+            Install-PackageProvider -Name NuGet -Force | Out-Null
+            Install-Module -Name Microsoft.WinGet.Client -Force -Repository PSGallery | Out-Null
+            Repair-WinGetPackageManager -AllUsers
+          }
+          winget --version
+
+      - name: Import packages from winget packages.json
+        shell: pwsh
+        run: |
+          winget import `
+            --import-file windows/winget/packages.json `
+            --ignore-unavailable `
+            --no-upgrade `
+            --accept-package-agreements `
+            --accept-source-agreements
+
+      - name: Smoke test core tools
+        shell: pwsh
+        run: |
+          # Refresh PATH to include newly installed tools
+          $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" +
+                      [System.Environment]::GetEnvironmentVariable("PATH", "User")
+
+          $tools = @(
+            @{ cmd = "chezmoi";  args = "--version" },
+            @{ cmd = "git";      args = "--version" },
+            @{ cmd = "gh";       args = "--version" },
+            @{ cmd = "fd";       args = "--version" },
+            @{ cmd = "rg";       args = "--version" },
+            @{ cmd = "jq";       args = "--version" },
+            @{ cmd = "eza";      args = "--version" },
+            @{ cmd = "zoxide";   args = "--version" },
+            @{ cmd = "fzf";      args = "--version" }
+          )
+
+          Write-Host "=== Smoke testing core tools ==="
+          $failed = @()
+          foreach ($tool in $tools) {
+            try {
+              $output = & $tool.cmd $tool.args 2>&1
+              Write-Host "OK  $($tool.cmd): $output"
+            } catch {
+              Write-Host "FAIL $($tool.cmd): $_" -ForegroundColor Red
+              $failed += $tool.cmd
+            }
+          }
+
+          if ($failed.Count -gt 0) {
+            Write-Error "Failed tools: $($failed -join ', ')"
+            exit 1
+          }
+          Write-Host "=== All core tools OK ==="

--- a/.github/workflows/test-winget.yml
+++ b/.github/workflows/test-winget.yml
@@ -30,9 +30,15 @@ jobs:
           # Ensure winget is available on the runner
           if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
             Write-Host "Installing Microsoft.WinGet.Client..."
-            Install-PackageProvider -Name NuGet -Force | Out-Null
-            Install-Module -Name Microsoft.WinGet.Client -Force -Repository PSGallery | Out-Null
+            Install-PackageProvider -Name NuGet -Force
+            Install-Module -Name Microsoft.WinGet.Client -Force -Repository PSGallery
             Repair-WinGetPackageManager -AllUsers
+          }
+          # Validate winget is functional before proceeding
+          winget source update
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "winget source update failed (exit $LASTEXITCODE)"
+            exit 1
           }
           winget --version
 
@@ -45,35 +51,46 @@ jobs:
             --no-upgrade `
             --accept-package-agreements `
             --accept-source-agreements
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "winget import failed (exit $LASTEXITCODE)"
+            exit 1
+          }
 
       - name: Smoke test core tools
         shell: pwsh
         run: |
-          # Refresh PATH to include newly installed tools
-          $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" +
-                      [System.Environment]::GetEnvironmentVariable("PATH", "User")
+          # Merge registry paths with current process PATH so newly installed
+          # tools are discoverable while preserving runner-injected entries
+          $machinePath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
+          $userPath = [System.Environment]::GetEnvironmentVariable("PATH", "User")
+          $env:PATH = "$machinePath;$userPath;$env:PATH"
 
           $tools = @(
-            @{ cmd = "chezmoi";  args = "--version" },
-            @{ cmd = "git";      args = "--version" },
-            @{ cmd = "gh";       args = "--version" },
-            @{ cmd = "fd";       args = "--version" },
-            @{ cmd = "rg";       args = "--version" },
-            @{ cmd = "jq";       args = "--version" },
-            @{ cmd = "eza";      args = "--version" },
-            @{ cmd = "zoxide";   args = "--version" },
-            @{ cmd = "fzf";      args = "--version" }
+            @{ cmd = "chezmoi"; args = "--version" },
+            @{ cmd = "git";     args = "--version" },
+            @{ cmd = "gh";      args = "--version" },
+            @{ cmd = "fd";      args = "--version" },
+            @{ cmd = "rg";      args = "--version" },
+            @{ cmd = "jq";      args = "--version" },
+            @{ cmd = "eza";     args = "--version" },
+            @{ cmd = "zoxide";  args = "--version" },
+            @{ cmd = "fzf";     args = "--version" }
           )
 
           Write-Host "=== Smoke testing core tools ==="
           $failed = @()
           foreach ($tool in $tools) {
-            try {
-              $output = & $tool.cmd $tool.args 2>&1
-              Write-Host "OK  $($tool.cmd): $output"
-            } catch {
-              Write-Host "FAIL $($tool.cmd): $_" -ForegroundColor Red
+            if (-not (Get-Command $tool.cmd -ErrorAction SilentlyContinue)) {
+              Write-Host "FAIL $($tool.cmd): not found in PATH" -ForegroundColor Red
               $failed += $tool.cmd
+              continue
+            }
+            $output = & $tool.cmd $tool.args 2>&1
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "FAIL $($tool.cmd): exit code $LASTEXITCODE" -ForegroundColor Red
+              $failed += $tool.cmd
+            } else {
+              Write-Host "OK  $($tool.cmd): $output"
             }
           }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -272,14 +272,14 @@ flowchart TD
     PR["Pull Request"]
 
     PR -->|"nix/** flake.*"| NX
-    PR -->|"windows/winget/** nix/packages/sets.nix"| WG
+    PR -->|"windows/winget/packages.json\nnix/packages/sets.nix"| WG
     PR -->|"nix/packages/** windows/winget/**"| CO
     PR -->|"scripts/powershell/**"| PS
 
     subgraph NX["test-nix.yml (ubuntu-latest)"]
         N1["① nix flake check\n評価エラー検知"]
         N2["② nix build .#default\n実ビルド"]
-        N3["③ nix shell smoke test\nchezmoi git gh fd rg bat jq eza zoxide fzf"]
+        N3["③ nix shell smoke test\nchezmoi git gh fd rg bat jq eza zoxide fzf unzip"]
         N4["④ nix fmt\nフォーマット確認"]
         N1 --> N2 --> N3 --> N4
     end
@@ -305,12 +305,12 @@ flowchart TD
 
 ### ワークフロー詳細
 
-| Workflow               | ランナー       | 何を保証するか                                       | トリガー                                     |
-| ---------------------- | -------------- | ---------------------------------------------------- | -------------------------------------------- |
-| `test-nix.yml`         | ubuntu-latest  | Nix 式が評価でき、バイナリがビルドでき、ツールが動く | `nix/**`, `flake.*`                          |
-| `test-winget.yml`      | windows-latest | winget パッケージがインストールでき、ツールが動く    | `windows/winget/**`, `nix/packages/sets.nix` |
-| `test-consistency.yml` | ubuntu-latest  | Nix 定義と `windows/winget/packages.json` が一致     | `nix/packages/**`, `windows/winget/**`       |
-| `test-powershell.yml`  | windows-latest | PowerShell ハンドラーのロジックが正しく動く          | `scripts/powershell/**`                      |
+| Workflow               | ランナー       | 何を保証するか                                       | トリガー                                                |
+| ---------------------- | -------------- | ---------------------------------------------------- | ------------------------------------------------------- |
+| `test-nix.yml`         | ubuntu-latest  | Nix 式が評価でき、バイナリがビルドでき、ツールが動く | `nix/**`, `flake.*`                                     |
+| `test-winget.yml`      | windows-latest | winget パッケージがインストールでき、ツールが動く    | `windows/winget/packages.json`, `nix/packages/sets.nix` |
+| `test-consistency.yml` | ubuntu-latest  | Nix 定義と `windows/winget/packages.json` が一致     | `nix/packages/**`, `windows/winget/**`                  |
+| `test-powershell.yml`  | windows-latest | PowerShell ハンドラーのロジックが正しく動く          | `scripts/powershell/**`                                 |
 
 ### テストレベルの判断基準
 
@@ -325,20 +325,20 @@ flowchart TD
 
 ### 検証ツール一覧
 
-| ツール  | Nix smoke test | winget smoke test | 備考           |
-| ------- | :------------: | :---------------: | -------------- |
-| chezmoi |       ✅       |        ✅         |                |
-| git     |       ✅       |        ✅         |                |
-| gh      |       ✅       |        ✅         |                |
-| fd      |       ✅       |        ✅         |                |
-| rg      |       ✅       |        ✅         | ripgrep        |
-| bat     |       ✅       |        ❌         | winget ID なし |
-| jq      |       ✅       |        ✅         |                |
-| eza     |       ✅       |        ✅         |                |
-| zoxide  |       ✅       |        ✅         |                |
-| fzf     |       ✅       |        ✅         |                |
-| unzip   |       ✅       |        ❌         | winget ID なし |
-| p7zip   |       ✅       |        ❌         | winget ID なし |
+| ツール  | Nix smoke test | winget smoke test | 備考                             |
+| ------- | :------------: | :---------------: | -------------------------------- |
+| chezmoi |       ✅       |        ✅         |                                  |
+| git     |       ✅       |        ✅         |                                  |
+| gh      |       ✅       |        ✅         |                                  |
+| fd      |       ✅       |        ✅         |                                  |
+| rg      |       ✅       |        ✅         | ripgrep                          |
+| bat     |       ✅       |        ❌         | winget ID なし                   |
+| jq      |       ✅       |        ✅         |                                  |
+| eza     |       ✅       |        ✅         |                                  |
+| zoxide  |       ✅       |        ✅         |                                  |
+| fzf     |       ✅       |        ✅         |                                  |
+| unzip   |       ✅       |        ❌         | winget ID なし                   |
+| p7zip   |       ❌       |        ❌         | winget ID なし、CLI 動作が不安定 |
 
 ### CI で意図的に実行しないもの
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -258,44 +258,97 @@ Should -Invoke Invoke-Wsl -Times 1 -Exactly
 ### テストピラミッド
 
 ```
-          /  E2E  \          ← ローカル手動: VM で実際にインストール
-         /  Build  \         ← CI: nix build、NixOS config ビルド
-        / Integration\       ← CI: nixos-rebuild (dry)、install.cmd
-       /  Unit Tests  \      ← CI: Pester、パッケージ整合性
-      / Static Analysis\     ← CI: flake check、lint、fmt
+       /   Smoke Test   \    ← CI: nix shell --version、winget + --version
+      /    Build Test    \   ← CI: nix build .#default（実ビルド）
+     / Consistency Test  \   ← CI: winget-export diff（JSON 整合性）
+    /     Unit Tests      \  ← CI: Pester（PowerShell ハンドラー）
+   /   Static Analysis    \  ← CI: flake check、lint、fmt
 ```
 
-### CI (GitHub Actions) で実行するテスト
+### CI ワークフロー全体像
 
-| Workflow               | ランナー | テスト内容                                                                                                                        |
-| ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `test-nix.yml`         | Linux    | `nix flake check --no-build` (評価エラー検知)、`nix fmt -- --fail-on-change` (フォーマット)、`nix build --dry-run` (ビルド可能性) |
-| `test-powershell.yml`  | Windows  | PSScriptAnalyzer (lint)、Pester ユニットテスト (ハンドラー)                                                                       |
-| `test-consistency.yml` | Linux    | `nix build .#winget-export` と `windows/winget/packages.json` の diff                                                             |
+```mermaid
+flowchart TD
+    PR["Pull Request"]
 
-### テスト対象の判断基準
+    PR -->|"nix/** flake.*"| NX
+    PR -->|"windows/winget/** nix/packages/sets.nix"| WG
+    PR -->|"nix/packages/** windows/winget/**"| CO
+    PR -->|"scripts/powershell/**"| PS
 
-| レベル          | 対象                       | 方法                         | 場所         |
-| --------------- | -------------------------- | ---------------------------- | ------------ |
-| Static Analysis | nix 構文、フォーマット     | `nix flake check`、`nix fmt` | CI (Linux)   |
-| Unit Test       | PowerShell ハンドラー      | Pester + モック              | CI (Windows) |
-| Unit Test       | パッケージ整合性           | winget-export diff           | CI (Linux)   |
-| Build Test      | NixOS config、package sets | `nix build --dry-run`        | CI (Linux)   |
-| E2E             | 実際のインストール         | 手動実行                     | ローカル     |
+    subgraph NX["test-nix.yml (ubuntu-latest)"]
+        N1["① nix flake check\n評価エラー検知"]
+        N2["② nix build .#default\n実ビルド"]
+        N3["③ nix shell smoke test\nchezmoi git gh fd rg bat jq eza zoxide fzf"]
+        N4["④ nix fmt\nフォーマット確認"]
+        N1 --> N2 --> N3 --> N4
+    end
 
-### CI で実行しないもの
+    subgraph WG["test-winget.yml (windows-latest)"]
+        W1["① winget import\npackages.json 全量インストール"]
+        W2["② smoke test\nchezmoi git gh fd rg jq eza zoxide fzf"]
+        W1 --> W2
+    end
 
-- **Vagrant/Ansible による VM テスト**: GitHub Actions 標準ランナーはネスト仮想化非対応。個人リポジトリに有料ランナーは過剰
-- **Windows E2E**: UAC、GUI インストーラー等の自動化が困難
-- **NixOS VM test (`nixosTest`)**: 将来オプション。systemd サービスのテストが必要になったら追加
+    subgraph CO["test-consistency.yml (ubuntu-latest)"]
+        C1["① nix build .#winget-export\nNix から JSON 生成"]
+        C2["② diff\n生成 JSON ↔ リポジトリ JSON"]
+        C1 --> C2
+    end
 
-### GitHub Actions 無料枠 (public repo)
+    subgraph PS["test-powershell.yml (windows-latest)"]
+        P1["① Pester\nユニットテスト"]
+        P2["② Codecov\nカバレッジ"]
+        P1 --> P2
+    end
+```
 
-| ランナー | 無料枠/月 | 消費レート |
-| -------- | --------- | ---------- |
-| Linux    | 2,000 分  | 1x         |
-| Windows  | 2,000 分  | 2x         |
-| macOS    | 2,000 分  | 10x        |
+### ワークフロー詳細
+
+| Workflow               | ランナー       | 何を保証するか                                       | トリガー                                     |
+| ---------------------- | -------------- | ---------------------------------------------------- | -------------------------------------------- |
+| `test-nix.yml`         | ubuntu-latest  | Nix 式が評価でき、バイナリがビルドでき、ツールが動く | `nix/**`, `flake.*`                          |
+| `test-winget.yml`      | windows-latest | winget パッケージがインストールでき、ツールが動く    | `windows/winget/**`, `nix/packages/sets.nix` |
+| `test-consistency.yml` | ubuntu-latest  | Nix 定義と `windows/winget/packages.json` が一致     | `nix/packages/**`, `windows/winget/**`       |
+| `test-powershell.yml`  | windows-latest | PowerShell ハンドラーのロジックが正しく動く          | `scripts/powershell/**`                      |
+
+### テストレベルの判断基準
+
+| レベル           | 対象                          | 方法                              | ワークフロー     |
+| ---------------- | ----------------------------- | --------------------------------- | ---------------- |
+| Static Analysis  | Nix 構文、フォーマット        | `nix flake check`, `nix fmt`      | test-nix         |
+| Unit Test        | PowerShell ハンドラー         | Pester + モック                   | test-powershell  |
+| Consistency Test | SSOT ↔ 生成 JSON              | winget-export diff                | test-consistency |
+| Build Test       | Nix package sets              | `nix build .#default`（実ビルド） | test-nix         |
+| Smoke Test       | core CLI ツール（Nix 側）     | `nix shell` + `--version`         | test-nix         |
+| Smoke Test       | core CLI ツール（Windows 側） | `winget import` + `--version`     | test-winget      |
+
+### 検証ツール一覧
+
+| ツール  | Nix smoke test | winget smoke test | 備考           |
+| ------- | :------------: | :---------------: | -------------- |
+| chezmoi |       ✅       |        ✅         |                |
+| git     |       ✅       |        ✅         |                |
+| gh      |       ✅       |        ✅         |                |
+| fd      |       ✅       |        ✅         |                |
+| rg      |       ✅       |        ✅         | ripgrep        |
+| bat     |       ✅       |        ❌         | winget ID なし |
+| jq      |       ✅       |        ✅         |                |
+| eza     |       ✅       |        ✅         |                |
+| zoxide  |       ✅       |        ✅         |                |
+| fzf     |       ✅       |        ✅         |                |
+| unzip   |       ✅       |        ❌         | winget ID なし |
+| p7zip   |       ✅       |        ❌         | winget ID なし |
+
+### CI で意図的に実行しないもの
+
+- **Windows GUI アプリの E2E**: VS Code, Docker Desktop 等は UAC・GUI インストーラーが自動化非対応
+- **WSL 内 nixos-rebuild switch**: GitHub Actions runner はネスト仮想化非対応
+- **NixOS VM test (`nixosTest`)**: systemd サービスのテストが必要になった時点で追加
+
+### GitHub Actions（public repo）
+
+public リポジトリは **Linux/Windows/macOS ランナーすべて無制限無料**。
 
 ---
 

--- a/docs/superpowers/specs/2026-05-09-cross-platform-ci-design.md
+++ b/docs/superpowers/specs/2026-05-09-cross-platform-ci-design.md
@@ -1,0 +1,97 @@
+---
+title: クロスプラットフォーム環境検証 CI 設計
+date: 2026-05-09
+status: implemented
+linear: LIF-127
+---
+
+# クロスプラットフォーム環境検証 CI 設計
+
+## 目的
+
+Nix（WSL/NixOS）と Windows（winget）で **同じ CLI ツールが実際に動く** ことを CI で自動検証する。
+「JSON が整合している」だけでなく、「バイナリが存在して `--version` が返る」レベルを保証する。
+
+## 背景・調査
+
+### 業界の実態
+
+| プロジェクト                | アプローチ                            | 何を保証するか        |
+| --------------------------- | ------------------------------------- | --------------------- |
+| 大多数の個人 NixOS dotfiles | `nix flake check` のみ                | Nix 式の評価可能性    |
+| eza, nix-community/nh       | `nix build .#checks.*`                | 実コンパイル + テスト |
+| home-manager 本体           | `home-manager switch` → uninstall     | 実際のユーザー体験    |
+| starship                    | インストール後に `starship --version` | バイナリ動作確認      |
+
+winget CI は個人 dotfiles では前例がほぼない。`windows-latest` runner では winget が標準で利用可能（Windows Server 2025）。
+
+### 設計決定
+
+**Approach A+B の組み合わせ:**
+
+- **Nix 側（B）**: `nix build` 実ビルド + `nix shell` でクロスプラットフォームツール全検証
+- **Windows 側（A）**: winget import + core ツールの `--version` スモークテスト
+- **既存の整合性チェック**: `test-consistency.yml` は変更なし
+
+Approach C（全量 winget + 全ツール検証）は winget Store API への依存による flakiness リスクを避けるため見送り。
+
+## アーキテクチャ
+
+```mermaid
+flowchart LR
+    SSOT["nix/packages/sets.nix\n(SSOT)"]
+
+    subgraph CI["GitHub Actions CI"]
+        direction TB
+        CNX["test-nix.yml\n(ubuntu-latest)\n① flake check\n② nix build .#default\n③ nix shell smoke test"]
+        CWG["test-winget.yml\n(windows-latest)\n① winget import\n② core tools smoke test"]
+        CCO["test-consistency.yml\n(ubuntu-latest)\n① nix build .#winget-export\n② JSON diff"]
+    end
+
+    SSOT --> CNX
+    SSOT --> CWG
+    SSOT --> CCO
+```
+
+## ワークフロー仕様
+
+### test-nix.yml（拡張）
+
+**トリガー**: `nix/**`, `flake.nix`, `flake.lock`
+
+| ステップ           | 変更前      | 変更後                                               |
+| ------------------ | ----------- | ---------------------------------------------------- |
+| Build package sets | `--dry-run` | 実ビルド                                             |
+| Smoke test         | なし        | **追加**: `nix shell .#default` で core ツール全検証 |
+
+**検証ツール**: chezmoi, git, gh, fd, rg, bat, jq, eza, zoxide, fzf
+
+### test-winget.yml（新規）
+
+**トリガー**: `windows/winget/packages.json`, `nix/packages/sets.nix`
+
+1. winget ブートストラップ（runner に未搭載の場合のみ）
+2. `winget import windows/winget/packages.json --ignore-unavailable --no-upgrade`
+3. core ツールの `--version` 確認
+
+**検証ツール（winget ID あり）**: chezmoi, git, gh, fd, rg, jq, eza, zoxide, fzf
+（bat/unzip/p7zip は winget ID なしのため対象外）
+
+### test-consistency.yml（変更なし）
+
+JSON 整合性チェックのみ。
+
+## トレードオフ
+
+| 項目                   | 判断                                       |
+| ---------------------- | ------------------------------------------ |
+| winget 全量 import     | ✅ 採用（packages.json のシナリオテスト）  |
+| Windows で全ツール検証 | ❌ core のみ（Store API flakiness を限定） |
+| home-manager switch    | ❌ 過剰（tool 本体の CI ではないため）     |
+| Cachix                 | ❌ 未設定（nixpkgs binary cache で十分）   |
+
+## 検証対象外（意図的）
+
+- bat, unzip, p7zip: winget ID なし → Windows インストール検証不可
+- Windows-only パッケージ（VS Code 等）: GUI インストーラーが CI 非対応
+- WSL 内での nixos-rebuild switch: runner がネスト仮想化非対応


### PR DESCRIPTION
## Summary

Closes LIF-127

Nix と Windows（winget）で同じ CLI ツールが実際に動くことを CI で自動検証する。

- **`test-nix.yml` 拡張**: `--dry-run` → 実ビルド + `nix shell` でスモークテスト追加
  - 検証ツール: chezmoi, git, gh, fd, rg, bat, jq, eza, zoxide, fzf
- **`test-winget.yml` 新規**: winget ブートストラップ → `winget import` 全量 → core ツール `--version`
  - 検証ツール: chezmoi, git, gh, fd, rg, jq, eza, zoxide, fzf
- **`docs/architecture.md` 更新**: Mermaid CI 全体図・テストピラミッド・ツール別カバレッジ表を追加
- **`docs/superpowers/specs/2026-05-09-cross-platform-ci-design.md` 新規**: 設計スペック

## Test plan

- [x] test-nix.yml: `nix build .#default` 実ビルドが通る（CI pass 確認）
- [x] test-nix.yml: `nix shell .#default` でコアツール全 OK（CI pass 確認）
- [ ] test-winget.yml: `winget import` + スモークテストが通る（PR #78 で winget import → targeted install に改善中）
- [x] docs の Mermaid ダイアグラムが正しくレンダリングされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)