### PR TITLE
feat: add registry.localhost as Docker insecure-registry (issue #34)

### DIFF
--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -60,6 +60,21 @@
 
   users.users.nixos.extraGroups = [ "docker" ];
 
+  # Provide containerd hosts.toml for registry.localhost so kind nodes can
+  # mount /etc/containerd/certs.d and use the in-cluster Zot as a mirror.
+  # kind.yaml: extraMounts hostPath=/etc/containerd/certs.d
+  system.activationScripts.containerdCertsD = {
+    text = ''
+      mkdir -p /etc/containerd/certs.d/registry.localhost
+      cat > /etc/containerd/certs.d/registry.localhost/hosts.toml << 'EOF'
+server = "http://registry.localhost"
+
+[host."http://zot.infra.svc.cluster.local:5080"]
+  capabilities = ["pull", "resolve"]
+EOF
+    '';
+  };
+
   # Generate CDI spec on each activation so kind worker nodes can mount
   # /etc/cdi and use GPU resources through containerd CDI.
   system.activationScripts.nvidiaCdi = {

--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -54,6 +54,9 @@
   # GPU access inside kind nodes is handled via CDI (see k8s/kind/cluster.yaml).
   # Windows can reach the socket via: DOCKER_HOST=unix:///wsl.localhost/NixOS/var/run/docker.sock
   virtualisation.docker.enable = true;
+  virtualisation.docker.daemon.settings = {
+    insecure-registries = [ "registry.localhost" ];
+  };
 
   users.users.nixos.extraGroups = [ "docker" ];
 


### PR DESCRIPTION
## Summary

- `nix/modules/wsl/default.nix` に `virtualisation.docker.daemon.settings.insecure-registries` を追加
- `registry.localhost` を insecure レジストリとして登録し、NixOS WSL ホストから Zot (in-cluster OCI レジストリ) へ push できるようにする

## 背景

k8s-manager issue #34 の対応。kind クラスター内の Zot レジストリ (`registry.localhost`) は HTTP で動作するため、dockerd に insecure として登録しないと push が拒否される。

## Test plan

- [ ] マージ後、NixOS WSL 内で `sudo nixos-rebuild switch` を実行
- [ ] `docker info | grep -A5 "Insecure"` で `registry.localhost` が表示されることを確認
- [ ] `docker push registry.localhost/test/alpine:latest` が成功することを確認 (kind クラスター再作成後)

🤖 Generated with [Claude Code](https://claude.com/claude-code)