### PR TITLE
ci: CI ハードニング第2弾 — winget/nix/ps 改善 (LIF-136)

### DIFF
--- a/.github/workflows/test-consistency.yml
+++ b/.github/workflows/test-consistency.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
     paths:
       - "nix/packages/**"
+      - "nix/flakes/**"
       - "nix/home/**"
       - "flake.nix"
       - "flake.lock"
@@ -16,6 +17,7 @@ on:
     branches: [main]
     paths:
       - "nix/packages/**"
+      - "nix/flakes/**"
       - "nix/home/**"
       - "flake.nix"
       - "flake.lock"
@@ -32,11 +34,13 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
@@ -45,6 +49,7 @@ jobs:
         run: nix build .#winget-export -o /tmp/winget-export
 
       - name: Verify winget packages.json is in sync
+        shell: bash
         run: |
           jq -S '[.Sources[] | {name: .SourceDetails.Name, ids: ([.Packages[].PackageIdentifier] | sort)}]' \
             /tmp/winget-export/winget/packages.json > /tmp/nix-ids.json
@@ -53,4 +58,5 @@ jobs:
           diff /tmp/nix-ids.json /tmp/repo-ids.json
 
       - name: Verify pnpm packages.json is in sync
+        shell: bash
         run: diff <(jq -S . /tmp/winget-export/pnpm/packages.json) <(jq -S . windows/pnpm/packages.json)

--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -26,11 +26,13 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6

--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: always() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           files: scripts/powershell/coverage.xml
           flags: powershell

--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -22,18 +22,40 @@ permissions:
 
 jobs:
   test:
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Cache PowerShell modules
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~\Documents\PowerShell\Modules
+          key: ${{ runner.os }}-psmodules-pester-5.6.1-pssa-1.22.0
 
       - name: Install PowerShell modules
         shell: pwsh
         run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          function Invoke-WithRetry {
+            param([scriptblock]$Script, [int]$Max = 3)
+            for ($i = 1; $i -le $Max; $i++) {
+              try { & $Script; return } catch {
+                if ($i -eq $Max) { throw }
+                Write-Warning "Attempt $i failed: $_. Retrying in $($i * 5)s..."
+                Start-Sleep -Seconds ($i * 5)
+              }
+            }
+          }
+
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module -Name Pester           -RequiredVersion 5.6.1  -Scope CurrentUser -Force
-          Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.22.0 -Scope CurrentUser -Force
+          Invoke-WithRetry { Install-Module -Name Pester           -RequiredVersion 5.6.1  -Scope CurrentUser -Force -Repository PSGallery }
+          Invoke-WithRetry { Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.22.0 -Scope CurrentUser -Force -Repository PSGallery }
 
       - name: Run tests
         shell: pwsh
@@ -88,7 +110,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        if: always() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           files: scripts/powershell/coverage.xml
           flags: powershell

--- a/.github/workflows/test-winget.yml
+++ b/.github/workflows/test-winget.yml
@@ -38,10 +38,19 @@ jobs:
           Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
 
+          # On Windows runners winget lives in the AppX path which is not always on PATH.
+          # Add it unconditionally so Get-Command can find it without a fallback install.
+          $appxBin = "$env:LOCALAPPDATA\Microsoft\WindowsApps"
+          if ($appxBin -notin ($env:PATH -split ';')) {
+            $env:PATH = "$appxBin;$env:PATH"
+          }
+
           # Ensure winget is available on the runner
           if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
-            Write-Host "Installing Microsoft.WinGet.Client..."
-            Install-PackageProvider -Name NuGet -Force
+            Write-Host "winget not found — installing Microsoft.WinGet.Client..."
+            $ErrorActionPreference = 'Continue'
+            Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -ErrorAction SilentlyContinue
+            $ErrorActionPreference = 'Stop'
             Install-Module -Name Microsoft.WinGet.Client -Force -Repository PSGallery
             Repair-WinGetPackageManager -AllUsers
           }

--- a/.github/workflows/test-winget.yml
+++ b/.github/workflows/test-winget.yml
@@ -45,11 +45,15 @@ jobs:
             Install-Module -Name Microsoft.WinGet.Client -Force -Repository PSGallery
             Repair-WinGetPackageManager -AllUsers
           }
-          # Validate winget is functional before proceeding
-          # Note: source update can return non-zero on transient CDN errors; treat as warning
+          # Validate winget is functional before proceeding.
+          # source update can return non-zero on transient CDN errors; treat as warning.
+          # Temporarily suspend Stop preference so native command stderr doesn't abort.
+          $ErrorActionPreference = 'Continue'
           winget source update
