### PR TITLE
fix(LIF-214): migrate lspconfig to vim.lsp.config / vim.lsp.enable

### DIFF
--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -210,12 +210,15 @@ return {
     },
 
     -- LSP: configurations
+    -- Uses nvim 0.11+ `vim.lsp.config()` / `vim.lsp.enable()`. The legacy
+    -- `require("lspconfig")[name].setup()` flow prints a deprecation warning
+    -- and will be removed in nvim-lspconfig v3.0.0. nvim-lspconfig is still
+    -- the source of bundled server defaults (`cmd`, `filetypes`, etc.).
     {
         "neovim/nvim-lspconfig",
         event = { "BufReadPre", "BufNewFile" },
         dependencies = { "hrsh7th/cmp-nvim-lsp" },
         config = function()
-            local lspconfig = require("lspconfig")
             local capabilities = require("cmp_nvim_lsp").default_capabilities()
 
             local on_attach = function(_, bufnr)
@@ -231,6 +234,12 @@ return {
                     vim.lsp.buf.format({ async = true })
                 end, "Format")
             end
+
+            -- Defaults applied to every server via the '*' wildcard.
+            vim.lsp.config("*", {
+                capabilities = capabilities,
+                on_attach = on_attach,
+            })
 
             local servers = {
                 nixd = {
@@ -336,10 +345,9 @@ return {
                 ruff = {},
             }
 
-            for server, config in pairs(servers) do
-                config.capabilities = capabilities
-                config.on_attach = on_attach
-                lspconfig[server].setup(config)
+            for name, cfg in pairs(servers) do
+                vim.lsp.config(name, cfg)
+                vim.lsp.enable(name)
             end
         end,
     },


### PR DESCRIPTION
## Summary

nvim 起動時に出る `nvim-lspconfig` の deprecation warning を解消：

```
The `require('lspconfig')` "framework" is deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead.
Feature will be removed in nvim-lspconfig v3.0.0
```

## Changes

`chezmoi/editors/nvim/lua/plugins/init.lua` の `neovim/nvim-lspconfig` config 関数：

- `local lspconfig = require("lspconfig")` を削除
- `vim.lsp.config("*", { capabilities, on_attach })` で全 server 共通 default を設定
- per-server: `vim.lsp.config(name, cfg)` + `vim.lsp.enable(name)` に置換

## 動作

- nvim-lspconfig 自身は **dependency として残す**（bundled server definition cmd/filetypes を提供）
- mason-lspconfig.nvim は変更なし（install 担当）
- 既存 LSP（nixd, gopls, rust_analyzer, ts_ls, yamlls, taplo, bashls, lua_ls, marksman, ruff）と既存 keymap (gd, gr, K, &lt;leader&gt;rn/ca/f) は挙動変化なし

## Test plan

- [ ] nvim 起動時に `require('lspconfig')` deprecation warning が出ない
- [ ] `:LspInfo` で各 server が attach されている
- [ ] `gd` 等の LSP keymap が動く
- [ ] `:checkhealth lsp` がエラーなし

## Refs

- Closes LIF-214
- Companion: nvim-lspconfig v3.0.0 への前進準備

🤖 Generated with [Claude Code](https://claude.com/claude-code)
