### PR TITLE
feat(LIF-205): add bootstrap.sh and dcnvim for devcontainer workflow

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,16 +21,18 @@ have() { command -v "$1" >/dev/null 2>&1; }
 
 # ── sudo wrapper ────────────────────────────────────────────────────────
 SUDO=""
-if [ "$(id -u)" -ne 0 ]; then
-  if have sudo; then
-    SUDO="sudo"
-  else
-    log "no sudo available — apt install will be skipped"
-  fi
+can_install=0
+if [ "$(id -u)" -eq 0 ]; then
+  can_install=1
+elif have sudo; then
+  SUDO="sudo"
+  can_install=1
+else
+  log "no sudo and not root — apt install will be skipped"
 fi
 
 # ── apt packages (Debian/Ubuntu base only; best effort otherwise) ───────
-if have apt-get; then
+if [ "$can_install" -eq 1 ] && have apt-get; then
   need=()
   have tmux || need+=("tmux")
   have curl || need+=("curl")
@@ -42,20 +44,27 @@ if have apt-get; then
     $SUDO env DEBIAN_FRONTEND=noninteractive \
       apt-get install -y -qq --no-install-recommends "${need[@]}"
   fi
-else
+elif ! have apt-get; then
   log "apt-get not found — package install skipped (install tmux/curl/git manually)"
 fi
 
 # ── modern Neovim (distro nvim is usually too old for lazy.nvim) ────────
+# Read --version once with sed `q` so nvim is not killed by SIGPIPE under
+# `set -o pipefail` (which would abort the entire script on the
+# already-installed path and break idempotency).
 need_nvim=1
 if have nvim; then
