### PR TITLE
fix: change split-right key from | to \ for JIS keyboard compatibility

### DIFF
--- a/chezmoi/terminals/warp/keybindings.yaml
+++ b/chezmoi/terminals/warp/keybindings.yaml
@@ -12,7 +12,7 @@ workspace:activate_next_tab: ctrl-tab
 workspace:activate_prev_tab: ctrl-shift-tab
 
 # Pane split — | (vertical line) = split right, - (horizontal line) = split down
-pane_group:add_right: ctrl-alt-|
+pane_group:add_right: ctrl-alt-\
 pane_group:add_down: ctrl-alt--
 
 # Pane navigation

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -116,7 +116,7 @@ config.keys = {
     { key = "r", mods = "ALT", action = act.SendString("\x1br") },
 
     -- Pane split/close/zoom (Ctrl+Alt)
-    { key = "|", mods = "CTRL|ALT", action = act.SplitHorizontal({ domain = "CurrentPaneDomain" }) },
+    { key = "\\", mods = "CTRL|ALT", action = act.SplitHorizontal({ domain = "CurrentPaneDomain" }) },
     { key = "-", mods = "CTRL|ALT", action = act.SplitVertical({ domain = "CurrentPaneDomain" }) },
     { key = "x", mods = "CTRL|ALT", action = act.CloseCurrentPane({ confirm = true }) },
     { key = "w", mods = "CTRL|ALT", action = act.TogglePaneZoomState },

--- a/chezmoi/terminals/windows-terminal/settings.json
+++ b/chezmoi/terminals/windows-terminal/settings.json
@@ -132,7 +132,7 @@
     },
     {
       "id": "User.splitPane.horizontal",
-      "keys": "ctrl+alt+|"
+      "keys": "ctrl+alt+\\"
     },
     {
       "id": "User.splitPane.vertical",


### PR DESCRIPTION
## Summary

- split right のキーを `|`（Shift+¥）から `\`（バックスラッシュ）に変更
- 日本語 JIS キーボードでは `|` の scan code が Windows Terminal のキーマッチングと合わず `^\` がシェルに素通りしていた
- `\` は Shift 不要な 3キーコンボで確実に動作する

## 変更ファイル

- `warp/keybindings.yaml`: `ctrl-alt-|` → `ctrl-alt-\`
- `wezterm/wezterm.lua`: `key = "|"` → `key = "\\"`
- `windows-terminal/settings.json`: `ctrl+alt+|` → `ctrl+alt+\`

## Test plan

- [ ] Windows Terminal: `Ctrl+Alt+\` で pane が右に分割されること
- [ ] Warp: `Ctrl+Alt+\` で pane が右に分割されること
- [ ] WezTerm: `Ctrl+Alt+\` で pane が右に分割されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)