### PR TITLE
fix(warp): replace deprecated font_family with font_name in settings.toml

### DIFF
--- a/chezmoi/terminals/warp/settings.toml
+++ b/chezmoi/terminals/warp/settings.toml
@@ -19,7 +19,6 @@ is_settings_sync_enabled = false
 [appearance]
 
 [appearance.text]
-font_family = "Moralerspace Neon HWJPDOC"
 font_name = "Moralerspace Neon HWJPDOC"
 ai_font_name = "Moralerspace Neon HWJPDOC"
 match_ai_font = false

--- a/chezmoi/terminals/warp/settings.toml
+++ b/chezmoi/terminals/warp/settings.toml
@@ -20,6 +20,9 @@ is_settings_sync_enabled = false
 
 [appearance.text]
 font_family = "Moralerspace Neon HWJPDOC"
+font_name = "Moralerspace Neon HWJPDOC"
+ai_font_name = "Moralerspace Neon HWJPDOC"
+match_ai_font = false
 notebook_font_size = 10.0
 font_size = 10.0
 


### PR DESCRIPTION
## Summary

- `[appearance.text]` に `font_name`, `ai_font_name`, `match_ai_font` を追加
- `font_family` は旧パラメータで現行 Warp では無視されていた

## 背景

Warp の UI でフォントを設定した際に書き込まれるファイルを確認したところ、`font_family` ではなく `font_name` が実際に使用されるパラメータであることが判明。chezmoi source に `font_family` しかなかったため、デプロイ後も "Hack (default)" のままだった。

## Test plan

- [x] Warp UI でフォント選択時に `font_name` が書き込まれることを確認（実機で確認済み）
- [ ] `chezmoi apply` 後、Warp 再起動でフォントが `Moralerspace Neon HWJPDOC` になることを確認

Closes LIF-149

🤖 Generated with [Claude Code](https://claude.com/claude-code)