### PR TITLE
fix(wsl): fcitx5 profile に force = true を追加

### DIFF
--- a/nix/home/wsl/users.nix
+++ b/nix/home/wsl/users.nix
@@ -21,26 +21,31 @@
       # GCM 本体のパスは WSL 限定なので home-manager の WSL プロファイルに置く。
       # Exclude WSL mount paths from zoxide's database to avoid indexing
       # temporary runtime files under /mnt/wsl/ and /mnt/wslg/.
+
       # Declaratively manage fcitx5 input method profile.
       # fcitx5 overwrites this file on exit, so home-manager re-applies it on
-      # each activation (nrs). Users should not edit this file manually.
-      home.file.".config/fcitx5/profile".text = ''
-        [Groups/0]
-        Name=Default
-        Default Layout=us
-        DefaultIM=mozc
+      # each activation (nrs). force = true is required to overwrite the file
+      # even when fcitx5 has already written its own copy.
+      home.file.".config/fcitx5/profile" = {
+        force = true;
+        text = ''
+          [Groups/0]
+          Name=Default
+          Default Layout=us
+          DefaultIM=mozc
 
-        [Groups/0/Items/0]
-        Name=keyboard-us
-        Layout=
+          [Groups/0/Items/0]
+          Name=keyboard-us
+          Layout=
 
-        [Groups/0/Items/1]
-        Name=mozc
-        Layout=
+          [Groups/0/Items/1]
+          Name=mozc
+          Layout=
 
-        [GroupOrder]
-        0=Default
-      '';
+          [GroupOrder]
+          0=Default
+        '';
+      };
 
       home.sessionVariables = {
         _ZO_EXCLUDE_DIRS = "/mnt/wsl/*:/mnt/wslg/*";


### PR DESCRIPTION
## Summary

- `home.file.".config/fcitx5/profile"` に `force = true` を追加
  - fcitx5 デーモンが終了時に profile を書き込むため、次回 `nrs` 時に home-manager activation が "Existing file would be clobbered" で失敗する問題を修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)