### PR TITLE
feat(chezmoi): WSL の GPG signing を復活させる op-ssh-sign-wsl wrapper を追加 (LIF-188)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ Thumbs.db
 *_private
 *.local
 chezmoi/private_dot_claude/settings.local.json
+# chezmoi naming convention: `dot_local` deploys to `~/.local/` and is part
+# of the SSoT — exclude it from the `*_local` pattern above.
+!chezmoi/dot_local/
+!chezmoi/dot_local/**
 
 # History files
 *_history

--- a/chezmoi/dot_gitconfig.tmpl
+++ b/chezmoi/dot_gitconfig.tmpl
@@ -10,16 +10,7 @@
 
 {{- $isWSL := and (eq .chezmoi.os "linux") (contains "microsoft" (lower .chezmoi.kernel.osrelease)) }}
 [commit]
-{{- if $isWSL }}
-  # WSL: git's signing buffer is created in /tmp (WSL FS) but Windows
-  # op-ssh-sign.exe cannot read Linux paths. A proper fix needs a wrapper
-  # that stages the buffer in a Windows-accessible location. Until then,
-  # WSL commits are unsigned by default. Set per-repo `commit.gpgsign=true`
-  # to opt in once a workaround is in place.
-  gpgsign = false
-{{- else }}
   gpgsign = true
-{{- end }}
 
 [gpg]
   format = ssh
@@ -29,10 +20,11 @@
   program = C:/Program Files/1Password/app/8/op-ssh-sign.exe
 {{- else if eq .chezmoi.os "darwin" }}
   program = /Applications/1Password.app/Contents/MacOS/op-ssh-sign
-{{- else if and (eq .chezmoi.os "linux") (contains "microsoft" (lower .chezmoi.kernel.osrelease)) }}
-  # WSL: native Linux 1Password isn't installed; reach the Windows binary
-  # via the Store-installed execution alias on PATH.
-  program = op-ssh-sign.exe
+{{- else if $isWSL }}
+  # WSL: native Linux 1Password isn't installed and the Windows
+  # op-ssh-sign.exe has interop quirks (ignores positional payload,
+  # rejects Linux pubkey paths). The wrapper bridges those gaps.
+  program = ~/.local/bin/op-ssh-sign-wsl
 {{- else }}
   program = /opt/1Password/op-ssh-sign
 {{- end }}

--- a/chezmoi/dot_local/bin/executable_op-ssh-sign-wsl
+++ b/chezmoi/dot_local/bin/executable_op-ssh-sign-wsl
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# op-ssh-sign-wsl — wrap Windows op-ssh-sign.exe so WSL git users can sign
+# commits with their 1Password SSH key.
+#
+# git invokes the signing program as:
+#     <program> -Y sign -n git -f <pubkey> <buffer_path>
+#
+# op-ssh-sign.exe (the 1Password helper) has three quirks we work around:
+#   (1) It ignores the trailing positional payload arg and reads stdin
+#       instead. We pipe the buffer file through stdin.
+#   (2) git expects the signature at <buffer>.sig, but op-ssh-sign.exe
+#       writes to stdout. We redirect stdout to that path.
+#   (3) Being a Windows binary, it can't read Linux paths for -f <pubkey>.
+#       We translate via wslpath -w for any WSL-side path.
+#
+# The trailing positional buffer arg can also be a WSL path; we read it
+# directly via bash redirection so no translation is needed.
+set -euo pipefail
+
+args=("$@")
+last_idx=$((${#args[@]} - 1))
+buffer="${args[$last_idx]}"
+
+# Translate any -f <pubkey> path from WSL to Windows form.
+for i in "${!args[@]}"; do
+  if (( i > 0 )) \
+      && [[ "${args[$((i-1))]}" == "-f" ]] \
+      && [[ "${args[$i]}" == /* ]] \
+      && [[ "${args[$i]}" != /mnt/* ]]; then
+    args[$i]=$(wslpath -w "${args[$i]}")
+  fi
+done
+
+# Drop the positional buffer arg (op-ssh-sign.exe reads stdin instead).
+unset "args[$last_idx]"
+
+# Sign: stdin = buffer contents, stdout = signature → <buffer>.sig
+op-ssh-sign.exe "${args[@]}" < "$buffer" > "$buffer.sig"

--- a/chezmoi/dot_local/bin/executable_op-ssh-sign-wsl
+++ b/chezmoi/dot_local/bin/executable_op-ssh-sign-wsl
@@ -17,6 +17,14 @@
 # directly via bash redirection so no translation is needed.
 set -euo pipefail
 
+# Defensive: git always passes at least `-Y sign -n git -f <pubkey> <buffer>`,
+# but guard against being called with no positional buffer (verify mode etc.)
+# to avoid `bad array subscript` under set -u.
+if (( $# < 1 )); then
+  echo "op-ssh-sign-wsl: missing positional payload arg" >&2
+  exit 64
+fi
+
 args=("$@")
 last_idx=$((${#args[@]} - 1))
 buffer="${args[$last_idx]}"

--- a/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
@@ -95,15 +95,13 @@ Describe 'gitconfig テンプレート' {
     }
 
     It 'op-ssh-sign-wsl wrapper script が deploy 対象として存在すること' {
-        $wrapperPath = Join-Path $script:chezmoiRoot "dot_local/dot_bin/executable_op-ssh-sign-wsl"
+        $wrapperPath = Join-Path $script:chezmoiRoot "dot_local/bin/executable_op-ssh-sign-wsl"
         Test-Path -Path $wrapperPath | Should -Be $true -Because "LIF-188: gpg.ssh.program が指す wrapper の本体"
     }
 
     It 'op-ssh-sign-wsl wrapper が op-ssh-sign.exe を最終的に呼ぶこと' {
-        $wrapperPath = Join-Path $script:chezmoiRoot "dot_local/dot_bin/executable_op-ssh-sign-wsl"
-        if (Test-Path -Path $wrapperPath) {
-            (Get-Content -Path $wrapperPath -Raw) | Should -Match 'op-ssh-sign\.exe' -Because "wrapper 最終的に Windows binary を起動"
-        }
+        $wrapperPath = Join-Path $script:chezmoiRoot "dot_local/bin/executable_op-ssh-sign-wsl"
+        (Get-Content -Path $wrapperPath -Raw) | Should -Match 'op-ssh-sign\.exe' -Because "wrapper 最終的に Windows binary を起動"
     }
 
     It 'ssh-keygen を gpg.ssh.program に使用していないこと' {

--- a/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
@@ -71,16 +71,8 @@ Describe 'gitconfig テンプレート' {
         $script:gitconfigContent | Should -Match 'format\s*=\s*ssh'
     }
 
-    It 'commit.gpgsign が true に設定されていること (non-WSL)' {
-        # WSL では gpgsign=false が default (op-ssh-sign.exe が WSL /tmp の signing buffer を読めないため)。
-        # template の else ブランチで true なので、template 全体としては true 設定が存在する。
-        $script:gitconfigContent | Should -Match 'gpgsign\s*=\s*true'
-    }
-
-    It 'WSL では gpgsign=false にして待避していること' {
-        $script:gitconfigContent | Should -Match '(?s)isWSL.+?gpgsign\s*=\s*false' -Because (
-            "WSL での signing は git の /tmp 経由 buffer が Windows op-ssh-sign から読めないため不可"
-        )
+    It 'commit.gpgsign が true に設定されていること' {
+        $script:gitconfigContent | Should -Match 'gpgsign\s*=\s*true' -Because "全 OS で commit 署名を有効にする (WSL は LIF-188 wrapper 経由)"
     }
 
     It 'Windows 用に op-ssh-sign.exe が gpg.ssh.program に設定されていること' {
@@ -95,11 +87,23 @@ Describe 'gitconfig テンプレート' {
         $script:gitconfigContent | Should -Match '/opt/1Password/op-ssh-sign'
     }
 
-    It 'WSL 検出ブランチで op-ssh-sign.exe を使うこと' {
-        # template の WSL 分岐: contains "microsoft" (lower .chezmoi.kernel.osrelease)
-        $script:gitconfigContent | Should -Match '(?s)contains\s+"microsoft".+?program\s*=\s*op-ssh-sign\.exe' -Because (
-            "WSL では native Linux 1Password が無いので Windows store の op-ssh-sign.exe を PATH 経由で使う"
+    It 'WSL 検出ブランチで op-ssh-sign-wsl wrapper を使うこと' {
+        # template の WSL 分岐: $isWSL → ~/.local/bin/op-ssh-sign-wsl
+        $script:gitconfigContent | Should -Match '(?s)\$isWSL.+?program\s*=\s*~/\.local/bin/op-ssh-sign-wsl' -Because (
+            "WSL では op-ssh-sign.exe の interop quirks (positional payload 無視、Linux パス非対応) を wrapper で吸収する (LIF-188)"
         )
+    }
+
+    It 'op-ssh-sign-wsl wrapper script が deploy 対象として存在すること' {
+        $wrapperPath = Join-Path $script:chezmoiRoot "dot_local/dot_bin/executable_op-ssh-sign-wsl"
+        Test-Path -Path $wrapperPath | Should -Be $true -Because "LIF-188: gpg.ssh.program が指す wrapper の本体"
+    }
+
+    It 'op-ssh-sign-wsl wrapper が op-ssh-sign.exe を最終的に呼ぶこと' {
+        $wrapperPath = Join-Path $script:chezmoiRoot "dot_local/dot_bin/executable_op-ssh-sign-wsl"
+        if (Test-Path -Path $wrapperPath) {
+            (Get-Content -Path $wrapperPath -Raw) | Should -Match 'op-ssh-sign\.exe' -Because "wrapper 最終的に Windows binary を起動"
+        }
     }
 
     It 'ssh-keygen を gpg.ssh.program に使用していないこと' {


### PR DESCRIPTION
## Summary

[LIF-187](https://github.com/rurusasu/dotfiles/pull/114) で WSL は暫定的に `commit.gpgsign = false` に落としていたが、bash wrapper を導入して WSL からも 1Password で SSH 署名できるよう復活させる。

## 問題の root cause

WSL の git が `op-ssh-sign.exe` (Windows binary) を起動する際の 3 つの interop quirks:

1. **op-ssh-sign.exe は positional payload arg を無視して stdin だけ読む** — git は `program -Y sign -n git -f <pubkey> <buffer_path>` 形式で呼ぶため、buffer 内容が読まれず空の signature が返る (exit 0)
2. **git は signature を `<buffer>.sig` から読む** — op-ssh-sign.exe は stdout に書く
3. **op-ssh-sign.exe は Linux パスの `-f <pubkey>` を読めない** — Windows binary なので

## 解決

新規 bash wrapper `~/.local/bin/op-ssh-sign-wsl` がこれら 3 つを吸収:

\`\`\`bash
#!/usr/bin/env bash
set -euo pipefail

args=("$@")
last_idx=$((${#args[@]} - 1))
buffer="${args[$last_idx]}"

# (1) -f <pubkey> path を WSL → Windows 形式に変換
for i in "${!args[@]}"; do
  if (( i > 0 )) \\
      && [[ "${args[$((i-1))]}" == "-f" ]] \\
      && [[ "${args[$i]}" == /* ]] \\
      && [[ "${args[$i]}" != /mnt/* ]]; then
    args[$i]=$(wslpath -w "${args[$i]}")
  fi
done

# (2) positional buffer arg を drop し stdin 経由に
unset "args[$last_idx]"

# (3) stdout を <buffer>.sig にリダイレクト
op-ssh-sign.exe "${args[@]}" < "$buffer" > "$buffer.sig"
\`\`\`

git は `gpg.ssh.program = ~/.local/bin/op-ssh-sign-wsl` を呼ぶだけで透過的に署名できる。

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `chezmoi/dot_local/bin/executable_op-ssh-sign-wsl` | **新規** wrapper script (chmod +x) |
| `chezmoi/dot_gitconfig.tmpl` | WSL ブランチで gpg.ssh.program を wrapper に + `commit.gpgsign = true` を全 OS で復活 |
| `scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1` | wrapper の存在/内容を検証 + WSL ブランチが wrapper を指すことを検証 + 旧 gpgsign=false テストを削除 |
| `.gitignore` | `*_local` glob が `chezmoi/dot_local/` を誤って exclude していたのを例外で修正 |

## Test plan

- [x] wrapper 単体テスト: `op-sign-wrap.sh -Y sign -n git -f <linux_path> <linux_path>` で signature 取得
- [x] git 実 commit テスト: `git -c gpg.ssh.program=<wrapper> commit ...` が成功
- [x] `git cat-file -p HEAD` で `gpgsig -----BEGIN SSH SIGNATURE-----` 確認
- [x] **このコミット自体が wrapper 経由で署名されている** (signature in commit object)
- [ ] CI (`test-nix.yml`, `test-consistency.yml`, `test-powershell.yml`) 通過

## 既知の制約

- `git verify-commit` は `gpg.ssh.allowedSignersFile` 未設定だと "needs to be configured" を返す。これは signing 自体ではなく trust chain の問題で、本 PR の範囲外
- WSL 側に Linux op-ssh-sign を入れる代替手段もあるが (`nixpkgs._1password`)、Windows 側 1Password agent をそのまま使う方が現状の SSH 鍵管理と整合

## 関連

- Closes [LIF-188](https://linear.app/life-style-base/issue/LIF-188/)
- 親: [LIF-187](https://github.com/rurusasu/dotfiles/pull/114) (WSL gpgsign=false 暫定対応) ← merged
- ベース: [LIF-182](https://github.com/rurusasu/dotfiles/pull/110) (gitconfig multi-identity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)