### PR TITLE
test(powershell): PSScriptAnalyzer テストの信頼性修正 (LIF-130)

### DIFF
--- a/scripts/powershell/tests/PSScriptAnalyzer.Tests.ps1
+++ b/scripts/powershell/tests/PSScriptAnalyzer.Tests.ps1
@@ -3,22 +3,26 @@ BeforeAll {
     $settingsPath = Join-Path $projectRoot "PSScriptAnalyzerSettings.psd1"
 
     # PSScriptAnalyzer モジュールの確認と自動インストール
-    if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer)) {
-        Write-Host "PSScriptAnalyzer をインストールしています..." -ForegroundColor Yellow
+    if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer | Where-Object { $_.Version -eq '1.22.0' })) {
+        Write-Host "PSScriptAnalyzer 1.22.0 をインストールしています..." -ForegroundColor Yellow
         try {
-            Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force -SkipPublisherCheck
+            Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.22.0 -Scope CurrentUser -Force
         } catch {
-            throw "PSScriptAnalyzer の自動インストールに失敗しました: $($_.Exception.Message). 手動でインストールしてください: Install-Module PSScriptAnalyzer -Scope CurrentUser -Force"
+            throw "PSScriptAnalyzer の自動インストールに失敗しました: $($_.Exception.Message). 手動でインストールしてください: Install-Module PSScriptAnalyzer -RequiredVersion 1.22.0 -Scope CurrentUser -Force"
         }
     }
 
-    Import-Module PSScriptAnalyzer -Force
+    Import-Module PSScriptAnalyzer -RequiredVersion 1.22.0 -Force
 
     # テスト対象ファイルの収集（動的に検出）
     $sourceFiles = @(
         Get-ChildItem -Path "$projectRoot\lib" -Filter "*.ps1" -ErrorAction SilentlyContinue
         Get-ChildItem -Path "$projectRoot\handlers" -Filter "Handler.*.ps1" -ErrorAction SilentlyContinue
     ) | Select-Object -ExpandProperty FullName
+
+    if ($sourceFiles.Count -eq 0) {
+        Write-Warning "ソースファイルが見つかりません (lib/ または handlers/ が存在しない可能性があります)。'全体的なコード品質' テストはスキップされます。"
+    }
 }
 
 Describe 'PSScriptAnalyzer - 静的解析' {
@@ -45,7 +49,7 @@ Describe 'PSScriptAnalyzer - 静的解析' {
     }
 
     Context '全体的なコード品質' {
-        It 'should have no Critical issues in all source files' {
+        It 'should have no Critical issues in all source files' -Skip:($sourceFiles.Count -eq 0) {
             $allResults = @()
             foreach ($file in $sourceFiles) {
                 $results = Invoke-ScriptAnalyzer -Path $file -Settings $settingsPath -Severity Error
@@ -65,7 +69,7 @@ Describe 'PSScriptAnalyzer - 静的解析' {
             $allResults | Should -BeNullOrEmpty
         }
 
-        It 'should have 0 Error/Warning issues in the entire project' {
+        It 'should have 0 Error/Warning issues in the entire project' -Skip:($sourceFiles.Count -eq 0) {
             $allResults = @()
             foreach ($file in $sourceFiles) {
                 $results = Invoke-ScriptAnalyzer -Path $file -Settings $settingsPath -Severity Error,Warning

--- a/scripts/powershell/tests/PSScriptAnalyzer.Tests.ps1
+++ b/scripts/powershell/tests/PSScriptAnalyzer.Tests.ps1
@@ -1,20 +1,33 @@
+BeforeDiscovery {
+    # Discovery フェーズで $sourceFiles を確定させる（-Skip: 評価に必要）
+    $projectRoot = Split-Path -Parent $PSScriptRoot
+    $sourceFiles = @(
+        Get-ChildItem -Path "$projectRoot\lib" -Filter "*.ps1" -ErrorAction SilentlyContinue
+        Get-ChildItem -Path "$projectRoot\handlers" -Filter "Handler.*.ps1" -ErrorAction SilentlyContinue
+    ) | Select-Object -ExpandProperty FullName
+}
+
 BeforeAll {
     $projectRoot = Split-Path -Parent $PSScriptRoot
     $settingsPath = Join-Path $projectRoot "PSScriptAnalyzerSettings.psd1"
 
     # PSScriptAnalyzer モジュールの確認と自動インストール
-    if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer | Where-Object { $_.Version -eq '1.22.0' })) {
+    if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer | Where-Object { $_.Version -eq ([version]'1.22.0') })) {
         Write-Host "PSScriptAnalyzer 1.22.0 をインストールしています..." -ForegroundColor Yellow
         try {
-            Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.22.0 -Scope CurrentUser -Force
+            Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.22.0 -Scope CurrentUser -Force -ErrorAction Stop
         } catch {
             throw "PSScriptAnalyzer の自動インストールに失敗しました: $($_.Exception.Message). 手動でインストールしてください: Install-Module PSScriptAnalyzer -RequiredVersion 1.22.0 -Scope CurrentUser -Force"
         }
     }
 
-    Import-Module PSScriptAnalyzer -RequiredVersion 1.22.0 -Force
+    try {
+        Import-Module PSScriptAnalyzer -RequiredVersion 1.22.0 -Force -ErrorAction Stop
+    } catch {
+        throw "PSScriptAnalyzer 1.22.0 のインポートに失敗しました: $($_.Exception.Message)"
+    }
 
-    # テスト対象ファイルの収集（動的に検出）
+    # Run フェーズ用に再収集（BeforeDiscovery で収集済みの変数はフェーズをまたいで引き継がれない）
     $sourceFiles = @(
         Get-ChildItem -Path "$projectRoot\lib" -Filter "*.ps1" -ErrorAction SilentlyContinue
         Get-ChildItem -Path "$projectRoot\handlers" -Filter "Handler.*.ps1" -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary

LIF-126 のコードレビューで発見された pre-existing 問題を修正。

- **Pin PSScriptAnalyzer version:** Install-Module を -RequiredVersion 1.22.0 に固定、-SkipPublisherCheck を削除
- **BeforeDiscovery ブロック追加:** Pester 5 の Discovery/Run フェーズ分離に対応。-Skip: は Discovery フェーズで評価されるため BeforeDiscovery で $sourceFiles を収集
- **空ファイル時のガード:** $sourceFiles が空のとき Write-Warning を出力、It ブロックに -Skip:($sourceFiles.Count -eq 0) を追加
- **エラーハンドリング強化:** -ErrorAction Stop を Install-Module と Import-Module に追加、try-catch で確実にキャッチ
- **型安全なバージョン比較:** ([version]'1.22.0') キャストを使用

## Test plan

- [x] PSScriptAnalyzer.Tests.ps1 の構文エラーがないことを確認（Parser::ParseFile → SYNTAX OK）
- [x] バージョン 1.22.0 が CI ワークフロー (LIF-126, test-powershell.yml) と一致することを確認
- [x] $sourceFiles.Count -eq 0 のとき 全体的なコード品質 テストが SKIP になることを確認（sourceFiles.Count=16 → Skip=False、空時は Skip=True）
- [x] 通常環境（lib/ handlers/ が存在）でテストが正常に PASS することを確認（24/24 passed）

Closes LIF-130
Relates to LIF-126

🤖 Generated with [Claude Code](https://claude.com/claude-code)