### PR TITLE
fix(LIF-208): eager-load oil.nvim to hijack netrw

### DIFF
--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -12,11 +12,15 @@ return {
     },
 
     -- File explorer
+    -- Eager-load so oil hijacks netrw at startup; otherwise `nvim <dir>`
+    -- (e.g. `nvim .` from tmux/`dcnvim`) is handled by built-in netrw
+    -- before oil's setup runs.
     {
         "stevearc/oil.nvim",
-        cmd = "Oil",
+        lazy = false,
         keys = { { "-", "<cmd>Oil<cr>", desc = "Open parent directory" } },
         opts = {
+            default_file_explorer = true,
             view_options = { show_hidden = true },
         },
     },


### PR DESCRIPTION
## Summary

`nvim <directory>`（特に `dcnvim` 経由の `nvim .`）で oil ではなく netrw が開いてしまう不具合を修正。

## 原因

`chezmoi/editors/nvim/lua/plugins/init.lua` の `oil.nvim` spec は `cmd = "Oil"` と `keys = "-"` で lazy load されており、`nvim .` のディレクトリ引数が処理される時点で oil の `setup()` がまだ走っていない。組み込み netrw がディレクトリ表示を先取りして oil の hijack が成立しない。

## Changes

```lua
-- before
{
    "stevearc/oil.nvim",
    cmd = "Oil",
    keys = { { "-", "<cmd>Oil<cr>", desc = "Open parent directory" } },
    opts = { view_options = { show_hidden = true } },
},

-- after
{
    "stevearc/oil.nvim",
    lazy = false,
    keys = { { "-", "<cmd>Oil<cr>", desc = "Open parent directory" } },
    opts = {
        default_file_explorer = true,
        view_options = { show_hidden = true },
    },
},
```

- `lazy = false` で起動時にロード（oil 公式 README の推奨パターン）
- `default_file_explorer = true` を明示して netrw 置き換えを明確化

## 影響

- 起動時間が oil の setup 分だけ増（microseconds オーダー）
- `nvim <dir>` で oil の UI が出る
- `-` キーマップは挙動変化なし
- host / container 両側に等しく適用される（dotfiles symlink 経由）

## Test plan

- [ ] `nvim .` で oil が開く
- [ ] `-` で親ディレクトリの oil
- [ ] `:Oil` 直接実行
- [ ] `:checkhealth oil` がエラーなし
- [ ] container 側 nvim でも同じ挙動（container 内で `cd ~/.dotfiles && git pull` 後 nvim 再起動）

## Refs

- Closes LIF-208
- Follow-up to LIF-205（dcnvim 経由の使用感を整える）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
