### PR TITLE
fix(LIF-197): install devcontainer CLI and fix plugin lazy-load config

### DIFF
--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -134,12 +134,10 @@ return {
             { "<leader>dd", "<cmd>DevcontainerDown<cr>", desc = "Devcontainer down" },
             { "<leader>dt", "<cmd>DevcontainerToggle<cr>", desc = "Devcontainer toggle log" },
         },
-        config = function()
-            require("devcontainer-cli").setup({
-                dotfiles_repository = "https://github.com/rurusasu/dotfiles",
-                dotfiles_branch = "main",
-                dotfiles_targetPath = "~/.dotfiles",
-            })
-        end,
+        opts = {
+            dotfiles_repository = "https://github.com/rurusasu/dotfiles",
+            dotfiles_branch = "main",
+            dotfiles_targetPath = "~/.dotfiles",
+        },
     },
 }

--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -134,7 +134,7 @@ return {
             { "<leader>dd", "<cmd>DevcontainerDown<cr>", desc = "Devcontainer down" },
             { "<leader>dt", "<cmd>DevcontainerToggle<cr>", desc = "Devcontainer toggle log" },
         },
-        init = function()
+        config = function()
             require("devcontainer-cli").setup({
                 dotfiles_repository = "https://github.com/rurusasu/dotfiles",
                 dotfiles_branch = "main",

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -130,6 +130,11 @@ let
       winget = null;
       category = "dev";
     };
+    devcontainer = {
+      pkg = pkgs.devcontainer;
+      winget = null;
+      category = "dev";
+    };
 
     # ── terminal ──────────────────────────────────────────
     wezterm = {


### PR DESCRIPTION
## Summary
- `devcontainer-cli.nvim` の `init` → `config` に変更（lazy-load キーマップ未登録の修正）
- `nix/packages/sets.nix` に `pkgs.devcontainer` を追加（CLI コマンド not found の修正）

## Root cause

### キーマップ未登録
`init` 関数内で `require("devcontainer-cli")` を呼んでいたが、`init` はプラグイン未ロード時に実行されるため require が失敗し、`<leader>d` 系キーマップが登録されなかった。`config` に変更することでプラグインロード後に setup が実行される。

### devcontainer コマンド not found
WSL 環境に `devcontainer` CLI がインストールされていなかった。`pkgs.devcontainer` (v0.86.0) を dev カテゴリに追加して解決。

## Test plan
- [ ] nvim 再起動後に `<Space>d` で which-key に `d` グループが表示される
- [ ] `.devcontainer/devcontainer.json` があるプロジェクトで `<Space>du` が動作する
- [ ] `nrs` 後に `devcontainer --version` が返る

Closes LIF-197

🤖 Generated with [Claude Code](https://claude.com/claude-code)