### PR TITLE
feat: add workmux, fix font variant, add nvim diagnostic keymap

### DIFF
--- a/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy.ps1.tmpl
@@ -1,6 +1,6 @@
 {{ if eq .chezmoi.os "windows" -}}
 # Deploy editor configurations for Windows
-# hash: {{ include "editors/vscode/settings.json" | sha256sum }}{{ include "editors/vscode/keybindings.json" | sha256sum }}{{ include "editors/cursor/settings.json" | sha256sum }}{{ include "editors/cursor/keybindings.json" | sha256sum }}{{ include "editors/zed/settings.json" | sha256sum }}{{ include "editors/zed/keymap.json" | sha256sum }}{{ include "editors/nvim/init.lua" | sha256sum }}{{ include "editors/nvim/lua/config/options.lua" | sha256sum }}{{ include "editors/nvim/lua/config/keymaps.lua" | sha256sum }}{{ include "editors/nvim/lua/config/osc7.lua" | sha256sum }}{{ include "editors/nvim/lua/plugins/init.lua" | sha256sum }}
+# hash: {{ include "editors/vscode/settings.json" | sha256sum }}{{ include "editors/vscode/keybindings.json" | sha256sum }}{{ include "editors/cursor/settings.json" | sha256sum }}{{ include "editors/cursor/keybindings.json" | sha256sum }}{{ include "editors/zed/settings.json" | sha256sum }}{{ include "editors/zed/keymap.json" | sha256sum }}
 
 $ErrorActionPreference = "Stop"
 
@@ -44,57 +44,6 @@ Deploy-File "$ChezmoiSource\editors\cursor\keybindings.json" "$CursorConfig\keyb
 $ZedConfig = "$env:APPDATA\Zed"
 Deploy-File "$ChezmoiSource\editors\zed\settings.json" "$ZedConfig\settings.json"
 Deploy-File "$ChezmoiSource\editors\zed\keymap.json" "$ZedConfig\keymap.json"
-
-# Neovim
-$NvimConfig = "$env:LOCALAPPDATA\nvim"
-$NvimSource = "$ChezmoiSource\editors\nvim"
-if (Test-Path -LiteralPath $NvimSource) {
-  Write-Host "Deploying Neovim configuration..."
-  if (-not (Test-Path -LiteralPath $NvimConfig)) {
-    New-Item -ItemType Directory -Path $NvimConfig -Force | Out-Null
-  }
-  Copy-Item -Path "$NvimSource\*" -Destination $NvimConfig -Recurse -Force
-  Write-Host "Deployed: $NvimConfig"
-
-  # Headless :Lazy sync so first nvim launch does not need manual :Lazy sync.
-  # Best-effort with 90s cap; cannot block chezmoi apply. Skipped silently if
-  # nvim or a C compiler is missing — both must be present for
-  # nvim-treesitter's parser build (:TSUpdate) to succeed.
-  $nvim = Get-Command nvim -ErrorAction SilentlyContinue
-  $compiler = @('zig', 'cl', 'gcc', 'clang') |
-    Where-Object { Get-Command $_ -ErrorAction SilentlyContinue } |
-    Select-Object -First 1
-  if ($nvim -and $compiler) {
-    Write-Host "Pre-warming lazy.nvim plugins (best effort, 90s cap)..."
-    $lazyLog = Join-Path $env:LOCALAPPDATA 'nvim-bootstrap.log'
-    # Start-Process -PassThru -NoNewWindow with redirected I/O has a known
-    # .NET issue where the returned Process object's ExitCode is null even
-    # after the process has exited. Use Start-Job so a separate PowerShell
-    # process owns nvim and reports $LASTEXITCODE via the pipeline.
-    $job = Start-Job -ScriptBlock {
-      param($NvimPath, $LogPath)
-      & $NvimPath --headless "+Lazy! sync" +qa *> $LogPath
-      return $LASTEXITCODE
-    } -ArgumentList $nvim.Source, $lazyLog
-    if (Wait-Job $job -Timeout 90) {
-      $exitCode = Receive-Job $job
-      Remove-Job $job
-      if ($exitCode -ne 0) {
-        Write-Host "lazy.nvim pre-warm exited $exitCode; see $lazyLog"
-      } else {
-        Write-Host "lazy.nvim pre-warm complete."
-      }
-    } else {
-      Stop-Job $job
-      Remove-Job $job
-      Write-Host "lazy.nvim pre-warm timed out; see $lazyLog"
-    }
-  } elseif (-not $nvim) {
-    Write-Host "nvim not on PATH; skipping :Lazy sync (run winget install Neovim.Neovim)."
-  } else {
-    Write-Host "No C compiler on PATH (zig/cl/gcc/clang); skipping :Lazy sync (run winget install zig.zig)."
-  }
-}
 
 Write-Host "Editor configurations deployed."
 {{ end -}}

