### PR TITLE
feat(cluster): upgrade kindest/node to v1.35.1

### DIFF
--- a/k8s/kind/cluster.yaml
+++ b/k8s/kind/cluster.yaml
@@ -8,12 +8,18 @@ containerdConfigPatches:
       cdi_spec_dirs = ["/etc/cdi"]
 nodes:
   - role: control-plane
+    image: kindest/node:v1.35.1
   - role: control-plane
+    image: kindest/node:v1.35.1
   - role: control-plane
+    image: kindest/node:v1.35.1
   - role: worker
+    image: kindest/node:v1.35.1
   - role: worker
-  # GPU worker: CDI spec mounted from host /etc/cdi
+    image: kindest/node:v1.35.1
+  # GPU worker: CDI spec and WSL libs mounted from host
   - role: worker
+    image: kindest/node:v1.35.1
     extraMounts:
       - hostPath: /etc/cdi
         containerPath: /etc/cdi


### PR DESCRIPTION
## Summary
- Pin all kind nodes to  (from v1.35.0)
- Recreated cluster with new image — all 6 nodes running v1.35.1

## Test plan
- [x]  succeeded with v1.35.1 image
- [x] All 6 nodes Ready
- [x] gpu-node-patcher running,  registered on learning-worker3

🤖 Generated with [Claude Code](https://claude.com/claude-code)