### PR TITLE
fix(chezmoi): Linux での PS1 誤実行防止と gemini-warp 非対話化

### DIFF
--- a/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy_vscode_mcp.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy_vscode_mcp.ps1.tmpl
@@ -1,3 +1,4 @@
+{{- if eq .chezmoi.os "windows" }}
 # chezmoi:template:hash={{ include ".chezmoidata/mcp_servers.yaml" | sha256sum }}
 
 $userDir = Join-Path $env:APPDATA "Code\User"
@@ -63,3 +64,4 @@ if (Test-Path $settingsPath) {
         Write-Host "[vscode-mcp] Removed deprecated 'mcp' block from settings.json"
     }
 }
+{{- end }}

--- a/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy_zed_mcp.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy_zed_mcp.ps1.tmpl
@@ -1,3 +1,4 @@
+{{- if eq .chezmoi.os "windows" }}
 # chezmoi:template:hash={{ include ".chezmoidata/mcp_servers.yaml" | sha256sum }}
 
 $settingsPath = Join-Path $env:APPDATA "Zed\settings.json"
@@ -72,3 +73,4 @@ $json = $settings | ConvertTo-Json -Depth 20
 [System.IO.File]::WriteAllText($settingsPath, $json, [System.Text.UTF8Encoding]::new($false))
 Write-Host "[zed-mcp] Updated $($servers.Count) context servers in $settingsPath"
 Write-Host "[zed-mcp] Note: JSONC comments were removed during merge"
+{{- end }}

--- a/chezmoi/.chezmoiscripts/deploy/llms/run_onchange_deploy_claude_code_mcp.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/llms/run_onchange_deploy_claude_code_mcp.ps1.tmpl
@@ -1,3 +1,4 @@
+{{- if eq .chezmoi.os "windows" }}
 # chezmoi:template:hash={{ include ".chezmoidata/mcp_servers.yaml" | sha256sum }}
 
 if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
@@ -25,3 +26,4 @@ Write-Host "[claude-code-mcp] Added/updated {{ .name }} (stdio)"
 {{ end }}
 
 Write-Host "[claude-code-mcp] Done"
+{{- end }}

--- a/chezmoi/.chezmoiscripts/run_always_install-gemini-warp_linux.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_always_install-gemini-warp_linux.sh.tmpl
@@ -9,7 +9,7 @@ if ! command -v gemini &>/dev/null; then
 fi
 
 echo "[gemini-warp] Installing Warp extension..."
-gemini extensions install https://github.com/warpdotdev/gemini-cli-warp || {
+echo "y" | gemini extensions install https://github.com/warpdotdev/gemini-cli-warp || {
   echo "[gemini-warp] Warning: extension install returned non-zero (may already be installed)"
 }
 echo "[gemini-warp] Done. Restart Gemini CLI for the extension to activate."

--- a/chezmoi/.chezmoiscripts/run_always_install-gemini-warp_linux.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_always_install-gemini-warp_linux.sh.tmpl
@@ -9,7 +9,7 @@ if ! command -v gemini &>/dev/null; then
 fi
 
 echo "[gemini-warp] Installing Warp extension..."
-echo "y" | gemini extensions install https://github.com/warpdotdev/gemini-cli-warp || {
+gemini extensions install https://github.com/warpdotdev/gemini-cli-warp --consent || {
   echo "[gemini-warp] Warning: extension install returned non-zero (may already be installed)"
 }
 echo "[gemini-warp] Done. Restart Gemini CLI for the extension to activate."


### PR DESCRIPTION
## Summary

- Windows 専用の `.ps1.tmpl` 3 件に `{{- if eq .chezmoi.os "windows" }}` ガードを追加 (vscode-mcp, zed-mcp, claude-code-mcp)
- `run_always_install-gemini-warp_linux.sh.tmpl` の `gemini extensions install` に `--consent` フラグを追加し非対話化

## Background

`chezmoi apply` を NixOS WSL で実行すると `_windows` サフィックスのない `.ps1` スクリプトが Linux でも実行されて `powershell: not found` エラーになっていた。また gemini-warp インストール時に `[Y/n]` プロンプトで処理が止まっていた。

## Test plan

- [ ] WSL で `chezmoi apply` が正常完了する
- [ ] Windows で VS Code / Zed / Claude Code の MCP 設定が引き続き反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)