### PR TITLE
chore(nvim): clean up redundant codecompanion.nvim adapter config for v19

### DIFF
--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -194,28 +194,15 @@ return {
                 acp = {
                     claude_code = function()
                         return require("codecompanion.adapters").extend("claude_code", {
-                            env = {
-                                CLAUDE_CODE_OAUTH_TOKEN = "CLAUDE_CODE_OAUTH_TOKEN",
-                            },
                             defaults = {
                                 mcpServers = "inherit_from_config",
                             },
                         })
                     end,
-                    opencode = function()
-                        return require("codecompanion.adapters").extend("opencode", {})
-                    end,
                     codex = function()
                         return require("codecompanion.adapters").extend("codex", {
                             defaults = {
                                 auth_method = "chatgpt",
-                            },
-                        })
-                    end,
-                    gemini_cli = function()
-                        return require("codecompanion.adapters").extend("gemini_cli", {
-                            defaults = {
-                                auth_method = "oauth-personal",
                             },
                         })
                     end,


### PR DESCRIPTION
## Summary

- Remove `env.CLAUDE_CODE_OAUTH_TOKEN` from `claude_code` adapter override — already defined in the built-in v19 adapter
- Remove `opencode` empty `extend({})` wrapper — v19 registers it in `adapters.acp` defaults
- Remove `gemini_cli` `auth_method = "oauth-personal"` override — that is already the v19 default

## What's kept

- `claude_code` with `mcpServers = "inherit_from_config"` — passes CodeCompanion's MCP servers into the ACP session
- `codex` with `auth_method = "chatgpt"` — non-default, uses ChatGPT auth
- `interactions.chat/inline.adapter = "claude_code"` — default adapter override
- `interactions.chat.keymaps.send` with `<C-CR>` insert-mode binding

## Test plan

- [ ] `<leader>aa` opens CodeCompanion chat backed by claude_code adapter
- [ ] Ctrl+Enter in insert mode sends the message
- [ ] No startup errors or deprecation warnings

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)