### PR TITLE
fix: skip work 1Password account when not registered on this PC

### DIFF
--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.ps1.tmpl
@@ -3,9 +3,14 @@
 # hash: {{ include "ssh/config.tmpl" | sha256sum }}
 {{/* Accept either op or op.exe (symmetric with the Unix variant). */}}
 {{- $hasOp := or (lookPath "op") (lookPath "op.exe") }}
+{{- $hasWorkAccount := false }}
 {{- if $hasOp }}
+{{- $accounts := output $hasOp "account" "list" }}
+{{- $hasWorkAccount = contains .op_account_work $accounts }}
 # personal-pubkey-hash: {{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" .op_account_personal | sha256sum }}
+{{- if $hasWorkAccount }}
 # work-pubkey-hash:     {{ onepasswordRead "op://Employee/GitHub Work/public key" .op_account_work | sha256sum }}
+{{- end }}
 {{- end }}
 
 $ErrorActionPreference = "Stop"
@@ -39,10 +44,12 @@ Deploy-Content $sshConfig "$HomeDir\.ssh\config"
 $personalPubkey = '{{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" .op_account_personal }}'
 Deploy-Content $personalPubkey "$HomeDir\.ssh\signing_key.pub"
 
+{{- if $hasWorkAccount }}
 # Work SSH public key (from kohei-miki-im8's Employee vault on the work
 # 1Password account; passed as the 2nd onepasswordRead arg).
 $workPubkey = '{{ onepasswordRead "op://Employee/GitHub Work/public key" .op_account_work }}'
 Deploy-Content $workPubkey "$HomeDir\.ssh\github_work.pub"
+{{- end }}
 {{- else }}
 Write-Host "WARNING: op/op.exe CLI not available, skipping public key deployment"
 {{- end }}

--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.sh.tmpl
@@ -5,9 +5,14 @@
 {{/* Under WSL the chezmoi config routes [onepassword].command to op.exe, so
      accept either binary as evidence that 1Password CLI is reachable. */}}
 {{- $hasOp := or (lookPath "op") (lookPath "op.exe") }}
+{{- $hasWorkAccount := false }}
 {{- if $hasOp }}
+{{- $accounts := output $hasOp "account" "list" }}
+{{- $hasWorkAccount = contains .op_account_work $accounts }}
 # personal-pubkey-hash: {{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" .op_account_personal | sha256sum }}
+{{- if $hasWorkAccount }}
 # work-pubkey-hash:     {{ onepasswordRead "op://Employee/GitHub Work/public key" .op_account_work | sha256sum }}
+{{- end }}
 {{- end }}
 
 set -euo pipefail
@@ -36,11 +41,13 @@ PERSONAL_PUBKEY='{{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/pub
 deploy_content "$PERSONAL_PUBKEY" "$HOME_DIR/.ssh/signing_key.pub"
 chmod 644 "$HOME_DIR/.ssh/signing_key.pub"
 
+{{- if $hasWorkAccount }}
 # Work SSH public key (from kohei-miki-im8's Employee vault on the work
 # 1Password account; passed as the 2nd onepasswordRead arg).
 WORK_PUBKEY='{{ onepasswordRead "op://Employee/GitHub Work/public key" .op_account_work }}'
 deploy_content "$WORK_PUBKEY" "$HOME_DIR/.ssh/github_work.pub"
 chmod 644 "$HOME_DIR/.ssh/github_work.pub"
+{{- end }}
 {{- else }}
 echo "WARNING: op/op.exe CLI not available, skipping public key deployment"
 {{- end }}


### PR DESCRIPTION
## Summary

- `run_onchange_deploy.ps1.tmpl` / `.sh.tmpl` で会社用 1Password アカウントが未登録の PC でも `chezmoi apply` がエラーにならないよう修正
- `op account list` の出力に会社アカウント UUID が含まれる場合のみ `onepasswordRead "op://Employee/..."` を呼ぶ `$hasWorkAccount` フラグを追加
- ハッシュコメント（change detection 用）と実際の鍵デプロイの両方を条件分岐で囲む

## Test plan

- [ ] 会社アカウントあり → `github_work.pub` がデプロイされること
- [ ] 会社アカウントなし → エラーなしで個人鍵のみデプロイされること
- [ ] CI（Actions）がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)