### PR TITLE
feat(font): Moralerspace フォントを nix パッケージ管理に追加 (LIF-138)

### DIFF
--- a/nix/flakes/packages.nix
+++ b/nix/flakes/packages.nix
@@ -57,6 +57,10 @@
           name = "dotfiles-editors";
           paths = unfreeSets.editors;
         };
+        fonts = pkgs.buildEnv {
+          name = "dotfiles-fonts";
+          paths = sets.fonts;
+        };
 
         # Windows package export
         winget-export = import ../packages/winget.nix { inherit pkgs lib; };

--- a/nix/modules/host/default.nix
+++ b/nix/modules/host/default.nix
@@ -37,6 +37,7 @@ in
       };
 
       nixpkgs.config.allowUnfree = true;
+      fonts.fontconfig.enable = true;
       programs.zsh.enable = true;
 
       programs.git = {

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -160,6 +160,13 @@ let
       category = "editors";
     };
 
+    # ── fonts ─────────────────────────────────────────────
+    moralerspace = {
+      pkg = pkgs.moralerspace;
+      winget = null;
+      category = "fonts";
+    };
+
     # ── llm ───────────────────────────────────────────────
     claude-code = {
       pkg = pkgs.claude-code;


### PR DESCRIPTION
## Summary

- \`nix/packages/sets.nix\` に \`fonts\` カテゴリを追加
- \`pkgs.moralerspace\` (v2.0.0) を登録
- \`nix/flakes/packages.nix\` に fonts 個別セットを追加
- \`nix/modules/host/default.nix\` に \`fonts.fontconfig.enable = true\` を追加

## Background

LIF-137 (PR #87) でフォント設定を Moralerspace に統一したが、フォント自体が nix パッケージ管理に入っていないと指摘された。本 PR でその対応を行う。

Windows については winget での Moralerspace 配布がないため \`winget = null\`（手動インストールが必要）。

## Changes

| ファイル | 変更 |
|---|---|
| \`nix/packages/sets.nix\` | fonts カテゴリ追加 + moralerspace エントリ追加 |
| \`nix/flakes/packages.nix\` | fonts 個別セット追加 (nix profile install .#fonts) |
| \`nix/modules/host/default.nix\` | fonts.fontconfig.enable = true 追加 |

## Linear

LIF-138: https://linear.app/life-style-base/issue/LIF-138/

## Test plan

- [x] \`nix eval .#packages.x86_64-linux\` がエラーなく評価できること（ローカル検証済み ✓）
- [x] \`sets.all\` に \`moralerspace\` が含まれること（ローカル検証済み ✓）
- [x] \`nix eval .#packages.x86_64-linux\` に \`fonts\` セットが存在すること（ローカル検証済み ✓）
- [ ] \`nixos-rebuild switch\` 後に \`fc-list | grep -i moralerspace\` でフォントが検出されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)