### PR TITLE
fix(nvim): codecompanion ACP アダプターを OAuth 認証に変更

### DIFF
--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -208,20 +208,14 @@ return {
                     codex = function()
                         return require("codecompanion.adapters").extend("codex", {
                             defaults = {
-                                auth_method = "openai-api-key",
-                            },
-                            env = {
-                                OPENAI_API_KEY = "OPENAI_API_KEY",
+                                auth_method = "chatgpt",
                             },
                         })
                     end,
                     gemini_cli = function()
                         return require("codecompanion.adapters").extend("gemini_cli", {
                             defaults = {
-                                auth_method = "gemini-api-key",
-                            },
-                            env = {
-                                GEMINI_API_KEY = "GEMINI_API_KEY",
+                                auth_method = "oauth-personal",
                             },
                         })
                     end,


### PR DESCRIPTION
## Summary

- `codex`: `"chatgpt"` OAuth に変更（ブラウザで ChatGPT ログインフロー）
- `gemini_cli`: `"oauth-personal"` に変更（Google アカウントログイン）
- `OPENAI_API_KEY` / `GEMINI_API_KEY` の env 設定を削除

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)