### PR TITLE
fix: tm uses switch-client inside tmux, attach-session outside

### DIFF
--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -153,11 +153,18 @@ in
 
       # tm: ghq + fzf でリポジトリ選択 → tmux セッション作成/切替
       tm() {
-        local repo
+        local repo path name
         repo=$(ghq list | fzf) || return
-        local name=''${repo##*/}
-        local path="$(ghq root)/$repo"
-        tmux new-session -A -s "$name" -c "$path"
+        name=''${repo##*/}
+        path="$(ghq root)/$repo"
+        tmux list-sessions -F "#{session_name}" 2>/dev/null |
+          grep -qE "^''${name}$" ||
+          tmux new-session -d -c "$path" -s "$name"
+        if [[ -n "''${TMUX:-}" ]]; then
+          tmux switch-client -t "$name"
+        else
+          tmux attach-session -t "$name"
+        fi
       }
 
       # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -157,8 +157,7 @@ in
         repo=$(ghq list | fzf) || return
         name=''${repo##*/}
         path="$(ghq root)/$repo"
-        tmux list-sessions -F "#{session_name}" 2>/dev/null |
-          grep -qE "^''${name}$" ||
+        tmux has-session -t "$name" 2>/dev/null ||
           tmux new-session -d -c "$path" -s "$name"
         if [[ -n "''${TMUX:-}" ]]; then
           tmux switch-client -t "$name"


### PR DESCRIPTION
## Summary
- tmux 内から `tm` を実行した場合は `switch-client` でセッション切り替え
- tmux 外から実行した場合は `attach-session` でアタッチ
- izumin5210/dotfiles の実装に合わせた挙動

## Before
```zsh
tmux new-session -A -s "$name" -c "$path"
```
tmux 内から実行すると nested tmux になってしまう問題があった。

## After
```zsh
tmux list-sessions | grep -q "^${name}$" || tmux new-session -d ...
[[ -n "${TMUX:-}" ]] && tmux switch-client -t "$name" || tmux attach-session -t "$name"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)