### PR TITLE
fix(nvim): lualine セクション構成をベストプラクティスに修正

### DIFF
--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -124,7 +124,8 @@ return {
                 section_separators = "",
             },
             sections = {
-                lualine_b = { "branch", { "filename", path = 1 }, "diff", "diagnostics" },
+                lualine_b = { "branch", "diff", "diagnostics" },
+                lualine_c = { { "filename", path = 1 } },
             },
         },
     },


### PR DESCRIPTION
## Summary

- `lualine_b` を Git コンテキストのみに整理（`branch`, `diff`, `diagnostics`）
- `lualine_c` にファイルパスを移動（`{ "filename", path = 1 }`）
- `[No Name]` 2重表示バグも同時に修正

## Before / After

```
# Before
main | [No Name] [No Name] +1 ~0 -0   ← 2重表示バグあり

# After
main | +1 ~0 -0    lua/plugins/init.lua
```

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)