### PR TITLE
fix: add WSL ghq roots pointing to Windows mnt paths

### DIFF
--- a/chezmoi/dot_gitconfig.tmpl
+++ b/chezmoi/dot_gitconfig.tmpl
@@ -64,6 +64,9 @@
 {{- if eq .chezmoi.os "windows" }}
   root = D:/my_programing
   root = D:/ruru
+{{- else if and (eq .chezmoi.os "linux") (contains "microsoft" (lower .chezmoi.kernel.osrelease)) }}
+  root = /mnt/d/my_programing
+  root = /mnt/d/ruru
 {{- else }}
   root = ~/ghq
 {{- end }}

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -153,11 +153,17 @@ in
 
       # tm: ghq + fzf でリポジトリ選択 → tmux セッション作成/切替
       tm() {
-        local repo
+        local repo path name
         repo=$(ghq list | fzf) || return
-        local name=''${repo##*/}
-        local path="$(ghq root)/$repo"
-        tmux new-session -A -s "$name" -c "$path"
+        name=''${repo##*/}
+        path="$(ghq root)/$repo"
+        tmux has-session -t "$name" 2>/dev/null ||
+          tmux new-session -d -c "$path" -s "$name"
+        if [[ -n "''${TMUX:-}" ]]; then
+          tmux switch-client -t "$name"
+        else
+          tmux attach-session -t "$name"
+        fi
       }
 
       # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)


### PR DESCRIPTION
## Summary
- WSL から `tm` 実行時に ghq list が空になる問題を修正
- `dot_gitconfig.tmpl` の WSL 向け設定に `/mnt/d/my_programing` と `/mnt/d/ruru` を追加
- Windows の `D:\` ドライブを WSL マウントパス経由で参照

## Test plan
- [ ] WSL で `ghq list` がリポジトリを返すこと
- [ ] WSL で `tm` が起動しリポジトリを選択できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)