### PR TITLE
feat: add registry mirror, insecure-registry, containerd certs.d, and 1password-cli for k8s

### DIFF
--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -60,6 +60,21 @@
 
   users.users.nixos.extraGroups = [ "docker" ];
 
+  # Provide containerd hosts.toml for registry.localhost so kind nodes can
+  # mount /etc/containerd/certs.d and use the in-cluster Zot as a mirror.
+  # kind.yaml: extraMounts hostPath=/etc/containerd/certs.d
+  system.activationScripts.containerdCertsD = {
+    text = ''
+      mkdir -p /etc/containerd/certs.d/registry.localhost
+      cat > /etc/containerd/certs.d/registry.localhost/hosts.toml << 'EOF'
+server = "http://registry.localhost"
+
+[host."http://zot.infra.svc.cluster.local:5080"]
+  capabilities = ["pull", "resolve"]
+EOF
+    '';
+  };
+
   # Generate CDI spec on each activation so kind worker nodes can mount
   # /etc/cdi and use GPU resources through containerd CDI.
   system.activationScripts.nvidiaCdi = {

--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -54,6 +54,9 @@
   # GPU access inside kind nodes is handled via CDI (see k8s/kind/cluster.yaml).
   # Windows can reach the socket via: DOCKER_HOST=unix:///wsl.localhost/NixOS/var/run/docker.sock
   virtualisation.docker.enable = true;
+  virtualisation.docker.daemon.settings = {
+    insecure-registries = [ "registry.localhost" ];
+  };
 
   users.users.nixos.extraGroups = [ "docker" ];
 

--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -3,6 +3,7 @@
   environment.systemPackages = with pkgs; [
     coreutils
     nvidia-container-toolkit
+    _1password-cli
     # Japanese input: fcitx5+mozc installed as system packages.
     # i18n.inputMethod is intentionally NOT used here because it auto-generates
     # app-org.fcitx.Fcitx5@autostart.service, which conflicts with the Home Manager
@@ -65,13 +66,13 @@
   # kind.yaml: extraMounts hostPath=/etc/containerd/certs.d
   system.activationScripts.containerdCertsD = {
     text = ''
-      mkdir -p /etc/containerd/certs.d/registry.localhost
-      cat > /etc/containerd/certs.d/registry.localhost/hosts.toml << 'EOF'
-server = "http://registry.localhost"
+            mkdir -p /etc/containerd/certs.d/registry.localhost
+            cat > /etc/containerd/certs.d/registry.localhost/hosts.toml << 'EOF'
+      server = "http://registry.localhost"
 
-[host."http://zot.infra.svc.cluster.local:5080"]
-  capabilities = ["pull", "resolve"]
-EOF
+      [host."http://zot.infra.svc.cluster.local:5080"]
+        capabilities = ["pull", "resolve"]
+      EOF
     '';
   };
 


### PR DESCRIPTION
## Summary

- Add  to dockerd  (issue #34) — allows kind nodes to pull from in-cluster Zot without TLS
- Add  activation script — generates  on each NixOS rebuild, mounting into kind nodes via extraMounts
- Add  to WSL system packages — enables  inside WSL for task: Available tasks for this project:
* build:                         Dry build NixOS configuration (via WSL)
* chezmoi:                       Apply chezmoi dotfiles
* commit:                        Sync skills, format, lint, and commit (via WSL)
* default:                       Show available tasks
* dev:                           Enter nix develop shell (via WSL)
* fmt:                           Run nix fmt (via WSL)
* install:                       Run Windows installer
* lint:                          Run pre-commit on all files (via WSL)
* push:                          Push to remote (via WSL)
* rebuild:                       Run nixos-rebuild switch (via WSL)
* shell:                         Enter NixOS shell
* sync:                          Format, lint, commit and push (via WSL)
* test:                          Run PowerShell tests
* update:                        Update flake inputs (via WSL)
* docker:compact:                Prune Docker objects and compact VHDX to reclaim SSD space (requires admin)
* docker:compact:schedule:       Register weekly Windows Scheduled Task to auto-compact Docker VHDX (requires admin)
* docker:prune:                  DESTRUCTIVE: Remove all unused Docker images, containers, networks, and build cache
* fmt:check:                     Check formatting without changes (via WSL)
* hooks:check:                   Run all pre-commit hooks manually on all files (via WSL)
* hooks:install:                 Install pre-commit git hooks (via WSL)
* hooks:uninstall:               Uninstall pre-commit git hooks (via WSL)
* skills:sync:                   Sync Claude Code skills from deployed ~/.claude/skills/ back to chezmoi source
* test:coverage:                 Run PowerShell tests with coverage in k8s-manager

## Test plan

- [ ]  completes without errors
- [ ] 2.34.0 works inside NixOS WSL
- [ ]  shows correct mirror config
- [ ] task: Available tasks for this project:
* build:                         Dry build NixOS configuration (via WSL)
* chezmoi:                       Apply chezmoi dotfiles
* commit:                        Sync skills, format, lint, and commit (via WSL)
* default:                       Show available tasks
* dev:                           Enter nix develop shell (via WSL)
* fmt:                           Run nix fmt (via WSL)
* install:                       Run Windows installer
* lint:                          Run pre-commit on all files (via WSL)
* push:                          Push to remote (via WSL)
* rebuild:                       Run nixos-rebuild switch (via WSL)
* shell:                         Enter NixOS shell
* sync:                          Format, lint, commit and push (via WSL)
* test:                          Run PowerShell tests
* update:                        Update flake inputs (via WSL)
* docker:compact:                Prune Docker objects and compact VHDX to reclaim SSD space (requires admin)
* docker:compact:schedule:       Register weekly Windows Scheduled Task to auto-compact Docker VHDX (requires admin)
* docker:prune:                  DESTRUCTIVE: Remove all unused Docker images, containers, networks, and build cache
* fmt:check:                     Check formatting without changes (via WSL)
* hooks:check:                   Run all pre-commit hooks manually on all files (via WSL)
* hooks:install:                 Install pre-commit git hooks (via WSL)
* hooks:uninstall:               Uninstall pre-commit git hooks (via WSL)
* skills:sync:                   Sync Claude Code skills from deployed ~/.claude/skills/ back to chezmoi source
* test:coverage:                 Run PowerShell tests with coverage injects all k8s secrets via 1Password

🤖 Generated with [Claude Code](https://claude.com/claude-code)