### PR TITLE
fix(LIF-213): finalize ExitCode before reading it in nvim pre-warm

### DIFF
--- a/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy.ps1.tmpl
@@ -72,13 +72,21 @@ if (Test-Path -LiteralPath $NvimSource) {
       -NoNewWindow -PassThru `
       -RedirectStandardOutput $lazyLog `
       -RedirectStandardError "$lazyLog.err"
-    if (-not $proc.WaitForExit(90000)) {
+    # WaitForExit(timeout) returns bool but does not guarantee ExitCode is
+    # populated on Process objects returned via Start-Process -PassThru with
+    # redirected I/O. Call WaitForExit() (no args) once HasExited is true to
+    # finalize ExitCode before reading it.
+    $proc.WaitForExit(90000) | Out-Null
+    if (-not $proc.HasExited) {
       $proc.Kill()
       Write-Host "lazy.nvim pre-warm timed out; see $lazyLog"
-    } elseif ($proc.ExitCode -ne 0) {
-      Write-Host "lazy.nvim pre-warm exited $($proc.ExitCode); see $lazyLog"
     } else {
-      Write-Host "lazy.nvim pre-warm complete."
+      $proc.WaitForExit()
+      if ($proc.ExitCode -ne 0) {
+        Write-Host "lazy.nvim pre-warm exited $($proc.ExitCode); see $lazyLog"
+      } else {
+        Write-Host "lazy.nvim pre-warm complete."
+      }
     }
   } elseif (-not $nvim) {
     Write-Host "nvim not on PATH; skipping :Lazy sync (run winget install Neovim.Neovim)."


### PR DESCRIPTION
## Summary

LIF-212 で追加した Windows 用 nvim pre-warm が、`:Lazy sync` が成功しても "lazy.nvim pre-warm exited ;" と空 exit code で報告されるのを修正。

## 原因

`Start-Process -PassThru` + redirected I/O の Process オブジェクトは、`WaitForExit(timeout)` 直後では `ExitCode` プロパティが populate されていない（.NET の既知挙動）。

## 修正

`WaitForExit(90000)` → `HasExited` 判定 → 引数なし `WaitForExit()` で ExitCode 確定 → 読み取り、の順に変更。

## Refs

- Closes LIF-213
- Fixup to LIF-212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
