### PR TITLE
fix(LIF-215): use Start-Job to actually capture nvim pre-warm exit code

### DIFF
--- a/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy.ps1.tmpl
@@ -67,26 +67,27 @@ if (Test-Path -LiteralPath $NvimSource) {
   if ($nvim -and $compiler) {
     Write-Host "Pre-warming lazy.nvim plugins (best effort, 90s cap)..."
     $lazyLog = Join-Path $env:LOCALAPPDATA 'nvim-bootstrap.log'
-    $proc = Start-Process -FilePath $nvim.Source `
-      -ArgumentList '--headless', '+Lazy! sync', '+qa' `
-      -NoNewWindow -PassThru `
-      -RedirectStandardOutput $lazyLog `
-      -RedirectStandardError "$lazyLog.err"
-    # WaitForExit(timeout) returns bool but does not guarantee ExitCode is
-    # populated on Process objects returned via Start-Process -PassThru with
-    # redirected I/O. Call WaitForExit() (no args) once HasExited is true to
-    # finalize ExitCode before reading it.
-    $proc.WaitForExit(90000) | Out-Null
-    if (-not $proc.HasExited) {
-      $proc.Kill()
-      Write-Host "lazy.nvim pre-warm timed out; see $lazyLog"
-    } else {
-      $proc.WaitForExit()
-      if ($proc.ExitCode -ne 0) {
-        Write-Host "lazy.nvim pre-warm exited $($proc.ExitCode); see $lazyLog"
+    # Start-Process -PassThru -NoNewWindow with redirected I/O has a known
+    # .NET issue where the returned Process object's ExitCode is null even
+    # after the process has exited. Use Start-Job so a separate PowerShell
+    # process owns nvim and reports $LASTEXITCODE via the pipeline.
+    $job = Start-Job -ScriptBlock {
+      param($NvimPath, $LogPath)
+      & $NvimPath --headless "+Lazy! sync" +qa *> $LogPath
+      return $LASTEXITCODE
+    } -ArgumentList $nvim.Source, $lazyLog
+    if (Wait-Job $job -Timeout 90) {
+      $exitCode = Receive-Job $job
+      Remove-Job $job
+      if ($exitCode -ne 0) {
+        Write-Host "lazy.nvim pre-warm exited $exitCode; see $lazyLog"
       } else {
         Write-Host "lazy.nvim pre-warm complete."
       }
+    } else {
+      Stop-Job $job
+      Remove-Job $job
+      Write-Host "lazy.nvim pre-warm timed out; see $lazyLog"
     }
   } elseif (-not $nvim) {
     Write-Host "nvim not on PATH; skipping :Lazy sync (run winget install Neovim.Neovim)."


### PR DESCRIPTION
## Summary

LIF-213 で `WaitForExit()` を後追いで呼ぶ workaround を入れたが、実機検証で **`exited ;` が依然として空 exit code を表示**することが判明。`Start-Process -PassThru -NoNewWindow -RedirectStandardOutput/Error` の組み合わせには PowerShell/.NET の既知バグ ([PowerShell#9143](https://github.com/PowerShell/PowerShell/issues/9143)) があり、後追い `WaitForExit()` でも ExitCode が `null` のままになる場合がある。

## 修正

`Start-Job` ベースに変更：

```powershell
$job = Start-Job -ScriptBlock {
    param($NvimPath, $LogPath)
    & $NvimPath --headless "+Lazy! sync" +qa *> $LogPath
    return $LASTEXITCODE
} -ArgumentList $nvim.Source, $lazyLog

if (Wait-Job $job -Timeout 90) {
    $exitCode = Receive-Job $job
    ...
}
```

- 別 PowerShell プロセスに nvim 実行を委譲、`$LASTEXITCODE` を pipeline 経由で受け取る
- 親側は `Wait-Job -Timeout 90` で同期＋timeout 制御
- 全ストリームを 1 ログファイル (`*> $LogPath`) に統合（stdout/stderr 別ファイルにする意味は実用上なかった）

## Test plan

- [ ] Windows で `chezmoi apply` 再実行
- [ ] 正常終了時に `lazy.nvim pre-warm complete.` が出る
- [ ] 失敗時に正しい数値の exit code が出る

## Refs

- Closes LIF-215
- Replaces LIF-213 (had no effect on the underlying issue)
- 親 LIF: LIF-212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