-  ver=$(nvim --version | head -1 | sed -n 's/^NVIM v\([0-9]*\.[0-9]*\).*/\1/p')
-  if [ -n "$ver" ]; then
+  ver=$(nvim --version 2>/dev/null | sed -n '1{s/^NVIM v\([0-9]*\.[0-9]*\).*/\1/p;q}')
+  if [ -z "$ver" ]; then
+    log "Neovim present but version string unparseable; will reinstall"
+  else
     major=${ver%.*}
     minor=${ver#*.}
     if [ "$major" -gt 0 ] || { [ "$major" -eq 0 ] && [ "$minor" -ge 9 ]; }; then
       need_nvim=0
       log "Neovim $ver already present"
+    else
+      log "Neovim $ver is too old (need >= 0.9); will reinstall"
     fi
   fi
 fi
@@ -71,35 +80,67 @@ if [ "$need_nvim" -eq 1 ]; then
     log "installing Neovim release ($asset) to ~/.local/nvim"
     mkdir -p "$HOME/.local/bin"
     tmp=$(mktemp -d)
-    curl -fsSL "https://github.com/neovim/neovim/releases/latest/download/$asset" |
-      tar -xz -C "$tmp"
-    rm -rf "$HOME/.local/nvim"
-    mv "$tmp"/nvim-linux-* "$HOME/.local/nvim"
+    # Stage into $tmp, verify, then swap. Never `rm` the existing
+    # ~/.local/nvim until the new install is confirmed extracted.
+    if ! curl -fsSL "https://github.com/neovim/neovim/releases/latest/download/$asset" |
+      tar -xz -C "$tmp"; then
+      log "curl/tar failed; aborting (existing nvim untouched)"
+      rm -rf "$tmp"
+      exit 1
+    fi
+    new_dir=$(find "$tmp" -maxdepth 1 -type d -name 'nvim-linux-*' | head -1)
+    if [ -z "$new_dir" ] || [ ! -d "$new_dir" ]; then
+      log "extraction produced no nvim-linux-* dir; aborting (existing nvim untouched)"
+      rm -rf "$tmp"
+      exit 1
+    fi
+    old_backup=""
+    if [ -e "$HOME/.local/nvim" ]; then
+      old_backup="$HOME/.local/nvim.old.$$"
+      mv "$HOME/.local/nvim" "$old_backup"
+    fi
+    mv "$new_dir" "$HOME/.local/nvim"
     ln -sfn "$HOME/.local/nvim/bin/nvim" "$HOME/.local/bin/nvim"
-    rmdir "$tmp" 2>/dev/null || true
+    [ -n "$old_backup" ] && rm -rf "$old_backup"
+    rm -rf "$tmp"
   else
     log "skipping Neovim install (arch=$arch, curl/tar missing?)"
   fi
 fi
 
-# ── PATH wiring for future interactive shells ───────────────────────────
-if ! grep -q '\.local/bin' "$HOME/.bashrc" 2>/dev/null; then
-  printf '\n# Added by dotfiles bootstrap\nexport PATH="$HOME/.local/bin:$PATH"\n' \
-    >>"$HOME/.bashrc"
-fi
+# ── PATH wiring for future shells ───────────────────────────────────────
+# `bash -l` (used by `dcnvim`) reads ~/.profile, not ~/.bashrc. Append to
+# both so PATH is visible regardless of which init path runs.
+for f in "$HOME/.profile" "$HOME/.bashrc"; do
+  if ! grep -q '\.local/bin' "$f" 2>/dev/null; then
+    printf '\n# Added by dotfiles bootstrap\nexport PATH="$HOME/.local/bin:$PATH"\n' >>"$f"
+  fi
+done
 
 # ── nvim config symlink ─────────────────────────────────────────────────
+# `ln -sfn` does not replace a real directory at the target; check first
+# so a stale `~/.config/nvim/` from a previous provisioner is removed.
 mkdir -p "$HOME/.config"
-ln -sfn "$ROOT/chezmoi/editors/nvim" "$HOME/.config/nvim"
-log "linked $HOME/.config/nvim -> $ROOT/chezmoi/editors/nvim"
+target="$HOME/.config/nvim"
+if [ -e "$target" ] && [ ! -L "$target" ]; then
+  log "removing existing non-symlink $target"
+  rm -rf "$target"
+fi
+ln -sfn "$ROOT/chezmoi/editors/nvim" "$target"
+log "linked $target -> $ROOT/chezmoi/editors/nvim"
 
 # ── lazy.nvim plugin pre-warm (best effort) ─────────────────────────────
+# stderr goes to a log file so a broken init.lua or plugin compile error
+# can be diagnosed rather than blackholed.
 NVIM_BIN="$HOME/.local/bin/nvim"
 [ -x "$NVIM_BIN" ] || NVIM_BIN="$(command -v nvim 2>/dev/null || true)"
 if [ -n "$NVIM_BIN" ] && [ -x "$NVIM_BIN" ]; then
   log "pre-warming lazy.nvim plugins (best effort, 90s cap)"
-  timeout 90 "$NVIM_BIN" --headless "+Lazy! sync" +qa 2>/dev/null ||
-    log "lazy.nvim pre-warm timed out or failed — run :Lazy sync inside nvim"
+  lazy_log="$HOME/.local/share/nvim-bootstrap.log"
+  mkdir -p "$(dirname "$lazy_log")"
+  if ! timeout 90 "$NVIM_BIN" --headless "+Lazy! sync" +qa >"$lazy_log" 2>&1; then
+    log "lazy.nvim pre-warm did not complete cleanly; see $lazy_log"
+  fi
 fi
 
 log "bootstrap complete"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Devcontainer dotfiles bootstrap.
+#
+# Auto-detected and executed by devcontainer-cli when this repository
+# is supplied as `--dotfiles-repository`. Sets up the minimum needed
+# for the "host terminal → container tmux+nvim" workflow:
+#
+#   1. tmux + git + curl + tar via apt (Debian/Ubuntu base only).
+#   2. Modern Neovim release into ~/.local/nvim with bin symlink.
+#   3. Symlink chezmoi/editors/nvim → ~/.config/nvim.
+#   4. Headless lazy.nvim plugin pre-warm (best effort, 90s cap).
+#
+# Idempotent — safe to re-run on every DevcontainerUp.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+log() { printf '\033[1;34m[bootstrap]\033[0m %s\n' "$*" >&2; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# ── sudo wrapper ────────────────────────────────────────────────────────
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  if have sudo; then
+    SUDO="sudo"
+  else
+    log "no sudo available — apt install will be skipped"
+  fi
+fi
+
+# ── apt packages (Debian/Ubuntu base only; best effort otherwise) ───────
+if have apt-get; then
+  need=()
+  have tmux || need+=("tmux")
+  have curl || need+=("curl")
+  have git || need+=("git")
+  have tar || need+=("tar")
+  if [ "${#need[@]}" -gt 0 ]; then
+    log "apt install: ${need[*]}"
+    $SUDO apt-get update -qq
+    $SUDO env DEBIAN_FRONTEND=noninteractive \
+      apt-get install -y -qq --no-install-recommends "${need[@]}"
+  fi
+else
+  log "apt-get not found — package install skipped (install tmux/curl/git manually)"
+fi
+
+# ── modern Neovim (distro nvim is usually too old for lazy.nvim) ────────
+need_nvim=1
+if have nvim; then
+  ver=$(nvim --version | head -1 | sed -n 's/^NVIM v\([0-9]*\.[0-9]*\).*/\1/p')
+  if [ -n "$ver" ]; then
+    major=${ver%.*}
+    minor=${ver#*.}
+    if [ "$major" -gt 0 ] || { [ "$major" -eq 0 ] && [ "$minor" -ge 9 ]; }; then
+      need_nvim=0
+      log "Neovim $ver already present"
+    fi
+  fi
+fi
+
+if [ "$need_nvim" -eq 1 ]; then
+  arch=$(uname -m)
+  case "$arch" in
+  x86_64) asset="nvim-linux-x86_64.tar.gz" ;;
+  aarch64) asset="nvim-linux-arm64.tar.gz" ;;
+  *) asset="" ;;
+  esac
+  if [ -n "$asset" ] && have curl && have tar; then
+    log "installing Neovim release ($asset) to ~/.local/nvim"
+    mkdir -p "$HOME/.local/bin"
+    tmp=$(mktemp -d)
+    curl -fsSL "https://github.com/neovim/neovim/releases/latest/download/$asset" |
+      tar -xz -C "$tmp"
+    rm -rf "$HOME/.local/nvim"
+    mv "$tmp"/nvim-linux-* "$HOME/.local/nvim"
+    ln -sfn "$HOME/.local/nvim/bin/nvim" "$HOME/.local/bin/nvim"
+    rmdir "$tmp" 2>/dev/null || true
+  else
+    log "skipping Neovim install (arch=$arch, curl/tar missing?)"
+  fi
+fi
+
+# ── PATH wiring for future interactive shells ───────────────────────────
+if ! grep -q '\.local/bin' "$HOME/.bashrc" 2>/dev/null; then
+  printf '\n# Added by dotfiles bootstrap\nexport PATH="$HOME/.local/bin:$PATH"\n' \
+    >>"$HOME/.bashrc"
+fi
+
+# ── nvim config symlink ─────────────────────────────────────────────────
+mkdir -p "$HOME/.config"
+ln -sfn "$ROOT/chezmoi/editors/nvim" "$HOME/.config/nvim"
+log "linked $HOME/.config/nvim -> $ROOT/chezmoi/editors/nvim"
+
+# ── lazy.nvim plugin pre-warm (best effort) ─────────────────────────────
+NVIM_BIN="$HOME/.local/bin/nvim"
+[ -x "$NVIM_BIN" ] || NVIM_BIN="$(command -v nvim 2>/dev/null || true)"
+if [ -n "$NVIM_BIN" ] && [ -x "$NVIM_BIN" ]; then
+  log "pre-warming lazy.nvim plugins (best effort, 90s cap)"
+  timeout 90 "$NVIM_BIN" --headless "+Lazy! sync" +qa 2>/dev/null ||
+    log "lazy.nvim pre-warm timed out or failed — run :Lazy sync inside nvim"
+fi
+
+log "bootstrap complete"

