### PR TITLE
feat(LIF-221): switch WSL to native dockerd with nvidia default runtime

### DIFF
--- a/k8s/kind/cluster.yaml
+++ b/k8s/kind/cluster.yaml
@@ -3,9 +3,9 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: learning
 containerdConfigPatches:
   - |-
-    [plugins."io.containerd.grpc.v1.cri".cdi]
-      enabled = true
-      spec-dirs = ["/etc/cdi"]
+    [plugins."io.containerd.grpc.v1.cri"]
+      enable_cdi = true
+      cdi_spec_dirs = ["/etc/cdi"]
 nodes:
   - role: control-plane
   - role: control-plane

--- a/k8s/kind/cluster.yaml
+++ b/k8s/kind/cluster.yaml
@@ -1,10 +1,28 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: learning
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+      privileged_without_host_devices = false
+      runtime_engine = ""
+      runtime_root = ""
+      runtime_type = "io.containerd.runc.v2"
+    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
+      BinaryName = "/usr/bin/nvidia-container-runtime"
+    [plugins."io.containerd.grpc.v1.cri".cdi]
+      enabled = true
+      spec-dirs = ["/etc/cdi"]
 nodes:
   - role: control-plane
   - role: control-plane
   - role: control-plane
   - role: worker
   - role: worker
+  # GPU worker: CDI spec mounted from host /etc/cdi
   - role: worker
+    extraMounts:
+      - hostPath: /etc/cdi
+        containerPath: /etc/cdi
+      - hostPath: /usr/lib/wsl/lib
+        containerPath: /usr/lib/wsl/lib

--- a/k8s/kind/cluster.yaml
+++ b/k8s/kind/cluster.yaml
@@ -3,13 +3,6 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: learning
 containerdConfigPatches:
   - |-
-    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
-      privileged_without_host_devices = false
-      runtime_engine = ""
-      runtime_root = ""
-      runtime_type = "io.containerd.runc.v2"
-    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
-      BinaryName = "/usr/bin/nvidia-container-runtime"
     [plugins."io.containerd.grpc.v1.cri".cdi]
       enabled = true
       spec-dirs = ["/etc/cdi"]

--- a/nix/hosts/wsl/configuration.nix
+++ b/nix/hosts/wsl/configuration.nix
@@ -15,10 +15,6 @@
   wsl.enable = true;
   wsl.defaultUser = "nixos";
 
-  # Enable Docker Desktop WSL integration
-  # Required for kind to use Docker Desktop as container runtime
-  mySettings.wsl.dockerDesktopIntegration = true;
-
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions
   # on your system were taken. It's perfectly fine and recommended to leave

--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -77,11 +77,9 @@
   wsl.wslConf.network.generateHosts = false;
 
   # Ensure nix-ld works for non-login shells (e.g. VS Code WSL server).
-  # /usr/lib/wsl/lib is added for NVIDIA GPU access via WSL2 (libcuda, nvidia-smi, etc.)
   environment.variables = {
     NIX_LD = "/run/current-system/sw/share/nix-ld/lib/ld.so";
     NIX_LD_LIBRARY_PATH = "/run/current-system/sw/share/nix-ld/lib";
     WARP_ENABLE_WAYLAND = "1";
-    LD_LIBRARY_PATH = "/usr/lib/wsl/lib";
   };
 }

--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -50,20 +50,23 @@
     config.common.default = "*";
   };
 
-  # Native dockerd with nvidia as default runtime.
+  # Native dockerd. Kind node containers use regular runc at the docker level;
+  # GPU access inside kind nodes is handled via CDI (see k8s/kind/cluster.yaml).
   # Windows can reach the socket via: DOCKER_HOST=unix:///wsl.localhost/NixOS/var/run/docker.sock
-  virtualisation.docker = {
-    enable = true;
-    daemon.settings = {
-      "default-runtime" = "nvidia";
-      runtimes.nvidia = {
-        path = "nvidia-container-runtime";
-        args = [ ];
-      };
-    };
-  };
+  virtualisation.docker.enable = true;
 
   users.users.nixos.extraGroups = [ "docker" ];
+
+  # Generate CDI spec on each activation so kind worker nodes can mount
+  # /etc/cdi and use GPU resources through containerd CDI.
+  system.activationScripts.nvidiaCdi = {
+    deps = [ "wslWhoami" ];
+    text = ''
+      mkdir -p /etc/cdi
+      ${pkgs.nvidia-container-toolkit}/bin/nvidia-ctk cdi generate \
+        --output /etc/cdi/nvidia.yaml 2>/dev/null || true
+    '';
+  };
 
   # Re-register WSLInterop binfmt entry after systemd clears it on boot.
   # Without this, Windows .exe files (e.g. VS Code) cannot be executed from WSL.

