### PR TITLE
feat(LIF-212): automate Windows nvim setup via chezmoi apply

### DIFF
--- a/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy.ps1.tmpl
@@ -1,6 +1,6 @@
 {{ if eq .chezmoi.os "windows" -}}
 # Deploy editor configurations for Windows
-# hash: {{ include "editors/vscode/settings.json" | sha256sum }}{{ include "editors/vscode/keybindings.json" | sha256sum }}{{ include "editors/cursor/settings.json" | sha256sum }}{{ include "editors/cursor/keybindings.json" | sha256sum }}{{ include "editors/zed/settings.json" | sha256sum }}{{ include "editors/zed/keymap.json" | sha256sum }}
+# hash: {{ include "editors/vscode/settings.json" | sha256sum }}{{ include "editors/vscode/keybindings.json" | sha256sum }}{{ include "editors/cursor/settings.json" | sha256sum }}{{ include "editors/cursor/keybindings.json" | sha256sum }}{{ include "editors/zed/settings.json" | sha256sum }}{{ include "editors/zed/keymap.json" | sha256sum }}{{ include "editors/nvim/init.lua" | sha256sum }}{{ include "editors/nvim/lua/config/options.lua" | sha256sum }}{{ include "editors/nvim/lua/config/keymaps.lua" | sha256sum }}{{ include "editors/nvim/lua/config/osc7.lua" | sha256sum }}{{ include "editors/nvim/lua/plugins/init.lua" | sha256sum }}
 
 $ErrorActionPreference = "Stop"
 
@@ -55,6 +55,36 @@ if (Test-Path -LiteralPath $NvimSource) {
   }
   Copy-Item -Path "$NvimSource\*" -Destination $NvimConfig -Recurse -Force
   Write-Host "Deployed: $NvimConfig"
+
+  # Headless :Lazy sync so first nvim launch does not need manual :Lazy sync.
+  # Best-effort with 90s cap; cannot block chezmoi apply. Skipped silently if
+  # nvim or a C compiler is missing — both must be present for
+  # nvim-treesitter's parser build (:TSUpdate) to succeed.
+  $nvim = Get-Command nvim -ErrorAction SilentlyContinue
+  $compiler = @('zig', 'cl', 'gcc', 'clang') |
+    Where-Object { Get-Command $_ -ErrorAction SilentlyContinue } |
+    Select-Object -First 1
+  if ($nvim -and $compiler) {
+    Write-Host "Pre-warming lazy.nvim plugins (best effort, 90s cap)..."
+    $lazyLog = Join-Path $env:LOCALAPPDATA 'nvim-bootstrap.log'
+    $proc = Start-Process -FilePath $nvim.Source `
+      -ArgumentList '--headless', '+Lazy! sync', '+qa' `
+      -NoNewWindow -PassThru `
+      -RedirectStandardOutput $lazyLog `
+      -RedirectStandardError "$lazyLog.err"
+    if (-not $proc.WaitForExit(90000)) {
+      $proc.Kill()
+      Write-Host "lazy.nvim pre-warm timed out; see $lazyLog"
+    } elseif ($proc.ExitCode -ne 0) {
+      Write-Host "lazy.nvim pre-warm exited $($proc.ExitCode); see $lazyLog"
+    } else {
+      Write-Host "lazy.nvim pre-warm complete."
+    }
+  } elseif (-not $nvim) {
+    Write-Host "nvim not on PATH; skipping :Lazy sync (run winget install Neovim.Neovim)."
+  } else {
+    Write-Host "No C compiler on PATH (zig/cl/gcc/clang); skipping :Lazy sync (run winget install zig.zig)."
+  }
 }
 
 Write-Host "Editor configurations deployed."

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -189,6 +189,13 @@
         },
         {
           "PackageIdentifier": "ZedIndustries.Zed"
+        },
+        {
+          "PackageIdentifier": "zig.zig",
+          "verifyCommand": {
+            "args": ["version"],
+            "command": "zig"
+          }
         }
       ],
       "SourceDetails": {


### PR DESCRIPTION
## Summary

Windows 側で初回 nvim 起動時に `nvim-treesitter is not available. Run :Lazy sync and restart Neovim.` warning が出るのを自動化で解消。container 側の `bootstrap.sh` と同じ思想を Windows 側 chezmoi deploy script に組み込み。

## Changes

### `windows/winget/packages.json`

`zig.zig` を追加（既存の `ZedIndustries.Zed` の直後、winget source）：

- 単一バイナリで軽量
- `zig cc` が nvim-treesitter のパーサ build を担う
- `verifyCommand` に `zig version` を設定

### `chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy.ps1.tmpl`

1. **`hash:` directive 拡張**: nvim source 5 ファイル（`init.lua` + `lua/config/*.lua` + `lua/plugins/init.lua`）を追加。nvim だけ変更しても script が再走する。
2. **`:Lazy sync` の headless 実行**:
   - `Get-Command nvim` と `Get-Command zig/cl/gcc/clang` を確認
   - 両方揃っていれば `Start-Process nvim --headless +"Lazy! sync" +qa` を 90s timeout 付きで起動
   - stdout / stderr を `$LOCALAPPDATA\nvim-bootstrap.log` / `.err` に redirect
   - timeout / exit code != 0 の場合は actionable な参照先を Write-Host
   - 前提が欠けている場合は `winget install ...` のヒントを表示してスキップ（apply 全体は止めない）

## なぜ zig

| 候補 | 採用？ | 理由 |
|---|---|---|
| **zig** | ✅ | 単一バイナリ・軽量、nvim-treesitter 公式対応の `zig cc` |
| gcc (MinGW) | △ | 旧来から動く、サイズ大 |
| cl (MSVC Build Tools) | △ | VS Build Tools の install が重い |
| clang (LLVM) | △ | サイズ大 |

deploy script 側では `zig/cl/gcc/clang` のいずれかが PATH にあれば OK にしてあるので、ユーザが既に他の compiler を入れていれば追加 install 不要。

## Test plan

- [ ] Windows で `chezmoi apply` を再走させると `Pre-warming lazy.nvim plugins...` が出る
- [ ] 90s 以内に `lazy.nvim pre-warm complete.` で完了
- [ ] 完了後 nvim を起動しても `nvim-treesitter is not available` warning が出ない
- [ ] zig 未 install 環境で `chezmoi apply` を走らせると、`No C compiler on PATH ...` のヒントが表示されて apply 自体は完走する
- [ ] nvim 未 install 環境でも同様（`nvim not on PATH ...`）
- [ ] nvim source 変更で `hash:` 値が変わり script が再走する

## Refs

- Closes LIF-212
- Companion to bootstrap.sh (container 側) と editors/run_onchange_deploy.sh.tmpl (Linux 側)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
