### PR TITLE
docs: nix/ ツリー図と nix/flakes/AGENTS.md の実態不一致を修正 (LIF-185)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,9 +31,7 @@ dotfiles/
 │   ├── flakes/             # Flake inputs/outputs, treefmt
 │   ├── hosts/              # Host-specific configs (WSL, Linux)
 │   ├── modules/            # Custom NixOS modules (system-level)
-│   ├── profiles/           # Reusable config profiles
-│   ├── lib/                # Helper functions
-│   └── overlays/           # Nixpkgs overlays
+│   └── lib/                # Helper functions
 ├── chezmoi/                # User dotfiles (shell/git/terminal/VS Code/LLM)
 ├── scripts/                # All scripts
 │   ├── sh/                 # Shell scripts (Linux/WSL)

--- a/nix/flakes/AGENTS.md
+++ b/nix/flakes/AGENTS.md
@@ -3,7 +3,9 @@
 ## 管理対象
 
 - `default.nix`: flake-parts エントリ
+- `home.nix`: 非 NixOS 向け standalone home-manager 設定 wiring
 - `hosts.nix`: `nixosConfigurations` wiring
+- `lib/`: ヘルパー関数
 - `packages.nix`: package outputs
 - `systems.nix`: 対応プラットフォーム
 - `treefmt.nix`: formatter wiring


### PR DESCRIPTION
## Summary

LIF-181 PR review で 2 agent が独立して発見した、ドキュメントと実態の乖離を解消。

## 変更内容

### `docs/architecture.md`

実在しない phantom ディレクトリを tree 図から削除:

- `nix/profiles/` ← 実在しない
- `nix/overlays/` ← 実在しない

実態に合わせて `lib/` を末尾の `└──` に調整。

### `nix/flakes/AGENTS.md`

実在するが listing 漏れだった項目を追加:

- `home.nix`: 非 NixOS 向け standalone home-manager 設定 wiring
- `lib/`: ヘルパー関数

## Test plan

- [x] `ls nix/` の結果と `docs/architecture.md` の tree 図が一致（flakes, home, hosts, lib, modules, packages のみ）
- [x] `ls nix/flakes/` の結果と `nix/flakes/AGENTS.md` の listing が一致（7 項目）
- [x] markdown box-drawing が syntactically valid
- [x] `nix fmt` 通過（0 changed）
- [ ] CI (`test-nix.yml`) 通過
- [ ] CI (`test-consistency.yml`) 通過

## 関連

- Closes [LIF-185](https://linear.app/life-style-base/issue/LIF-185/docs-nix-ツリー図と-nixflakesagentsmd-の実態不一致を修正)
- 発見元: [LIF-181](https://linear.app/life-style-base/issue/LIF-181/nixtemplates-削除して未使用テンプレート機能を撤去) / [PR #108](https://github.com/rurusasu/dotfiles/pull/108)

🤖 Generated with [Claude Code](https://claude.com/claude-code)