### PR TITLE
feat(lsp): replace ts_ls with oxlint, add ty for Python

### DIFF
--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -403,6 +403,11 @@ return {
                 },
                 marksman = {},
                 ruff = {},
+                ty = {
+                    cmd = { "ty", "server" },
+                    filetypes = { "python" },
+                    root_markers = { "pyproject.toml", "setup.py", "setup.cfg", ".git" },
+                },
             }
 
             for name, cfg in pairs(servers) do

--- a/chezmoi/editors/nvim/lua/plugins/init.lua
+++ b/chezmoi/editors/nvim/lua/plugins/init.lua
@@ -256,7 +256,6 @@ return {
             ensure_installed = {
                 "gopls",
                 "rust_analyzer",
-                "ts_ls",
                 "yamlls",
                 "taplo",
                 "bashls",
@@ -280,24 +279,35 @@ return {
         config = function()
             local capabilities = require("cmp_nvim_lsp").default_capabilities()
 
-            local on_attach = function(_, bufnr)
-                local map = function(keys, func, desc)
-                    vim.keymap.set("n", keys, func, { buffer = bufnr, desc = desc })
-                end
-                map("gd", vim.lsp.buf.definition, "Go to definition")
-                map("gr", vim.lsp.buf.references, "References")
-                map("K", vim.lsp.buf.hover, "Hover docs")
-                map("<leader>rn", vim.lsp.buf.rename, "Rename")
-                map("<leader>ca", vim.lsp.buf.code_action, "Code action")
-                map("<leader>f", function()
-                    vim.lsp.buf.format({ async = true })
-                end, "Format")
-            end
+            -- nvim 0.11+: use LspAttach autocmd instead of on_attach in vim.lsp.config
+            vim.api.nvim_create_autocmd("LspAttach", {
+                callback = function(args)
+                    local bufnr = args.buf
+                    local map = function(keys, func, desc)
+                        vim.keymap.set("n", keys, func, { buffer = bufnr, desc = desc })
+                    end
+                    -- gd: LSP definition if supported, else telescope grep across files
+                    map("gd", function()
+                        local clients = vim.lsp.get_clients({ bufnr = bufnr, method = "textDocument/definition" })
+                        if #clients > 0 then
+                            vim.lsp.buf.definition()
+                        else
+                            require("telescope.builtin").grep_string({ word_match = "-w" })
+                        end
+                    end, "Go to definition")
+                    map("gr", vim.lsp.buf.references, "References")
+                    map("K", vim.lsp.buf.hover, "Hover docs")
+                    map("<leader>rn", vim.lsp.buf.rename, "Rename")
+                    map("<leader>ca", vim.lsp.buf.code_action, "Code action")
+                    map("<leader>f", function()
+                        vim.lsp.buf.format({ async = true })
+                    end, "Format")
+                end,
+            })
 
             -- Defaults applied to every server via the '*' wildcard.
             vim.lsp.config("*", {
                 capabilities = capabilities,
-                on_attach = on_attach,
             })
 
             local servers = {
@@ -356,19 +366,10 @@ return {
                         },
                     },
                 },
-                ts_ls = {
-                    init_options = {
-                        preferences = {
-                            importModuleSpecifierPreference = "non-relative",
-                            includeInlayParameterNameHints = "all",
-                            includeInlayParameterNameHintsWhenArgumentMatchesName = false,
-                            includeInlayFunctionParameterTypeHints = true,
-                            includeInlayVariableTypeHints = true,
-                            includeInlayPropertyDeclarationTypeHints = true,
-                            includeInlayFunctionLikeReturnTypeHints = true,
-                            includeInlayEnumMemberValueHints = true,
-                        },
-                    },
+                oxlint = {
+                    cmd = { "oxlint", "--lsp" },
+                    filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue", "svelte" },
+                    root_markers = { "package.json", ".git" },
                 },
                 yamlls = {
                     settings = {

--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -29,31 +29,34 @@
   # can authenticate from WSL. The NixOS-native op binary has no socket from the
   # Windows app; op.exe on Windows connects via the named pipe directly.
   # op run is kept on the native binary because it injects secrets into Linux processes.
-  system.activationScripts.opWrapper = {
-    text = ''
-            mkdir -p /usr/local/bin
-            cat > /usr/local/bin/op << 'WRAPPER'
-      #!/bin/bash
-      OP_NATIVE="/etc/profiles/per-user/nixos/bin/op"
-      # op run injects secrets into Linux processes — keep on native binary
-      if [ "$1" = "run" ] && [ -x "$OP_NATIVE" ]; then
-        exec "$OP_NATIVE" "$@"
-      fi
-      # Find op.exe via Windows PATH (available in WSL via interop)
-      OP_EXE=$(IFS=:; for p in $PATH; do
-        [ -f "$p/op.exe" ] && echo "$p/op.exe" && break
-      done)
-      if [ -z "$OP_EXE" ]; then
-        echo "[ERROR] op.exe not found in PATH" >&2
-        exit 1
-      fi
-      OP_VARS=$(env | grep ^OP_ | cut -d= -f1 | tr '\n' ':')
-      export WSLENV="''${WSLENV:-}:''${OP_VARS%:}"
-      exec "$OP_EXE" "$@"
-      WRAPPER
-            chmod +x /usr/local/bin/op
-    '';
-  };
+  system.activationScripts.opWrapper =
+    let
+      opScript = pkgs.writeShellScript "op-wrapper" ''
+        OP_NATIVE="/etc/profiles/per-user/nixos/bin/op"
+        # op run injects secrets into Linux processes — keep on native binary
+        if [ "$1" = "run" ] && [ -x "$OP_NATIVE" ]; then
+          exec "$OP_NATIVE" "$@"
+        fi
+        # Find op.exe via Windows PATH (available in WSL via interop)
+        OP_EXE=$(IFS=:; for p in $PATH; do
+          [ -f "$p/op.exe" ] && echo "$p/op.exe" && break
+        done)
+        if [ -z "$OP_EXE" ]; then
+          echo "[ERROR] op.exe not found in PATH" >&2
+          exit 1
+        fi
+        OP_VARS=$(env | grep ^OP_ | cut -d= -f1 | tr '\n' ':')
+        export WSLENV="''${WSLENV:-}:''${OP_VARS%:}"
+        exec "$OP_EXE" "$@"
+      '';
+    in
+    {
+      text = ''
+        mkdir -p /usr/local/bin
+        cp ${opScript} /usr/local/bin/op
+        chmod +x /usr/local/bin/op
+      '';
+    };
 
   # Allow running dynamically linked binaries in WSL (e.g. VS Code Server).
   programs.nix-ld = {

--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -25,6 +25,36 @@
     '';
   };
 
+  # Delegate op CLI to Windows op.exe so 1Password desktop app (Windows Hello)
+  # can authenticate from WSL. The NixOS-native op binary has no socket from the
+  # Windows app; op.exe on Windows connects via the named pipe directly.
+  # op run is kept on the native binary because it injects secrets into Linux processes.
+  system.activationScripts.opWrapper = {
+    text = ''
+            mkdir -p /usr/local/bin
+            cat > /usr/local/bin/op << 'WRAPPER'
+      #!/bin/bash
+      OP_NATIVE="/etc/profiles/per-user/nixos/bin/op"
+      # op run injects secrets into Linux processes — keep on native binary
+      if [ "$1" = "run" ] && [ -x "$OP_NATIVE" ]; then
+        exec "$OP_NATIVE" "$@"
+      fi
+      # Find op.exe via Windows PATH (available in WSL via interop)
+      OP_EXE=$(IFS=:; for p in $PATH; do
+        [ -f "$p/op.exe" ] && echo "$p/op.exe" && break
+      done)
+      if [ -z "$OP_EXE" ]; then
+        echo "[ERROR] op.exe not found in PATH" >&2
+        exit 1
+      fi
+      OP_VARS=$(env | grep ^OP_ | cut -d= -f1 | tr '\n' ':')
+      export WSLENV="''${WSLENV:-}:''${OP_VARS%:}"
+      exec "$OP_EXE" "$@"
+      WRAPPER
+            chmod +x /usr/local/bin/op
+    '';
+  };
+
   # Allow running dynamically linked binaries in WSL (e.g. VS Code Server).
   programs.nix-ld = {
     enable = true;

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -301,6 +301,11 @@ let
       winget = null;
       category = "lsp";
     };
+    ty = {
+      pkg = pkgs.ty;
+      winget = "astral-sh.ty";
+      category = "lsp";
+    };
     ruff = {
       pkg = pkgs.ruff;
       winget = null;
@@ -341,11 +346,6 @@ let
       winget = null;
       category = "lsp";
     };
-    typescript-language-server = {
-      pkg = pkgs.typescript-language-server;
-      winget = null;
-      category = "lsp";
-    };
     astro-language-server = {
       pkg = pkgs.astro-language-server;
       winget = null;
@@ -353,7 +353,7 @@ let
     };
     oxlint = {
       pkg = pkgs.oxlint;
-      winget = null;
+      winget = "oxc-project.oxlint";
       category = "lsp";
     };
   };

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -4,6 +4,9 @@
     {
       "Packages": [
         {
+          "PackageIdentifier": "AgileBits.1Password"
+        },
+        {
           "PackageIdentifier": "AgileBits.1Password.CLI",
           "verifyCommand": {
             "args": ["--version"],
@@ -11,52 +14,36 @@
           }
         },
         {
-          "PackageIdentifier": "twpayne.chezmoi",
+          "PackageIdentifier": "Anthropic.Claude"
+        },
+        {
+          "PackageIdentifier": "Anysphere.Cursor"
+        },
+        {
+          "PackageIdentifier": "BurntSushi.ripgrep.MSVC",
           "verifyCommand": {
             "args": ["--version"],
-            "command": "chezmoi"
+            "command": "rg"
           }
         },
         {
-          "PackageIdentifier": "direnv.direnv",
-          "verifyCommand": {
-            "args": ["--version"],
-            "command": "direnv"
-          }
-        },
-        {
-          "PackageIdentifier": "eza-community.eza",
-          "verifyCommand": {
-            "args": ["--version"],
-            "command": "eza"
-          }
-        },
-        {
-          "PackageIdentifier": "sharkdp.fd",
-          "verifyCommand": {
-            "args": ["--version"],
-            "command": "fd"
-          }
-        },
-        {
-          "PackageIdentifier": "junegunn.fzf",
-          "verifyCommand": {
-            "args": ["--version"],
-            "command": "fzf"
-          }
-        },
-        {
-          "PackageIdentifier": "GitHub.cli",
-          "verifyCommand": {
-            "args": ["--version"],
-            "command": "gh"
-          }
+          "PackageIdentifier": "Docker.DockerDesktop"
         },
         {
           "PackageIdentifier": "Git.Git",
           "verifyCommand": {
             "args": ["--version"],
             "command": "git"
+          }
+        },
+        {
+          "PackageIdentifier": "GitHub.Copilot"
+        },
+        {
+          "PackageIdentifier": "GitHub.cli",
+          "verifyCommand": {
+            "args": ["--version"],
+            "command": "gh"
           }
         },
         {
@@ -67,41 +54,10 @@
           }
         },
         {
-          "PackageIdentifier": "Python.Python.3.13",
-          "verifyCommand": {
-            "args": ["--version"],
-            "command": "python"
-          }
+          "PackageIdentifier": "Google.Antigravity"
         },
         {
-          "PackageIdentifier": "Task.Task",
-          "verifyCommand": {
-            "args": ["--version"],
-            "command": "task"
-          }
-        },
-        {
-          "PackageIdentifier": "jqlang.jq"
-        },
-        {
-          "PackageIdentifier": "Neovim.Neovim",
-          "verifyCommand": {
-            "args": ["--version"],
-            "command": "nvim"
-          }
-        },
-        {
-          "PackageIdentifier": "OpenJS.NodeJS.LTS",
-          "verifyCommand": {
-            "args": ["--version"],
-            "command": "node"
-          }
-        },
-        {
-          "PackageIdentifier": "Obsidian.Obsidian"
-        },
-        {
-          "PackageIdentifier": "SST.opencode"
+          "PackageIdentifier": "Google.Chrome"
         },
         {
           "PackageIdentifier": "Google.CloudSDK",
@@ -118,11 +74,52 @@
           }
         },
         {
-          "PackageIdentifier": "BurntSushi.ripgrep.MSVC",
+          "PackageIdentifier": "Microsoft.PowerToys"
+        },
+        {
+          "PackageIdentifier": "Microsoft.VCRedist.2015+.x64"
+        },
+        {
+          "PackageIdentifier": "Microsoft.VisualStudioCode"
+        },
+        {
+          "PackageIdentifier": "Microsoft.WSL"
+        },
+        {
+          "PackageIdentifier": "Microsoft.WindowsTerminal"
+        },
+        {
+          "PackageIdentifier": "Neovim.Neovim",
           "verifyCommand": {
             "args": ["--version"],
-            "command": "rg"
+            "command": "nvim"
           }
+        },
+        {
+          "PackageIdentifier": "Obsidian.Obsidian"
+        },
+        {
+          "PackageIdentifier": "OpenAI.Codex"
+        },
+        {
+          "PackageIdentifier": "OpenJS.NodeJS.LTS",
+          "verifyCommand": {
+            "args": ["--version"],
+            "command": "node"
+          }
+        },
+        {
+          "PackageIdentifier": "Oven-sh.Bun"
+        },
+        {
+          "PackageIdentifier": "Python.Python.3.13",
+          "verifyCommand": {
+            "args": ["--version"],
+            "command": "python"
+          }
+        },
+        {
+          "PackageIdentifier": "SST.opencode"
         },
         {
           "PackageIdentifier": "SlackTechnologies.Slack"
@@ -135,17 +132,23 @@
           }
         },
         {
-          "PackageIdentifier": "astral-sh.uv",
+          "PackageIdentifier": "TablePlus.TablePlus"
+        },
+        {
+          "PackageIdentifier": "Task.Task",
           "verifyCommand": {
             "args": ["--version"],
-            "command": "uv"
+            "command": "task"
           }
+        },
+        {
+          "PackageIdentifier": "TheBrowserCompany.Arc"
         },
         {
           "PackageIdentifier": "Warp.Warp"
         },
         {
-          "PackageIdentifier": "wez.wezterm"
+          "PackageIdentifier": "ZedIndustries.Zed"
         },
         {
           "PackageIdentifier": "ajeetdsouza.zoxide",
@@ -155,61 +158,64 @@
           }
         },
         {
-          "PackageIdentifier": "AgileBits.1Password"
+          "PackageIdentifier": "astral-sh.ty"
         },
         {
-          "PackageIdentifier": "Anthropic.Claude"
+          "PackageIdentifier": "astral-sh.uv",
+          "verifyCommand": {
+            "args": ["--version"],
+            "command": "uv"
+          }
         },
         {
-          "PackageIdentifier": "Anysphere.Cursor"
-        },
-        {
-          "PackageIdentifier": "TheBrowserCompany.Arc"
-        },
-        {
-          "PackageIdentifier": "Docker.DockerDesktop"
-        },
-        {
-          "PackageIdentifier": "GitHub.Copilot"
+          "PackageIdentifier": "direnv.direnv",
+          "verifyCommand": {
+            "args": ["--version"],
+            "command": "direnv"
+          }
         },
         {
           "PackageIdentifier": "dprint.dprint"
         },
         {
+          "PackageIdentifier": "eza-community.eza",
+          "verifyCommand": {
+            "args": ["--version"],
+            "command": "eza"
+          }
+        },
+        {
           "PackageIdentifier": "hadolint.hadolint"
         },
         {
-          "PackageIdentifier": "Google.Chrome"
+          "PackageIdentifier": "jqlang.jq"
         },
         {
-          "PackageIdentifier": "Google.Antigravity"
+          "PackageIdentifier": "junegunn.fzf",
+          "verifyCommand": {
+            "args": ["--version"],
+            "command": "fzf"
+          }
         },
         {
-          "PackageIdentifier": "Microsoft.PowerToys"
+          "PackageIdentifier": "oxc-project.oxlint"
         },
         {
-          "PackageIdentifier": "Microsoft.VCRedist.2015+.x64"
+          "PackageIdentifier": "sharkdp.fd",
+          "verifyCommand": {
+            "args": ["--version"],
+            "command": "fd"
+          }
         },
         {
-          "PackageIdentifier": "Microsoft.VisualStudioCode"
+          "PackageIdentifier": "twpayne.chezmoi",
+          "verifyCommand": {
+            "args": ["--version"],
+            "command": "chezmoi"
+          }
         },
         {
-          "PackageIdentifier": "Microsoft.WindowsTerminal"
-        },
-        {
-          "PackageIdentifier": "Microsoft.WSL"
-        },
-        {
-          "PackageIdentifier": "OpenAI.Codex"
-        },
-        {
-          "PackageIdentifier": "TablePlus.TablePlus"
-        },
-        {
-          "PackageIdentifier": "Oven-sh.Bun"
-        },
-        {
-          "PackageIdentifier": "ZedIndustries.Zed"
+          "PackageIdentifier": "wez.wezterm"
         },
         {
           "PackageIdentifier": "zig.zig",


### PR DESCRIPTION
## Summary

- **TypeScript**: `ts_ls` を `oxlint --lsp` に置き換え (JS/TS/JSX/TSX/Vue/Svelte)
- **Python**: `ty` LSP を追加 (定義ジャンプ・型チェック対応)
- **neovim**: `LspAttach` autocmd 方式に移行 (nvim 0.11+ 推奨)
- **gd**: LSP 未対応バッファは telescope `grep_string` にフォールバック (cross-file 検索)
- **sets.nix**: `ty` (winget: `astral-sh.ty`)、`oxlint` winget ID (`oxc-project.oxlint`) を追加、`typescript-language-server` を削除

## Test plan

- [ ] TypeScript ファイルで oxlint の diagnostics が表示される
- [ ] Python ファイルで `gd` が定義ジャンプする
- [ ] YAML/TypeScript ファイルで `gd` が telescope grep にフォールバックする
- [ ] `nrs` で ty・oxlint が NixOS にインストールされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)