### PR TITLE
feat(chezmoi): 1Password SSH agent.toml で host 別の鍵フィルタを導入 (LIF-184)

### DIFF
--- a/chezmoi/AppData/Roaming/1Password/AGENTS.md
+++ b/chezmoi/AppData/Roaming/1Password/AGENTS.md
@@ -1,0 +1,31 @@
+# chezmoi/AppData/Roaming/1Password: Windows-side 1Password 設定
+
+## 管理対象
+
+- `ssh/agent.toml`: 1Password SSH エージェントの鍵フィルタ
+
+## 役割
+
+1Password 8 の SSH エージェントが offer する鍵を whitelist で絞り込み、
+OpenSSH の `MaxAuthTries=6` 制約を超えないようにする。
+
+## デプロイ先
+
+`%APPDATA%\1Password\ssh\agent.toml`（= `~/AppData/Roaming/1Password/ssh/agent.toml`）
+
+1Password 8 (Windows) はこのパスを起動時に読み込み、agent を再起動すると
+反映される。
+
+## ルール
+
+- 各 `[[ssh-keys]]` の `item` は **item ID** で書く（rename 耐性 + 同名 item
+  との曖昧さ回避）。
+- `vault` と `account` も併記して `WHERE` 句的に絞り込み、誤マッチを防ぐ。
+- `account` は sign-in address（例: `my.1password.com`）で書くと
+  human-readable。UUID でも動作する。
+
+## 関連
+
+- LIF-184: 本 file 導入
+- ssh/config.tmpl の `IdentityFile` で参照する公開鍵は item ID と
+  対になっている（personal=signing_key.pub, work=github_work.pub）。

--- a/chezmoi/AppData/Roaming/1Password/ssh/agent.toml
+++ b/chezmoi/AppData/Roaming/1Password/ssh/agent.toml
@@ -1,0 +1,24 @@
+# 1Password SSH agent key filter.
+#
+# Avoids OpenSSH "Too many authentication failures" errors caused by the
+# agent offering more than MaxAuthTries (default 6) keys before the right
+# one is reached. By whitelisting only the keys we actually use, the agent
+# offers them in declared order and SSH succeeds on the first try.
+#
+# Reference: https://developer.1password.com/docs/ssh/agent/config/
+#
+# Item IDs are used (rather than names) to be robust against renames and
+# to disambiguate from sibling items with the same display name (e.g.
+# Private vault contains both an SSH_KEY and a LOGIN item titled "GitHub").
+
+# Personal GitHub SSH key (account: rurusasu / my.1password.com)
+[[ssh-keys]]
+item = "xnoq6xbcdktkph76e2bg37ou6y"
+vault = "Private"
+account = "my.1password.com"
+
+# Work GitHub SSH key (account: kohei-miki-im8 / aimatecoltd.1password.com)
+[[ssh-keys]]
+item = "jj25m5a2xkp4ckswmyvp2dwlxe"
+vault = "Employee"
+account = "aimatecoltd.1password.com"


### PR DESCRIPTION
## Summary

1Password エージェントが保管している全 SSH 鍵を順次 offer すると、OpenSSH の `MaxAuthTries=6` を超えて **"Too many authentication failures"** で接続失敗する。鍵が 7 個以上になった時点で詰む。

[1Password 公式 doc](https://developer.1password.com/docs/ssh/agent/config/) 推奨の `agent.toml` で必要な鍵のみ whitelist 化することで、エージェントが正しい鍵を 1 トライで offer するようになる。

## 追加ファイル

### `chezmoi/AppData/Roaming/1Password/ssh/agent.toml`

```toml
# Personal GitHub SSH key (account: rurusasu / my.1password.com)
[[ssh-keys]]
item = "xnoq6xbcdktkph76e2bg37ou6y"
vault = "Private"
account = "my.1password.com"

# Work GitHub SSH key (account: kohei-miki-im8 / aimatecoltd.1password.com)
[[ssh-keys]]
item = "jj25m5a2xkp4ckswmyvp2dwlxe"
vault = "Employee"
account = "aimatecoltd.1password.com"
```

**item ID を採用した理由**:
- rename 耐性
- `Private` vault には同名 \`GitHub\` item が SSH_KEY と LOGIN で 2 つあり、名前指定だと曖昧

### `chezmoi/AppData/Roaming/1Password/AGENTS.md`
- 配置先と運用ルールを記載

## デプロイ先

`%APPDATA%\1Password\ssh\agent.toml`（= `~/AppData/Roaming/1Password/ssh/agent.toml`）

公式 doc の仕様に準拠。1Password 8 (Windows) はこのパスを起動時に読み込む。

## Test plan

- [x] `chezmoi cat ~/AppData/Roaming/1Password/ssh/agent.toml` で内容が正しく出力
- [x] `chezmoi managed` で新ファイルが tracked リストに含まれる
- [x] TOML syntax 確認（手動）
- [ ] CI (`test-nix.yml`, `test-consistency.yml`, `test-powershell.yml`) 通過
- [ ] Windows で `chezmoi apply` → 1Password アプリ再起動 → `ssh -T git@github.com` / `ssh -T git@github-work` が 1 トライで通る（手動確認用）

## 既存パターンとの一貫性

`chezmoi/AppData/Roaming/Claude/` と同じ構造で Windows AppData を管理。

## 関連

- Closes [LIF-184](https://linear.app/life-style-base/issue/LIF-184/chezmoi-1password-ssh-agenttoml-で-host-別の鍵フィルタを導入)
- 前提: [LIF-182](https://github.com/rurusasu/dotfiles/pull/110) (gitconfig 基盤) + [LIF-183](https://github.com/rurusasu/dotfiles/pull/111) (github-work alias + work pubkey deploy) ← どちらも merged
- 残り: [LIF-186](https://linear.app/life-style-base/issue/LIF-186/chezmoi-wsl-から-opexe-を使うための-wslenvop-account-を-home-manager-で自動設定) (WSL→Windows env var passthrough)

🤖 Generated with [Claude Code](https://claude.com/claude-code)