### PR TITLE
feat: unify terminal keybindings under Ctrl+Alt prefix

### DIFF
--- a/chezmoi/terminals/warp/keybindings.yaml
+++ b/chezmoi/terminals/warp/keybindings.yaml
@@ -1,28 +1,28 @@
 # Warp keybindings — managed via chezmoi
 # Format: flat YAML map of action_name to key-binding (no root key)
 # Reference: https://github.com/warpdotdev/keysets/blob/main/FORMAT.md
-# Aligned with WezTerm and Windows Terminal conventions.
+# All terminal multiplexer operations use Ctrl+Alt prefix.
 #
 # Not configurable here (no action name in Warp):
 #   close pane (Ctrl+Alt+X), toggle zoom (Ctrl+Alt+W)
 
-# Pane split — matches WezTerm (Ctrl+Alt+H/V) and Windows Terminal
-# Warp uses add_right (split right) / add_down (split down)
-pane_group:add_right: ctrl-alt-h
-pane_group:add_down: ctrl-alt-v
-
-# Pane navigation — matches WezTerm/WT vim-style (Ctrl+Shift+H/J/K/L)
-pane_group:navigate_left: ctrl-shift-H
-pane_group:navigate_down: ctrl-shift-J
-pane_group:navigate_up: ctrl-shift-K
-pane_group:navigate_right: ctrl-shift-L
-
-# Tab navigation — matches Windows Terminal (Ctrl+Tab / Ctrl+Shift+Tab)
+# Tab
+workspace:open_tab: ctrl-alt-t
 workspace:activate_next_tab: ctrl-tab
 workspace:activate_prev_tab: ctrl-shift-tab
 
-# AI natural language search — matches WezTerm/nvim leader (Ctrl+Space / Space)
+# Pane split — | (vertical line) = split right, - (horizontal line) = split down
+pane_group:add_right: ctrl-alt-|
+pane_group:add_down: ctrl-alt--
+
+# Pane navigation
+pane_group:navigate_left: ctrl-alt-h
+pane_group:navigate_down: ctrl-alt-j
+pane_group:navigate_up: ctrl-alt-k
+pane_group:navigate_right: ctrl-alt-l
+
+# AI natural language search
 input:toggle_natural_language_command_search: ctrl-space
 
-# Workflows panel (Ctrl+Alt+Q) — zoxide/fzf workflows are registered here
+# Workflows panel
 input:toggle_workflows: ctrl-alt-q

--- a/chezmoi/terminals/warp/keybindings.yaml
+++ b/chezmoi/terminals/warp/keybindings.yaml
@@ -7,7 +7,7 @@
 #   close pane (Ctrl+Alt+X), toggle zoom (Ctrl+Alt+W)
 
 # Tab
