### PR TITLE
fix: set clipboard=unnamedplus unconditionally in nvim WSL config

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/options.lua
+++ b/chezmoi/dot_config/nvim/lua/config/options.lua
@@ -30,7 +30,8 @@ opt.wrap = false
 opt.splitbelow = true
 opt.splitright = true
 
--- Clipboard: use win32yank in WSL, system clipboard elsewhere
+-- Clipboard: always use unnamedplus; in WSL route it through win32yank.exe
+opt.clipboard = "unnamedplus"
 if vim.fn.has("wsl") == 1 then
     vim.g.clipboard = {
         name = "win32yank",
@@ -38,8 +39,6 @@ if vim.fn.has("wsl") == 1 then
         paste = { ["+"] = "win32yank.exe -o --lf", ["*"] = "win32yank.exe -o --lf" },
         cache_enabled = 0,
     }
-else
-    opt.clipboard = "unnamedplus"
 end
 
 -- Undo persistence


### PR DESCRIPTION
## Summary
- `opt.clipboard = "unnamedplus"` was only set in the non-WSL branch, so normal yanks in WSL didn't sync to the Windows clipboard
- Move it above the `if has("wsl")` block so it applies everywhere; the `vim.g.clipboard` override then routes `+`/`*` register operations through `win32yank.exe`

## Test plan
- [ ] In WSL nvim: `yy` copies current line to Windows clipboard (paste with Ctrl+V in Windows app)
- [ ] In Windows/macOS nvim: `yy` still copies to system clipboard via `unnamedplus`

🤖 Generated with [Claude Code](https://claude.com/claude-code)