### PR TITLE
fix(LIF-201): delete unnamed buffers before DevcontainerConnect

### DIFF
--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -166,9 +166,21 @@ return {
         dependencies = { "akinsho/toggleterm.nvim" },
         keys = {
             { "<leader>du", "<cmd>DevcontainerUp<cr>", desc = "Devcontainer up" },
-            { "<leader>dc", "<cmd>DevcontainerConnect<cr>", desc = "Devcontainer connect" },
             { "<leader>dd", "<cmd>DevcontainerDown<cr>", desc = "Devcontainer down" },
             { "<leader>dt", "<cmd>DevcontainerToggle<cr>", desc = "Devcontainer toggle log" },
+            {
+                "<leader>dc",
+                function()
+                    -- wqa fails on unnamed buffers; delete them first
+                    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+                        if vim.api.nvim_buf_is_valid(buf) and vim.api.nvim_buf_get_name(buf) == "" then
+                            vim.api.nvim_buf_delete(buf, { force = true })
+                        end
+                    end
+                    vim.cmd("DevcontainerConnect")
+                end,
+                desc = "Devcontainer connect",
+            },
         },
         opts = {
             dotfiles_repository = "https://github.com/rurusasu/dotfiles",


### PR DESCRIPTION
## Summary

- `<leader>dc` 実行時に `E141: No file name for buffer 1` が発生するバグを修正
- 原因: プラグインの `M.connect()` が `vim.cmd("wqa")` を呼ぶが unnamed buffer は書き込めない
- 修正: キーマップを関数に変更し、接続前に unnamed buffer を全削除してから `DevcontainerConnect` を呼ぶ

## Test plan

- [ ] Neovim を空のバッファで起動し `<leader>dc` を実行してエラーが出ないこと
- [ ] ファイルを開いた状態でも `<leader>dc` が正常に動作すること

Closes [LIF-201](https://linear.app/life-style-base/issue/LIF-201)

🤖 Generated with [Claude Code](https://claude.com/claude-code)