### PR TITLE
feat: add gcloud CLI cross-platform (NixOS + Windows)

### DIFF
--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -289,6 +289,11 @@ let
       winget = "SST.opencode";
       category = "infra";
     };
+    google-cloud-sdk = {
+      pkg = pkgs.google-cloud-sdk;
+      winget = "Google.CloudSDK";
+      category = "infra";
+    };
 
     # ── lsp ───────────────────────────────────────────────
     nixd = {
@@ -487,6 +492,10 @@ lib.mapAttrs (_: names: resolve names) grouped
     python3 = {
       command = "python";
       args = [ "--version" ];
+    };
+    google-cloud-sdk = {
+      command = "gcloud";
+      args = [ "version" ];
     };
   };
 

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -104,6 +104,13 @@
           "PackageIdentifier": "SST.opencode"
         },
         {
+          "PackageIdentifier": "Google.CloudSDK",
+          "verifyCommand": {
+            "args": ["version"],
+            "command": "gcloud"
+          }
+        },
+        {
           "PackageIdentifier": "Microsoft.PowerShell",
           "verifyCommand": {
             "args": ["--version"],


### PR DESCRIPTION
## Summary

- `nix/packages/sets.nix`: `google-cloud-sdk` を catalog に追加（`infra` カテゴリ、`winget = "Google.CloudSDK"`）、`wingetVerify` に `gcloud version` を追加
- `windows/winget/packages.json`: `Google.CloudSDK` を追加（sets.nix と同期）

## 動作

| プラットフォーム | インストール方法 |
|---|---|
| NixOS / WSL | `nix profile install .#full` or `nrs` |
| Windows | `winget import windows/winget/packages.json` |

## Test plan

- [ ] CI `Verify winget packages.json is in sync` が pass すること
- [ ] NixOS: `gcloud version` が動作すること（次回 `nix profile upgrade` 後）
- [ ] Windows: `winget import` 後に `gcloud version` が動作すること

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)