### PR TITLE
feat: add workmux direnv, yolo mode, and zsh completion

### DIFF
--- a/chezmoi/dot_config/workmux/config.yaml
+++ b/chezmoi/dot_config/workmux/config.yaml
@@ -4,9 +4,16 @@ merge_strategy: rebase
 agent: cc
 
 agents:
-  cc: "claude"
+  cc: "claude --dangerously-skip-permissions"
   cx: "codex --auto-approve"
   oc: "opencode"
+
+files:
+  symlink:
+    - .envrc
+
+post_create:
+  - direnv allow
 
 panes:
   - command: <agent>

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -58,6 +58,11 @@ in
         eval "$(task --completion zsh)"
       fi
 
+      # workmux completion
+      if command -v workmux >/dev/null 2>&1; then
+        eval "$(workmux completions zsh)"
+      fi
+
       # Emit OSC 7 so terminals can open split/tab in current directory
       autoload -Uz add-zsh-hook
       __emit_osc7_cwd() {


### PR DESCRIPTION
## Summary

- `cc` agent をデフォルトで yolo mode に（`--dangerously-skip-permissions`）
- direnv 連携: `.envrc` を worktree 間で symlink 共有、`post_create` で `direnv allow`
- zsh shell completion を `nix/home/common.nix` の `initContent` に追加

## 変更ファイル

- `chezmoi/dot_config/workmux/config.yaml`: yolo mode / direnv symlink / post_create
- `nix/home/common.nix`: `eval "$(workmux completions zsh)"`

## Test plan

- [ ] `workmux add` でworktreeを作成したとき `.envrc` がsymlinkされ `direnv allow` が実行されること
- [ ] `workmux add` でclaudeがpermission promptなしで起動すること
- [ ] zshで `workmux <Tab>` が補完されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)