### PR TITLE
feat(LIF-218): add Bun setup handler for WinGet Links symlink

### DIFF
--- a/scripts/powershell/handlers/Handler.Bun.ps1
+++ b/scripts/powershell/handlers/Handler.Bun.ps1
@@ -1,0 +1,125 @@
+<#
+.SYNOPSIS
+    Bun ポータブルパッケージ設定ハンドラー
+
+.DESCRIPTION
+    winget の Oven-sh.Bun パッケージは portable archive 形式で、
+    実行ファイルが bun-windows-x64\bun.exe というサブディレクトリに配置される。
+    winget は自動で PATH も Links shim も作らないため、このハンドラーで
+    WinGet\Links に bun.exe シンボリックリンクを作成し、Links を USER PATH に追加する。
+
+.NOTES
+    Order = 8 (Codex の後、Docker の前)
+#>
+
+$libPath = Split-Path -Parent $PSScriptRoot
+. (Join-Path $libPath "lib\Invoke-ExternalCommand.ps1")
+
+class BunHandler : SetupHandlerBase {
+    BunHandler() {
+        $this.Name = "Bun"
+        $this.Description = "Bun シンボリックリンク作成"
+        $this.Order = 8
+        $this.RequiresAdmin = $false
+        $this.Phase = 1
+    }
+
+    [bool] CanApply([SetupContext]$ctx) {
+        $bunExe = $this.GetBunExecutablePath()
+        if (-not $bunExe) {
+            $this.Log("Bun パッケージがインストールされていません", "Gray")
+            return $false
+        }
+
+        $linksPath = $this.GetLinksPath()
+        $linkPath = Join-Path $linksPath "bun.exe"
+
+        if (Test-Path $linkPath) {
+            $this.Log("bun.exe リンクは既に存在します", "Gray")
+            return $false
+        }
+
+        return $true
+    }
+
+    [SetupResult] Apply([SetupContext]$ctx) {
+        try {
+            $bunExe = $this.GetBunExecutablePath()
+            if (-not $bunExe) {
+                return $this.CreateFailureResult("Bun 実行ファイルが見つかりません")
+            }
+
+            $linksPath = $this.GetLinksPath()
+            if (-not (Test-Path $linksPath)) {
+                New-Item -ItemType Directory -Path $linksPath -Force | Out-Null
+            }
+
+            $linkPath = Join-Path $linksPath "bun.exe"
+            $this.Log("シンボリックリンクを作成しています: $linkPath -> $bunExe")
+
+            # Windows ではシンボリックリンク作成に管理者権限または開発者モードが必要
+            # 失敗した場合はハードリンクまたはコピーにフォールバック
+            $linkCreated = $false
+
+            try {
+                New-Item -ItemType SymbolicLink -Path $linkPath -Target $bunExe -Force -ErrorAction Stop | Out-Null
+                $this.Log("シンボリックリンクを作成しました", "Green")
+                $linkCreated = $true
+            }
+            catch {
+                $this.LogWarning("シンボリックリンク作成失敗: $($_.Exception.Message)")
+            }
+
+            if (-not $linkCreated) {
+                try {
+                    New-Item -ItemType HardLink -Path $linkPath -Target $bunExe -Force -ErrorAction Stop | Out-Null
+                    $this.Log("ハードリンクを作成しました", "Green")
+                    $linkCreated = $true
+                }
+                catch {
+                    $this.LogWarning("ハードリンク作成失敗: $($_.Exception.Message)")
+                }
+            }
+
+            if (-not $linkCreated) {
+                Copy-Item -Path $bunExe -Destination $linkPath -Force
+                $this.Log("ファイルをコピーしました", "Green")
+            }
+
+            $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+            if ($userPath -notlike "*$linksPath*") {
+                $this.Log("PATH に Links フォルダを追加しています...")
+                $newPath = "$userPath;$linksPath"
+                [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+                $env:Path = "$env:Path;$linksPath"
+                $this.Log("PATH を更新しました", "Green")
+            }
+
+            return $this.CreateSuccessResult("bun.exe リンクを作成しました")
+        }
+        catch {
+            return $this.CreateFailureResult("Bun 設定に失敗しました", $_)
+        }
+    }
+
+    hidden [string] GetBunExecutablePath() {
+        $packagesBase = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Packages"
+        $bunPattern = "Oven-sh.Bun_*"
+
+        $bunDir = Get-ChildItem -Path $packagesBase -Directory -Filter $bunPattern -ErrorAction SilentlyContinue | Select-Object -First 1
+        if (-not $bunDir) {
+            return $null
+        }
+
+        $exePath = Join-Path $bunDir.FullName "bun-windows-x64\bun.exe"
+        if (Test-Path $exePath) {
+            return $exePath
+        }
+
+        return $null
+    }
+
+    hidden [string] GetLinksPath() {
+        return Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
+    }
+}

--- a/scripts/powershell/handlers/Handler.Bun.ps1
+++ b/scripts/powershell/handlers/Handler.Bun.ps1
@@ -34,8 +34,10 @@ class BunHandler : SetupHandlerBase {
         $linksPath = $this.GetLinksPath()
         $linkPath = Join-Path $linksPath "bun.exe"
 
-        if (Test-Path $linkPath) {
-            $this.Log("bun.exe リンクは既に存在します", "Gray")
+        # リンクが既にあっても Links パスが USER PATH に無い場合は適用する。
+        # (手動 shim, 過去の部分実行, copy フォールバック後を想定。)
+        if ((Test-Path $linkPath) -and $this.IsLinksInUserPath($linksPath)) {
+            $this.Log("bun.exe リンクと PATH 設定は既に完了しています", "Gray")
             return $false
         }
 
@@ -55,47 +57,55 @@ class BunHandler : SetupHandlerBase {
             }
 
             $linkPath = Join-Path $linksPath "bun.exe"
-            $this.Log("シンボリックリンクを作成しています: $linkPath -> $bunExe")
 
-            # Windows ではシンボリックリンク作成に管理者権限または開発者モードが必要
-            # 失敗した場合はハードリンクまたはコピーにフォールバック
-            $linkCreated = $false
+            # リンクが無いときだけ作成。既存リンクは尊重して再作成しない。
+            if (-not (Test-Path $linkPath)) {
+                $this.Log("シンボリックリンクを作成しています: $linkPath -> $bunExe")
 
-            try {
-                New-Item -ItemType SymbolicLink -Path $linkPath -Target $bunExe -Force -ErrorAction Stop | Out-Null
-                $this.Log("シンボリックリンクを作成しました", "Green")
-                $linkCreated = $true
-            }
-            catch {
-                $this.LogWarning("シンボリックリンク作成失敗: $($_.Exception.Message)")
-            }
+                # Windows ではシンボリックリンク作成に管理者権限または開発者モードが必要。
+                # 失敗時はハードリンク、それも失敗ならコピーへフォールバック。
+                $linkCreated = $false
 
-            if (-not $linkCreated) {
                 try {
-                    New-Item -ItemType HardLink -Path $linkPath -Target $bunExe -Force -ErrorAction Stop | Out-Null
-                    $this.Log("ハードリンクを作成しました", "Green")
+                    New-Item -ItemType SymbolicLink -Path $linkPath -Target $bunExe -ErrorAction Stop | Out-Null
+                    $this.Log("シンボリックリンクを作成しました", "Green")
                     $linkCreated = $true
                 }
                 catch {
-                    $this.LogWarning("ハードリンク作成失敗: $($_.Exception.Message)")
+                    $this.LogWarning("シンボリックリンク作成失敗: $($_.Exception.Message)")
+                }
+
+                if (-not $linkCreated) {
+                    try {
+                        New-Item -ItemType HardLink -Path $linkPath -Target $bunExe -ErrorAction Stop | Out-Null
+                        $this.Log("ハードリンクを作成しました", "Green")
+                        $linkCreated = $true
+                    }
+                    catch {
+                        $this.LogWarning("ハードリンク作成失敗: $($_.Exception.Message)")
+                    }
+                }
+
+                if (-not $linkCreated) {
+                    Copy-Item -Path $bunExe -Destination $linkPath -Force
+                    $this.Log("ファイルをコピーしました", "Green")
                 }
             }
-
-            if (-not $linkCreated) {
-                Copy-Item -Path $bunExe -Destination $linkPath -Force
-                $this.Log("ファイルをコピーしました", "Green")
+            else {
+                $this.Log("bun.exe リンクは既に存在します", "Gray")
             }
 
-            $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-            if ($userPath -notlike "*$linksPath*") {
+            # PATH は常に冪等チェック。リンクが既存でも PATH 未設定なら追加する。
+            if (-not $this.IsLinksInUserPath($linksPath)) {
                 $this.Log("PATH に Links フォルダを追加しています...")
-                $newPath = "$userPath;$linksPath"
-                [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+                $userPath = Get-UserEnvironmentPath
+                $newPath = if ($userPath) { "$userPath;$linksPath" } else { $linksPath }
+                Set-UserEnvironmentPath -Path $newPath
                 $env:Path = "$env:Path;$linksPath"
                 $this.Log("PATH を更新しました", "Green")
             }
 
-            return $this.CreateSuccessResult("bun.exe リンクを作成しました")
+            return $this.CreateSuccessResult("bun.exe リンクと PATH を設定しました")
         }
         catch {
             return $this.CreateFailureResult("Bun 設定に失敗しました", $_)
@@ -121,5 +131,11 @@ class BunHandler : SetupHandlerBase {
 
     hidden [string] GetLinksPath() {
         return Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
+    }
+
+    hidden [bool] IsLinksInUserPath([string]$linksPath) {
+        $userPath = Get-UserEnvironmentPath
+        if (-not $userPath) { return $false }
+        return $userPath -like "*$linksPath*"
     }
 }

--- a/scripts/powershell/tests/handlers/Handler.Bun.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Bun.Tests.ps1
@@ -51,7 +51,7 @@ Describe 'BunHandler' {
         }
     }
 
-    Context 'CanApply - bun.exe link already exists' {
+    Context 'CanApply - link exists AND PATH already configured' {
         BeforeEach {
             Mock Get-ChildItem {
                 return [PSCustomObject]@{
@@ -61,14 +61,38 @@ Describe 'BunHandler' {
                 $Path -like "*WinGet\Packages" -and $Filter -like "Oven-sh.Bun_*"
             }
 
-            # bun-windows-x64\bun.exe も Links\bun.exe も存在
             Mock Test-Path { return $true }
+            # 実行環境ごとに変わる Links パスを含めて USER PATH を返す
+            $script:expectedLinks = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedLinks" }
             Mock Write-Host { }
         }
 
-        It 'should return false when link exists' {
+        It 'should return false when both link and PATH are set' {
             $result = $handler.CanApply($ctx)
             $result | Should -Be $false
+        }
+    }
+
+    Context 'CanApply - link exists but PATH not configured' {
+        BeforeEach {
+            Mock Get-ChildItem {
+                return [PSCustomObject]@{
+                    FullName = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\Oven-sh.Bun_Microsoft.Winget.Source_8wekyb3d8bbwe"
+                }
+            } -ParameterFilter {
+                $Path -like "*WinGet\Packages" -and $Filter -like "Oven-sh.Bun_*"
+            }
+
+            Mock Test-Path { return $true }
+            # USER PATH に Links が含まれていない状態
+            Mock Get-UserEnvironmentPath { return "C:\Windows;C:\Windows\System32" }
+            Mock Write-Host { }
+        }
+
+        It 'should return true so Apply can add PATH' {
+            $result = $handler.CanApply($ctx)
+            $result | Should -Be $true
         }
     }
 
@@ -89,6 +113,7 @@ Describe 'BunHandler' {
                 if ($Path -like "*Links") { return $true }
                 return $false
             }
+            Mock Get-UserEnvironmentPath { return "" }
             Mock Write-Host { }
         }
 
@@ -135,6 +160,8 @@ Describe 'BunHandler' {
             Mock New-Item { } -ParameterFilter { $ItemType -eq "HardLink" }
             Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
             Mock Copy-Item { }
+            Mock Get-UserEnvironmentPath { return "C:\Windows" }
+            Mock Set-UserEnvironmentPath { }
 
             Mock Write-Host { }
         }
@@ -168,6 +195,8 @@ Describe 'BunHandler' {
             Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
 
             Mock Copy-Item { }
+            Mock Get-UserEnvironmentPath { return "C:\Windows" }
+            Mock Set-UserEnvironmentPath { }
 
             Mock Write-Host { }
         }
@@ -176,6 +205,38 @@ Describe 'BunHandler' {
             $result = $handler.Apply($ctx)
             $result.Success | Should -Be $true
             Should -Invoke Copy-Item -Times 1
+        }
+    }
+
+    Context 'Apply - link exists but PATH missing (recovers from previous partial run)' {
+        BeforeEach {
+            Mock Get-ChildItem {
+                return [PSCustomObject]@{
+                    FullName = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\Oven-sh.Bun_Microsoft.Winget.Source_8wekyb3d8bbwe"
+                }
+            } -ParameterFilter {
+                $Path -like "*WinGet\Packages" -and $Filter -like "Oven-sh.Bun_*"
+            }
+
+            # link はすでに存在するが PATH に含まれていない状態を再現
+            Mock Test-Path { return $true }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
+            Mock New-Item { throw "should not be called when link exists" } -ParameterFilter {
+                $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
+            }
+            Mock Copy-Item { }
+            Mock Get-UserEnvironmentPath { return "C:\Windows;C:\Windows\System32" }
+            Mock Set-UserEnvironmentPath { }
+
+            Mock Write-Host { }
+        }
+
+        It 'should add Links to PATH without recreating the link' {
+            $result = $handler.Apply($ctx)
+            $result.Success | Should -Be $true
+            Should -Invoke Set-UserEnvironmentPath -Times 1
+            Should -Invoke Copy-Item -Times 0
+            Should -Invoke New-Item -Times 0 -ParameterFilter { $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink" }
         }
     }
 }

--- a/scripts/powershell/tests/handlers/Handler.Bun.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Bun.Tests.ps1
@@ -1,0 +1,181 @@
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Handler.Bun.ps1 のユニットテスト
+
+.DESCRIPTION
+    BunHandler クラスのテスト
+#>
+
+BeforeAll {
+    . $PSScriptRoot/../../lib/SetupHandler.ps1
+    . $PSScriptRoot/../../lib/Invoke-ExternalCommand.ps1
+    . $PSScriptRoot/../../handlers/Handler.Bun.ps1
+    $script:projectRoot = (Resolve-Path -LiteralPath "$PSScriptRoot/../../../..").Path
+}
+
+Describe 'BunHandler' {
+    BeforeEach {
+        $script:handler = [BunHandler]::new()
+        $script:ctx = [SetupContext]::new($script:projectRoot)
+    }
+
+    Context 'Constructor' {
+        It 'should set <property> correctly' -ForEach @(
+            @{ property = "Name"; expected = "Bun"; checkType = "Be" }
+            @{ property = "Description"; expected = $null; checkType = "Not -BeNullOrEmpty" }
+            @{ property = "Order"; expected = 8; checkType = "Be" }
+            @{ property = "RequiresAdmin"; expected = $false; checkType = "Be" }
+        ) {
+            if ($checkType -eq "Be") {
+                $handler.$property | Should -Be $expected
+            }
+            else {
+                $handler.$property | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'CanApply - Bun not installed' {
+        BeforeEach {
+            Mock Get-ChildItem { return $null } -ParameterFilter {
+                $Path -like "*WinGet\Packages" -and $Filter -like "Oven-sh.Bun_*"
+            }
+            Mock Write-Host { }
+        }
+
+        It 'should return false' {
+            $result = $handler.CanApply($ctx)
+            $result | Should -Be $false
+        }
+    }
+
+    Context 'CanApply - bun.exe link already exists' {
+        BeforeEach {
+            Mock Get-ChildItem {
+                return [PSCustomObject]@{
+                    FullName = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\Oven-sh.Bun_Microsoft.Winget.Source_8wekyb3d8bbwe"
+                }
+            } -ParameterFilter {
+                $Path -like "*WinGet\Packages" -and $Filter -like "Oven-sh.Bun_*"
+            }
+
+            # bun-windows-x64\bun.exe も Links\bun.exe も存在
+            Mock Test-Path { return $true }
+            Mock Write-Host { }
+        }
+
+        It 'should return false when link exists' {
+            $result = $handler.CanApply($ctx)
+            $result | Should -Be $false
+        }
+    }
+
+    Context 'CanApply - Bun installed but no link' {
+        BeforeEach {
+            Mock Get-ChildItem {
+                return [PSCustomObject]@{
+                    FullName = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\Oven-sh.Bun_Microsoft.Winget.Source_8wekyb3d8bbwe"
+                }
+            } -ParameterFilter {
+                $Path -like "*WinGet\Packages" -and $Filter -like "Oven-sh.Bun_*"
+            }
+
+            Mock Test-Path {
+                param($Path)
+                if ($Path -like "*bun-windows-x64\bun.exe") { return $true }
+                if ($Path -like "*Links\bun.exe") { return $false }
+                if ($Path -like "*Links") { return $true }
+                return $false
+            }
+            Mock Write-Host { }
+        }
+
+        It 'should return true' {
+            $result = $handler.CanApply($ctx)
+            $result | Should -Be $true
+        }
+    }
+
+    Context 'Apply - executable not found' {
+        BeforeEach {
+            Mock Get-ChildItem { return $null } -ParameterFilter {
+                $Path -like "*WinGet\Packages" -and $Filter -like "Oven-sh.Bun_*"
+            }
+            Mock Test-Path { return $false }
+            Mock Write-Host { }
+        }
+
+        It 'should return failure when executable path is null' {
+            $result = $handler.Apply($ctx)
+            $result.Success | Should -Be $false
+            $result.Message | Should -Match "実行ファイルが見つかりません"
+        }
+    }
+
+    Context 'Apply - creates link successfully' {
+        BeforeEach {
+            Mock Get-ChildItem {
+                return [PSCustomObject]@{
+                    FullName = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\Oven-sh.Bun_Microsoft.Winget.Source_8wekyb3d8bbwe"
+                }
+            } -ParameterFilter {
+                $Path -like "*WinGet\Packages" -and $Filter -like "Oven-sh.Bun_*"
+            }
+
+            Mock Test-Path {
+                param($Path)
+                if ($Path -like "*bun-windows-x64\bun.exe") { return $true }
+                if ($Path -like "*Links") { return $true }
+                return $false
+            }
+
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "HardLink" }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
+            Mock Copy-Item { }
+
+            Mock Write-Host { }
+        }
+
+        It 'should return success result' {
+            $result = $handler.Apply($ctx)
+            $result.Success | Should -Be $true
+        }
+    }
+
+    Context 'Apply - fallback to copy when symlink fails' {
+        BeforeEach {
+            Mock Get-ChildItem {
+                return [PSCustomObject]@{
+                    FullName = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\Oven-sh.Bun_Microsoft.Winget.Source_8wekyb3d8bbwe"
+                }
+            } -ParameterFilter {
+                $Path -like "*WinGet\Packages" -and $Filter -like "Oven-sh.Bun_*"
+            }
+
+            Mock Test-Path {
+                param($Path)
+                if ($Path -like "*bun-windows-x64\bun.exe") { return $true }
+                if ($Path -like "*Links") { return $true }
+                return $false
+            }
+
+            Mock New-Item { throw "Administrator privilege required" } -ParameterFilter {
+                $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
+            }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
+
+            Mock Copy-Item { }
+
+            Mock Write-Host { }
+        }
+
+        It 'should fallback to copy and return success' {
+            $result = $handler.Apply($ctx)
+            $result.Success | Should -Be $true
+            Should -Invoke Copy-Item -Times 1
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `Handler.Bun.ps1` を新設し、`Oven-sh.Bun_*/bun-windows-x64/bun.exe` から `%LOCALAPPDATA%\Microsoft\WinGet\Links\bun.exe` にシンボリックリンクを作成
- フォールバック: シンボリックリンク失敗 → ハードリンク → コピー
- Links ディレクトリを USER PATH に自動追加
- `Order = 8`（Codex の後、Docker の前）
- `Handler.Codex.ps1` の踏襲パターン
- 関連: [LIF-218](https://linear.app/life-style-base/issue/LIF-218/add-bun-setup-handler-winget-links-symlink)

## 背景
winget の `Oven-sh.Bun` は portable archive 形式で、`bun.exe` がサブディレクトリに配置されるため、winget は自動でPATHにもLinks shimにも追加しない。結果として `bun` コマンドが Windows Terminal から呼べない状態だった（Codex で同じ問題があり、既に `Handler.Codex.ps1` で同パターンを採用済み）。

## Test plan
- [x] `Invoke-Tests.ps1 -Path .\handlers\Handler.Bun.Tests.ps1` で10件全パス
  - Constructor: Name / Description / Order=8 / RequiresAdmin
  - CanApply: 未インストール / リンク済み / リンク未作成
  - Apply: 実行ファイル未検出 / 正常作成 / symlink失敗時のcopyフォールバック
- [x] 実機でハンドラーをApplyし `bun.exe` symlink が生成されることを確認
- [x] 新規 PowerShell セッションで `bun --version` が `1.3.13` を返す
- [x] `pre-commit run --all-files`（task commit経由）通過