--- a/chezmoi/.chezmoiscripts/setup/fonts/run_onchange_setup.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/setup/fonts/run_onchange_setup.ps1.tmpl
@@ -1,6 +1,6 @@
 {{ if eq .chezmoi.os "windows" -}}
-# Install MoralerspaceHWJPDOC font for Windows
-# hash: MoralerspaceHWJPDOC v2.0.0
+# Install MoralerspaceNeonHWJPDOC font for Windows
+# hash: MoralerspaceNeonHWJPDOC v2.0.0
 
 $ErrorActionPreference = "Stop"
 
@@ -17,7 +17,7 @@ public class FontHelper {
 "@
 
 $FontVersion  = "v2.0.0"
-$FontName     = "MoralerspaceHWJPDOC"
+$FontName     = "MoralerspaceNeonHWJPDOC"
 $DownloadUrl  = "https://github.com/yuru7/moralerspace/releases/download/$FontVersion/${FontName}_${FontVersion}.zip"
 $TempDir      = Join-Path $env:TEMP "chezmoi-fonts\$FontName"
 $FontsDir     = Join-Path $env:LOCALAPPDATA "Microsoft\Windows\Fonts"
@@ -26,7 +26,7 @@ $RegistryPath = "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts"
 function Test-FontInstalled {
   $key = Get-ItemProperty -Path $RegistryPath -ErrorAction SilentlyContinue
   if ($null -eq $key) { return $false }
-  return ($key.PSObject.Properties.Name | Where-Object { $_ -like "*HWJPDOC*" }).Count -gt 0
+  return ($key.PSObject.Properties.Name | Where-Object { $_ -like "*NeonHWJPDOC*" }).Count -gt 0
 }
 
 if (Test-FontInstalled) {

--- a/chezmoi/dot_config/nvim/lua/config/keymaps.lua
+++ b/chezmoi/dot_config/nvim/lua/config/keymaps.lua
@@ -40,6 +40,9 @@ map("n", "<C-s>", "<cmd>w<cr>", { desc = "Save file" })
 map("n", "<leader>q", "<cmd>q<cr>", { desc = "Quit" })
 map("n", "<leader>Q", "<cmd>qa!<cr>", { desc = "Quit all" })
 
+-- Diagnostics
+map("n", "<leader>e", vim.diagnostic.open_float, { desc = "Show diagnostic" })
+
 -- File explorer
 map("n", "-", "<cmd>Oil<cr>", { desc = "Open parent directory" })
 

--- a/chezmoi/dot_config/workmux/config.yaml
+++ b/chezmoi/dot_config/workmux/config.yaml
@@ -1,0 +1,14 @@
+nerdfont: true
+merge_strategy: rebase
+
+agent: cc
+
+agents:
+  cc: "claude"
+  cx: "codex --auto-approve"
+  oc: "opencode"
+
+panes:
+  - command: <agent>
+    focus: true
+  - split: horizontal

--- a/flake.lock
+++ b/flake.lock
@@ -171,6 +171,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1768305791,
+        "narHash": "sha256-AIdl6WAn9aymeaH/NvBj0H9qM+XuAuYbGMZaP0zcXAQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1412caf7bf9e660f2f962917c14b1ea1c3bc695e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
@@ -179,7 +195,8 @@
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs_3",
         "systems": "systems_2",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix",
+        "workmux": "workmux"
       }
     },
     "systems": {
@@ -229,6 +246,24 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "workmux": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_4"
+      },
+      "locked": {
+        "lastModified": 1779222788,
+        "narHash": "sha256-jzEU7Ng7eAUVIYQHgWI320/lmgauuxr9JOfLHfYu1K0=",
+        "owner": "raine",
+        "repo": "workmux",
+        "rev": "f234924ce5c179e597827fab5712e48113335426",
+        "type": "github"
+      },
+      "original": {
+        "owner": "raine",
+        "repo": "workmux",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,7 @@
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    workmux.url = "github:raine/workmux";
   };
 
   outputs =

