### PR TITLE
fix(LIF-193): replace sed-based quote stripping with git commit -F - pipe

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,12 +48,12 @@ tasks:
       MSG: '{{.CLI_ARGS | default "update"}}'
     env:
       GIT_COMMIT_MSG: "{{.MSG}}"
-      WSLENV: "GIT_COMMIT_MSG:$WSLENV"
+      WSLENV: "GIT_COMMIT_MSG"
     cmds:
       - task: skills:sync
       - task: fmt
       - task: lint
-      - wsl -d {{.DISTRO}} -- bash -lc "cd {{.DOTFILES_PATH}} && git add -A && printf '%s' \"$GIT_COMMIT_MSG\" | git commit -F -"
+      - wsl -d {{.DISTRO}} -- bash -lc "cd {{.DOTFILES_PATH}} && git add -A && printf '%s\n' \"$GIT_COMMIT_MSG\" | git commit -F -"
 
   push:
     desc: Push to remote (via WSL)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -53,7 +53,7 @@ tasks:
       - task: skills:sync
       - task: fmt
       - task: lint
-      - wsl -d {{.DISTRO}} -- bash -lc "cd {{.DOTFILES_PATH}} && git add -A && git commit -m \"\$(echo \"$GIT_COMMIT_MSG\" | sed \"s/^'//;s/'$//\")\""
+      - wsl -d {{.DISTRO}} -- bash -lc "cd {{.DOTFILES_PATH}} && git add -A && printf '%s' \"$GIT_COMMIT_MSG\" | git commit -F -"
 
   push:
     desc: Push to remote (via WSL)


### PR DESCRIPTION
## Summary
- `task commit` の WSL コマンドで sed によるクォート除去を廃止
- `printf '%s' "$GIT_COMMIT_MSG" | git commit -F -` に変更し、クォートのネストを回避

## Root cause
以下のコマンドで `sed` の式がクォートの多重エスケープにより壊れていた:

```bash
git commit -m "$(echo "$GIT_COMMIT_MSG" | sed "s/^'//;s/'$//")"
```

`wsl -d NixOS -- bash -lc "..."` を経由すると、task runner・bash・WSL の3層でクォートが展開され、sed が `"s/^'...` の代わりに `"` を先頭文字として受け取り失敗していた。

## Fix
```bash
printf '%s' "$GIT_COMMIT_MSG" | git commit -F -
```
クォートのネストをなくし、WSLENV 経由で渡されたメッセージをそのまま stdin で渡す。

## Test plan
- [ ] `task commit -- "fix(XXX): message with (parens)"` が正常にコミットできることを確認

Closes LIF-193

🤖 Generated with [Claude Code](https://claude.com/claude-code)