--- a/chezmoi/shells/bashrc
+++ b/chezmoi/shells/bashrc
@@ -136,5 +136,24 @@ __fzf_history_widget() {
 }
 bind -x '"\er": __fzf_history_widget'
 
+# devcontainer: enter the project's devcontainer in a tmux session
+# and start nvim inside it. Terminal-agnostic (works in WezTerm,
+# Windows Terminal, Warp, etc.). Re-running attaches to the existing
+# tmux session so nvim state survives terminal close.
+#
+# Usage: dcnvim [workspace-folder]   # defaults to $PWD
+#
+# Requires: @devcontainers/cli on host; bootstrap.sh ran inside the
+# container to provide nvim + tmux. See bootstrap.sh at repo root.
+dcnvim() {
+  local workspace="${1:-$PWD}"
+  if ! command -v devcontainer >/dev/null 2>&1; then
+    echo "dcnvim: devcontainer CLI not found. Install with: npm i -g @devcontainers/cli" >&2
+    return 127
+  fi
+  devcontainer exec --workspace-folder "$workspace" -- \
+    bash -lc 'tmux new -A -s main "nvim ."'
+}
+
 # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)
 [[ -f "$HOME/.config/shell/secret.sh" ]] && source "$HOME/.config/shell/secret.sh"

