### PR TITLE
chore: .gitattributes に sh.tmpl / ps1.tmpl の改行ルールを追加 (LIF-143)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,10 @@
 
 # Unix系シェルスクリプトはLFを使用
 *.sh text eol=lf
+*.sh.tmpl text eol=lf
+
+# PowerShellテンプレートはCRLFを使用
+*.ps1.tmpl text eol=crlf working-tree-encoding=UTF-8
 
 # その他のテキストファイルはLFを使用
 *.md text eol=lf


### PR DESCRIPTION
## Summary

- `*.sh.tmpl text eol=lf` を追加 — Windows でチェックアウト時に CRLF になり Linux でシェバンが `bash\r` として解釈される問題を恒久対応
- `*.ps1.tmpl text eol=crlf working-tree-encoding=UTF-8` を追加 — PowerShell テンプレートは明示的に CRLF を維持

## Background

`chezmoi apply` 時に `.sh.tmpl` の CRLF が原因で `env: 'bash\r': No such file or directory` エラーが発生していた。

Closes LIF-143

🤖 Generated with [Claude Code](https://claude.com/claude-code)