### PR TITLE
feat(LIF-228): add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    groups:
+      actions-patch:
+        update-types: ["patch"]
+      actions-minor:
+        update-types: ["minor"]
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` to enable weekly Dependabot updates for GitHub Actions
- Schedule: Monday 09:00 JST — groups patch and minor updates separately
- Adds `dependencies` label to Dependabot PRs

## Background

- In March 2025, `tj-actions/changed-files@v44` was hijacked; SHA-pinned repos were protected
- All actions in this repo are already SHA-pinned, but manual updates create drift risk
- Dependabot reads the version comment alongside the SHA and generates update PRs automatically

## Test plan

- [x] `.github/dependabot.yml` is valid YAML with correct schema
- [x] `package-ecosystem: github-actions` targets all workflow files under `/`
- [x] Weekly Monday schedule at 09:00 Asia/Tokyo
- [x] Patch and minor updates grouped separately
- [x] `dependencies` label applied to PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)