### PR TITLE
fix(LIF-206): drop rustup to resolve rust-analyzer bin collision

### DIFF
--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -100,11 +100,6 @@ let
       winget = null;
       category = "dev";
     };
-    rustup = {
-      pkg = pkgs.rustup;
-      winget = "Rustlang.Rustup";
-      category = "dev";
-    };
     gnumake = {
       pkg = pkgs.gnumake;
       winget = null;

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -104,9 +104,6 @@
           }
         },
         {
-          "PackageIdentifier": "Rustlang.Rustup"
-        },
-        {
           "PackageIdentifier": "SlackTechnologies.Slack"
         },
         {


### PR DESCRIPTION
## Summary

LIF-205 のマージ後、`nrs` が次のエラーで失敗するのを修正：

```
pkgs.buildEnv error: two given paths contain a conflicting subpath:
  /nix/store/.../rustup-1.29.0/bin/rust-analyzer
  /nix/store/.../rust-analyzer-2026-04-27/bin/rust-analyzer
```

`rustup` と `rust-analyzer` standalone が双方 `bin/rust-analyzer` を提供するため、Home Manager の `pkgs.buildEnv` で衝突。

## Changes

| File | Change |
| --- | --- |
| `nix/packages/sets.nix` | `rustup` エントリ (L103-107) を削除 |
| `windows/winget/packages.json` | `Rustlang.Rustup` を削除 |

## 採用しなかった案

- **rust-analyzer standalone を削除して rustup の rust-analyzer を使う** — standalone の方が rolling release で新しく、nvim LSP の挙動も安定。standalone を残すのが妥当。

## 影響

- host で `cargo` / `rustc` / `rustfmt` がデフォルトで使えなくなる。
- Rust project では per-project `nix develop` / `shell.nix` / rust-overlay で toolchain を投入する運用に。
- nvim の `rust_analyzer` LSP は `rust-analyzer` standalone で継続動作。

## Test plan

- [ ] WSL で `sudo nixos-rebuild dry-build --flake ~/.dotfiles --impure` が衝突なく通る
- [ ] merge 後に `nrs` が成功する
- [ ] LIF-205 の zsh 側 `dcnvim` 関数が `type dcnvim` で見える
- [ ] `which rust-analyzer` が `/etc/profiles/per-user/<user>/bin/rust-analyzer` を指す

## Refs

- Closes LIF-206
- Unblocks LIF-205 (zsh dcnvim deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
