### PR TITLE
feat(chezmoi/ssh): github-work host alias と work SSH 公開鍵デプロイを追加 (LIF-183)

### DIFF
--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.ps1.tmpl
@@ -1,7 +1,9 @@
 {{ if eq .chezmoi.os "windows" -}}
 # Deploy SSH configuration for Windows
 # hash: {{ include "ssh/config.tmpl" | sha256sum }}
-{{- if lookPath "op" }}
+{{/* Accept either op or op.exe (symmetric with the Unix variant). */}}
+{{- $hasOp := or (lookPath "op") (lookPath "op.exe") }}
+{{- if $hasOp }}
 # personal-pubkey-hash: {{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" | sha256sum }}
 # work-pubkey-hash:     {{ onepasswordRead "op://Employee/GitHub Work/public key" "FXVKKR2KWFCMHGMEA7HQYK6XRE" | sha256sum }}
 {{- end }}
@@ -32,7 +34,7 @@ $sshConfig = @'
 '@
 Deploy-Content $sshConfig "$HomeDir\.ssh\config"
 
-{{- if lookPath "op" }}
+{{- if $hasOp }}
 # Personal SSH public key (from rurusasu's Private vault).
 $personalPubkey = '{{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" }}'
 Deploy-Content $personalPubkey "$HomeDir\.ssh\signing_key.pub"
@@ -42,7 +44,7 @@ Deploy-Content $personalPubkey "$HomeDir\.ssh\signing_key.pub"
 $workPubkey = '{{ onepasswordRead "op://Employee/GitHub Work/public key" "FXVKKR2KWFCMHGMEA7HQYK6XRE" }}'
 Deploy-Content $workPubkey "$HomeDir\.ssh\github_work.pub"
 {{- else }}
-Write-Host "WARNING: op CLI not available, skipping public key deployment"
+Write-Host "WARNING: op/op.exe CLI not available, skipping public key deployment"
 {{- end }}
 
 Write-Host "SSH configuration deployed."

--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.ps1.tmpl
@@ -2,7 +2,8 @@
 # Deploy SSH configuration for Windows
 # hash: {{ include "ssh/config.tmpl" | sha256sum }}
 {{- if lookPath "op" }}
-# pubkey-hash: {{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" | sha256sum }}
+# personal-pubkey-hash: {{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" | sha256sum }}
+# work-pubkey-hash:     {{ onepasswordRead "op://Employee/GitHub Work/public key" "FXVKKR2KWFCMHGMEA7HQYK6XRE" | sha256sum }}
 {{- end }}
 
 $ErrorActionPreference = "Stop"
@@ -32,10 +33,16 @@ $sshConfig = @'
 Deploy-Content $sshConfig "$HomeDir\.ssh\config"
 
 {{- if lookPath "op" }}
-$pubkey = '{{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" }}'
-Deploy-Content $pubkey "$HomeDir\.ssh\signing_key.pub"
+# Personal SSH public key (from rurusasu's Private vault).
+$personalPubkey = '{{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" }}'
+Deploy-Content $personalPubkey "$HomeDir\.ssh\signing_key.pub"
+
+# Work SSH public key (from kohei-miki-im8's Employee vault on the work
+# 1Password account; passed as the 2nd onepasswordRead arg).
+$workPubkey = '{{ onepasswordRead "op://Employee/GitHub Work/public key" "FXVKKR2KWFCMHGMEA7HQYK6XRE" }}'
+Deploy-Content $workPubkey "$HomeDir\.ssh\github_work.pub"
 {{- else }}
-Write-Host "WARNING: op CLI not available, skipping signing_key.pub deployment"
+Write-Host "WARNING: op CLI not available, skipping public key deployment"
 {{- end }}
 
 Write-Host "SSH configuration deployed."

--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.sh.tmpl
@@ -2,7 +2,10 @@
 #!/bin/bash
 # Deploy SSH configuration for Linux/macOS
 # hash: {{ include "ssh/config.tmpl" | sha256sum }}
