### PR TITLE
fix(LIF-192): add eol=lf for yaml/yml files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,6 +24,8 @@
 *.json text eol=lf
 *.toml text eol=lf
 *.lock text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
 
 # バイナリファイル（変換しない）
 *.png binary


### PR DESCRIPTION
## Summary
- `.gitattributes` に `*.yaml` / `*.yml` の `eol=lf` 指定を追加
- `text=auto` + `core.autocrlf=true` (Windows) による false-positive `M` を解消

## Root cause
YAML ファイルが `.gitattributes` で未定義だったため `text=auto` にフォールバックし、WSL/Unix ツールが書き込んだ LF ファイルを Windows git が「CRLF に変換すべき」とみなして変更済みと判定していた。

## Test plan
- [ ] `git status` で Warp YAML ファイルが `M` 表示されないことを確認
- [ ] `git diff` で差分がゼロであることを確認

Closes LIF-192

🤖 Generated with [Claude Code](https://claude.com/claude-code)