### PR TITLE
feat(LIF-209): add k8s learning tools to nix packages SSOT

### DIFF
--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -217,6 +217,46 @@ let
       winget = null;
       category = "k8s";
     };
+    kustomize = {
+      pkg = pkgs.kustomize;
+      winget = null;
+      category = "k8s";
+    };
+    stern = {
+      pkg = pkgs.stern;
+      winget = null;
+      category = "k8s";
+    };
+    argocd = {
+      pkg = pkgs.argocd;
+      winget = null;
+      category = "k8s";
+    };
+    cilium-cli = {
+      pkg = pkgs.cilium-cli;
+      winget = null;
+      category = "k8s";
+    };
+    kubeseal = {
+      pkg = pkgs.kubeseal;
+      winget = null;
+      category = "k8s";
+    };
+    sops = {
+      pkg = pkgs.sops;
+      winget = null;
+      category = "k8s";
+    };
+    trivy = {
+      pkg = pkgs.trivy;
+      winget = null;
+      category = "k8s";
+    };
+    dive = {
+      pkg = pkgs.dive;
+      winget = null;
+      category = "k8s";
+    };
 
     # ── infra ─────────────────────────────────────────────
     go-task = {


### PR DESCRIPTION
## Summary
- `nix/packages/sets.nix` の `k8s` カテゴリに学習用CLIを8点追加（`kustomize`, `stern`, `argocd`, `cilium-cli`, `kubeseal`, `sops`, `trivy`, `dive`）
- kindベースのローカル学習フェーズで使う標準セット。いずれも winget 非対応のためNix経由で配布
- 関連: [LIF-209](https://linear.app/life-style-base/issue/LIF-209/add-k8s-learning-tools-to-nix-packages-ssot)

## Test plan
- [x] `nix fmt` 通過（変更なし）
- [x] `sudo nixos-rebuild dry-build --flake ~/.dotfiles --impure` 通過 — 8パッケージすべて解決済み
- [x] `pre-commit run --all-files`（task commit 経由）通過
- [ ] マージ後 `nrs` で実反映し、各CLIの `--version` を確認