-{{- if lookPath "op" }}
+{{/* Under WSL the chezmoi config routes [onepassword].command to op.exe, so
+     accept either binary as evidence that 1Password CLI is reachable. */}}
+{{- $hasOp := or (lookPath "op") (lookPath "op.exe") }}
+{{- if $hasOp }}
 # personal-pubkey-hash: {{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" | sha256sum }}
 # work-pubkey-hash:     {{ onepasswordRead "op://Employee/GitHub Work/public key" "FXVKKR2KWFCMHGMEA7HQYK6XRE" | sha256sum }}
 {{- end }}
@@ -27,7 +30,7 @@ SSH_CONFIG='{{ include "ssh/config.tmpl" }}'
 deploy_content "$SSH_CONFIG" "$HOME_DIR/.ssh/config"
 chmod 600 "$HOME_DIR/.ssh/config"
 
-{{- if lookPath "op" }}
+{{- if $hasOp }}
 # Personal SSH public key (from rurusasu's Private vault).
 PERSONAL_PUBKEY='{{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" }}'
 deploy_content "$PERSONAL_PUBKEY" "$HOME_DIR/.ssh/signing_key.pub"
@@ -39,7 +42,7 @@ WORK_PUBKEY='{{ onepasswordRead "op://Employee/GitHub Work/public key" "FXVKKR2K
 deploy_content "$WORK_PUBKEY" "$HOME_DIR/.ssh/github_work.pub"
 chmod 644 "$HOME_DIR/.ssh/github_work.pub"
 {{- else }}
-echo "WARNING: op CLI not available, skipping public key deployment"
+echo "WARNING: op/op.exe CLI not available, skipping public key deployment"
 {{- end }}
 
 echo "SSH configuration deployed."

--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.sh.tmpl
@@ -3,7 +3,8 @@
 # Deploy SSH configuration for Linux/macOS
 # hash: {{ include "ssh/config.tmpl" | sha256sum }}
 {{- if lookPath "op" }}
-# pubkey-hash: {{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" | sha256sum }}
+# personal-pubkey-hash: {{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" | sha256sum }}
+# work-pubkey-hash:     {{ onepasswordRead "op://Employee/GitHub Work/public key" "FXVKKR2KWFCMHGMEA7HQYK6XRE" | sha256sum }}
 {{- end }}
 
 set -euo pipefail
@@ -27,11 +28,18 @@ deploy_content "$SSH_CONFIG" "$HOME_DIR/.ssh/config"
 chmod 600 "$HOME_DIR/.ssh/config"
 
 {{- if lookPath "op" }}
-PUBKEY='{{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" }}'
-deploy_content "$PUBKEY" "$HOME_DIR/.ssh/signing_key.pub"
+# Personal SSH public key (from rurusasu's Private vault).
+PERSONAL_PUBKEY='{{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" }}'
+deploy_content "$PERSONAL_PUBKEY" "$HOME_DIR/.ssh/signing_key.pub"
 chmod 644 "$HOME_DIR/.ssh/signing_key.pub"
+
+# Work SSH public key (from kohei-miki-im8's Employee vault on the work
+# 1Password account; passed as the 2nd onepasswordRead arg).
+WORK_PUBKEY='{{ onepasswordRead "op://Employee/GitHub Work/public key" "FXVKKR2KWFCMHGMEA7HQYK6XRE" }}'
+deploy_content "$WORK_PUBKEY" "$HOME_DIR/.ssh/github_work.pub"
+chmod 644 "$HOME_DIR/.ssh/github_work.pub"
 {{- else }}
-echo "WARNING: op CLI not available, skipping signing_key.pub deployment"
+echo "WARNING: op CLI not available, skipping public key deployment"
 {{- end }}
 
 echo "SSH configuration deployed."

--- a/chezmoi/ssh/AGENTS.md
+++ b/chezmoi/ssh/AGENTS.md
@@ -9,8 +9,13 @@
 - 1Password SSH Agent の OS 別パス分岐を維持する。
 - GitHub host alias 変更時は既存リポジトリ接続への影響を確認する。
 - 秘密鍵の実体は置かない。
