### PR TITLE
fix(warp): WSL NixOS での日本語入力を fcitx5+mozc で対応 (LIF-178)

### DIFF
--- a/nix/home/wsl/users.nix
+++ b/nix/home/wsl/users.nix
@@ -50,8 +50,7 @@
       systemd.user.services.fcitx5 = {
         Unit = {
           Description = "Fcitx5 input method daemon";
-          After = [ "graphical-session.target" ];
-          PartOf = [ "graphical-session.target" ];
+          After = [ "basic.target" ];
         };
         Service = {
           ExecStart = "/run/current-system/sw/bin/fcitx5 --disable=wayland";
@@ -61,7 +60,7 @@
             "WAYLAND_DISPLAY="
           ];
         };
-        Install.WantedBy = [ "graphical-session.target" ];
+        Install.WantedBy = [ "default.target" ];
       };
 
       # gnome-keyring as a user systemd service.

--- a/nix/home/wsl/users.nix
+++ b/nix/home/wsl/users.nix
@@ -27,11 +27,32 @@
         # nixpkgs installs Warp CLI as "warp-terminal"; alias to match Windows naming.
         # LD_LIBRARY_PATH must include wayland because Warp dlopen()s libwayland-client
         # at runtime and the binary bypasses nix-ld (it links directly against NixOS glibc).
-        warp = "LD_LIBRARY_PATH=${pkgs.wayland}/lib:\${LD_LIBRARY_PATH:-} MESA_D3D12_DEFAULT_ADAPTER_NAME=Microsoft warp-terminal";
+        warp = "LD_LIBRARY_PATH=${pkgs.wayland}/lib:\${LD_LIBRARY_PATH:-} MESA_D3D12_DEFAULT_ADAPTER_NAME=Microsoft GTK_IM_MODULE=fcitx QT_IM_MODULE=fcitx XMODIFIERS=@im=fcitx warp-terminal";
         # NixOS rebuild shortcuts
         nrs = "sudo nixos-rebuild switch --flake ~/.dotfiles --impure && nix profile upgrade '.*' || nix profile install ~/.dotfiles#default";
         nrt = "sudo nixos-rebuild test --flake ~/.dotfiles --impure";
         nrb = "sudo nixos-rebuild boot --flake ~/.dotfiles --impure";
+      };
+
+      # fcitx5 user systemd service (X11 mode only).
+      # WSLg's Wayland compositor does not support zwp_input_method_v2, so
+      # WAYLAND_DISPLAY is explicitly unset to force X11/XWayland mode where
+      # fcitx5's GTK_IM_MODULE bridge works.
+      systemd.user.services.fcitx5 = {
+        Unit = {
+          Description = "Fcitx5 input method daemon (X11 mode)";
+          After = [ "graphical-session.target" ];
+          PartOf = [ "graphical-session.target" ];
+        };
+        Service = {
+          ExecStart = "/run/current-system/sw/bin/fcitx5 --disable=wayland";
+          Restart = "on-failure";
+          Environment = [
+            "DISPLAY=:0"
+            "WAYLAND_DISPLAY="
+          ];
+        };
+        Install.WantedBy = [ "graphical-session.target" ];
       };
 
       # gnome-keyring as a user systemd service.

--- a/nix/home/wsl/users.nix
+++ b/nix/home/wsl/users.nix
@@ -21,26 +21,35 @@
       # GCM 本体のパスは WSL 限定なので home-manager の WSL プロファイルに置く。
       # Exclude WSL mount paths from zoxide's database to avoid indexing
       # temporary runtime files under /mnt/wsl/ and /mnt/wslg/.
