### PR TITLE
feat(LIF-207): add dcnvim function to PowerShell profile

### DIFF
--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -144,6 +144,50 @@ if (-not $env:CLAUDE_CODE_GIT_BASH_PATH) {
     Remove-Variable _candidate -ErrorAction SilentlyContinue
 }
 
+# devcontainer: enter the project's devcontainer in a tmux session
+# and start nvim inside it. Terminal-agnostic mirror of the zsh/bash
+# `dcnvim` defined in nix/home/common.nix and chezmoi/shells/bashrc.
+# Re-running attaches to the existing tmux session so nvim state
+# survives terminal close.
+#
+# Usage: dcnvim [-Workspace <path>]   # defaults to $PWD
+#
+# Requires: @devcontainers/cli on host; bootstrap.sh ran inside the
+# container to provide nvim + tmux. See bootstrap.sh at repo root.
+function dcnvim {
+    [CmdletBinding()]
+    param([string]$Workspace = (Get-Location).Path)
+
+    if (-not (Get-Command devcontainer -ErrorAction SilentlyContinue)) {
+        Write-Error "dcnvim: devcontainer CLI not found. Install with: npm i -g @devcontainers/cli"
+        return
+    }
+    if (-not (Test-Path (Join-Path $Workspace ".devcontainer")) -and
+        -not (Test-Path (Join-Path $Workspace ".devcontainer.json"))) {
+        Write-Error "dcnvim: no .devcontainer/ or .devcontainer.json under $Workspace"
+        return
+    }
+
+    # bash -l reads ~/.profile (not ~/.bashrc); export PATH inline so the
+    # container's just-bootstrapped ~/.local/bin/nvim is found. nvim/tmux
+    # presence is checked explicitly because tmux exits 0 if its child
+    # command is missing, masking the failure to the host.
+    $payload = @'
+export PATH="$HOME/.local/bin:$PATH"
+command -v nvim >/dev/null 2>&1 || {
+  echo "dcnvim: nvim not installed in container — run ~/.dotfiles/bootstrap.sh first" >&2
+  exit 127
+}
+command -v tmux >/dev/null 2>&1 || {
+  echo "dcnvim: tmux not installed in container — run ~/.dotfiles/bootstrap.sh first" >&2
+  exit 127
+}
+tmux new -A -s main "nvim ."
+'@
+
+    & devcontainer exec --workspace-folder $Workspace -- bash -lc $payload
+}
+
 # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)
 $_secretPs1 = Join-Path $HOME ".config\shell\secret.ps1"
 if (Test-Path $_secretPs1) { . $_secretPs1 }


### PR DESCRIPTION
## Summary

Windows PowerShell から `dcnvim` を叩くと `The term 'dcnvim' is not recognized` で失敗するのを修正。LIF-205 では zsh / bash 版のみ追加していたので、pwsh 版を補完。

## Changes

`chezmoi/shells/Microsoft.PowerShell_profile.ps1` に `function dcnvim` を追加：

- `$Workspace` parameter（既定値 `Get-Location`）
- `devcontainer` CLI の存在チェック
- `.devcontainer/` または `.devcontainer.json` の存在チェック
- `bash -lc` payload は zsh / bash 版と同一文字列（here-string `@'...'@` で literal 渡し）
- 戻り値は `devcontainer exec` の exit code（call 演算子 `&` 経由）

## なぜ here-string

PowerShell の `"..."` は `$VAR` を補間してしまうため、bash 用の `$HOME` / `$PWD` / `$?` 等が PowerShell 側で展開されないよう `@'...'@`（single-quoted here-string）で literal 渡しにする。

## Test plan

- [ ] Windows PowerShell で `chezmoi apply` 後、`Get-Command dcnvim` が `Function` を返す
- [ ] devcontainer プロジェクトで `dcnvim` を実行すると container 内で tmux+nvim が起動する
- [ ] `.devcontainer/` の無いディレクトリで実行するとエラーメッセージが出る
- [ ] `devcontainer` CLI 未 install のホストで実行するとエラーメッセージが出る
- [ ] zsh / bash 版と挙動が一致する（同じ `bash -lc` payload なので container 側は同一）

## Refs

- Closes LIF-207
- Follow-up to LIF-205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
