### PR TITLE
feat(nvim): add better-escape.nvim and disable sidekick tmux integration

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -184,6 +184,20 @@ return {
         opts = {},
     },
 
+    -- Terminal-mode escape: jk → Normal-mode (faster than <C-\><C-n>)
+    {
+        "max397574/better-escape.nvim",
+        event = "InsertEnter",
+        opts = {
+            timeout = 100,
+            default_mappings = false,
+            mappings = {
+                i = { j = { k = "<ESC>" } },
+                t = { j = { k = "<C-\\><C-n>" } },
+            },
+        },
+    },
+
     -- UI utilities (required by sidekick.nvim)
     {
         "folke/snacks.nvim",
@@ -263,7 +277,7 @@ return {
             cli = {
                 mux = {
                     backend = "tmux",
-                    enabled = true,
+                    enabled = false,
                 },
                 tools = {
                     aider = false,


### PR DESCRIPTION
## Summary

- **better-escape.nvim 追加**: Terminal-mode / Insert-mode で `jk` 高速入力 → Normal-mode に戻れるようにする（`<C-\><C-n>` の代替）
- **Sidekick.nvim tmux 無効化**: 自前の worktree + tmux セッション管理と競合するため `mux.enabled = false` に変更

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `lua/plugins/init.lua` | better-escape.nvim 追加、sidekick mux.enabled → false |

## Keymap

| モード | キー | 動作 |
|--------|------|------|
| Insert | `jk` | `<ESC>` |
| Terminal | `jk` | `<C-\><C-n>` (Normal-mode へ) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)