### PR TITLE
fix(wsl): fcitx5 mozc 認識不良と profile を Nix で管理

### DIFF
--- a/nix/home/wsl/users.nix
+++ b/nix/home/wsl/users.nix
@@ -21,6 +21,27 @@
       # GCM 本体のパスは WSL 限定なので home-manager の WSL プロファイルに置く。
       # Exclude WSL mount paths from zoxide's database to avoid indexing
       # temporary runtime files under /mnt/wsl/ and /mnt/wslg/.
+      # Declaratively manage fcitx5 input method profile.
+      # fcitx5 overwrites this file on exit, so home-manager re-applies it on
+      # each activation (nrs). Users should not edit this file manually.
+      home.file.".config/fcitx5/profile".text = ''
+        [Groups/0]
+        Name=Default
+        Default Layout=us
+        DefaultIM=mozc
+
+        [Groups/0/Items/0]
+        Name=keyboard-us
+        Layout=
+
+        [Groups/0/Items/1]
+        Name=mozc
+        Layout=
+
+        [GroupOrder]
+        0=Default
+      '';
+
       home.sessionVariables = {
         _ZO_EXCLUDE_DIRS = "/mnt/wsl/*:/mnt/wslg/*";
         # fcitx5 GTK_IM_MODULE bridge: Warp runs in Wayland mode but reads these

--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -11,6 +11,11 @@
     fcitx5-gtk
   ];
 
+  # Merge /share/fcitx5 from all installed packages into /run/current-system/sw/share/fcitx5.
+  # Without this, fcitx5 cannot find addon/inputmethod conf files provided by
+  # separate packages like fcitx5-mozc (only the fcitx5 package itself is searched by default).
+  environment.pathsToLink = [ "/share/fcitx5" ];
+
   system.activationScripts.wslWhoami = {
     text = ''
       mkdir -p /usr/bin


### PR DESCRIPTION
## Summary

- `environment.pathsToLink = [ "/share/fcitx5" ]` を追加し、`fcitx5-mozc` のアドオン conf ファイル (`share/fcitx5/addon/mozc.conf`, `share/fcitx5/inputmethod/mozc.conf`) を `/run/current-system/sw/share/fcitx5/` にマージ
  - これがないと fcitx5 は自パッケージのパスしか検索せず mozc を認識できない
- `home.file.".config/fcitx5/profile"` でプロファイルを宣言的に管理し、mozc をデフォルト入力メソッドとして設定

## Test plan

- [ ] `nrs` 後に fcitx5 ログに `Group Item mozc in group Default is not valid` が出ないことを確認
- [ ] `nrs` 後に Warp 上で `Ctrl+Space` で mozc に切り替えられることを確認
- [ ] `nrs` 後に Warp 上で日本語が入力できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)