--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -2,6 +2,7 @@
 {
   environment.systemPackages = with pkgs; [
     coreutils
+    nvidia-container-toolkit
     # Japanese input: fcitx5+mozc installed as system packages.
     # i18n.inputMethod is intentionally NOT used here because it auto-generates
     # app-org.fcitx.Fcitx5@autostart.service, which conflicts with the Home Manager
@@ -49,6 +50,21 @@
     config.common.default = "*";
   };
 
+  # Native dockerd with nvidia as default runtime.
+  # Windows can reach the socket via: DOCKER_HOST=unix:///wsl.localhost/NixOS/var/run/docker.sock
+  virtualisation.docker = {
+    enable = true;
+    daemon.settings = {
+      "default-runtime" = "nvidia";
+      runtimes.nvidia = {
+        path = "nvidia-container-runtime";
+        args = [ ];
+      };
+    };
+  };
+
+  users.users.nixos.extraGroups = [ "docker" ];
+
   # Re-register WSLInterop binfmt entry after systemd clears it on boot.
   # Without this, Windows .exe files (e.g. VS Code) cannot be executed from WSL.
   wsl.interop.register = true;
@@ -58,9 +74,11 @@
   wsl.wslConf.network.generateHosts = false;
 
   # Ensure nix-ld works for non-login shells (e.g. VS Code WSL server).
+  # /usr/lib/wsl/lib is added for NVIDIA GPU access via WSL2 (libcuda, nvidia-smi, etc.)
   environment.variables = {
     NIX_LD = "/run/current-system/sw/share/nix-ld/lib/ld.so";
     NIX_LD_LIBRARY_PATH = "/run/current-system/sw/share/nix-ld/lib";
     WARP_ENABLE_WAYLAND = "1";
+    LD_LIBRARY_PATH = "/usr/lib/wsl/lib";
   };
 }

--- a/scripts/sh/nixos-wsl-postinstall.sh
+++ b/scripts/sh/nixos-wsl-postinstall.sh
@@ -284,11 +284,6 @@ if [[ ! -f $HOST_CONFIG_PATH ]]; then
   if [[ -f /etc/nixos/configuration.nix ]]; then
     cp -f /etc/nixos/configuration.nix "$HOST_CONFIG_PATH"
     sed -i '\|<nixos-wsl/modules>|d' "$HOST_CONFIG_PATH"
-    # Add Docker Desktop integration setting for k3s
-    sed -i '/wsl.defaultUser/a\
-\
-  # Enable Docker Desktop WSL integration handling for k3s\
-  mySettings.wsl.dockerDesktopIntegration = true;' "$HOST_CONFIG_PATH"
     echo "Created: $HOST_CONFIG_PATH"
   fi
 else


### PR DESCRIPTION
## Summary

- Enable  in NixOS WSL (native dockerd, no Docker Desktop)
- Add  to WSL system packages for NAME:
   NVIDIA Container Toolkit CLI - Tools to configure the NVIDIA Container Toolkit

USAGE:
   NVIDIA Container Toolkit CLI [global options] [command [command options]]

VERSION:
   1.18.2
commit: refs/tags/v1.18.2

COMMANDS:
   hook     A collection of hooks that may be injected into an OCI spec
   runtime  A collection of runtime-related utilities for the NVIDIA Container Toolkit
   info     Provide information about the system
   cdi      Provide tools for interacting with Container Device Interface specifications
   system   A collection of system-related utilities for the NVIDIA Container Toolkit
   config   Interact with the NVIDIA Container Toolkit configuration
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --debug, -d      Enable debug-level logging (default: false) [$NVIDIA_CTK_DEBUG]
   --quiet          Suppress all output except for errors; overrides --debug (default: false) [$NVIDIA_CTK_QUIET]
   --config string  Path to the config file [$NVIDIA_CTK_CONFIG]
   --help, -h       show help
   --version, -v    print the version CDI spec generation
- Activation script:  on each NixOS rebuild
- Remove  — Docker Desktop WSL socket workaround no longer needed
- Update : enable CDI in containerd (containerd 2.x keys), mount  and  into GPU worker node
- Remove  sed from  to prevent conflict on fresh installs

## Motivation

Docker Desktop cannot set  declaratively via  (requires manual UI click per machine).
Native dockerd in NixOS WSL lets us configure docker declaratively. GPU access inside kind pods is handled via CDI (not docker-level nvidia runtime).

Windows can reach the daemon via:


## Architecture



## Test plan

