### PR TITLE
fix(powershell): WslInstallHandler で外部コマンドを Invoke-* ラッパー経由に修正 (LIF-133)

### DIFF
--- a/scripts/powershell/handlers/Handler.WslInstall.ps1
+++ b/scripts/powershell/handlers/Handler.WslInstall.ps1
@@ -54,7 +54,7 @@ class WslInstallHandler : SetupHandlerBase {
 
             # 方法1: wsl --install --no-distribution
             $this.Log("wsl --install --no-distribution を実行中...")
-            $output = & wsl --install --no-distribution 2>&1
+            $output = Invoke-Wsl --install --no-distribution 2>&1
             $output | ForEach-Object { $this.Log("  $_", "Gray") }
 
             if ($LASTEXITCODE -eq 0) {
@@ -94,7 +94,7 @@ class WslInstallHandler : SetupHandlerBase {
 
         foreach ($feature in $features) {
             $this.Log("dism.exe: $feature を有効化中...")
-            $output = & dism.exe /online /enable-feature /featurename:$feature /all /norestart 2>&1
+            $output = Invoke-Dism /online /enable-feature /featurename:$feature /all /norestart 2>&1
             $output | ForEach-Object { $this.Log("  $_", "Gray") }
 
             if ($LASTEXITCODE -ne 0) {

--- a/scripts/powershell/lib/Invoke-ExternalCommand.ps1
+++ b/scripts/powershell/lib/Invoke-ExternalCommand.ps1
@@ -34,6 +34,25 @@ function Invoke-Wsl {
 
 <#
 .SYNOPSIS
+    dism.exe コマンドを実行する
+.PARAMETER Arguments
+    dism.exe に渡す引数
+.OUTPUTS
+    コマンドの出力
+.EXAMPLE
+    Invoke-Dism /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart
+#>
+function Invoke-Dism {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments)]
+        [string[]]$Arguments
+    )
+    & dism.exe @Arguments
+}
+
+<#
+.SYNOPSIS
     chezmoi コマンドを実行する
 .PARAMETER Arguments
     chezmoi に渡す引数

--- a/scripts/powershell/tests/handlers/Handler.WslInstall.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.WslInstall.Tests.ps1
@@ -86,7 +86,7 @@ Describe 'WslInstallHandler' {
             }
             $script:dismCalls = @()
             Mock Invoke-Dism {
-                $script:dismCalls += ($args -join " ")
+                $script:dismCalls += ($Arguments -join " ")
                 $global:LASTEXITCODE = 0
                 return "The operation completed successfully."
             }
@@ -96,6 +96,8 @@ Describe 'WslInstallHandler' {
             $result.Success | Should -Be $true
             $result.Message | Should -Match '再起動が必要'
             $script:dismCalls.Count | Should -Be 2
+            $script:dismCalls[0] | Should -Match 'Microsoft-Windows-Subsystem-Linux'
+            $script:dismCalls[1] | Should -Match 'VirtualMachinePlatform'
         }
 
         It 'should return failure when both wsl --install and dism fail' {
@@ -112,6 +114,22 @@ Describe 'WslInstallHandler' {
 
             $result.Success | Should -Be $false
             $result.Message | Should -Match 'dism.exe'
+        }
+
+        It 'should return failure when second dism feature fails' {
+            Mock Invoke-Wsl {
+                $global:LASTEXITCODE = 1
+                return "Installation failed"
+            }
+            Mock Invoke-Dism {
+                # VirtualMachinePlatform の有効化が失敗するシナリオ
+                $global:LASTEXITCODE = if ($Arguments -match 'VirtualMachinePlatform') { 1 } else { 0 }
+            }
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $false
+            Should -Invoke Invoke-Dism -Times 2
         }
     }
 }

--- a/scripts/powershell/tests/handlers/Handler.WslInstall.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.WslInstall.Tests.ps1
@@ -66,7 +66,7 @@ Describe 'WslInstallHandler' {
 
         It 'should run wsl --install --no-distribution' {
             $script:wslInstallCalled = $false
-            Mock wsl {
+            Mock Invoke-Wsl {
                 $script:wslInstallCalled = $true
                 $global:LASTEXITCODE = 0
                 return "Installing WSL..."
@@ -80,12 +80,12 @@ Describe 'WslInstallHandler' {
         }
 
         It 'should fallback to dism when wsl --install fails' {
-            Mock wsl {
+            Mock Invoke-Wsl {
                 $global:LASTEXITCODE = 1
                 return "Installation failed"
             }
             $script:dismCalls = @()
-            Mock dism.exe {
+            Mock Invoke-Dism {
                 $script:dismCalls += ($args -join " ")
                 $global:LASTEXITCODE = 0
                 return "The operation completed successfully."
@@ -99,11 +99,11 @@ Describe 'WslInstallHandler' {
         }
 
         It 'should return failure when both wsl --install and dism fail' {
-            Mock wsl {
+            Mock Invoke-Wsl {
                 $global:LASTEXITCODE = 1
                 return "Installation failed"
             }
-            Mock dism.exe {
+            Mock Invoke-Dism {
                 $global:LASTEXITCODE = 1
                 return "Error"
             }

--- a/scripts/powershell/tests/lib/Invoke-ExternalCommand.Tests.ps1
+++ b/scripts/powershell/tests/lib/Invoke-ExternalCommand.Tests.ps1
@@ -73,6 +73,24 @@ Describe 'Invoke-Wsl' {
     }
 }
 
+Describe 'Invoke-Dism' {
+    It 'should pass arguments to dism.exe' {
+        Mock dism.exe { return "test output" }
+
+        $result = Invoke-Dism /online /get-features
+
+        Should -Invoke dism.exe -Times 1
+    }
+
+    It 'should pass multiple arguments' {
+        Mock dism.exe { return "The operation completed successfully." }
+
+        Invoke-Dism /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart
+
+        Should -Invoke dism.exe -Times 1
+    }
+}
+
 Describe 'Invoke-Diskpart' {
     BeforeAll {
         $script:tempDir = Join-Path $env:TEMP "diskpart_test_$(Get-Random)"


### PR DESCRIPTION
## Summary

- \`Invoke-ExternalCommand.ps1\` に \`Invoke-Dism\` ラッパーを追加
- \`Handler.WslInstall.ps1\` の \`wsl\`/\`dism.exe\` 直接呼び出しを \`Invoke-Wsl\`/\`Invoke-Dism\` に変更
- \`Handler.WslInstall.Tests.ps1\` のモックを \`Invoke-Wsl\`/\`Invoke-Dism\` に変更
- \`\$args\` → \`\$Arguments\` 修正、引数内容検証、部分失敗シナリオ追加
- \`Invoke-Dism\` のユニットテストを \`Invoke-ExternalCommand.Tests.ps1\` に追加

## Problem

\`Handler.WslInstall.ps1\` が外部コマンドを直接呼び出しており、CLAUDE.md の実装ルール違反：
- \`& wsl --install --no-distribution\` → \`Invoke-Wsl\` を使うべき
- \`& dism.exe /online /enable-feature ...\` → \`Invoke-Dism\` を使うべき（ラッパーが未定義）

テストも \`Mock wsl\` / \`Mock dism.exe\` を使っており、テスト方針「外部コマンドはラッパー関数を Mock する」違反。

## Test plan

- [x] \`task test:powershell\` でテストが全て通ること
- [x] \`Invoke-Dism\` が \`Invoke-ExternalCommand.ps1\` に追加されていること
- [x] \`Handler.WslInstall.ps1\` に \`& wsl\` / \`& dism.exe\` の直接呼び出しが残っていないこと
- [x] \`Handler.WslInstall.Tests.ps1\` が \`Invoke-Wsl\` / \`Invoke-Dism\` をモックしていること

> **Note:** \`Handler.Pnpm.Tests.ps1\` に pre-existing のフレーキー失敗（\`pnpm setup\` タイムアウト）が1件あるが、main ブランチでも同様に再現するため本 PR の変更とは無関係。

Closes LIF-133

🤖 Generated with [Claude Code](https://claude.com/claude-code)