### PR TITLE
feat(LIF-194): modernize opencode LSP configuration

### DIFF
--- a/chezmoi/dot_config/opencode/opencode.json
+++ b/chezmoi/dot_config/opencode/opencode.json
@@ -1,4 +1,175 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@warp-dot-dev/opencode-warp"]
+  "plugin": ["@warp-dot-dev/opencode-warp"],
+  "lsp": {
+    "nixd": {
+      "command": ["nixd"],
+      "initialization": {
+        "formatting": {
+          "command": ["nixfmt"]
+        },
+        "options": {
+          "nixos": {
+            "expr": "(builtins.getFlake (builtins.getEnv \"HOME\" + \"/.dotfiles\")).nixosConfigurations.nixos.options"
+          }
+        }
+      }
+    },
+    "ruff": {
+      "command": ["ruff", "server"],
+      "initialization": {
+        "settings": {
+          "lineLength": 88,
+          "lint": {
+            "preview": true
+          },
+          "format": {
+            "preview": true
+          },
+          "organizeImports": true,
+          "fixAll": true
+        }
+      }
+    },
+    "yaml-language-server": {
+      "command": ["yaml-language-server", "--stdio"],
+      "extensions": [".yaml", ".yml"],
+      "initialization": {
+        "yaml": {
+          "format": {
+            "enable": true
+          },
+          "validate": true,
+          "completion": true,
+          "hover": true,
+          "schemaStore": {
+            "enable": true
+          }
+        }
+      }
+    },
+    "taplo": {
+      "command": ["taplo", "lsp", "stdio"],
+      "extensions": [".toml"],
+      "initialization": {
+        "evenBetterToml": {
+          "formatter": {
+            "alignEntries": false,
+            "reorderKeys": true
+          }
+        }
+      }
+    },
+    "bash-language-server": {
+      "command": ["bash-language-server", "start"],
+      "extensions": [".sh", ".bash"],
+      "initialization": {
+        "bashIde": {
+          "globPattern": "**/*@(.sh|.bash)",
+          "enableSourceErrorDiagnostics": true
+        }
+      }
+    },
+    "lua-language-server": {
+      "command": ["lua-language-server"],
+      "extensions": [".lua"],
+      "initialization": {
+        "Lua": {
+          "runtime": {
+            "version": "LuaJIT"
+          },
+          "diagnostics": {
+            "globals": ["vim"]
+          },
+          "workspace": {
+            "checkThirdParty": false
+          },
+          "telemetry": {
+            "enable": false
+          }
+        }
+      }
+    },
+    "marksman": {
+      "command": ["marksman", "server"],
+      "extensions": [".md", ".mdx"]
+    },
+    "gopls": {
+      "command": ["gopls"],
+      "extensions": [".go"],
+      "initialization": {
+        "usePlaceholders": true,
+        "semanticTokens": true,
+        "staticcheck": true,
+        "gofumpt": true,
+        "hints": {
+          "assignVariableTypes": true,
+          "compositeLiteralFields": true,
+          "compositeLiteralTypes": true,
+          "constantValues": true,
+          "functionTypeParameters": true,
+          "parameterNames": true,
+          "rangeVariableTypes": true
+        },
+        "analyses": {
+          "unusedparams": true,
+          "shadow": true,
+          "nilness": true,
+          "unusedwrite": true,
+          "useany": true
+        }
+      }
+    },
+    "rust-analyzer": {
+      "command": ["rust-analyzer"],
+      "extensions": [".rs"],
+      "initialization": {
+        "checkOnSave": true,
+        "check": {
+          "command": "clippy",
+          "features": "all"
+        },
+        "inlayHints": {
+          "bindingModeHints": { "enable": true },
+          "closureCaptureHints": { "enable": true },
+          "closureReturnTypeHints": { "enable": "always" },
+          "lifetimeElisionHints": { "enable": "skip_trivial" },
+          "typeHints": { "hideNamedConstructor": false }
+        },
+        "procMacro": { "enable": true },
+        "cargo": {
+          "allFeatures": true,
+          "buildScripts": { "enable": true }
+        }
+      }
+    },
+    "typescript-language-server": {
+      "command": ["typescript-language-server", "--stdio"],
+      "extensions": [".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"],
+      "initialization": {
+        "preferences": {
+          "importModuleSpecifierPreference": "non-relative",
+          "includeInlayParameterNameHints": "all",
+          "includeInlayParameterNameHintsWhenArgumentMatchesName": false,
+          "includeInlayFunctionParameterTypeHints": true,
+          "includeInlayVariableTypeHints": true,
+          "includeInlayPropertyDeclarationTypeHints": true,
+          "includeInlayFunctionLikeReturnTypeHints": true,
+          "includeInlayEnumMemberValueHints": true
+        }
+      }
+    },
+    "oxlint": {
+      "command": ["oxlint", "--lsp-server"],
+      "extensions": [".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs", ".astro", ".vue"]
+    },
+    "prisma": {
+      "command": ["prisma-language-server", "--stdio"],
+      "extensions": [".prisma"]
+    },
+    "astro": {
+      "command": ["astro-language-server", "--stdio"],
+      "extensions": [".astro"]
+    }
+  }
 }

