### PR TITLE
feat: add telescope-ghq.nvim for ghq repo navigation

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -77,9 +77,17 @@ return {
             { "<leader>ff", "<cmd>Telescope find_files<cr>", desc = "Find files" },
             { "<leader>fg", "<cmd>Telescope live_grep<cr>", desc = "Live grep" },
             { "<leader>fb", "<cmd>Telescope buffers<cr>", desc = "Buffers" },
+            { "<leader>fq", "<cmd>Telescope ghq list<cr>", desc = "ghq repos" },
         },
-        dependencies = { "nvim-lua/plenary.nvim" },
-        opts = {},
+        dependencies = {
+            "nvim-lua/plenary.nvim",
+            "nvim-telescope/telescope-ghq.nvim",
+        },
+        config = function(_, opts)
+            local telescope = require("telescope")
+            telescope.setup(opts)
+            telescope.load_extension("ghq")
+        end,
     },
 
     -- Treesitter


### PR DESCRIPTION
## Summary
- Add `nvim-telescope/telescope-ghq.nvim` as telescope dependency
- `<leader>fq` → `Telescope ghq list` でリポジトリ一覧
- `<CR>`: git_files で開く / `<C-x>` `<C-v>` `<C-t>`: cd

🤖 Generated with [Claude Code](https://claude.com/claude-code)