### PR TITLE
feat(nix): WSL から op.exe を呼ぶための WSLENV/OP_ACCOUNT を home-manager で自動設定 (LIF-186)

### DIFF
--- a/nix/home/wsl/users.nix
+++ b/nix/home/wsl/users.nix
@@ -54,6 +54,14 @@
         GTK_IM_MODULE = "fcitx";
         QT_IM_MODULE = "fcitx";
         XMODIFIERS = "@im=fcitx";
+        # 1Password multi-account: chezmoi's [onepassword].command routes to
+        # op.exe under WSL (LIF-182), but Windows binaries inherit env vars
+        # from WSL only when WSLENV lists them. /u makes OP_ACCOUNT visible
+        # only when crossing WSL→Windows (not the other direction).
+        # Without this, op.exe fails with "multiple accounts found" because
+        # chezmoi templates call op signin without --account.
+        WSLENV = "OP_ACCOUNT/u";
+        OP_ACCOUNT = "EJLA3HRAVZBCXIQ7SRSFGQBTNU";
       };
 
       programs.zsh.shellAliases = {


### PR DESCRIPTION
## Summary

LIF-182 で chezmoi の `[onepassword].command` を WSL では `op.exe` に切替えたが、Windows binary は WSL から呼ばれた際 env var を自動継承しない。multi-account 1Password 環境では `op.exe` が `--account` を要求するため、chezmoi templates の `onepasswordRead` が `"multiple accounts found"` で失敗していた（LIF-183 PR レビュー過程で表面化）。

これまで手動で:

\`\`\`bash
export WSLENV=\"OP_ACCOUNT:\$WSLENV\"
export OP_ACCOUNT=\"EJLA3HRAVZBCXIQ7SRSFGQBTNU\"
\`\`\`

を都度 export する必要があった。これを home-manager の `sessionVariables` で zsh 起動時に自動設定し、`chezmoi apply` がそのまま動くようにする。

## 変更内容

`nix/home/wsl/users.nix` の `home.sessionVariables` に追加:

| 変数 | 値 | 役割 |
|---|---|---|
| `WSLENV` | `"OP_ACCOUNT/u"` | `/u` 修飾子で **WSL→Windows 方向のみ** propagate（逆方向は不要） |
| `OP_ACCOUNT` | `"EJLA3HRAVZBCXIQ7SRSFGQBTNU"` | personal 1Password account UUID |

work account への切替は `onepasswordRead` の 2nd 引数で明示する既存パターン（LIF-183 で確立）を維持。

## Test plan

- [x] `nix fmt` 通過 (278 files / 0 changed)
- [x] `nix flake check --impure --no-build` 通過 (all checks passed)
- [ ] CI (`test-nix.yml`) 通過
- [ ] `nrs` 後の新規 zsh セッションで `echo \$WSLENV` / `echo \$OP_ACCOUNT` が値を返す（手動確認）
- [ ] WSL から `chezmoi apply` を手動 export なしで実行して `onepasswordRead` 系のエラーが出ない（手動確認）

## 関連

- Closes [LIF-186](https://linear.app/life-style-base/issue/LIF-186/chezmoi-wsl-から-opexe-を使うための-wslenvop-account-を-home-manager-で自動設定)
- 親: [LIF-182](https://github.com/rurusasu/dotfiles/pull/110) (chezmoi.toml の op.exe 切替) ← merged
- 発見元: [LIF-183](https://github.com/rurusasu/dotfiles/pull/111) PR レビュー過程

🤖 Generated with [Claude Code](https://claude.com/claude-code)