### PR TITLE
fix(LIF-233): sync sets.nix SSOT — add winget IDs for go/python3 and zig.zig

### DIFF
--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -475,6 +475,14 @@ lib.mapAttrs (_: names: resolve names) grouped
       command = "task";
       args = [ "--version" ];
     };
+    go = {
+      command = "go";
+      args = [ "version" ];
+    };
+    python3 = {
+      command = "python";
+      args = [ "--version" ];
+    };
   };
 
   # Windows-only packages (no nix equivalent)

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -92,12 +92,12 @@ let
     };
     python3 = {
       pkg = pkgs.python3;
-      winget = null;
+      winget = "Python.Python.3.13";
       category = "dev";
     };
     go = {
       pkg = pkgs.go;
-      winget = null;
+      winget = "GoLang.Go";
       category = "dev";
     };
     gnumake = {
@@ -499,6 +499,7 @@ lib.mapAttrs (_: names: resolve names) grouped
       "TablePlus.TablePlus"
       "Oven-sh.Bun"
       "ZedIndustries.Zed"
+      "zig.zig"
     ];
     msstore = [
       "9NT1R1C2HH7J"


### PR DESCRIPTION
## Summary

- `go`: `winget = null` → `"GoLang.Go"` in `sets.nix`
- `python3`: `winget = null` → `"Python.Python.3.13"` in `sets.nix`
- `zig.zig` added to `windowsOnly.winget` in `sets.nix`

Fixes the `ci-consistency` failure: the Nix-generated `winget-export` was missing these three IDs that `windows/winget/packages.json` already contained.

## Test plan

- [ ] `ci-consistency` passes (diff between Nix-generated and repo packages.json is empty)
- [ ] `ci-nix` passes (sets.nix still evaluates correctly)

Closes LIF-233

🤖 Generated with [Claude Code](https://claude.com/claude-code)