-          if ($LASTEXITCODE -ne 0) {
-            Write-Warning "winget source update returned $LASTEXITCODE — continuing anyway"
+          $sourceUpdateExit = $LASTEXITCODE
+          $ErrorActionPreference = 'Stop'
+          if ($sourceUpdateExit -ne 0) {
+            Write-Warning "winget source update returned $sourceUpdateExit — continuing anyway"
           }
           winget --version
 
@@ -87,9 +91,13 @@ jobs:
 
           $installFailed = @()
           foreach ($id in $corePackages) {
-            # Skip if already installed to keep the step idempotent
+            # Skip if already installed to keep the step idempotent.
+            # winget list may write to stderr on miss; use Continue to avoid false termination.
+            $ErrorActionPreference = 'Continue'
             $listed = winget list --exact --id $id --source winget 2>&1
-            if ($LASTEXITCODE -eq 0 -and ($listed | Select-String -Quiet $id)) {
+            $listExit = $LASTEXITCODE
+            $ErrorActionPreference = 'Stop'
+            if ($listExit -eq 0 -and ($listed | Select-String -Quiet $id)) {
               Write-Host "SKIP $id (already installed)"
               continue
             }
@@ -97,9 +105,14 @@ jobs:
             Write-Host "Installing $id..."
             try {
               Invoke-WithRetry {
+                # Use Continue inside the scriptblock: winget writes stderr progress
+                # that would trip Stop before we can check $LASTEXITCODE.
+                $ErrorActionPreference = 'Continue'
                 winget install --id $id --exact --source winget --silent `
                   --accept-package-agreements --accept-source-agreements --disable-interactivity
-                if ($LASTEXITCODE -ne 0) { throw "winget exit $LASTEXITCODE" }
+                $installExit = $LASTEXITCODE
+                $ErrorActionPreference = 'Stop'
+                if ($installExit -ne 0) { throw "winget exit $installExit" }
               }
             } catch {
               Write-Warning "winget install failed for $id: $_"

--- a/.github/workflows/test-winget.yml
+++ b/.github/workflows/test-winget.yml
@@ -115,7 +115,7 @@ jobs:
                 if ($installExit -ne 0) { throw "winget exit $installExit" }
               }
             } catch {
-              Write-Warning "winget install failed for $id: $_"
+              Write-Warning "winget install failed for ${id}: $_"
               $installFailed += $id
             }
           }

--- a/.github/workflows/test-winget.yml
+++ b/.github/workflows/test-winget.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   smoke-test:
-    runs-on: windows-2022
+    runs-on: windows-latest
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -37,13 +37,6 @@ jobs:
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
-
-          # On Windows runners winget lives in the AppX path which is not always on PATH.
-          # Add it unconditionally so Get-Command can find it without a fallback install.
-          $appxBin = "$env:LOCALAPPDATA\Microsoft\WindowsApps"
-          if ($appxBin -notin ($env:PATH -split ';')) {
-            $env:PATH = "$appxBin;$env:PATH"
-          }
 
           # Ensure winget is available on the runner
           if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {

--- a/.github/workflows/test-winget.yml
+++ b/.github/workflows/test-winget.yml
@@ -2,6 +2,12 @@ name: Windows Environment Smoke Test
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "windows/winget/packages.json"
+      - "nix/packages/sets.nix"
+      - ".github/workflows/test-winget.yml"
   pull_request:
     branches: [main]
     paths:
@@ -18,15 +24,20 @@ permissions:
 
 jobs:
   smoke-test:
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Bootstrap winget
         shell: pwsh
         run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
           # Ensure winget is available on the runner
           if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
             Write-Host "Installing Microsoft.WinGet.Client..."
@@ -45,6 +56,20 @@ jobs:
       - name: Install core CLI tools
         shell: pwsh
         run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          function Invoke-WithRetry {
+            param([scriptblock]$Script, [int]$Max = 3)
+            for ($i = 1; $i -le $Max; $i++) {
+              try { & $Script; return } catch {
+                if ($i -eq $Max) { throw }
+                Write-Warning "Attempt $i failed: $_. Retrying in $($i * 5)s..."
+                Start-Sleep -Seconds ($i * 5)
+              }
+            }
+          }
+
           # Install only the cross-platform core CLI tools that are smoke-tested below.
           # GUI apps (Docker Desktop, Chrome, VS Code, etc.) are excluded to avoid
           # GUI installer timeouts and UAC failures blocking CLI-only PRs.
@@ -62,10 +87,22 @@ jobs:
 
           $installFailed = @()
           foreach ($id in $corePackages) {
+            # Skip if already installed to keep the step idempotent
+            $listed = winget list --exact --id $id --source winget 2>&1
+            if ($LASTEXITCODE -eq 0 -and ($listed | Select-String -Quiet $id)) {
+              Write-Host "SKIP $id (already installed)"
+              continue
+            }
+
             Write-Host "Installing $id..."
-            winget install --id $id --source winget --silent --accept-package-agreements --accept-source-agreements
-            if ($LASTEXITCODE -ne 0) {
-              Write-Warning "winget install failed for $id (exit $LASTEXITCODE)"
+            try {
+              Invoke-WithRetry {
+                winget install --id $id --exact --source winget --silent `
+                  --accept-package-agreements --accept-source-agreements --disable-interactivity
+                if ($LASTEXITCODE -ne 0) { throw "winget exit $LASTEXITCODE" }
+              }
+            } catch {
+              Write-Warning "winget install failed for $id: $_"
               $installFailed += $id
             }
           }


### PR DESCRIPTION
## Summary

- `test-winget.yml`: `push` トリガー追加、`windows-2022` 固定、winget install に idempotent チェック + retry、`Set-StrictMode` + `$ErrorActionPreference = 'Stop'`、`persist-credentials: false`
- `test-consistency.yml`: `nix/flakes/**` を path フィルターに追加（winget-export の依存が未登録だった）、`ubuntu-24.04` 固定、`shell: bash` 明示、`persist-credentials: false`
- `test-nix.yml`: `ubuntu-24.04` 固定、`persist-credentials: false`
- `test-powershell.yml`: `windows-2022` 固定、`Set-StrictMode` + retry、PSModule キャッシュ追加、Codecov 条件を fork 除外ロジックに維持、`persist-credentials: false`

Closes LIF-136

## Test plan

- [x] `test-consistency.yml`: `nix/flakes/**` が push/PR paths に追加済みであることをファイルで確認（行 9, 20）
- [x] `test-winget.yml`: `push` トリガーがファイルに追加済みであることを確認（行 5）
- [x] `test-powershell.yml`: ローカル Pester 実行で全 570 テスト合格（Failed: 0, Skipped: 0）
- [x] `test-nix.yml`: `ubuntu-24.04` がファイルに設定済みであることを確認（行 29）

🤖 Generated with [Claude Code](https://claude.com/claude-code)