### PR TITLE
fix(warp): disable is_settings_sync_enabled to prevent cloud override of chezmoi settings

### DIFF
--- a/chezmoi/terminals/warp/settings.toml
+++ b/chezmoi/terminals/warp/settings.toml
@@ -14,7 +14,7 @@ telemetry_enabled = true
 crash_reporting_enabled = true
 
 [account]
-is_settings_sync_enabled = true
+is_settings_sync_enabled = false
 
 [appearance]
 


### PR DESCRIPTION
## Summary

- `chezmoi/terminals/warp/settings.toml`: `is_settings_sync_enabled = true` → `false`

## 背景

chezmoi でデプロイした Warp 設定を、Warp のクラウド同期が上書きしてフォント等の設定が失われる問題を修正。dotfiles リポジトリを source of truth とするため、アプリ側クラウド同期を無効化する。

## Test plan

- [x] source ファイル `chezmoi/terminals/warp/settings.toml` に `is_settings_sync_enabled = false` が設定されていることを確認
- [ ] `chezmoi apply` 後、Warp の Settings で "Sync settings" が OFF になっていることを確認
- [ ] Warp 再起動後もフォント設定が維持されることを確認

Closes LIF-148

🤖 Generated with [Claude Code](https://claude.com/claude-code)