### PR TITLE
fix(fonts): 全設定ファイルのフォントサイズを 10 に統一 (LIF-146)

### DIFF
--- a/chezmoi/editors/cursor/settings.json
+++ b/chezmoi/editors/cursor/settings.json
@@ -1,5 +1,5 @@
 {
-  "editor.fontSize": 12,
+  "editor.fontSize": 10,
   "editor.fontFamily": "Moralerspace",
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "ibecker.treefmt-vscode",
@@ -51,7 +51,7 @@
   "editor.suggest.shareSuggestSelections": true,
   "editor.suggest.selectionMode": "always",
   "editor.snippetSuggestions": "top",
-  "editor.suggestFontSize": 12,
+  "editor.suggestFontSize": 10,
   "editor.suggest.preview": true,
   "editor.suggest.showInlineDetails": true,
   "editor.mouseWheelZoom": true,
@@ -129,7 +129,7 @@
     "default": "left"
   },
   "terminal.integrated.fontFamily": "Moralerspace",
-  "terminal.integrated.fontSize": 12,
+  "terminal.integrated.fontSize": 10,
   "terminal.integrated.defaultProfile.linux": "bash",
   "terminal.integrated.tabs.enabled": true,
   "terminal.integrated.shellIntegration.enabled": true,

--- a/chezmoi/editors/vscode/settings.json
+++ b/chezmoi/editors/vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "editor.fontSize": 12,
+  "editor.fontSize": 10,
   "editor.fontFamily": "Moralerspace",
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "ibecker.treefmt-vscode",
@@ -51,7 +51,7 @@
   "editor.suggest.shareSuggestSelections": true,
   "editor.suggest.selectionMode": "always",
   "editor.snippetSuggestions": "top",
-  "editor.suggestFontSize": 12,
+  "editor.suggestFontSize": 10,
   "editor.suggest.preview": true,
   "editor.suggest.showInlineDetails": true,
   "editor.mouseWheelZoom": true,
@@ -129,7 +129,7 @@
     "default": "right"
   },
   "terminal.integrated.fontFamily": "Moralerspace",
-  "terminal.integrated.fontSize": 12,
+  "terminal.integrated.fontSize": 10,
   "terminal.integrated.defaultProfile.linux": "bash",
   "terminal.integrated.tabs.enabled": true,
   "terminal.integrated.shellIntegration.enabled": true,

--- a/chezmoi/editors/zed/settings.json
+++ b/chezmoi/editors/zed/settings.json
@@ -26,8 +26,8 @@
     "dark": "Material Icon Theme"
   },
   "theme": "GitHub Dark Dimmed",
-  "ui_font_size": 14,
-  "buffer_font_size": 12,
+  "ui_font_size": 10,
+  "buffer_font_size": 10,
   "buffer_font_family": "Moralerspace",
   // Vim mode
   "vim_mode": false,
@@ -66,7 +66,7 @@
     "shell": {
       "program": "pwsh"
     },
-    "font_size": 12,
+    "font_size": 10,
     "line_height": "comfortable",
     "copy_on_select": false,
     "vim_mode": false

--- a/chezmoi/terminals/warp/settings.toml
+++ b/chezmoi/terminals/warp/settings.toml
@@ -20,8 +20,8 @@ is_settings_sync_enabled = true
 
 [appearance.text]
 font_family = "Moralerspace"
-notebook_font_size = 8.0
-font_size = 8.0
+notebook_font_size = 10.0
+font_size = 10.0
 
 [appearance.themes]
 system_theme = false

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -75,7 +75,7 @@ config.color_scheme = "gruvbox-custom"
 
 -- Font settings
 config.font = wezterm.font("Moralerspace")
-config.font_size = 8.0
+config.font_size = 10.0
 
 -- IME support
 config.use_ime = true

--- a/chezmoi/terminals/windows-terminal/settings.json
+++ b/chezmoi/terminals/windows-terminal/settings.json
@@ -164,7 +164,7 @@
     "defaults": {
       "font": {
         "face": "Moralerspace",
-        "size": 8
+        "size": 10
       },
       "useAcrylic": true,
       "opacity": 85,


### PR DESCRIPTION
## Summary

- WezTerm / Warp / Zed / Cursor / VS Code / Windows Terminal の全設定ファイルのフォントサイズを 10 に統一
- Warp・WezTerm・Windows Terminal は 8 → 10、その他は 12 → 10 に変更

## Closes

[LIF-146](https://linear.app/life-style-base/issue/LIF-146/fix-全設定ファイルのフォントサイズを-10-に統一)

## Test plan

- [x] `chezmoi apply` で各設定ファイルが正しく展開されること
- [x] WezTerm・Warp・Windows Terminal でフォントサイズ 10 が反映されること
- [x] Zed・Cursor・VS Code でフォントサイズ 10 が反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)