### PR TITLE
docs(LIF-211): document chezmoi init requirement and op account convention

### DIFF
--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -1,4 +1,17 @@
 # chezmoi configuration
+#
+# ⚠️ When this file changes, run `chezmoi init` to regenerate the active
+#    ~/.config/chezmoi/chezmoi.toml. Otherwise `chezmoi apply` keeps using
+#    the old config — `[data]` additions show up as
+#    `map has no entry for key "..."` errors. chezmoi prints a warning
+#    ("config file template has changed, run chezmoi init to regenerate
+#    config file") but does not block the apply.
+#
+# ⚠️ For `onepasswordRead`, always pass the account as the 2nd argument
+#    (e.g. `onepasswordRead "op://Private/..." .op_account_personal`).
+#    chezmoi 2.70.x silently ignores `[onepassword] account = "..."` in
+#    its flat form, so this is the only reliable way to disambiguate
+#    multi-account 1Password setups. See LIF-210.
 
 sourceDir = {{ .chezmoi.sourceDir | quote }}
 

--- a/chezmoi/AGENTS.md
+++ b/chezmoi/AGENTS.md
@@ -14,10 +14,12 @@
 
 1. `.chezmoiignore.tmpl` がターゲット名ベースで正しく除外されること。
 2. `onepasswordRead` を使う箇所は `lookPath "op"` でガードすること。
-3. `AGENTS.md`/`README.md` は deploy 対象にしないこと。
-4. `.tmpl` ファイルを deploy スクリプトから参照する場合は `include` でインライン展開すること（ファイルコピーでは未展開のまま配置される）。
-5. SSH config の `IdentityFile` で参照する公開鍵は、deploy スクリプトで必ずデプロイすること。
-6. `gpg.ssh.program` には 1Password の `op-ssh-sign` を使うこと（`ssh-keygen` は 1Password の鍵にアクセスできない）。
+3. `onepasswordRead` には 2 引数目で account を明示すること（`.op_account_personal` / `.op_account_work`）。chezmoi 2.70.x で `[onepassword] account` flat 形式は黙って無視される。
+4. `.chezmoi.toml.tmpl` を変更したら `chezmoi init` で再生成すること。`[data]` 追加が反映されず `map has no entry for key` で apply が止まる。
+5. `AGENTS.md`/`README.md` は deploy 対象にしないこと。
+6. `.tmpl` ファイルを deploy スクリプトから参照する場合は `include` でインライン展開すること（ファイルコピーでは未展開のまま配置される）。
+7. SSH config の `IdentityFile` で参照する公開鍵は、deploy スクリプトで必ずデプロイすること。
+8. `gpg.ssh.program` には 1Password の `op-ssh-sign` を使うこと（`ssh-keygen` は 1Password の鍵にアクセスできない）。
 
 ## 実行
 


### PR DESCRIPTION
## Summary

LIF-210 で踏んだ chezmoi の 2 つの落とし穴を、次の編集者が即気付ける場所に永続化するドキュメント追加。挙動変更なし。

## Changes

### `chezmoi/.chezmoi.toml.tmpl`

ファイル冒頭にコメントブロックを追加：

1. **このファイルを変更したら `chezmoi init` で再生成する必要がある**。chezmoi は警告を出すが、apply は止まらず旧 config で実行されて `[data]` 追加が `map has no entry for key` で落ちる。
2. **`onepasswordRead` には 2 引数目で account を明示する**。chezmoi 2.70.x で flat `[onepassword] account = "..."` は無視される。

### `chezmoi/AGENTS.md`

「変更時の必須確認」リストに 2 項目を追加（CLAUDE.md は AGENTS.md への symlink なので片方の編集で両方反映）：

- 項目 3: `onepasswordRead` の 2 引数目に account を明示
- 項目 4: `.chezmoi.toml.tmpl` 変更後は `chezmoi init` で再生成

## なぜ両方に書くか

- **`.chezmoi.toml.tmpl` のコメント**: そのファイルを直接編集する人向け。「config を増やしたら？」と思った瞬間に目に入る。
- **AGENTS.md**: chezmoi 全体の編集者・agent 向け。「chezmoi で何かやる」前にざっと読む規約として。

## Refs

- Closes LIF-211
- Follow-up doc to LIF-210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
