### PR TITLE
feat(LIF-200): add codecompanion.nvim with Claude Code ACP adapter

### DIFF
--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -124,6 +124,42 @@ return {
         opts = {},
     },
 
+    -- AI coding assistant (codecompanion + Codex via ACP)
+    {
+        "olimorris/codecompanion.nvim",
+        dependencies = {
+            "nvim-lua/plenary.nvim",
+            "nvim-treesitter/nvim-treesitter",
+        },
+        cmd = { "CodeCompanion", "CodeCompanionChat", "CodeCompanionActions" },
+        keys = {
+            { "<leader>aa", "<cmd>CodeCompanionChat Toggle<cr>", desc = "AI chat toggle" },
+            { "<leader>ai", "<cmd>CodeCompanion<cr>", mode = { "n", "v" }, desc = "AI inline" },
+            { "<leader>ac", "<cmd>CodeCompanionActions<cr>", mode = { "n", "v" }, desc = "AI actions" },
+        },
+        opts = {
+            adapters = {
+                acp = {
+                    claude_code = function()
+                        return require("codecompanion.adapters").extend("claude_code", {
+                            env = {
+                                -- `claude setup-token` でブラウザ認証後に取得したトークンを参照
+                                CLAUDE_CODE_OAUTH_TOKEN = "CLAUDE_CODE_OAUTH_TOKEN",
+                            },
+                            defaults = {
+                                mcpServers = "inherit_from_config",
+                            },
+                        })
+                    end,
+                },
+            },
+            interactions = {
+                chat = { adapter = "claude_code" },
+                inline = { adapter = "claude_code" },
+            },
+        },
+    },
+
     -- Devcontainer
     {
         "erichlf/devcontainer-cli.nvim",

--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -124,7 +124,7 @@ return {
         opts = {},
     },
 
-    -- AI coding assistant (codecompanion + Codex via ACP)
+    -- AI coding assistant (codecompanion + Claude Code via ACP)
     {
         "olimorris/codecompanion.nvim",
         dependencies = {

--- a/docs/chezmoi/keybindings.md
+++ b/docs/chezmoi/keybindings.md
@@ -42,6 +42,10 @@
   - `Leader` は `Space`
   - `Space+e`: エクスプローラ
   - `Space+ff/fg/fb`: ファイル検索/grep/buffers
+  - `Space+aa`: AI チャット toggle (codecompanion)
+  - `Space+ai`: AI インライン補助 (codecompanion)
+  - `Space+ac`: AI アクションメニュー (codecompanion)
+  - `Space+du/dc/dd/dt`: Devcontainer up/connect/down/toggle
 - VS Code / Cursor
   - `Vim` 拡張は利用しない
   - `Ctrl+Shift+H/J/K/L`: editor group 移動


### PR DESCRIPTION
## Summary

- `olimorris/codecompanion.nvim` を Neovim プラグインに追加
- ACP（Agent Communication Protocol）経由で Claude Code CLI を接続
- 認証は `CLAUDE_CODE_OAUTH_TOKEN`（`claude setup-token` でブラウザ認証）
- 既存の MCP サーバー設定を `inherit_from_config` で引き継ぎ

## Keymaps

| キー | 動作 |
|------|------|
| `<leader>aa` | チャット画面のトグル |
| `<leader>ai` | インライン AI 補助 (n/v) |
| `<leader>ac` | アクションメニュー (n/v) |

## Test plan

- [ ] `chezmoi apply` で設定が展開されること
- [ ] Neovim 起動後 `:Lazy sync` でプラグインがインストールされること
- [ ] `claude setup-token` でトークンを取得し `CLAUDE_CODE_OAUTH_TOKEN` に設定後、`<leader>aa` でチャットが起動すること

Closes [LIF-200](https://linear.app/life-style-base/issue/LIF-200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)