### PR TITLE
feat(LIF-217): upgrade kind cluster config to HA topology

### DIFF
--- a/k8s/kind/cluster.yaml
+++ b/k8s/kind/cluster.yaml
@@ -3,6 +3,8 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: learning
 nodes:
   - role: control-plane
+  - role: control-plane
+  - role: control-plane
   - role: worker
   - role: worker
   - role: worker


### PR DESCRIPTION
## Summary
- `k8s/kind/cluster.yaml` の control-plane を 1 → 3 に増やし HA トポロジへ（cp×3 + worker×3、合計6ノード）
- kind が control-plane 複数時に内蔵 HAProxy を自動配置するため追加設定不要
- 動作確認済み: 6ノード Ready、etcd × 3 / kube-apiserver × 3 / scheduler × 3 / controller-manager × 3 すべて Running、quorum形成
- 関連: [LIF-217](https://linear.app/life-style-base/issue/LIF-217/upgrade-kind-cluster-config-to-ha-topology)

## 背景
ファイル自体は前作業中の `task commit -- ...` の `git add -A` に意図せず巻き込まれて main に存在する状態だった（cp×1+w×3）。このPRで正式に HA 構成へ引き上げる。

## Test plan
- [x] `nix fmt` 通過（変更なし）
- [x] `pre-commit run --all-files`（task commit 経由）通過
- [x] `kind create cluster --config k8s/kind/cluster.yaml` 成功
- [x] `kubectl wait --for=condition=Ready node --all --timeout=120s` 全6ノードReady
- [x] `kubectl get pods -n kube-system` でHAコンポーネント × 3 がRunning