### PR TITLE
feat(font): 全ターミナル・エディタのフォントを Moralerspace / 12 に統一 (LIF-137)

### DIFF
--- a/chezmoi/editors/cursor/settings.json
+++ b/chezmoi/editors/cursor/settings.json
@@ -1,5 +1,6 @@
 {
   "editor.fontSize": 12,
+  "editor.fontFamily": "Moralerspace",
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "ibecker.treefmt-vscode",
   "editor.minimap.enabled": true,
@@ -127,7 +128,7 @@
   "notebook.cellToolbarLocation": {
     "default": "left"
   },
-  "terminal.integrated.fontSize": 13,
+  "terminal.integrated.fontSize": 12,
   "terminal.integrated.defaultProfile.linux": "bash",
   "terminal.integrated.tabs.enabled": true,
   "terminal.integrated.shellIntegration.enabled": true,

--- a/chezmoi/editors/cursor/settings.json
+++ b/chezmoi/editors/cursor/settings.json
@@ -128,6 +128,7 @@
   "notebook.cellToolbarLocation": {
     "default": "left"
   },
+  "terminal.integrated.fontFamily": "Moralerspace",
   "terminal.integrated.fontSize": 12,
   "terminal.integrated.defaultProfile.linux": "bash",
   "terminal.integrated.tabs.enabled": true,

--- a/chezmoi/editors/vscode/settings.json
+++ b/chezmoi/editors/vscode/settings.json
@@ -128,6 +128,7 @@
   "notebook.cellToolbarLocation": {
     "default": "right"
   },
+  "terminal.integrated.fontFamily": "Moralerspace",
   "terminal.integrated.fontSize": 12,
   "terminal.integrated.defaultProfile.linux": "bash",
   "terminal.integrated.tabs.enabled": true,

--- a/chezmoi/editors/vscode/settings.json
+++ b/chezmoi/editors/vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "editor.fontSize": 12,
+  "editor.fontFamily": "Moralerspace",
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "ibecker.treefmt-vscode",
   "editor.minimap.enabled": true,
@@ -127,7 +128,7 @@
   "notebook.cellToolbarLocation": {
     "default": "right"
   },
-  "terminal.integrated.fontSize": 13,
+  "terminal.integrated.fontSize": 12,
   "terminal.integrated.defaultProfile.linux": "bash",
   "terminal.integrated.tabs.enabled": true,
   "terminal.integrated.shellIntegration.enabled": true,

--- a/chezmoi/editors/zed/settings.json
+++ b/chezmoi/editors/zed/settings.json
@@ -28,7 +28,7 @@
   "theme": "GitHub Dark Dimmed",
   "ui_font_size": 14,
   "buffer_font_size": 12,
-  "buffer_font_family": "Consolas",
+  "buffer_font_family": "Moralerspace",
   // Vim mode
   "vim_mode": false,
   // Editor settings
@@ -66,7 +66,7 @@
     "shell": {
       "program": "pwsh"
     },
-    "font_size": 13,
+    "font_size": 12,
     "line_height": "comfortable",
     "copy_on_select": false,
     "vim_mode": false

--- a/chezmoi/terminals/warp/settings.toml
+++ b/chezmoi/terminals/warp/settings.toml
@@ -19,8 +19,8 @@ is_settings_sync_enabled = true
 [appearance]
 
 [appearance.text]
-notebook_font_size = 14.0
-font_size = 13.0
+notebook_font_size = 12.0
+font_size = 12.0
 
 [appearance.themes]
 system_theme = false

--- a/chezmoi/terminals/warp/settings.toml
+++ b/chezmoi/terminals/warp/settings.toml
@@ -19,6 +19,7 @@ is_settings_sync_enabled = true
 [appearance]
 
 [appearance.text]
+font_family = "Moralerspace"
 notebook_font_size = 12.0
 font_size = 12.0
 

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -74,7 +74,7 @@ config.color_schemes = {
 config.color_scheme = "gruvbox-custom"
 
 -- Font settings
-config.font = wezterm.font("Consolas")
+config.font = wezterm.font("Moralerspace")
 config.font_size = 12.0
 
 -- IME support

--- a/chezmoi/terminals/windows-terminal/settings.json
+++ b/chezmoi/terminals/windows-terminal/settings.json
@@ -163,7 +163,7 @@
   "profiles": {
     "defaults": {
       "font": {
-        "face": "Consolas",
+        "face": "Moralerspace",
         "size": 12
       },
       "useAcrylic": true,


### PR DESCRIPTION
## Summary

- Windows Terminal / WezTerm / Warp / VS Code / Cursor / Zed のフォントを **Moralerspace・サイズ 12** に統一
- ターミナル内蔵フォントも含めて全 6 ファイルを変更

## Changes

| ファイル | 変更 |
|---|---|
| \`terminals/windows-terminal/settings.json\` | face: Consolas → Moralerspace |
| \`terminals/wezterm/wezterm.lua\` | font: Consolas → Moralerspace |
| \`terminals/warp/settings.toml\` | font_family 追加, font_size: 13→12, notebook_font_size: 14→12 |
| \`editors/vscode/settings.json\` | fontFamily 追加, terminal.integrated.fontFamily 追加, terminal.integrated.fontSize: 13→12 |
| \`editors/cursor/settings.json\` | fontFamily 追加, terminal.integrated.fontFamily 追加, terminal.integrated.fontSize: 13→12 |
| \`editors/zed/settings.json\` | buffer_font_family: Consolas→Moralerspace, terminal.font_size: 13→12 |

## Linear

LIF-137: https://linear.app/life-style-base/issue/LIF-137/

## Test plan

- [x] 全設定ファイル（6ファイル）でフォント名 Moralerspace とサイズ 12 が正しく設定されていることをローカルで検証済み
  - windows-terminal: face Moralerspace, size 12 ✓
  - wezterm: wezterm.font(Moralerspace), font_size 12.0 ✓
  - warp: font_family Moralerspace, font_size 12.0, notebook_font_size 12.0 ✓
  - vscode: editor.fontFamily Moralerspace, terminal.integrated.fontFamily Moralerspace, fontSize 12 ✓
  - cursor: 同上 ✓
  - zed: buffer_font_family Moralerspace, terminal.font_size 12 ✓
- [ ] chezmoi apply 後、各アプリで Moralerspace フォント・サイズ 12 が実際に表示されることを手動確認（Moralerspace フォントのインストールが前提 → LIF-138 で管理）

🤖 Generated with [Claude Code](https://claude.com/claude-code)