### PR TITLE
fix(vscode): PowerShell Extension Terminal 停止エラーを修正 (LIF-131)

### DIFF
--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -1,5 +1,9 @@
 # PowerShell profile managed by chezmoi
 
+# VS Code Extension Console skips heavy init (starship/zoxide/PSReadLine) to avoid
+# session startup timeout. Basic PowerShell functionality (syntax, completion) still works.
+if ($env:VSCODE_PID -or $env:VSCODE_INJECTION) { return }
+
 # Rebuild PATH from registry to ensure User PATH is available in elevated sessions.
 # Windows Terminal with "elevate: true" may not inherit User-scope PATH entries.
 $env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [Environment]::GetEnvironmentVariable("PATH", "User")


### PR DESCRIPTION
## Summary

Closes LIF-131

PowerShell Extension Console の起動タイムアウトを修正。

### 原因

VS Code Extension Console 起動時に `$PROFILE` が読み込まれ、`starship init` / `zoxide init` / `PSReadLine` の初期化がセッション確立タイムアウトを超えていた。

`powershell.startAsLoginShell.windows` は PowerShell 拡張機能のスキーマに存在しない（`osx`/`linux` のみ）ため無効だった。

### 修正

`Microsoft.PowerShell_profile.ps1` の先頭に VS Code 検出ガードを追加:

```powershell
if ($env:VSCODE_PID -or $env:VSCODE_INJECTION) { return }
```

Extension Console では重い初期化をスキップし、構文補完などの基本機能は引き続き動作する。

## Test plan

- [x] 通常の PowerShell セッション（Windows Terminal）でプロンプト・エイリアスが動作すること
- [x] VS Code Extension Console が起動タイムアウトエラーなく起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)