### PR TITLE
feat: add ghq root config to gitconfig template

### DIFF
--- a/chezmoi/dot_gitconfig.tmpl
+++ b/chezmoi/dot_gitconfig.tmpl
@@ -59,3 +59,11 @@
 [safe]
   directory = D:/ruru/dotfiles
 {{- end }}
+
+[ghq]
+{{- if eq .chezmoi.os "windows" }}
+  root = D:/my_programing
+  root = D:/ruru
+{{- else }}
+  root = ~/ghq
+{{- end }}


### PR DESCRIPTION
## Summary
- `dot_gitconfig.tmpl` に `[ghq]` セクションを追加
- Windows: `D:/my_programing`、`D:/ruru` の2つの root を設定
- Linux/WSL: `~/ghq` を設定

## Test plan
- [ ] `chezmoi apply` 後に `ghq root` が正しいパスを返すこと
- [ ] `tm` コマンドで両方の root のリポジトリが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)