### PR TITLE
feat(terminals): reduce font size to 8 and fix deploy issues (LIF-145)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -46,11 +46,14 @@ tasks:
     desc: Sync skills, format, lint, and commit (via WSL)
     vars:
       MSG: '{{.CLI_ARGS | default "update"}}'
+    env:
+      GIT_COMMIT_MSG: "{{.MSG}}"
+      WSLENV: "GIT_COMMIT_MSG"
     cmds:
       - task: skills:sync
       - task: fmt
       - task: lint
-      - wsl -d {{.DISTRO}} -- bash -lc "cd {{.DOTFILES_PATH}} && git add -A && git commit -m '{{.MSG}}'"
+      - wsl -d {{.DISTRO}} -- bash -lc 'cd {{.DOTFILES_PATH}} && git add -A && git commit -m "$GIT_COMMIT_MSG"'
 
   push:
     desc: Push to remote (via WSL)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -53,7 +53,7 @@ tasks:
       - task: skills:sync
       - task: fmt
       - task: lint
-      - wsl -d {{.DISTRO}} -- bash -lc 'cd {{.DOTFILES_PATH}} && git add -A && git commit -m "$GIT_COMMIT_MSG"'
+      - wsl -d {{.DISTRO}} -- bash -lc "cd {{.DOTFILES_PATH}} && git add -A && git commit -m \"\$(echo \"$GIT_COMMIT_MSG\" | sed 's/^.//;s/.$//') \""
 
   push:
     desc: Push to remote (via WSL)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,12 +48,12 @@ tasks:
       MSG: '{{.CLI_ARGS | default "update"}}'
     env:
       GIT_COMMIT_MSG: "{{.MSG}}"
-      WSLENV: "GIT_COMMIT_MSG"
+      WSLENV: "GIT_COMMIT_MSG:$WSLENV"
     cmds:
       - task: skills:sync
       - task: fmt
       - task: lint
-      - wsl -d {{.DISTRO}} -- bash -lc "cd {{.DOTFILES_PATH}} && git add -A && git commit -m \"\$(echo \"$GIT_COMMIT_MSG\" | sed 's/^.//;s/.$//') \""
+      - wsl -d {{.DISTRO}} -- bash -lc "cd {{.DOTFILES_PATH}} && git add -A && git commit -m \"\$(echo \"$GIT_COMMIT_MSG\" | sed \"s/^'//;s/'$//\")\""
 
   push:
     desc: Push to remote (via WSL)

--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -6,6 +6,9 @@ sourceDir = {{ .chezmoi.sourceDir | quote }}
     command = "op"
     account = "EJLA3HRAVZBCXIQ7SRSFGQBTNU"
 
+[scriptEnv]
+    OP_ACCOUNT = "EJLA3HRAVZBCXIQ7SRSFGQBTNU"
+
 [interpreters.ps1]
     command = "powershell"
     args = ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File"]

--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -4,6 +4,7 @@ sourceDir = {{ .chezmoi.sourceDir | quote }}
 
 [onepassword]
     command = "op"
+    account = "EJLA3HRAVZBCXIQ7SRSFGQBTNU"
 
 [interpreters.ps1]
     command = "powershell"

--- a/chezmoi/.chezmoiscripts/deploy/shells/run_onchange_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/shells/run_onchange_deploy.ps1.tmpl
@@ -1,6 +1,6 @@
 {{ if eq .chezmoi.os "windows" -}}
 # Deploy shell configurations for Windows
-# hash: {{ include "shells/bashrc" | sha256sum }}{{ include "shells/zshrc" | sha256sum }}{{ include "shells/profile" | sha256sum }}{{ include "shells/Microsoft.PowerShell_profile.ps1" | sha256sum }}{{ include "secret/env.sh" | sha256sum }}{{ include "secret/env.ps1" | sha256sum }}
+# hash: {{ include "shells/bashrc" | sha256sum }}{{ include "shells/profile" | sha256sum }}{{ include "shells/Microsoft.PowerShell_profile.ps1" | sha256sum }}{{ include "secret/env.sh" | sha256sum }}{{ include "secret/env.ps1" | sha256sum }}
 
 $ErrorActionPreference = "Stop"
 
@@ -30,7 +30,6 @@ function Deploy-File {
 Write-Host "Deploying shell configurations..."
 
 Deploy-File "$ChezmoiSource\shells\bashrc" "$HomeDir\.bashrc"
-Deploy-File "$ChezmoiSource\shells\zshrc" "$HomeDir\.zshrc"
 Deploy-File "$ChezmoiSource\shells\profile" "$HomeDir\.profile"
 
 # PowerShell profiles (PowerShell 7 and Windows PowerShell 5.1)

--- a/chezmoi/terminals/warp/settings.toml
+++ b/chezmoi/terminals/warp/settings.toml
@@ -20,8 +20,8 @@ is_settings_sync_enabled = true
 
 [appearance.text]
 font_family = "Moralerspace"
-notebook_font_size = 12.0
-font_size = 12.0
+notebook_font_size = 8.0
+font_size = 8.0
 
 [appearance.themes]
 system_theme = false

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -75,7 +75,7 @@ config.color_scheme = "gruvbox-custom"
 
 -- Font settings
 config.font = wezterm.font("Moralerspace")
-config.font_size = 12.0
+config.font_size = 8.0
 
 -- IME support
 config.use_ime = true

--- a/chezmoi/terminals/windows-terminal/settings.json
+++ b/chezmoi/terminals/windows-terminal/settings.json
@@ -164,7 +164,7 @@
     "defaults": {
       "font": {
         "face": "Moralerspace",
-        "size": 12
+        "size": 8
       },
       "useAcrylic": true,
       "opacity": 85,


### PR DESCRIPTION
## Summary

- Reduce font size from 12 to 8 across all terminals (Windows Terminal, WezTerm, Warp)
- Fix \`task commit\` to handle commit messages with spaces correctly via WSLENV
- Fix 1Password account ambiguity in chezmoi config
- Remove stale \`zshrc\` reference from shells deploy script

## Changes

- \`chezmoi/terminals/windows-terminal/settings.json\`: \`size: 12\` → \`8\`
- \`chezmoi/terminals/warp/settings.toml\`: \`font_size\`/\`notebook_font_size\`: \`12.0\` → \`8.0\`
- \`chezmoi/terminals/wezterm/wezterm.lua\`: \`font_size\`: \`12.0\` → \`8.0\`
- \`Taskfile.yml\`: Fix commit task quoting via WSLENV + sed strip
- \`chezmoi/.chezmoi.toml.tmpl\`: Add \`account\` and \`scriptEnv.OP_ACCOUNT\` for 1Password
- \`chezmoi/.chezmoiscripts/deploy/shells/run_onchange_deploy.ps1.tmpl\`: Remove stale zshrc refs

## Test plan

- [x] \`chezmoi apply\` runs without errors on Windows
- [x] Font size 8 visible in Windows Terminal, WezTerm, and Warp
- [x] \`task commit -- "fix: message with spaces"\` works correctly
- [x] 1Password secrets resolve without "multiple accounts found" error

Closes LIF-145

🤖 Generated with [Claude Code](https://claude.com/claude-code)