### PR TITLE
feat(LIF-195): add devcontainer-cli.nvim plugin

### DIFF
--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -127,18 +127,19 @@ return {
     -- Devcontainer
     {
         "erichlf/devcontainer-cli.nvim",
-        dependencies = { "nvim-lua/plenary.nvim" },
+        dependencies = { "akinsho/toggleterm.nvim" },
         keys = {
             { "<leader>du", "<cmd>DevcontainerUp<cr>", desc = "Devcontainer up" },
             { "<leader>dc", "<cmd>DevcontainerConnect<cr>", desc = "Devcontainer connect" },
             { "<leader>dd", "<cmd>DevcontainerDown<cr>", desc = "Devcontainer down" },
             { "<leader>dt", "<cmd>DevContainerToggle<cr>", desc = "Devcontainer toggle log" },
         },
-        opts = {
-            dotfiles_repository = "https://github.com/rurusasu/dotfiles",
-            dotfiles_branch = "main",
-            dotfiles_targetPath = "~/.dotfiles",
-            dotfiles_installCommand = "scripts/powershell/apply-chezmoi.ps1",
-        },
+        init = function()
+            require("devcontainer-cli").setup({
+                dotfiles_repository = "https://github.com/rurusasu/dotfiles",
+                dotfiles_branch = "main",
+                dotfiles_targetPath = "~/.dotfiles",
+            })
+        end,
     },
 }

--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -123,4 +123,22 @@ return {
         event = { "BufReadPost", "BufNewFile" },
         opts = {},
     },
+
+    -- Devcontainer
+    {
+        "erichlf/devcontainer-cli.nvim",
+        dependencies = { "nvim-lua/plenary.nvim" },
+        keys = {
+            { "<leader>du", "<cmd>DevcontainerUp<cr>", desc = "Devcontainer up" },
+            { "<leader>dc", "<cmd>DevcontainerConnect<cr>", desc = "Devcontainer connect" },
+            { "<leader>dd", "<cmd>DevcontainerDown<cr>", desc = "Devcontainer down" },
+            { "<leader>dt", "<cmd>DevContainerToggle<cr>", desc = "Devcontainer toggle log" },
+        },
+        opts = {
+            dotfiles_repository = "https://github.com/rurusasu/dotfiles",
+            dotfiles_branch = "main",
+            dotfiles_targetPath = "~/.dotfiles",
+            dotfiles_installCommand = "scripts/powershell/apply-chezmoi.ps1",
+        },
+    },
 }

--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -132,7 +132,7 @@ return {
             { "<leader>du", "<cmd>DevcontainerUp<cr>", desc = "Devcontainer up" },
             { "<leader>dc", "<cmd>DevcontainerConnect<cr>", desc = "Devcontainer connect" },
             { "<leader>dd", "<cmd>DevcontainerDown<cr>", desc = "Devcontainer down" },
-            { "<leader>dt", "<cmd>DevContainerToggle<cr>", desc = "Devcontainer toggle log" },
+            { "<leader>dt", "<cmd>DevcontainerToggle<cr>", desc = "Devcontainer toggle log" },
         },
         init = function()
             require("devcontainer-cli").setup({


### PR DESCRIPTION
## Summary
- `devcontainer-cli.nvim` を lazy.nvim プラグインとして追加
- コンテナのライフサイクル管理を nvim 内から操作可能に

## Keymaps (`<leader>d`)
| キー | コマンド | 内容 |
|---|---|---|
| `<leader>du` | `:DevcontainerUp` | コンテナビルド＆起動 |
| `<leader>dc` | `:DevcontainerConnect` | コンテナ内ターミナル接続 |
| `<leader>dd` | `:DevcontainerDown` | コンテナ停止 |
| `<leader>dt` | `:DevContainerToggle` | ログウィンドウ toggle |

## dotfiles 自動セットアップ
コンテナ起動時に `rurusasu/dotfiles` を clone して環境構築する設定を追加。
`dotfiles_installCommand` は Linux コンテナ向けに要調整。

## Test plan
- [ ] devcontainer プロジェクトで `:DevcontainerUp` が動作することを確認
- [ ] `:DevcontainerConnect` でコンテナ内ターミナルが開くことを確認
- [ ] which-key で `<leader>d` のキーマップが表示されることを確認

Closes LIF-195

🤖 Generated with [Claude Code](https://claude.com/claude-code)