### PR TITLE
feat(nvim): codecompanion チャットを Ctrl+Enter で送信

### DIFF
--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -222,7 +222,14 @@ return {
                 },
             },
             interactions = {
-                chat = { adapter = "claude_code" },
+                chat = {
+                    adapter = "claude_code",
+                    keymaps = {
+                        send = {
+                            modes = { n = "<CR>", i = "<C-CR>" },
+                        },
+                    },
+                },
                 inline = { adapter = "claude_code" },
             },
         },


### PR DESCRIPTION
## Summary

- INSERT モードのまま `<C-CR>`（Ctrl+Enter）で送信できるよう設定
- Normal モードは従来通り `<CR>`（Enter）

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)