### PR TITLE
fix: use ctrl+alt+| directly for Windows Terminal split right binding

### DIFF
--- a/chezmoi/terminals/windows-terminal/settings.json
+++ b/chezmoi/terminals/windows-terminal/settings.json
@@ -132,7 +132,7 @@
     },
     {
       "id": "User.splitPane.horizontal",
-      "keys": "ctrl+shift+alt+\\"
+      "keys": "ctrl+alt+|"
     },
     {
       "id": "User.splitPane.vertical",


### PR DESCRIPTION
## Summary

- Windows Terminal の split right バインドを `ctrl+shift+alt+\` から `ctrl+alt+|` に変更
- `\`（バックスラッシュキー名）が WT に正しく認識されなかったための修正
- `ctrl+alt+|` はキャラクタを直接指定する形式で WT がより確実に解釈できる

## Test plan

- [ ] Windows Terminal で `Ctrl+Alt+|` を押すと pane が右に分割されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)