- [x] Run /nix/store/fl02j17wiblasx27ky4psnyx4j6d7cky-nixos-system-nixos-26.05.20260505.549bd84 in NixOS WSL — **Done** (applied in this session)
- [x] Verify Client:
 Version:    29.4.3
 Context:    default
 Debug Mode: false
 Plugins:
  agent: Docker AI Agent Runner (Docker Inc.)
    Version:  v1.54.0
    Path:     /usr/local/lib/docker/cli-plugins/docker-agent
  ai: Docker AI Agent - Ask Gordon (Docker Inc.)
    Version:  v1.20.2
    Path:     /usr/local/lib/docker/cli-plugins/docker-ai
  buildx: Docker Buildx (Docker Inc.)
    Version:  v0.33.0-desktop.1
    Path:     /usr/local/lib/docker/cli-plugins/docker-buildx
  compose: Docker Compose (Docker Inc.)
    Version:  v5.1.3
    Path:     /usr/local/lib/docker/cli-plugins/docker-compose
  debug: Get a shell into any image or container (Docker Inc.)
    Version:  0.0.47
    Path:     /usr/local/lib/docker/cli-plugins/docker-debug
  desktop: Docker Desktop commands (Docker Inc.)
    Version:  v0.3.0
    Path:     /usr/local/lib/docker/cli-plugins/docker-desktop
  dhi: CLI for managing Docker Hardened Images (Docker Inc.)
    Version:  v0.0.3
    Path:     /usr/local/lib/docker/cli-plugins/docker-dhi
  extension: Manages Docker extensions (Docker Inc.)
    Version:  v0.2.31
    Path:     /usr/local/lib/docker/cli-plugins/docker-extension
  init: Creates Docker-related starter files for your project (Docker Inc.)
    Version:  v1.4.0
    Path:     /usr/local/lib/docker/cli-plugins/docker-init
  mcp: Docker MCP Plugin (Docker Inc.)
    Version:  v0.42.0
    Path:     /usr/local/lib/docker/cli-plugins/docker-mcp
  model: Docker Model Runner (Docker Inc.)
    Version:  v1.1.37
    Path:     /usr/local/lib/docker/cli-plugins/docker-model
  offload: Docker Offload (Docker Inc.)
    Version:  v0.5.85
    Path:     /usr/local/lib/docker/cli-plugins/docker-offload
  pass: Docker Pass Secrets Manager Plugin (beta) (Docker Inc.)
    Version:  v0.0.25
    Path:     /usr/local/lib/docker/cli-plugins/docker-pass
  sandbox:  (Docker Inc.)
    Version:  v0.12.0
    Path:     /usr/local/lib/docker/cli-plugins/docker-sandbox
  sbom: View the packaged-based Software Bill Of Materials (SBOM) for an image (Anchore Inc.)
    Version:  0.6.0
    Path:     /usr/local/lib/docker/cli-plugins/docker-sbom
  scout: Docker Scout (Docker Inc.)
    Version:  v1.20.4
    Path:     /usr/local/lib/docker/cli-plugins/docker-scout

Server:
 Containers: 7
  Running: 7
  Paused: 0
  Stopped: 0
 Images: 3
 Server Version: 29.4.1
 Storage Driver: overlayfs
  driver-type: io.containerd.snapshotter.v1
 Logging Driver: journald
 Cgroup Driver: systemd
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local splunk syslog
 CDI spec directories:
  /etc/cdi
  /var/run/cdi
 Discovered Devices:
  cdi: nvidia.com/gpu=all
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: refs/tags/v2.2.3
 runc version: 
 init version: 
 Security Options:
  seccomp
   Profile: builtin
  cgroupns
 Kernel Version: 6.6.114.1-microsoft-standard-WSL2
 Operating System: NixOS 26.05 (Yarara)
 OSType: linux
 Architecture: x86_64
 CPUs: 20
 Total Memory: 90.36GiB
 Name: nixos
 ID: b1079143-4802-443b-935a-75d2c0cdc023
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Experimental: false
 Insecure Registries:
  ::1/128
  127.0.0.0/8
 Live Restore Enabled: false
 Firewall Backend: iptables shows  (CDI approach; nvidia runtime not needed at docker level) — **Done** ✅
- [x] Verify  is generated by activation script — **Done** ✅
- [x] Recreate kind cluster:  — **Done** ✅ (6 nodes Ready)
- [ ] Verify nvidia-device-plugin pod is Running — **Pending**: k8s-manager needs update to use  instead of  (separate PR in k8s-manager)
- [ ] Verify GPU is schedulable — **Pending**: depends on device-plugin fix above

🤖 Generated with [Claude Code](https://claude.ai/claude-code)