### PR TITLE
fix(nix): PNPM_HOME を設定して pnpm globals を PATH に追加

### DIFF
--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -176,8 +176,14 @@ in
     FZF_DEFAULT_COMMAND = "fd ${fdOpts} --absolute-path --type f . .";
     FZF_ALT_C_COMMAND = "fd ${fdOpts} --absolute-path --type d . .";
     FZF_DEFAULT_OPTS = "--height=40% --layout=reverse --border --prompt='> '";
+    # pnpm global bin directory
+    PNPM_HOME = "$HOME/.local/share/pnpm";
   };
 
   # PATH: bun global binaries (claude-code, gemini-cli, etc.)
-  home.sessionPath = [ "$HOME/.bun/bin" ];
+  #       pnpm global binaries
+  home.sessionPath = [
+    "$HOME/.bun/bin"
+    "$HOME/.local/share/pnpm"
+  ];
 }


### PR DESCRIPTION
## Summary

- `home.sessionVariables` に `PNPM_HOME = "$HOME/.local/share/pnpm"` を追加
- `home.sessionPath` に `"$HOME/.local/share/pnpm"` を追加（bun と同パターン）

## Problem

NixOS/WSL で `pnpm install -g` 実行時に `ERR_PNPM_NO_GLOBAL_BIN_DIR` が発生。
Nix ストアは immutable なため npm install -g も不可。

## After

```bash
# nixos-rebuild switch 後にシェル再起動で有効になる
pnpm install -g @agentclientprotocol/claude-agent-acp
```

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)