### PR TITLE
fix: disable Mason auto-install for LSP servers managed by Nix

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -253,17 +253,9 @@ return {
         lazy = false,
         dependencies = { "williamboman/mason.nvim", "neovim/nvim-lspconfig" },
         opts = {
-            ensure_installed = {
-                "gopls",
-                "rust_analyzer",
-                "yamlls",
-                "taplo",
-                "bashls",
-                "lua_ls",
-                "marksman",
-                "ruff",
-            },
-            automatic_installation = true,
+            -- All LSP servers are managed by Nix; Mason must not attempt re-installation
+            ensure_installed = {},
+            automatic_installation = false,
         },
     },
 


### PR DESCRIPTION
## Summary

- `mason-lspconfig` の `ensure_installed` を空に、`automatic_installation = false` に変更
- gopls / rust_analyzer / yamlls / taplo / bashls / lua_ls / marksman / ruff は全て Nix で管理済みのため Mason による重複インストールが不要
- NixOS では Mason のバイナリダウンロードが動作しないため起動時に `failed to install gopls` エラーが出ていた

## Test plan

- [ ] nvim 起動時に `mason-lspconfig` のエラーが出ないこと
- [ ] gopls / rust_analyzer 等の LSP が正常に動作すること（Nix PATH 経由）

🤖 Generated with [Claude Code](https://claude.com/claude-code)