### PR TITLE
feat: add tm() shell function for ghq + tmux session management

### DIFF
--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -151,6 +151,15 @@ in
           '
       }
 
+      # tm: ghq + fzf でリポジトリ選択 → tmux セッション作成/切替
+      tm() {
+        local repo
+        repo=$(ghq list | fzf) || return
+        local name=''${repo##*/}
+        local path="$(ghq root)/$repo"
+        tmux new-session -A -s "$name" -c "$path"
+      }
+
       # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)
       [[ -f "$HOME/.config/shell/secret.sh" ]] && source "$HOME/.config/shell/secret.sh"
     '';


### PR DESCRIPTION
## Summary
- `tm` コマンド: fzf で ghq リポジトリを選択し、プロジェクト名で tmux セッションを作成/切替
- tmux-project プラグイン不要で同等の体験を実現

## Usage
```zsh
tm  # fzf でリポジトリ選択 → tmux セッションに入る
workmux sidebar  # セッション内で実行可能になる
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)