### PR TITLE
fix(LIF-202): use DevcontainerExec bash instead of DevcontainerConnect

### DIFF
--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -166,7 +166,7 @@ return {
         dependencies = { "akinsho/toggleterm.nvim" },
         keys = {
             { "<leader>du", "<cmd>DevcontainerUp<cr>", desc = "Devcontainer up" },
-            { "<leader>dc", "<cmd>DevcontainerExec bash<cr>", desc = "Devcontainer connect (shell)" },
+            { "<leader>dc", "<cmd>DevcontainerExec bash<cr>", desc = "Devcontainer shell" },
             { "<leader>dd", "<cmd>DevcontainerDown<cr>", desc = "Devcontainer down" },
             { "<leader>dt", "<cmd>DevcontainerToggle<cr>", desc = "Devcontainer toggle log" },
         },

--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -166,21 +166,9 @@ return {
         dependencies = { "akinsho/toggleterm.nvim" },
         keys = {
             { "<leader>du", "<cmd>DevcontainerUp<cr>", desc = "Devcontainer up" },
+            { "<leader>dc", "<cmd>DevcontainerExec bash<cr>", desc = "Devcontainer connect (shell)" },
             { "<leader>dd", "<cmd>DevcontainerDown<cr>", desc = "Devcontainer down" },
             { "<leader>dt", "<cmd>DevcontainerToggle<cr>", desc = "Devcontainer toggle log" },
-            {
-                "<leader>dc",
-                function()
-                    -- wqa fails on unnamed buffers; delete them first
-                    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
-                        if vim.api.nvim_buf_is_valid(buf) and vim.api.nvim_buf_get_name(buf) == "" then
-                            vim.api.nvim_buf_delete(buf, { force = true })
-                        end
-                    end
-                    vim.cmd("DevcontainerConnect")
-                end,
-                desc = "Devcontainer connect",
-            },
         },
         opts = {
             dotfiles_repository = "https://github.com/rurusasu/dotfiles",


### PR DESCRIPTION
## Summary

- `DevcontainerConnect` は `wqa` で Neovim を終了させる設計だが、Windows Terminal・Warp では新ペインが開かない（プラグイン未対応）
- `<leader>dc` を `DevcontainerExec bash` に変更し、toggleterm 内でコンテナの bash シェルを開く
- Neovim を閉じずにコンテナへ接続できるようになる

## Test plan

- [ ] `DevcontainerUp` でコンテナを起動後、`<leader>dc` で toggleterm にコンテナ内 bash が開くこと
- [ ] Neovim が閉じないこと
- [ ] Windows Terminal・Warp 両方で動作すること

Closes [LIF-202](https://linear.app/life-style-base/issue/LIF-202)

🤖 Generated with [Claude Code](https://claude.com/claude-code)