-      home.sessionVariables._ZO_EXCLUDE_DIRS = "/mnt/wsl/*:/mnt/wslg/*";
+      home.sessionVariables = {
+        _ZO_EXCLUDE_DIRS = "/mnt/wsl/*:/mnt/wslg/*";
+        # fcitx5 GTK_IM_MODULE bridge: Warp runs in Wayland mode but reads these
+        # env vars to delegate key events to the fcitx5 daemon via the GTK IM module.
+        GTK_IM_MODULE = "fcitx";
+        QT_IM_MODULE = "fcitx";
+        XMODIFIERS = "@im=fcitx";
+      };
 
       programs.zsh.shellAliases = {
         # nixpkgs installs Warp CLI as "warp-terminal"; alias to match Windows naming.
         # LD_LIBRARY_PATH must include wayland because Warp dlopen()s libwayland-client
         # at runtime and the binary bypasses nix-ld (it links directly against NixOS glibc).
-        warp = "LD_LIBRARY_PATH=${pkgs.wayland}/lib:\${LD_LIBRARY_PATH:-} MESA_D3D12_DEFAULT_ADAPTER_NAME=Microsoft GTK_IM_MODULE=fcitx QT_IM_MODULE=fcitx XMODIFIERS=@im=fcitx warp-terminal";
+        warp = "LD_LIBRARY_PATH=${pkgs.wayland}/lib:\${LD_LIBRARY_PATH:-} MESA_D3D12_DEFAULT_ADAPTER_NAME=Microsoft warp-terminal";
         # NixOS rebuild shortcuts
         nrs = "sudo nixos-rebuild switch --flake ~/.dotfiles --impure && nix profile upgrade '.*' || nix profile install ~/.dotfiles#default";
         nrt = "sudo nixos-rebuild test --flake ~/.dotfiles --impure";
         nrb = "sudo nixos-rebuild boot --flake ~/.dotfiles --impure";
       };
 
-      # fcitx5 user systemd service (X11 mode only).
+      # fcitx5 user systemd service.
       # WSLg's Wayland compositor does not support zwp_input_method_v2, so
-      # WAYLAND_DISPLAY is explicitly unset to force X11/XWayland mode where
-      # fcitx5's GTK_IM_MODULE bridge works.
+      # fcitx5 is started with --disable=wayland to prevent it from crashing
+      # ("waylandmodule: Connection removed"). Warp itself continues to run in
+      # Wayland mode; Japanese input works via the GTK_IM_MODULE=fcitx bridge
+      # which routes key events to this daemon regardless of display backend.
       systemd.user.services.fcitx5 = {
         Unit = {
-          Description = "Fcitx5 input method daemon (X11 mode)";
+          Description = "Fcitx5 input method daemon";
           After = [ "graphical-session.target" ];
           PartOf = [ "graphical-session.target" ];
         };

--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -1,7 +1,14 @@
 { config, pkgs, ... }:
 {
-  environment.systemPackages = [
-    pkgs.coreutils
+  environment.systemPackages = with pkgs; [
+    coreutils
+    # Japanese input: fcitx5+mozc installed as system packages.
+    # i18n.inputMethod is intentionally NOT used here because it auto-generates
+    # app-org.fcitx.Fcitx5@autostart.service, which conflicts with the Home Manager
+    # user systemd service that runs fcitx5 with --disable=wayland (required for WSLg).
+    fcitx5
+    fcitx5-mozc
+    fcitx5-gtk
   ];
 
   system.activationScripts.wslWhoami = {
@@ -21,14 +28,6 @@
       wayland
       libxkbcommon
     ];
-  };
-
-  # Japanese input via fcitx5+mozc.
-  # fcitx5 is started as a user systemd service by this option automatically.
-  i18n.inputMethod = {
-    enable = true;
-    type = "fcitx5";
-    fcitx5.addons = with pkgs; [ fcitx5-mozc ];
   };
 
   # PAM integration for gnome-keyring: auto-unlocks the keyring on login when a

--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -23,6 +23,14 @@
     ];
   };
 
+  # Japanese input via fcitx5+mozc.
+  # fcitx5 is started as a user systemd service by this option automatically.
+  i18n.inputMethod = {
+    enable = true;
+    type = "fcitx5";
+    fcitx5.addons = with pkgs; [ fcitx5-mozc ];
+  };
+
   # PAM integration for gnome-keyring: auto-unlocks the keyring on login when a
   # proper PAM session is used. The daemon itself is started by a Home Manager
   # user systemd service (see nix/home/wsl/users.nix) to avoid a duplicate


### PR DESCRIPTION
## Summary

- `i18n.inputMethod` に `fcitx5` + `fcitx5-mozc` を追加
- `systemd.user.services.fcitx5` を追加（`--disable=wayland` で X11/XWayland モード強制）
  - WSLg の Wayland コンポジターが `zwp_input_method_v2` 未対応のため Wayland モードで即終了する問題を回避
- `warp` エイリアスに `GTK_IM_MODULE=fcitx` / `QT_IM_MODULE=fcitx` / `XMODIFIERS=@im=fcitx` を追加

Closes LIF-178

## Test plan

- [ ] `nrs` 後に `systemctl --user status fcitx5.service` が `active (running)` であることを確認
- [ ] Warp 上で `Ctrl+Space` で mozc に切り替えられることを確認
- [ ] Warp 上で日本語が入力できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)