--- a/chezmoi/shells/bashrc
+++ b/chezmoi/shells/bashrc
@@ -151,8 +151,27 @@ dcnvim() {
     echo "dcnvim: devcontainer CLI not found. Install with: npm i -g @devcontainers/cli" >&2
     return 127
   fi
+  if [ ! -d "$workspace/.devcontainer" ] && [ ! -f "$workspace/.devcontainer.json" ]; then
+    echo "dcnvim: no .devcontainer/ or .devcontainer.json under $workspace" >&2
+    return 1
+  fi
+  # bash -l reads ~/.profile (not ~/.bashrc); export PATH inline so the
+  # container's just-bootstrapped ~/.local/bin/nvim is found. nvim/tmux
+  # presence is checked explicitly because tmux exits 0 if its child
+  # command is missing, masking the failure to the host.
   devcontainer exec --workspace-folder "$workspace" -- \
-    bash -lc 'tmux new -A -s main "nvim ."'
+    bash -lc '
+      export PATH="$HOME/.local/bin:$PATH"
+      command -v nvim >/dev/null 2>&1 || {
+        echo "dcnvim: nvim not installed in container — run ~/.dotfiles/bootstrap.sh first" >&2
+        exit 127
+      }
+      command -v tmux >/dev/null 2>&1 || {
+        echo "dcnvim: tmux not installed in container — run ~/.dotfiles/bootstrap.sh first" >&2
+        exit 127
+      }
+      tmux new -A -s main "nvim ."
+    '
 }
 
 # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -108,6 +108,25 @@ in
       zle -N __fzf_history_widget
       bindkey '^[r' __fzf_history_widget
 
+      # devcontainer: enter the project's devcontainer in a tmux session
+      # and start nvim inside it. Terminal-agnostic (works in WezTerm,
+      # Windows Terminal, Warp, etc.). Re-running attaches to the existing
+      # tmux session so nvim state survives terminal close.
+      #
+      # Usage: dcnvim [workspace-folder]   # defaults to $PWD
+      #
+      # Requires: @devcontainers/cli on host; bootstrap.sh ran inside the
+      # container to provide nvim + tmux. See bootstrap.sh at repo root.
+      dcnvim() {
+        local workspace="''${1:-$PWD}"
+        if ! command -v devcontainer >/dev/null 2>&1; then
+          echo "dcnvim: devcontainer CLI not found. Install with: npm i -g @devcontainers/cli" >&2
+          return 127
+        fi
+        devcontainer exec --workspace-folder "$workspace" -- \
+          bash -lc 'tmux new -A -s main "nvim ."'
+      }
+
       # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)
       [[ -f "$HOME/.config/shell/secret.sh" ]] && source "$HOME/.config/shell/secret.sh"
     '';

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -123,8 +123,27 @@ in
           echo "dcnvim: devcontainer CLI not found. Install with: npm i -g @devcontainers/cli" >&2
           return 127
         fi
