### PR TITLE
fix(wsl): fcitx5 service に FCITX_ADDON_DIRS を追加

### DIFF
--- a/nix/home/wsl/users.nix
+++ b/nix/home/wsl/users.nix
@@ -84,6 +84,10 @@
           Environment = [
             "DISPLAY=:0"
             "WAYLAND_DISPLAY="
+            # fcitx5 searches its own store-path lib dir by default, not the merged
+            # /run/current-system/sw path. This makes addon .so files from separate
+            # packages (e.g. fcitx5-mozc) visible at runtime.
+            "FCITX_ADDON_DIRS=/run/current-system/sw/lib/fcitx5"
           ];
         };
         Install.WantedBy = [ "default.target" ];


### PR DESCRIPTION
## Summary

fcitx5 はデフォルトで自パッケージのストアパス `lib/fcitx5/` しか検索しないため、`fcitx5-mozc` の `.so` が見つからず `Could not load addon mozc` が発生していた。

`FCITX_ADDON_DIRS=/run/current-system/sw/lib/fcitx5` を systemd service の `Environment` に追加し、全パッケージの addon `.so` をマージした `/run/current-system/sw/lib/fcitx5/` を検索パスに加える。

🤖 Generated with [Claude Code](https://claude.com/claude-code)