### PR TITLE
feat: claude-agent-acp をクロスプラットフォーム pnpm globals に追加

### DIFF
--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -389,6 +389,7 @@ lib.mapAttrs (_: names: resolve names) grouped
   pnpmGlobal = [
     "@tobilu/qmd"
     "@prisma/language-server"
+    "@agentclientprotocol/claude-agent-acp"
   ];
 
   # Post-install verification commands for pnpm packages.
@@ -404,6 +405,10 @@ lib.mapAttrs (_: names: resolve names) grouped
     };
     "@google/gemini-cli" = {
       command = "gemini";
+      args = [ "--version" ];
+    };
+    "@agentclientprotocol/claude-agent-acp" = {
+      command = "claude-agent-acp";
       args = [ "--version" ];
     };
   };

--- a/windows/pnpm/packages.json
+++ b/windows/pnpm/packages.json
@@ -22,6 +22,13 @@
         "args": ["--version"],
         "command": "gemini"
       }
+    },
+    {
+      "name": "@agentclientprotocol/claude-agent-acp",
+      "verifyCommand": {
+        "args": ["--version"],
+        "command": "claude-agent-acp"
+      }
     }
   ]
 }

--- a/windows/pnpm/packages.json
+++ b/windows/pnpm/packages.json
@@ -17,17 +17,17 @@
       }
     },
     {
-      "name": "@google/gemini-cli",
-      "verifyCommand": {
-        "args": ["--version"],
-        "command": "gemini"
-      }
-    },
-    {
       "name": "@agentclientprotocol/claude-agent-acp",
       "verifyCommand": {
         "args": ["--version"],
         "command": "claude-agent-acp"
+      }
+    },
+    {
+      "name": "@google/gemini-cli",
+      "verifyCommand": {
+        "args": ["--version"],
+        "command": "gemini"
       }
     }
   ]


### PR DESCRIPTION
## Summary

- `nix/packages/sets.nix` の `pnpmGlobal` に `@agentclientprotocol/claude-agent-acp` を追加
- `pnpmVerify` に `claude-agent-acp --version` による検証エントリを追加

## Background

Windows 環境で codecompanion.nvim の ACP (`<leader>aa`) 実行時に `claude-agent-acp` コマンドが見つからず `ENOENT` エラーが発生していた。`pnpmGlobal` に追加することで Windows / Linux 両環境のセットアップ時に自動インストールされる。

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)