### PR TITLE
fix(NixRebuild): capture stderr and surface error detail in logs

### DIFF
--- a/scripts/powershell/handlers/Handler.NixRebuild.ps1
+++ b/scripts/powershell/handlers/Handler.NixRebuild.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     NixOS-WSL の nixos-rebuild switch を実行するハンドラー
 
@@ -238,18 +238,26 @@ class NixRebuildHandler : SetupHandlerBase {
                 "bash", "-lc", "grep -qs 'directory = \*' /root/.gitconfig 2>/dev/null || printf '[safe]\n\tdirectory = *\n' >> /root/.gitconfig"
             ) | Out-Null
 
-            # root で nixos-rebuild switch を実行（nixos ユーザーの dotfiles を使用）
-            $output = Invoke-Wsl -Arguments @("-d", $distroName, "-u", "root", "--", "bash", "-lc", "cd /home/nixos/.dotfiles && nixos-rebuild switch --flake .#nixos")
+            # root で nixos-rebuild switch を実行。2>&1 で stderr も捕捉しエラー詳細をログに残す。
+            $output = Invoke-Wsl -Arguments @("-d", $distroName, "-u", "root", "--", "bash", "-lc", "cd /home/nixos/.dotfiles && nixos-rebuild switch --flake .#nixos 2>&1")
+            $nixosExitCode = $LASTEXITCODE
 
-            # 出力をログに表示
+            # error: で始まる行は LogError（赤）、それ以外は Gray で表示
+            $errorLines = [System.Collections.Generic.List[string]]::new()
             $output | ForEach-Object {
                 if ($_ -notmatch '^\s*$') {
-                    $this.Log("  $_", "Gray")
+                    if ($_ -match '^error:') {
+                        $this.LogError("  $_")
+                        $errorLines.Add([string]$_)
+                    } else {
+                        $this.Log("  $_", "Gray")
+                    }
                 }
             }
 
-            if ($LASTEXITCODE -ne 0) {
-                throw "nixos-rebuild switch が失敗しました (exit code: $LASTEXITCODE)"
+            if ($nixosExitCode -ne 0) {
+                $errorDetail = if ($errorLines.Count -gt 0) { ": $($errorLines[0])" } else { "" }
+                throw "nixos-rebuild switch が失敗しました (exit code: $nixosExitCode)$errorDetail"
             }
 
             $this.Log("nixos-rebuild switch 完了", "Green")

--- a/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Module Pester
+﻿#Requires -Module Pester
 
 <#
 .SYNOPSIS
@@ -114,6 +114,9 @@ if ($argStr -match "nixos-rebuild") { $global:LASTEXITCODE = 0; return @("buildi
 
             $result.Success | Should -Be $true
             $result.Message | Should -Be "NixOS 設定を適用しました"
+            Should -Invoke Write-Host -ParameterFilter {
+                $ForegroundColor -eq 'Gray' -and ([string]$Object) -match 'building NixOS'
+            } -Times 1
         }
 
         It 'should fail when nixos-rebuild switch fails' {
@@ -131,6 +134,10 @@ if ($argStr -match "nixos-rebuild") { $global:LASTEXITCODE = 1; return @("error:
 
             $result.Success | Should -Be $false
             $result.Message | Should -Match "nixos-rebuild switch が失敗しました"
+            $result.Message | Should -Match "error: build failed"
+            Should -Invoke Write-Host -ParameterFilter {
+                $ForegroundColor -eq 'Red' -and ([string]$Object) -match 'error: build failed'
+            } -Times 1
         }
 
         It 'should install pnpm global packages after nixos-rebuild' {
@@ -206,7 +213,7 @@ if ($argStr -match "nixos-rebuild") { $global:LASTEXITCODE = 0; return "" }
                 if ($argStr -match "command -v pnpm") { $global:LASTEXITCODE = 0; return "/nix/store/bin/pnpm" }
                 if ($argStr -match "pnpm ls -g") {
                     $global:LASTEXITCODE = 0
-                    return @("@tobilu/qmd@1.0.0", "@prisma/language-server@5.22.0", "@google/gemini-cli@0.32.1")
+                    return @("@tobilu/qmd@1.0.0", "@prisma/language-server@5.22.0", "@agentclientprotocol/claude-agent-acp@1.0.0", "@google/gemini-cli@0.32.1")
                 }
                 if ($argStr -match "pnpm add") {
                     $script:pnpmAddCalled = $true


### PR DESCRIPTION
## Summary

- `nixos-rebuild switch` の stderr を `2>&1` で捕捉し、PowerShell に素通りしていたエラー本文をログに残すよう修正
- `error:` で始まる行を `LogError`（赤）で表示し、それ以外はグレーで表示
- 失敗メッセージに最初のエラー行を含めることで Setup Summary だけで原因が分かるように改善
- `should skip already installed pnpm packages` テストが `windows/pnpm/packages.json` に追加された `@agentclientprotocol/claude-agent-acp` を考慮していなかった問題を修正
- ログ出力の正確性をテストで検証: 成功時にグレー出力、失敗時に赤出力 + メッセージ詳細を `Should -Invoke Write-Host` でアサート

## Test plan

- [ ] `Handler.NixRebuild.Tests.ps1` が 32/32 パスすること
- [ ] CI (PowerShell CI) がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)