### PR TITLE
fix: tm falls back to cd when tmux is not available

### DIFF
--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -153,6 +153,10 @@ in
 
       # tm: ghq + fzf でリポジトリ選択 → tmux セッション作成/切替
       tm() {
+        if ! command -v tmux &>/dev/null; then
+          cd "$(ghq list --full-path | fzf)" 2>/dev/null
+          return
+        fi
         local repo path name
         repo=$(ghq list | fzf) || return
         name=''${repo##*/}


### PR DESCRIPTION
tmux がない環境（devcontainer、bare NixOS）で tm を実行すると command not found になる問題を修正。tmux がない場合は ghq list --full-path | fzf で cd にフォールバック。

🤖 Generated with Claude Code