### PR TITLE
fix(warp): WSL NixOS での起動エラーを修正 (LIF-177)

### DIFF
--- a/nix/home/wsl/users.nix
+++ b/nix/home/wsl/users.nix
@@ -2,7 +2,7 @@
 # Imported by nix/flakes/lib/hosts.nix as home-manager.users.
 {
   nixos =
-    { ... }:
+    { pkgs, ... }:
     let
       # GCM のパスには空白 (`Program Files`) が含まれるため、git が helper 値を
       # `sh -c` に渡す前にトークン分割しないようリテラルなダブルクォートで包む。
@@ -24,12 +24,30 @@
       home.sessionVariables._ZO_EXCLUDE_DIRS = "/mnt/wsl/*:/mnt/wslg/*";
 
       programs.zsh.shellAliases = {
-        # nixpkgs installs Warp CLI as "warp-terminal"; alias to match Windows naming
-        warp = "warp-terminal";
+        # nixpkgs installs Warp CLI as "warp-terminal"; alias to match Windows naming.
+        # LD_LIBRARY_PATH must include wayland because Warp dlopen()s libwayland-client
+        # at runtime and the binary bypasses nix-ld (it links directly against NixOS glibc).
+        warp = "LD_LIBRARY_PATH=${pkgs.wayland}/lib:\${LD_LIBRARY_PATH:-} MESA_D3D12_DEFAULT_ADAPTER_NAME=Microsoft warp-terminal";
         # NixOS rebuild shortcuts
         nrs = "sudo nixos-rebuild switch --flake ~/.dotfiles --impure && nix profile upgrade '.*' || nix profile install ~/.dotfiles#default";
         nrt = "sudo nixos-rebuild test --flake ~/.dotfiles --impure";
         nrb = "sudo nixos-rebuild boot --flake ~/.dotfiles --impure";
+      };
+
+      # gnome-keyring as a user systemd service.
+      # WSL has no PAM login flow, so the daemon won't be auto-unlocked; running it
+      # via systemd with --unlock-on-start keeps the default keyring open without a
+      # password prompt, which is acceptable in a local WSL environment.
+      systemd.user.services.gnome-keyring = {
+        Unit = {
+          Description = "GNOME Keyring daemon";
+          After = [ "basic.target" ];
+        };
+        Service = {
+          ExecStart = "${pkgs.gnome-keyring}/bin/gnome-keyring-daemon --foreground --components=secrets";
+          Restart = "on-abort";
+        };
+        Install.WantedBy = [ "default.target" ];
       };
 
       programs.git = {

--- a/nix/home/wsl/users.nix
+++ b/nix/home/wsl/users.nix
@@ -35,9 +35,10 @@
       };
 
       # gnome-keyring as a user systemd service.
-      # WSL has no PAM login flow, so the daemon won't be auto-unlocked; running it
-      # via systemd with --unlock-on-start keeps the default keyring open without a
-      # password prompt, which is acceptable in a local WSL environment.
+      # WSL has no PAM login flow so the system-level keyring service is never
+      # auto-started. This user unit ensures the daemon runs on every login.
+      # The keyring starts locked; Warp will create a new default collection
+      # with an empty password on first use, which is acceptable for WSL.
       systemd.user.services.gnome-keyring = {
         Unit = {
           Description = "GNOME Keyring daemon";

--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -18,7 +18,22 @@
       stdenv.cc.cc
       zlib
       openssl
+      wayland
+      libxkbcommon
     ];
+  };
+
+  # Secret Service for Warp (and other apps) to persist credentials across restarts.
+  # Without this, Warp shows "Failed to acquire default Secret Service collection".
+  services.gnome.gnome-keyring.enable = true;
+  security.pam.services.login.enableGnomeKeyring = true;
+
+  # XDG desktop portal: provides color-scheme and other settings queries via D-Bus.
+  # Without this, Warp logs "XDG Settings Portal did not return response in time".
+  xdg.portal = {
+    enable = true;
+    extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
+    config.common.default = "*";
   };
 
   # Re-register WSLInterop binfmt entry after systemd clears it on boot.
@@ -33,5 +48,6 @@
   environment.variables = {
     NIX_LD = "/run/current-system/sw/share/nix-ld/lib/ld.so";
     NIX_LD_LIBRARY_PATH = "/run/current-system/sw/share/nix-ld/lib";
+    WARP_ENABLE_WAYLAND = "1";
   };
 }

--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -23,9 +23,10 @@
     ];
   };
 
-  # Secret Service for Warp (and other apps) to persist credentials across restarts.
-  # Without this, Warp shows "Failed to acquire default Secret Service collection".
-  services.gnome.gnome-keyring.enable = true;
+  # PAM integration for gnome-keyring: auto-unlocks the keyring on login when a
+  # proper PAM session is used. The daemon itself is started by a Home Manager
+  # user systemd service (see nix/home/wsl/users.nix) to avoid a duplicate
+  # instance competing for the org.freedesktop.secrets D-Bus name.
   security.pam.services.login.enableGnomeKeyring = true;
 
   # XDG desktop portal: provides color-scheme and other settings queries via D-Bus.


### PR DESCRIPTION
## Summary

- \`nix-ld\` ライブラリに \`wayland\`/\`libxkbcommon\` を追加し、Warp が \`dlopen()\` する \`libwayland-client\` を解決
- \`WARP_ENABLE_WAYLAND=1\` を \`environment.variables\` に追加
- \`warp\` エイリアスに \`LD_LIBRARY_PATH\` と \`MESA_D3D12_DEFAULT_ADAPTER_NAME=Microsoft\` を設定
- \`gnome-keyring\` PAM 統合を追加、ユーザー systemd サービスで WSL 起動時に自動開始
- \`xdg-desktop-portal\` + \`xdg-desktop-portal-gtk\` を追加（カラースキーム取得）

Closes LIF-177

## Test plan

- [x] \`warp\` コマンドで Warp が起動することを確認 — プロセス PID 20317 で起動を確認
- [x] \`NoWaylandLib\` エラーが出ないことを確認 — journalctl に該当エラーなし、Wayland windowing system で起動
- [x] \`Secret Service\` エラーが出ないことを確認 — \`org.freedesktop.secrets\` D-Bus ping が正常応答
- [x] \`XDG Settings Portal\` タイムアウトが出ないことを確認 — \`org.freedesktop.portal.Desktop\` D-Bus ping が正常応答

🤖 Generated with [Claude Code](https://claude.com/claude-code)