-- 公開鍵は deploy スクリプト内で `onepasswordRead` により 1Password から取得し `~/.ssh/signing_key.pub` に配置する。
-- 1Password 参照先: `op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key`（GitHub SSH_KEY アイテム）
+- 公開鍵は deploy スクリプト内で `onepasswordRead` により 1Password から取得し配置する:
+  - `~/.ssh/signing_key.pub` — personal (`Host github.com`)
+  - `~/.ssh/github_work.pub` — work (`Host github-work`)
+- 1Password 参照先:
+  - personal: `op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key` (rurusasu account, default chezmoi account)
+  - work: `op://Employee/GitHub Work/public key` (kohei-miki-im8 account, account UUID `FXVKKR2KWFCMHGMEA7HQYK6XRE` を `onepasswordRead` の 2nd 引数で明示指定)
+- `Host github-work` alias は LIF-182 で導入した `[includeIf "hasconfig:remote.*.url:git@github-work:**"]` の hook となる。work repo の remote URL を `git@github-work:org/repo` に変えると work identity (`~/.gitconfig-work`) が自動適用される。
 
 ## deploy スクリプトの注意点
 

--- a/chezmoi/ssh/config.tmpl
+++ b/chezmoi/ssh/config.tmpl
@@ -15,9 +15,18 @@ Host *
     IdentityAgent ~/.1password/agent.sock
 {{- end }}
 
-# GitHub (default)
+# GitHub (personal account: rurusasu)
 Host github.com
     HostName github.com
     User git
     IdentityFile ~/.ssh/signing_key.pub
+    IdentitiesOnly yes
+
+# GitHub (work account: kohei-miki-im8). Re-point work repo remotes to
+# `git@github-work:owner/repo` to switch SSH key and trigger the
+# hasconfig-based git identity override in ~/.gitconfig.
+Host github-work
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/github_work.pub
     IdentitiesOnly yes

