### PR TITLE
fix(LIF-219): correct false positives in chezmoi/nixrebuild tests

### DIFF
--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -24,8 +24,9 @@ Describe 'chezmoi テンプレート バリデーション' {
                 $content = Get-Content -Path $file.FullName -Raw -ErrorAction SilentlyContinue
                 if (-not $content) { continue }
 
-                # onepasswordRead を含むがファイル全体に lookPath "op" が無い場合は違反
-                if ($content -match 'onepasswordRead' -and $content -notmatch 'lookPath\s+"op"') {
+                # テンプレート展開 ({{...}}) 内の onepasswordRead 呼び出しのみが対象。
+                # コメント内の言及やドキュメント記述は除外する。
+                if ($content -match '\{\{[^}]*onepasswordRead' -and $content -notmatch 'lookPath\s+"op"') {
                     $violations += $file.FullName
                 }
             }
@@ -43,8 +44,11 @@ Describe 'chezmoi テンプレート バリデーション' {
 
                 $inOpGuard = $false
                 # $hasOp 変数経由の間接ガードも検出する
-                # パターン: $hasOp := and (hasKey . "op_env") (lookPath "op")
-                #           if and $hasOp ...
+                # 受理パターン:
+                #   $hasOp := and (hasKey . "op_env") (lookPath "op")
+                #   $hasOp := or  (lookPath "op")    (lookPath "op.exe")
+                #   {{- if and $hasOp ... }}
+                #   {{- if $hasOp }}
                 $hasOpVarGuard = $false
                 $inHasOpBlock = $false
                 $lineNum = 0
@@ -52,22 +56,24 @@ Describe 'chezmoi テンプレート バリデーション' {
                 foreach ($line in $lines) {
                     $lineNum++
 
-                    # 直接ガード: {{- if lookPath "op" }}
-                    if ($line -match '\{\{-?\s*if\s+lookPath\s+"op"') {
+                    # 直接ガード: {{- if lookPath "op" }} または {{- if (lookPath "op" ) ... }}
+                    if ($line -match '\{\{-?\s*if\s+[^}]*lookPath\s+"op"') {
                         $inOpGuard = $true
                     }
 
-                    # 間接ガード: $hasOp := and ... (lookPath "op")
-                    if ($line -match '\$hasOp\s*:=\s*and\s.*lookPath\s+"op"') {
+                    # 間接ガード: $hasOp := (and|or) ... (lookPath "op")
+                    if ($line -match '\$hasOp\s*:=\s*(?:and|or)\s.*lookPath\s+"op"') {
                         $hasOpVarGuard = $true
                     }
 
-                    # 間接ガードブロック開始: {{- if and $hasOp ...
-                    if ($line -match '\{\{-?\s*if\s+and\s+\$hasOp' -and $hasOpVarGuard) {
+                    # 間接ガードブロック開始: {{- if $hasOp }} / {{- if and $hasOp ... }}
+                    if ($line -match '\{\{-?\s*if\s+(?:and\s+)?\$hasOp' -and $hasOpVarGuard) {
                         $inHasOpBlock = $true
                     }
 
-                    if ($line -match 'onepasswordRead' -and -not $inOpGuard -and -not $inHasOpBlock) {
+                    # テンプレート展開 ({{...}}) 内の呼び出しのみを対象とする。
+                    # コメント (`# For onepasswordRead, ...`) やドキュメント記述は除外。
+                    if ($line -match '\{\{[^}]*onepasswordRead' -and -not $inOpGuard -and -not $inHasOpBlock) {
                         "$($file.Name):$lineNum should be inside a lookPath `"op`" block" |
                             Should -BeNullOrEmpty
                     }

--- a/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
@@ -206,7 +206,7 @@ if ($argStr -match "nixos-rebuild") { $global:LASTEXITCODE = 0; return "" }
                 if ($argStr -match "command -v pnpm") { $global:LASTEXITCODE = 0; return "/nix/store/bin/pnpm" }
                 if ($argStr -match "pnpm ls -g") {
                     $global:LASTEXITCODE = 0
-                    return @("@tobilu/qmd@1.0.0", "@google/gemini-cli@0.32.1")
+                    return @("@tobilu/qmd@1.0.0", "@prisma/language-server@5.22.0", "@google/gemini-cli@0.32.1")
                 }
                 if ($argStr -match "pnpm add") {
                     $script:pnpmAddCalled = $true


### PR DESCRIPTION
## Summary
- `scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1`:
  - `onepasswordRead` 検出をテンプレート展開 `{{...}}` 内に限定（コメント内の言及を誤検出していた）
  - 間接ガード（`$hasOp := or (lookPath "op") (lookPath "op.exe")` + `{{- if $hasOp }}`）を受理するよう正規表現を緩和
  - 直接ガードも `{{- if [...] lookPath "op" }}` のような複合条件をパース可能に拡張
- `scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1`:
  - `pnpm ls -g` モックに `@prisma/language-server@5.22.0` を追加して現在の SSOT (`windows/pnpm/packages.json`) に合わせる
- 関連: [LIF-219](https://linear.app/life-style-base/issue/LIF-219/fix-pre-existing-powershell-test-failures-chezmoitemplate-nixrebuild)

## 背景
[LIF-218](https://linear.app/life-style-base/issue/LIF-218) (Bun handler) のPR でCIが失敗し、3件のテスト失敗が発覚。いずれも pre-existing failure で、直近のPRが path filter により `test-powershell.yml` をトリガーしていなかったため見逃されていた。

## 検証

```
$ Invoke-Tests.ps1 -Path .\chezmoi\ChezmoiTemplate.Tests.ps1
Tests: 10 passed, 0 failed, 0 skipped / 10 total

$ Invoke-Tests.ps1 -Path .\handlers\Handler.NixRebuild.Tests.ps1
Tests: 32 passed, 0 failed, 0 skipped / 32 total

$ Invoke-Tests.ps1 (full suite)
Tests: 580 passed, 0 failed, 0 skipped / 580 total
```

## Test plan
- [x] `ChezmoiTemplate.Tests.ps1` 単体: 10/10
- [x] `Handler.NixRebuild.Tests.ps1` 単体: 32/32
- [x] 全テストスイート: 580/580
- [x] `pre-commit run --all-files`（task commit経由）通過

## 続き
このPRマージ後、`lif-218` (Bun handler) を rebase して再CIを通す。