### PR TITLE
fix(LIF-234): remove Codecov — await GitHub Native Coverage

### DIFF
--- a/.github/workflows/ci-chezmoi.yml
+++ b/.github/workflows/ci-chezmoi.yml
@@ -148,15 +148,6 @@ jobs:
 
           if ($result.FailedCount -gt 0) { exit 1 }
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        if: always() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
-        with:
-          files: scripts/powershell/coverage.xml
-          flags: chezmoi
-          name: chezmoi-coverage
-          fail_ci_if_error: false
-
       - name: Upload test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()

--- a/.github/workflows/ci-powershell.yml
+++ b/.github/workflows/ci-powershell.yml
@@ -202,15 +202,6 @@ jobs:
 
           if ($result.FailedCount -gt 0) { exit 1 }
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        if: always() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
-        with:
-          files: scripts/powershell/coverage.xml
-          flags: powershell
-          name: powershell-coverage
-          fail_ci_if_error: false
-
       - name: Upload test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 [![ci-chezmoi](https://github.com/rurusasu/dotfiles/actions/workflows/ci-chezmoi.yml/badge.svg)](https://github.com/rurusasu/dotfiles/actions/workflows/ci-chezmoi.yml)
 [![ci-winget](https://github.com/rurusasu/dotfiles/actions/workflows/ci-winget.yml/badge.svg)](https://github.com/rurusasu/dotfiles/actions/workflows/ci-winget.yml)
 [![ci-consistency](https://github.com/rurusasu/dotfiles/actions/workflows/ci-consistency.yml/badge.svg)](https://github.com/rurusasu/dotfiles/actions/workflows/ci-consistency.yml)
-[![powershell coverage](https://codecov.io/gh/rurusasu/dotfiles/branch/main/graph/badge.svg?flag=powershell)](https://codecov.io/gh/rurusasu/dotfiles)
-[![chezmoi coverage](https://codecov.io/gh/rurusasu/dotfiles/branch/main/graph/badge.svg?flag=chezmoi)](https://codecov.io/gh/rurusasu/dotfiles)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 NixOS/Home Manager + chezmoi を使った dotfiles の一元管理リポジトリ


### PR DESCRIPTION
## Summary

- Remove `codecov/codecov-action` upload steps from `ci-powershell.yml` and `ci-chezmoi.yml`
- Remove Codecov coverage badges from `README.md`

## Why

Codecov had a significant supply chain attack in 2021 (29,000 customers affected, CI env vars exfiltrated for 2 months). For a personal dotfiles repo it is overpowered. GitHub Native Coverage is in private preview and expected to launch publicly in 2026 — will adopt it at that time.

## Test plan

- [ ] `ci-powershell` passes (no Codecov upload step)
- [ ] `ci-chezmoi` passes (no Codecov upload step)
- [ ] README renders without "unknown" coverage badges

Closes LIF-234

🤖 Generated with [Claude Code](https://claude.com/claude-code)