--- a/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
@@ -154,7 +154,7 @@ Describe 'SSH deploy スクリプト' {
 
             foreach ($line in $lines) {
                 $lineNum++
-                if ($line -match '\{\{-?\s*if\s+lookPath\s+"op"') { $inOpGuard = $true }
+                if ($line -match '\{\{-?\s*if\s+(lookPath\s+"op[^"]*"|\$hasOp)\b') { $inOpGuard = $true }
                 if ($line -match 'onepasswordRead' -and -not $inOpGuard -and $line -notmatch '^\s*#') {
                     $violations += "line $lineNum"
                 }
@@ -185,7 +185,7 @@ Describe 'SSH deploy スクリプト' {
 
             foreach ($line in $lines) {
                 $lineNum++
-                if ($line -match '\{\{-?\s*if\s+lookPath\s+"op"') { $inOpGuard = $true }
+                if ($line -match '\{\{-?\s*if\s+(lookPath\s+"op[^"]*"|\$hasOp)\b') { $inOpGuard = $true }
                 if ($line -match 'onepasswordRead' -and -not $inOpGuard -and $line -notmatch '^\s*#') {
                     $violations += "line $lineNum"
                 }

--- a/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
@@ -15,7 +15,8 @@
 BeforeAll {
     $script:chezmoiRoot = Join-Path $PSScriptRoot "../../../../chezmoi"
     $script:sshConfigTmpl = Join-Path $script:chezmoiRoot "ssh/config.tmpl"
-    $script:gitconfigTmpl = Join-Path $script:chezmoiRoot "create_dot_gitconfig.tmpl"
+    $script:gitconfigTmpl = Join-Path $script:chezmoiRoot "dot_gitconfig.tmpl"
+    $script:gitconfigWorkTmpl = Join-Path $script:chezmoiRoot "dot_gitconfig-work.tmpl"
     $script:sshDeployPs1 = Join-Path $script:chezmoiRoot ".chezmoiscripts/deploy/ssh/run_onchange_deploy.ps1.tmpl"
     $script:sshDeploySh = Join-Path $script:chezmoiRoot ".chezmoiscripts/deploy/ssh/run_onchange_deploy.sh.tmpl"
     $script:chezmoiToml = Join-Path $script:chezmoiRoot ".chezmoi.toml.tmpl"
@@ -42,6 +43,10 @@ Describe 'SSH config テンプレート' {
         $script:sshContent | Should -Match 'IdentityFile.*signing_key\.pub'
     }
 
+    It 'github-work ホストが github_work.pub を IdentityFile に指定していること' {
+        $script:sshContent | Should -Match 'IdentityFile.*github_work\.pub' -Because "work account 用に分離した公開鍵を参照する"
+    }
+
     It 'IdentitiesOnly yes が設定されていること' {
         $script:sshContent | Should -Match 'IdentitiesOnly\s+yes' -Because "エージェントに不要な鍵を提示させないため"
     }
@@ -50,7 +55,7 @@ Describe 'SSH config テンプレート' {
         $identityFiles = [regex]::Matches($script:sshContent, 'IdentityFile\s+(.+)') |
             ForEach-Object { $_.Groups[1].Value.Trim() }
 
-        $deployedKeys = @('~/.ssh/signing_key.pub')
+        $deployedKeys = @('~/.ssh/signing_key.pub', '~/.ssh/github_work.pub')
         foreach ($keyPath in $identityFiles) {
             $keyPath | Should -BeIn $deployedKeys -Because "参照される公開鍵はすべて deploy スクリプトでデプロイされる必要がある"
         }
@@ -95,6 +100,30 @@ Describe 'gitconfig テンプレート' {
         $script:gitconfigContent | Should -Not -Match 'directory\s*=\s*\*' -Because (
             "CVE-2022-24765: safe.directory = * は dubious ownership チェックを全無効化する"
         )
+    }
+
+    It 'includeIf hasconfig フックが work identity を切替えるよう設定されていること' {
+        $script:gitconfigContent | Should -Match 'includeIf\s+"hasconfig:remote\.\*\.url:git@github-work:' -Because (
+            "ssh/config.tmpl の Host github-work alias と組み合わせて work identity を自動適用する"
+        )
+    }
+}
+
+Describe 'gitconfig-work テンプレート' {
+    BeforeAll {
+        $script:gitconfigWorkContent = Get-Content -Path $script:gitconfigWorkTmpl -Raw
+    }
+
+    It '[user] セクションを持つこと' {
+        $script:gitconfigWorkContent | Should -Match '\[user\]'
+    }
+
+    It 'work signingkey が github_work.pub を指していること' {
+        $script:gitconfigWorkContent | Should -Match 'github_work\.pub'
+    }
+
+    It 'git.work データから値を引いていること' {
+        $script:gitconfigWorkContent | Should -Match 'get \$work "name"' -Because "personal.yaml の git.work サブツリーから取得する"
     }
 }
 
@@ -195,16 +224,26 @@ Describe 'personal.yaml の git データ' {
         $script:personalYaml = Get-Content -Path (Join-Path $script:chezmoiRoot ".chezmoidata/personal.yaml") -Raw
     }
 
-    It 'git.name が設定されていること' {
-        $script:personalYaml | Should -Match 'name:\s*".+"'
+    It 'git.personal サブツリーが定義されていること' {
+        $script:personalYaml | Should -Match '(?ms)^git:\s*\r?\n.*?\bpersonal:' -Because "personal identity 用のサブツリーが必要 (multi-identity 構造)"
     }
 
-    It 'git.email が設定されていること' {
-        $script:personalYaml | Should -Match 'email:\s*".+"'
+    It 'git.work サブツリーが定義されていること' {
+        $script:personalYaml | Should -Match '(?ms)^git:\s*\r?\n.*?\bwork:' -Because "work identity 用のサブツリーが必要 (multi-identity 構造)"
     }
 
-    It 'git.signingkey のデフォルト値が signing_key.pub であること' {
+    It 'commit author email に noreply 形式が使われていること' {
+        $script:personalYaml | Should -Match '\+\w+@users\.noreply\.github\.com' -Because (
+            "公開リポへの実 email 露出を防ぐため GitHub noreply 形式に統一する"
+        )
+    }
+
+    It 'personal signingkey が signing_key.pub を指していること' {
         $script:personalYaml | Should -Match 'signing_key\.pub'
+    }
+
+    It 'work signingkey が github_work.pub を指していること' {
+        $script:personalYaml | Should -Match 'github_work\.pub'
     }
 
     It 'telegramUserId が含まれていないこと' {


### PR DESCRIPTION
## Summary

LIF-182 で導入した `hasconfig:remote.*.url:git@github-work:**` の判定 hook となる SSH host alias を整備し、work 用 SSH 公開鍵を Employee vault から取得してデプロイする。

これで personal/work の identity 切替が **実際に動作する** ようになる（LIF-182 単体では gitconfig 側の hook だけで、SSH alias がなかったので inert だった）。

## 変更内容

### `chezmoi/ssh/config.tmpl`
- 既存 `Host github.com`（personal: `rurusasu`）のコメントを明確化
- `Host github-work`（work: `kohei-miki-im8`）を追加
  - `HostName github.com` / `User git` / `IdentityFile ~/.ssh/github_work.pub` / `IdentitiesOnly yes`
  - `IdentityAgent` は `Host *` から継承（1Password agent socket）

### `chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.{sh,ps1}.tmpl`
- work 公開鍵を `op://Employee/GitHub Work/public key` から取得（`onepasswordRead` の 2nd 引数で work account UUID `FXVKKR2KWFCMHGMEA7HQYK6XRE` を明示指定）
- `~/.ssh/github_work.pub` に配置（Linux/macOS: chmod 644）
- personal pubkey deploy はそのまま維持
- pubkey-hash コメントを personal / work で分離（change detection 用）

### `chezmoi/ssh/AGENTS.md`
- 新 alias と 2 つの 1Password 参照先を記載
- work identity 切替の運用手順を追記

## 使い方

work repo の remote URL を切替:

\`\`\`bash
git remote set-url origin git@github-work:org/repo
\`\`\`

→ `~/.ssh/config` の `Host github-work` 経由で work SSH 鍵を使用
→ remote URL が `hasconfig:remote.*.url:git@github-work:**` に合致 → `~/.gitconfig-work` 自動 include
→ `Kohei Miki` + work noreply email で commit

## Test plan

- [x] `chezmoi execute-template < ssh/config.tmpl` で personal/work 両 Host blocks が描画
- [x] `op.exe read 'op://Employee/GitHub Work/public key' --account FXVKKR2KWFCMHGMEA7HQYK6XRE` が ssh-ed25519 鍵を返す（SHA256 一致確認済み）
- [x] deploy script template が personal/work 両 pubkey-hash を計算
- [ ] CI (`test-nix.yml`) 通過
- [ ] CI (`test-consistency.yml`) 通過
- [ ] CI (`test-powershell.yml`) 通過

## ⚠️ 既知の制約 — WSL 環境では env 設定が必要

WSL から `chezmoi apply` を実行する際、Linux op が `op.exe` に切り替わる（LIF-182）が、Windows op.exe は multi-account 環境では `OP_ACCOUNT` env var を要求する。WSL → Windows binary には env var が自動伝播しないため、現状は以下を shell に export しておく必要がある:

\`\`\`bash
export WSLENV=\"OP_ACCOUNT:\$WSLENV\"
export OP_ACCOUNT=\"EJLA3HRAVZBCXIQ7SRSFGQBTNU\"
\`\`\`

home-manager で自動設定する対応は [LIF-186](https://linear.app/life-style-base/issue/LIF-186/chezmoi-wsl-から-opexe-を使うための-wslenvop-account-を-home-manager-で自動設定) として分離。

## 関連

- Closes [LIF-183](https://linear.app/life-style-base/issue/LIF-183/chezmoissh-github-work-host-alias-追加-work-ssh-公開鍵デプロイ)
- 前提: [LIF-182](https://linear.app/life-style-base/issue/LIF-182/chezmoi-1password-駆動の-multi-identity-gitconfig-セットアップ) (gitconfig + 1Password 基盤) ← merged
- 後続: [LIF-184](https://linear.app/life-style-base/issue/LIF-184/chezmoi-1password-ssh-agenttoml-で-host-別の鍵フィルタを導入) (1Password agent.toml で鍵フィルタ), [LIF-186](https://linear.app/life-style-base/issue/LIF-186/chezmoi-wsl-から-opexe-を使うための-wslenvop-account-を-home-manager-で自動設定) (WSLENV/OP_ACCOUNT 自動化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)