+        if [ ! -d "$workspace/.devcontainer" ] && [ ! -f "$workspace/.devcontainer.json" ]; then
+          echo "dcnvim: no .devcontainer/ or .devcontainer.json under $workspace" >&2
+          return 1
+        fi
+        # bash -l reads ~/.profile (not ~/.bashrc); export PATH inline so
+        # the container's just-bootstrapped ~/.local/bin/nvim is found.
+        # nvim/tmux presence is checked because tmux exits 0 if its child
+        # command is missing, masking the failure to the host.
         devcontainer exec --workspace-folder "$workspace" -- \
-          bash -lc 'tmux new -A -s main "nvim ."'
+          bash -lc '
+            export PATH="$HOME/.local/bin:$PATH"
+            command -v nvim >/dev/null 2>&1 || {
+              echo "dcnvim: nvim not installed in container — run ~/.dotfiles/bootstrap.sh first" >&2
+              exit 127
+            }
+            command -v tmux >/dev/null 2>&1 || {
+              echo "dcnvim: tmux not installed in container — run ~/.dotfiles/bootstrap.sh first" >&2
+              exit 127
+            }
+            tmux new -A -s main "nvim ."
+          '
       }
 
       # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)


### PR DESCRIPTION
## Summary

- **bootstrap.sh（新規・実行属性付き）**: devcontainer-cli が --dotfiles-repository 引数で clone した際に auto-detect して実行される POSIX bootstrap。container 側に tmux / modern Neovim / nvim 設定 symlink を idempotent に揃える。
- **dcnvim() shell 関数**: nix/home/common.nix（zsh）と chezmoi/shells/bashrc（bash）に追加。host のどの terminal からでも `dcnvim` 一発で `devcontainer exec` → `tmux new -A -s main` → `nvim .` が走る。
- **devcontainer.json は一切編集しない**。user-specific レイヤを dotfiles 側に分離する設計。LIF-203 の補完であり撤回ではない。

## なぜ nested-nvim や sshfs ではないか

- VSCode の "Attach to Container" 完全相当は OSS には無い（distant.nvim 等は DIY 度が高い）。
- 実運用上は **container 内で nvim を動かし、host は terminal で繋ぐだけ** が最も枯れている（tmux で session 永続化、autossh 不要 = local docker のため）。
- host nvim の :terminal 経由で container nvim を起動すると nested になり leader/escape/clipboard が破綻する。

## Changes

| File | Change |
| --- | --- |
| `bootstrap.sh` | 新規・100755。apt で tmux/git/curl/tar、modern Neovim を `~/.local/nvim`、`~/.config/nvim` を symlink、`:Lazy! sync` を 90s 上限で pre-warm。冪等。 |
| `nix/home/common.nix` | `programs.zsh.initContent` に `dcnvim()` 関数を追加。 |
| `chezmoi/shells/bashrc` | bash 版 `dcnvim()` を追加。 |

## Test plan

- [ ] WSL で `chezmoi apply && nrs` 後、新規 zsh shell で `type dcnvim` が関数として表示される
- [ ] bash で `type dcnvim` も同様に表示される
- [ ] devcontainer プロジェクトで `<leader>du` (DevcontainerUp) 実行 → container 内に `~/.dotfiles` が clone され `bootstrap.sh` が走り、tmux と最新 nvim が install される
- [ ] container 内で `nvim --version` が 0.9 以上を返す
- [ ] container 内で `ls -la ~/.config/nvim` が repo 内 `chezmoi/editors/nvim` への symlink を示す
- [ ] WezTerm / Windows Terminal / Warp のいずれかから `dcnvim` で tmux session "main" に attach し nvim が起動する
- [ ] Ctrl+B → D で detach → terminal を閉じる → 再度 `dcnvim` で session が生き残っていることを確認
- [ ] devcontainer.json (econa_engine 等) に diff が出ていないこと

## Refs

- Closes LIF-205
- Complements LIF-203 / LIF-204

🤖 Generated with [Claude Code](https://claude.com/claude-code)
