### PR TITLE
feat: bind Shift+Enter to newline in WezTerm and Windows Terminal

### DIFF
--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -109,6 +109,9 @@ config.send_composed_key_when_left_alt_is_pressed = false
 config.send_composed_key_when_right_alt_is_pressed = false
 
 config.keys = {
+    -- Shift+Enter → insert newline (Claude Code, Codex, multi-line prompts)
+    { key = "Return", mods = "SHIFT", action = act.SendString("\n") },
+
     -- Alt+key → send ESC sequence for fzf/zoxide/PSReadLine bindings
     { key = "q", mods = "ALT", action = act.SendString("\x1bq") },
     { key = "d", mods = "ALT", action = act.SendString("\x1bd") },

--- a/chezmoi/terminals/windows-terminal/settings.json
+++ b/chezmoi/terminals/windows-terminal/settings.json
@@ -119,6 +119,10 @@
   "showTabsFullscreen": true,
   "keybindings": [
     {
+      "keys": "shift+enter",
+      "command": { "action": "sendInput", "input": "\n" }
+    },
+    {
       "id": "User.copy",
       "keys": "ctrl+c"
     },


### PR DESCRIPTION
Add Shift+Enter → newline (\n) binding to WezTerm and Windows Terminal so that Claude Code, Codex, and other multi-line prompts can be used consistently with Shift+Enter to insert a newline without submitting.