### PR TITLE
fix: use descriptive local variable names in tm() to avoid zsh PATH shadowing

### DIFF
--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -157,16 +157,16 @@ in
           cd "$(ghq list --full-path | fzf)" 2>/dev/null
           return
         fi
-        local repo dir name
-        repo=$(ghq list | fzf) || return
-        name=''${repo##*/}
-        dir="$(ghq root)/$repo"
-        tmux has-session -t "$name" 2>/dev/null ||
-          tmux new-session -d -c "$dir" -s "$name"
+        local repo_slug session_name repo_dir
+        repo_slug=$(ghq list | fzf) || return
+        session_name=''${repo_slug##*/}
+        repo_dir="$(ghq root)/$repo_slug"
+        tmux has-session -t "$session_name" 2>/dev/null ||
+          tmux new-session -d -c "$repo_dir" -s "$session_name"
         if [[ -n "''${TMUX:-}" ]]; then
-          tmux switch-client -t "$name"
+          tmux switch-client -t "$session_name"
         else
-          tmux attach-session -t "$name"
+          tmux attach-session -t "$session_name"
         fi
       }
 

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -157,12 +157,12 @@ in
           cd "$(ghq list --full-path | fzf)" 2>/dev/null
           return
         fi
-        local repo path name
+        local repo dir name
         repo=$(ghq list | fzf) || return
         name=''${repo##*/}
-        path="$(ghq root)/$repo"
+        dir="$(ghq root)/$repo"
         tmux has-session -t "$name" 2>/dev/null ||
-          tmux new-session -d -c "$path" -s "$name"
+          tmux new-session -d -c "$dir" -s "$name"
         if [[ -n "''${TMUX:-}" ]]; then
           tmux switch-client -t "$name"
         else


### PR DESCRIPTION
## Summary

- `local path` in zsh shadows the special `$path` array tied to `$PATH`, emptying PATH inside the function
- Fix: rename all local variables in `tm()` to descriptive names with no collision risk

| 変更前 | 変更後 |
|--------|--------|
| `repo` | `repo_slug` |
| `name` | `session_name` |
| `path` | `repo_dir` |

## Root cause

In zsh, `typeset -U path` (set in `.zshrc`) ties `$path` ↔ `$PATH`. Declaring `local path` in a function creates a local scope that shadows this tie and empties `PATH` for the rest of the call — causing `command not found: ghq/fzf` at the repo selection line even though both tools are on `PATH` at the prompt.

## Best practice applied

Avoid using zsh special array names (`path`, `fpath`, `manpath`, `cdpath`) as local variable names. Use function-scoped descriptive names (`repo_dir`, `session_name`) to eliminate collision risk entirely.

## Test plan

- [ ] Run `nrs` in WSL to apply updated home-manager config
- [ ] Run `exec zsh` to reload the shell
- [ ] Run `tm` — should open fzf with ghq repositories without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)