-workspace:open_tab: ctrl-alt-t
+workspace:open_new_tab: ctrl-alt-t
 workspace:activate_next_tab: ctrl-tab
 workspace:activate_prev_tab: ctrl-shift-tab
 

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -116,16 +116,16 @@ config.keys = {
     { key = "r", mods = "ALT", action = act.SendString("\x1br") },
 
     -- Pane split/close/zoom (Ctrl+Alt)
-    { key = "h", mods = "CTRL|ALT", action = act.SplitHorizontal({ domain = "CurrentPaneDomain" }) },
-    { key = "v", mods = "CTRL|ALT", action = act.SplitVertical({ domain = "CurrentPaneDomain" }) },
+    { key = "|", mods = "CTRL|ALT", action = act.SplitHorizontal({ domain = "CurrentPaneDomain" }) },
+    { key = "-", mods = "CTRL|ALT", action = act.SplitVertical({ domain = "CurrentPaneDomain" }) },
     { key = "x", mods = "CTRL|ALT", action = act.CloseCurrentPane({ confirm = true }) },
     { key = "w", mods = "CTRL|ALT", action = act.TogglePaneZoomState },
 
-    -- Pane navigation (Ctrl+Shift + H/J/K/L)
-    { key = "h", mods = "CTRL|SHIFT", action = act.ActivatePaneDirection("Left") },
-    { key = "j", mods = "CTRL|SHIFT", action = act.ActivatePaneDirection("Down") },
-    { key = "k", mods = "CTRL|SHIFT", action = act.ActivatePaneDirection("Up") },
-    { key = "l", mods = "CTRL|SHIFT", action = act.ActivatePaneDirection("Right") },
+    -- Pane navigation (Ctrl+Alt + H/J/K/L)
+    { key = "h", mods = "CTRL|ALT", action = act.ActivatePaneDirection("Left") },
+    { key = "j", mods = "CTRL|ALT", action = act.ActivatePaneDirection("Down") },
+    { key = "k", mods = "CTRL|ALT", action = act.ActivatePaneDirection("Up") },
+    { key = "l", mods = "CTRL|ALT", action = act.ActivatePaneDirection("Right") },
 
     -- Pane resize (Ctrl+Alt + Arrow)
     { key = "LeftArrow", mods = "CTRL|ALT", action = act.AdjustPaneSize({ "Left", 5 }) },
@@ -133,7 +133,8 @@ config.keys = {
     { key = "UpArrow", mods = "CTRL|ALT", action = act.AdjustPaneSize({ "Up", 5 }) },
     { key = "RightArrow", mods = "CTRL|ALT", action = act.AdjustPaneSize({ "Right", 5 }) },
 
-    -- Tab management (Leader)
+    -- Tab management (Ctrl+Alt+T, also Leader)
+    { key = "t", mods = "CTRL|ALT", action = act.SpawnTab("CurrentPaneDomain") },
     { key = "t", mods = "LEADER", action = act.SpawnTab("CurrentPaneDomain") },
     { key = "x", mods = "LEADER", action = act.CloseCurrentTab({ confirm = true }) },
     { key = "l", mods = "LEADER", action = act.ActivateTabRelative(1) },

--- a/chezmoi/terminals/windows-terminal/settings.json
+++ b/chezmoi/terminals/windows-terminal/settings.json
@@ -82,6 +82,26 @@
       "id": "User.moveFocus.down"
     },
     {
+      "command": "newTab",
+      "id": "User.newTab"
+    },
+    {
+      "command": { "action": "resizePane", "direction": "left" },
+      "id": "User.resizePane.left"
+    },
+    {
+      "command": { "action": "resizePane", "direction": "right" },
+      "id": "User.resizePane.right"
+    },
+    {
+      "command": { "action": "resizePane", "direction": "up" },
+      "id": "User.resizePane.up"
+    },
+    {
+      "command": { "action": "resizePane", "direction": "down" },
+      "id": "User.resizePane.down"
+    },
+    {
       "command": "unbound",
       "keys": "alt+c"
     },
@@ -112,11 +132,11 @@
     },
     {
       "id": "User.splitPane.horizontal",
-      "keys": "ctrl+alt+h"
+      "keys": "ctrl+shift+alt+\\"
     },
     {
       "id": "User.splitPane.vertical",
-      "keys": "ctrl+alt+v"
+      "keys": "ctrl+alt+-"
     },
     {
       "id": "User.closePane",
@@ -128,19 +148,19 @@
     },
     {
       "id": "User.moveFocus.left",
-      "keys": "ctrl+shift+h"
+      "keys": "ctrl+alt+h"
     },
     {
       "id": "User.moveFocus.right",
-      "keys": "ctrl+shift+l"
+      "keys": "ctrl+alt+l"
     },
     {
       "id": "User.moveFocus.up",
-      "keys": "ctrl+shift+k"
+      "keys": "ctrl+alt+k"
     },
     {
       "id": "User.moveFocus.down",
-      "keys": "ctrl+shift+j"
+      "keys": "ctrl+alt+j"
     },
     {
       "id": "User.nextTab",
@@ -153,6 +173,26 @@
     {
       "id": "User.toggleFullscreen",
       "keys": "f11"
+    },
+    {
+      "id": "User.newTab",
+      "keys": "ctrl+alt+t"
+    },
+    {
+      "id": "User.resizePane.left",
+      "keys": "ctrl+alt+left"
+    },
+    {
+      "id": "User.resizePane.right",
+      "keys": "ctrl+alt+right"
+    },
+    {
+      "id": "User.resizePane.up",
+      "keys": "ctrl+alt+up"
+    },
+    {
+      "id": "User.resizePane.down",
+      "keys": "ctrl+alt+down"
     }
   ],
   "newTabMenu": [


### PR DESCRIPTION
## Summary

- `Ctrl+Alt` プレフィックスに全操作を統一（Warp / WezTerm / Windows Terminal）
- `Ctrl+Alt+T` = new tab（新規追加）
- `Ctrl+Alt+|` = split right（旧 Ctrl+Alt+H）、`Ctrl+Alt+-` = split down（旧 Ctrl+Alt+V）
- `Ctrl+Alt+H/J/K/L` = pane 移動（旧 Ctrl+Shift+H/J/K/L）
- `Ctrl+Alt+↑↓←→` = pane resize（Windows Terminal に追加、WezTerm は既存）

## Test plan

- [ ] Warp: 各キーで pane split / navigation / new tab が動作すること
- [ ] WezTerm: `Ctrl+Alt+|` / `-` で split、`H/J/K/L` で pane 移動、`T` で new tab
- [ ] Windows Terminal: `Ctrl+Shift+Alt+\` で split right、`Ctrl+Alt+-` で split down
- [ ] Windows Terminal: `Ctrl+Alt+H/J/K/L` で pane 移動
- [ ] Windows Terminal: `Ctrl+Alt+T` で new tab、`Ctrl+Alt+Arrow` で resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)