### PR TITLE
fix(mcp): playwright MCP に --isolated フラグを追加しバージョンを最新化

### DIFF
--- a/chezmoi/.chezmoidata/mcp_servers.yaml
+++ b/chezmoi/.chezmoidata/mcp_servers.yaml
@@ -255,11 +255,13 @@ mcp_servers:
       - zed
 
   # Playwright - Browser automation MCP (VS Code only; used via Copilot chat)
+  # --isolated: セッションごとに独立したブラウザを起動し、複数セッション間の競合を防ぐ
   - name: playwright
     command: pnpm
     args:
       - "dlx"
-      - "@playwright/mcp@0.0.71"
+      - "@playwright/mcp@0.0.75"
+      - "--isolated"
     startup_timeout_sec: 60
     supports:
       - vscode


### PR DESCRIPTION
## Summary

- `@playwright/mcp` を `0.0.71` → `0.0.75` に更新
- `--isolated` フラグを追加し、複数の Claude Code セッションが同じ Playwright MCP サーバーを使う際のブラウザ競合を解消

## Background

複数セッションがデフォルト MCP を共有すると 1プロセス=1ブラウザのロックで競合が発生する。`--isolated` を付けることでセッションごとに独立したブラウザが起動され、並行実行が可能になる。

参考: `--isolated` フラグは `@playwright/mcp` 0.0.26 以降でサポートされており、0.0.75 でも継続してサポートされている。
- npm: https://www.npmjs.com/package/@playwright/mcp

## Test plan

- [ ] `chezmoi apply` 後に `%APPDATA%\Code\User\mcp.json` の playwright args に `--isolated` が含まれることを確認
- [ ] 複数の Copilot チャットセッションで Playwright MCP が並行して動作することを確認

Closes LIF-179

🤖 Generated with [Claude Code](https://claude.com/claude-code)