### PR TITLE
ci: GitHub Actions ハードニング (LIF-126)

### DIFF
--- a/.github/workflows/test-consistency.yml
+++ b/.github/workflows/test-consistency.yml
@@ -2,11 +2,23 @@ name: Package Consistency
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "nix/packages/**"
+      - "nix/home/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "windows/winget/packages.json"
+      - "windows/pnpm/packages.json"
+      - ".github/workflows/test-consistency.yml"
   pull_request:
     branches: [main]
     paths:
       - "nix/packages/**"
       - "nix/home/**"
+      - "flake.nix"
+      - "flake.lock"
       - "windows/winget/packages.json"
       - "windows/pnpm/packages.json"
       - ".github/workflows/test-consistency.yml"
@@ -28,9 +40,6 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
-        with:
-          extra_nix_config: |
-            accept-flake-config = true
 
       - name: Build winget-export from SSOT
         run: nix build .#winget-export -o /tmp/winget-export

--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -2,6 +2,13 @@ name: Nix Checks
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "nix/**"
+      - "flake.nix"
+      - "flake.lock"
+      - ".github/workflows/test-nix.yml"
   pull_request:
     branches: [main]
     paths:
@@ -27,9 +34,6 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
-        with:
-          extra_nix_config: |
-            accept-flake-config = true
 
       - name: Check flake evaluation
         run: nix flake check --no-build

--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -2,6 +2,11 @@ name: PowerShell Tests
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/powershell/**"
+      - ".github/workflows/test-powershell.yml"
   pull_request:
     branches: [main]
     paths:
@@ -22,11 +27,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install Pester
+
+      - name: Install PowerShell modules
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module -Name Pester -MinimumVersion 5.5.0 -Scope CurrentUser -Force -SkipPublisherCheck
+          Install-Module -Name Pester           -RequiredVersion 5.6.1  -Scope CurrentUser -Force
+          Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.22.0 -Scope CurrentUser -Force
 
       - name: Run tests
         shell: pwsh
@@ -38,16 +45,11 @@ jobs:
           $pesterConfig.Run.PassThru = $true
           $pesterConfig.Output.Verbosity = "Detailed"
 
-          # Code coverage
+          # Code coverage — dynamic discovery
           $sourceFiles = @(
-            "./lib/SetupHandler.ps1",
-            "./lib/Invoke-ExternalCommand.ps1",
-            "./handlers/Handler.WslConfig.ps1",
-            "./handlers/Handler.Docker.ps1",
-            "./handlers/Handler.VscodeServer.ps1",
-            "./handlers/Handler.Chezmoi.ps1",
-            "./handlers/Handler.ClaudeCode.ps1"
-          ) | Where-Object { Test-Path $_ }
+            Get-ChildItem ./lib      -Filter "*.ps1"          -ErrorAction SilentlyContinue
+            Get-ChildItem ./handlers -Filter "Handler.*.ps1"  -ErrorAction SilentlyContinue
+          ) | Select-Object -ExpandProperty FullName
 
           if ($sourceFiles.Count -gt 0) {
             $pesterConfig.CodeCoverage.Enabled = $true
@@ -82,13 +84,12 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        if: always()
+        if: always() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           files: scripts/powershell/coverage.xml
           flags: powershell
           name: powershell-coverage
           fail_ci_if_error: false
-          verbose: true
 
       - name: Upload test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -99,3 +100,4 @@ jobs:
             scripts/powershell/test-results.xml
             scripts/powershell/coverage.xml
           retention-days: 30
+          if-no-files-found: ignore

--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -47,9 +47,13 @@ jobs:
 
           # Code coverage — dynamic discovery
           $sourceFiles = @(
-            Get-ChildItem ./lib      -Filter "*.ps1"          -ErrorAction SilentlyContinue
-            Get-ChildItem ./handlers -Filter "Handler.*.ps1"  -ErrorAction SilentlyContinue
+            Get-ChildItem ./lib      -Filter "*.ps1"         -ErrorAction SilentlyContinue
+            Get-ChildItem ./handlers -Filter "Handler.*.ps1" -ErrorAction SilentlyContinue
           ) | Select-Object -ExpandProperty FullName
+
+          if ($sourceFiles.Count -eq 0) {
+            Write-Warning "Coverage disabled: no source files found under ./lib or ./handlers (PWD: $PWD)"
+          }
 
           if ($sourceFiles.Count -gt 0) {
             $pesterConfig.CodeCoverage.Enabled = $true
@@ -100,4 +104,4 @@ jobs:
             scripts/powershell/test-results.xml
             scripts/powershell/coverage.xml
           retention-days: 30
-          if-no-files-found: ignore
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

CI レビューで発見されたセキュリティ・カバレッジ・信頼性の問題を修正。

- **Security:** `accept-flake-config = true` を削除（フォーク PR が flake.nix 経由で Nix デーモン設定を上書き可能）
- **Security:** Pester を `MinimumVersion` から `RequiredVersion 5.6.1` に変更、`-SkipPublisherCheck` を削除
- **Security:** PSScriptAnalyzer `1.22.0` を CI で事前インストール（テストファイルの auto-install に依存しない）
- **Security:** Codecov アップロードをフォーク外 PR / push イベントに限定
- **Coverage:** 全ワークフローに `push: branches: [main]` トリガーを追加（現状は direct push が CI をスキップ）
- **Coverage:** `flake.nix` / `flake.lock` を `test-consistency.yml` のパスフィルターに追加
- **Coverage:** PowerShell カバレッジを `Get-ChildItem` による動的収集に変更（7 → 全 handlers）
- **Reliability:** artifact upload に `if-no-files-found: ignore` を追加
- **Reliability:** Codecov の `verbose: true` を削除

## Test plan

- [ ] `test-nix.yml`: push trigger で CI が起動することを確認
- [ ] `test-consistency.yml`: `flake.nix` 変更で CI が起動することを確認
- [ ] `test-powershell.yml`: Pester 5.6.1 で既存テストが全 pass することを確認
- [ ] `test-powershell.yml`: カバレッジ対象に handlers/* が含まれることを確認

Closes LIF-126

🤖 Generated with [Claude Code](https://claude.com/claude-code)