### PR TITLE
fix(LIF-191): pass --account to op.exe inject for multi-account environments

### DIFF
--- a/chezmoi/secret/env.sh
+++ b/chezmoi/secret/env.sh
@@ -27,12 +27,16 @@ command -v "$_op_cmd" >/dev/null 2>&1 || {
   return 0
 }
 
+# Use the same account as chezmoi's [onepassword].account (.chezmoi.toml.tmpl)
+# to avoid "multiple accounts found" errors from op.exe under WSL.
+_op_acct="${OP_ACCOUNT:-EJLA3HRAVZBCXIQ7SRSFGQBTNU}"
+
 _secret_tmpl='GH_TOKEN={{ op://Private/GitHubUsedUserPAT/credential }}
 TAVILY_API_KEY={{ op://Private/TavilyUsedUserPAT/credential }}'
 
 # `op inject` reads the template on stdin and emits KEY=value lines on stdout
 # with secrets substituted. `set -a` exports every assignment that follows.
-_resolved=$(printf '%s\n' "$_secret_tmpl" | "$_op_cmd" inject 2>/dev/null) || {
+_resolved=$(printf '%s\n' "$_secret_tmpl" | "$_op_cmd" inject --account "$_op_acct" 2>/dev/null) || {
   printf '[secret/env.sh] warning: %s inject failed; GH_TOKEN/TAVILY_API_KEY not set\n' "$_op_cmd" >&2
   _resolved=''
 }
@@ -43,4 +47,4 @@ if [ -n "$_resolved" ]; then
   eval "$_resolved"
   set +a
 fi
-unset _secret_tmpl _resolved _op_cmd
+unset _secret_tmpl _resolved _op_cmd _op_acct


### PR DESCRIPTION
## Summary
- 1Password に複数アカウント（Private + Employee）が設定されている場合、`op.exe inject` が `--account` なしで「multiple accounts found」エラーになる問題を修正
- chezmoi の `[onepassword].account` と同じアカウント ID を `--account` フラグで渡すよう変更
- `OP_ACCOUNT` 環境変数が設定されていればそちらを優先（home-manager の `sessionVariables` と整合）

## Test plan
- [x] WSL 対話シェルで `GH_TOKEN`/`TAVILY_API_KEY` が正しく設定されることを確認済み
- [x] `op.exe inject --account` で multi-account エラーが解消されることを確認済み
- [x] `OP_ACCOUNT` 環境変数がある場合はそちらが使用されることを確認済み

Closes LIF-191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>