### PR TITLE
ci(LIF-224): upgrade Windows runners to windows-2025

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: windows-2022
+    runs-on: windows-2025
     timeout-minutes: 20
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-winget.yml
+++ b/.github/workflows/test-winget.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   smoke-test:
-    runs-on: windows-latest
+    runs-on: windows-2025
     timeout-minutes: 30
     steps:
       - name: Checkout repository

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -281,7 +281,7 @@ flowchart TD
         N1 --> N2 --> N3 --> N4
     end
 
-    subgraph WG["test-winget.yml (windows-latest)"]
+    subgraph WG["test-winget.yml (windows-2025)"]
         W1["① winget import\npackages.json 全量インストール"]
         W2["② smoke test\nchezmoi git gh fd rg jq eza zoxide fzf"]
         W1 --> W2
@@ -293,7 +293,7 @@ flowchart TD
         C1 --> C2
     end
 
-    subgraph PS["test-powershell.yml (windows-latest)"]
+    subgraph PS["test-powershell.yml (windows-2025)"]
         P1["① Pester\nユニットテスト"]
         P2["② Codecov\nカバレッジ"]
         P1 --> P2
@@ -302,12 +302,12 @@ flowchart TD
 
 ### ワークフロー詳細
 
-| Workflow               | ランナー       | 何を保証するか                                       | トリガー                                                |
-| ---------------------- | -------------- | ---------------------------------------------------- | ------------------------------------------------------- |
-| `test-nix.yml`         | ubuntu-latest  | Nix 式が評価でき、バイナリがビルドでき、ツールが動く | `nix/**`, `flake.*`                                     |
-| `test-winget.yml`      | windows-latest | winget パッケージがインストールでき、ツールが動く    | `windows/winget/packages.json`, `nix/packages/sets.nix` |
-| `test-consistency.yml` | ubuntu-latest  | Nix 定義と `windows/winget/packages.json` が一致     | `nix/packages/**`, `windows/winget/**`                  |
-| `test-powershell.yml`  | windows-latest | PowerShell ハンドラーのロジックが正しく動く          | `scripts/powershell/**`                                 |
+| Workflow               | ランナー      | 何を保証するか                                       | トリガー                                                |
+| ---------------------- | ------------- | ---------------------------------------------------- | ------------------------------------------------------- |
+| `test-nix.yml`         | ubuntu-latest | Nix 式が評価でき、バイナリがビルドでき、ツールが動く | `nix/**`, `flake.*`                                     |
+| `test-winget.yml`      | windows-2025  | winget パッケージがインストールでき、ツールが動く    | `windows/winget/packages.json`, `nix/packages/sets.nix` |
+| `test-consistency.yml` | ubuntu-latest | Nix 定義と `windows/winget/packages.json` が一致     | `nix/packages/**`, `windows/winget/**`                  |
+| `test-powershell.yml`  | windows-2025  | PowerShell ハンドラーのロジックが正しく動く          | `scripts/powershell/**`                                 |
 
 ### テストレベルの判断基準
 


### PR DESCRIPTION
## Summary

- Replace `windows-2022` in `test-powershell.yml` with `windows-2025`
- Replace `windows-latest` in `test-winget.yml` with `windows-2025`

Pins both Windows CI workflows to Windows Server 2025 (the current latest stable), avoiding implicit runner changes when GitHub updates `windows-latest`.

## Test plan

- [ ] Verify PowerShell tests pass on windows-2025 runner
- [ ] Verify winget smoke tests pass on windows-2025 runner
- [ ] Confirm no regressions vs windows-2022 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