--- a/nix/flakes/home.nix
+++ b/nix/flakes/home.nix
@@ -6,12 +6,16 @@
 #   home-manager switch --flake .#aarch64-linux
 { inputs, ... }:
 let
+  workmuxOverlay = final: prev: {
+    workmux = inputs.workmux.packages.${prev.stdenv.hostPlatform.system}.default;
+  };
   mkHome =
     system:
     inputs.home-manager.lib.homeManagerConfiguration {
       pkgs = import inputs.nixpkgs {
         inherit system;
         config.allowUnfree = true;
+        overlays = [ workmuxOverlay ];
       };
       modules = [ ../home/common.nix ];
     };

--- a/nix/flakes/hosts.nix
+++ b/nix/flakes/hosts.nix
@@ -5,6 +5,9 @@
 }:
 let
   Hosts = import ./lib/hosts.nix { inherit inputs; };
+  workmuxOverlay = final: prev: {
+    workmux = inputs.workmux.packages.${prev.stdenv.hostPlatform.system}.default;
+  };
 in
 {
   flake = {
@@ -25,6 +28,7 @@ in
             inherit system siteLib;
             hostPath = ../hosts/wsl;
             homeModulePath = ../home/wsl/users.nix;
+            overlays = [ workmuxOverlay ];
             extraModules = [
               inputs.nixos-wsl.nixosModules.wsl
             ];
@@ -47,6 +51,7 @@ in
             inherit system siteLib;
             hostPath = ../hosts/linux;
             homeModulePath = ../home/linux/users.nix;
+            overlays = [ workmuxOverlay ];
           }
         );
     };

--- a/nix/flakes/packages.nix
+++ b/nix/flakes/packages.nix
@@ -8,13 +8,24 @@
 { ... }:
 {
   perSystem =
-    { pkgs, lib, ... }:
+    {
+      pkgs,
+      lib,
+      inputs',
+      ...
+    }:
     let
-      unfreePkgs = import pkgs.path {
-        system = pkgs.stdenv.hostPlatform.system;
-        config.allowUnfree = true;
+      workmuxOverlay = _: _: { workmux = inputs'.workmux.packages.default; };
+      unfreePkgs =
+        (import pkgs.path {
+          system = pkgs.stdenv.hostPlatform.system;
+          config.allowUnfree = true;
+        }).extend
+          workmuxOverlay;
+      sets = import ../packages/sets.nix {
+        pkgs = pkgs.extend workmuxOverlay;
+        inherit lib;
       };
-      sets = import ../packages/sets.nix { inherit pkgs lib; };
       unfreeSets = import ../packages/sets.nix {
         pkgs = unfreePkgs;
         inherit lib;

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -183,6 +183,11 @@ let
       winget = null;
       category = "llm";
     };
+    workmux = {
+      pkg = pkgs.workmux;
+      winget = null;
+      category = "llm";
+    };
 
     # ── communication ─────────────────────────────────────
     slack = {


### PR DESCRIPTION
## Summary

- Add [workmux](https://github.com/raine/workmux) as a flake input with overlay applied to WSL and Linux hosts
- Fix font installer to use `MoralerspaceNeonHWJPDOC` (was `MoralerspaceHWJPDOC`, didn't match terminal config referencing the Neon variant)
- Remove nvim deployment logic from the editors deploy script — nvim config is now managed directly via `chezmoi/dot_config/nvim`
- Add `<leader>e` keymap for `vim.diagnostic.open_float` in nvim

## Test plan

- [ ] `chezmoi apply` on Windows installs `MoralerspaceNeonHWJPDOC` font
- [ ] `nrs` on WSL/NixOS picks up workmux package
- [ ] `<leader>e` in nvim opens diagnostic float

🤖 Generated with [Claude Code](https://claude.com/claude-code)