--- a/chezmoi/dot_config/opencode/opencode.json
+++ b/chezmoi/dot_config/opencode/opencode.json
@@ -126,8 +126,7 @@
       "initialization": {
         "checkOnSave": true,
         "check": {
-          "command": "clippy",
-          "features": "all"
+          "command": "clippy"
         },
         "inlayHints": {
           "bindingModeHints": { "enable": true },
@@ -160,7 +159,7 @@
       }
     },
     "oxlint": {
-      "command": ["oxlint", "--lsp-server"],
+      "command": ["oxlint", "--lsp"],
       "extensions": [".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs", ".astro", ".vue"]
     },
     "prisma": {
@@ -168,7 +167,7 @@
       "extensions": [".prisma"]
     },
     "astro": {
-      "command": ["astro-language-server", "--stdio"],
+      "command": ["astro-ls", "--stdio"],
       "extensions": [".astro"]
     }
   }

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -249,6 +249,68 @@ let
       winget = "SST.opencode";
       category = "infra";
     };
+
+    # ── lsp ───────────────────────────────────────────────
+    nixd = {
+      pkg = pkgs.nixd;
+      winget = null;
+      category = "lsp";
+    };
+    ruff = {
+      pkg = pkgs.ruff;
+      winget = null;
+      category = "lsp";
+    };
+    yaml-language-server = {
+      pkg = pkgs.yaml-language-server;
+      winget = null;
+      category = "lsp";
+    };
+    taplo = {
+      pkg = pkgs.taplo;
+      winget = null;
+      category = "lsp";
+    };
+    bash-language-server = {
+      pkg = pkgs.bash-language-server;
+      winget = null;
+      category = "lsp";
+    };
+    lua-language-server = {
+      pkg = pkgs.lua-language-server;
+      winget = null;
+      category = "lsp";
+    };
+    marksman = {
+      pkg = pkgs.marksman;
+      winget = null;
+      category = "lsp";
+    };
+    gopls = {
+      pkg = pkgs.gopls;
+      winget = null;
+      category = "lsp";
+    };
+    rust-analyzer = {
+      pkg = pkgs.rust-analyzer;
+      winget = null;
+      category = "lsp";
+    };
+    typescript-language-server = {
+      pkg = pkgs.typescript-language-server;
+      winget = null;
+      category = "lsp";
+    };
+    astro-language-server = {
+      pkg = pkgs.astro-language-server;
+      winget = null;
+      category = "lsp";
+    };
+    oxlint = {
+      pkg = pkgs.oxlint;
+      winget = null;
+      category = "lsp";
+    };
   };
 
   # Group package names by category
@@ -286,6 +348,7 @@ lib.mapAttrs (_: names: resolve names) grouped
   # Cross-platform pnpm global packages
   pnpmGlobal = [
     "@tobilu/qmd"
+    "@prisma/language-server"
   ];
 
   # Post-install verification commands for pnpm packages.
@@ -294,6 +357,10 @@ lib.mapAttrs (_: names: resolve names) grouped
     "@tobilu/qmd" = {
       command = "qmd";
       args = [ "status" ];
+    };
+    "@prisma/language-server" = {
+      command = "prisma-language-server";
+      args = [ "--version" ];
     };
     "@google/gemini-cli" = {
       command = "gemini";

--- a/windows/pnpm/packages.json
+++ b/windows/pnpm/packages.json
@@ -10,6 +10,13 @@
       }
     },
     {
+      "name": "@prisma/language-server",
+      "verifyCommand": {
+        "args": ["--version"],
+        "command": "prisma-language-server"
+      }
+    },
+    {
       "name": "@google/gemini-cli",
       "verifyCommand": {
         "args": ["--version"],


### PR DESCRIPTION
## Summary

- 13 LSP servers を `opencode.json` に追加（nixd / ruff / yaml-language-server / taplo / bash-language-server / lua-language-server / marksman / gopls / rust-analyzer / typescript-language-server / oxlint / prisma / astro）
- `nix/packages/sets.nix` に `lsp` カテゴリを新設し対応パッケージを追加
- `@prisma/language-server` を `pnpmGlobal` に追加
- TypeScript linting は oxlint（Rust 実装・高速）、型検査・補完は typescript-language-server で分担

Closes LIF-194

## Test plan

- [ ] `nix fmt` / `pre-commit run --all-files` がパスすること（CI で確認）
- [ ] `chezmoi apply` 後 `~/.config/opencode/opencode.json` に LSP 設定が展開されること
- [ ] WSL で `nrs` 後に `nixd`, `gopls`, `rust-analyzer` 等の各バイナリが PATH に現れること
- [ ] opencode を開いて各言語ファイルで補完・診断が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)