### PR TITLE
feat(env): direnv 導入で nix-direnv ベースの devShell 自動ロードを実現 (LIF-180)

### DIFF
--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -57,6 +57,11 @@ else {
     }
 }
 
+# direnv (load .envrc per-directory; must init AFTER prompt hooks above)
+if (Get-Command direnv -ErrorAction SilentlyContinue) {
+    Invoke-Expression (& direnv hook pwsh | Out-String)
+}
+
 # qmd (markdown search engine)
 $env:QMD_EMBED_MODEL = "hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf"
 $env:QMD_RERANK_MODEL = "hf:giladgd/Qwen3-Reranker-4B-GGUF:Q8_0"

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -122,6 +122,13 @@ in
     enableZshIntegration = true;
   };
 
+  # ── direnv ───────────────────────────────────────────────────────────────
+  programs.direnv = {
+    enable = true;
+    nix-direnv.enable = true;
+    enableZshIntegration = true;
+  };
+
   # ── Environment variables ────────────────────────────────────────────────
   home.sessionVariables = {
     # qmd (markdown search engine)

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -68,6 +68,11 @@ let
       winget = "junegunn.fzf";
       category = "core";
     };
+    direnv = {
+      pkg = pkgs.direnv;
+      winget = "direnv.direnv";
+      category = "core";
+    };
     unzip = {
       pkg = pkgs.unzip;
       winget = null;
@@ -329,6 +334,10 @@ lib.mapAttrs (_: names: resolve names) grouped
     };
     fzf = {
       command = "fzf";
+      args = [ "--version" ];
+    };
+    direnv = {
+      command = "direnv";
       args = [ "--version" ];
     };
     starship = {

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -18,6 +18,13 @@
           }
         },
         {
+          "PackageIdentifier": "direnv.direnv",
+          "verifyCommand": {
+            "args": ["--version"],
+            "command": "direnv"
+          }
+        },
+        {
           "PackageIdentifier": "eza-community.eza",
           "verifyCommand": {
             "args": ["--version"],


### PR DESCRIPTION
## Summary

- `nix/packages/sets.nix`: catalog に `direnv` を追加 (core / winget: `direnv.direnv`) + `wingetVerify` エントリ
- `nix/home/common.nix`: `programs.direnv` 有効化 (`nix-direnv.enable`, `enableZshIntegration`)
- `windows/winget/packages.json`: `nix build .#winget-export` で再生成

## 背景

`nix/templates/python` などの devShell 利用時に毎回 `nix develop` を手で叩く必要があった。`nix/templates/AGENTS.md` には `direnv allow` を案内しているが、肝心の direnv 本体が未導入だった。

## 動作確認

- `sudo nixos-rebuild dry-build --flake . --impure` → 成功 (direnv 2.37.1 + nix-direnv 3.1.1 が反映予定)
- `nix fmt --fail-on-change` → 変更なし
- `nix build .#winget-export` → `direnv.direnv` エントリ生成を確認

## Test plan

- [x] `nrs` で apply (`nixos-rebuild switch --flake <worktree> --impure` で検証、direnv 2.37.1 + nix-direnv 3.1.1 が `/etc/profiles/per-user/nixos/bin/direnv` に配置)
- [x] zsh 再起動後、`.envrc` 入りのディレクトリで direnv が動くこと (`~/.zshrc` に `direnv hook zsh` が injected、`direnv exec` 動作確認)
- [x] `nix/templates/python` を試して `direnv allow` で devShell が自動ロードされること (`IN_NIX_SHELL=impure` + `VIRTUAL_ENV` 設定を確認)
- [x] Windows 側で `winget install direnv.direnv` の前提パッケージとして JSON が読み込まれること (`packages.json` の structure 検証 OK、`winget show direnv.direnv` で公式リポジトリに存在することを確認)

Closes LIF-180

🤖 Generated with [Claude Code](https://claude.com/claude-code)