### PR TITLE
feat: add GITHUB_WORK_TOKEN for multi-PC deployment

### DIFF
--- a/chezmoi/secret/env.sh
+++ b/chezmoi/secret/env.sh
@@ -7,7 +7,7 @@
 #
 # Fallback (standalone WSL / native Linux): op.exe inject runs once per session.
 
-[ -n "$GH_TOKEN" ] && [ -n "$TAVILY_API_KEY" ] && return 0
+[ -n "$GH_TOKEN" ] && [ -n "$TAVILY_API_KEY" ] && [ -n "$GITHUB_WORK_TOKEN" ] && return 0
 
 # Under WSL the Linux `op` CLI cannot bridge to the Windows 1Password app.
 # Use op.exe so secrets resolve without a separate Linux signin.
@@ -21,11 +21,13 @@ command -v "$_op_cmd" >/dev/null 2>&1 || {
   return 0
 }
 
-_op_acct="${OP_ACCOUNT:-EJLA3HRAVZBCXIQ7SRSFGQBTNU}"
+_personal_acct="${OP_ACCOUNT:-EJLA3HRAVZBCXIQ7SRSFGQBTNU}"
+_work_acct="aimatecoltd.1password.com"
+
 _secret_tmpl='GH_TOKEN={{ op://Private/GitHubUsedUserPAT/credential }}
 TAVILY_API_KEY={{ op://Private/TavilyUsedUserPAT/credential }}'
 
-_resolved=$(printf '%s\n' "$_secret_tmpl" | "$_op_cmd" inject --account "$_op_acct" 2>/dev/null) || {
+_resolved=$(printf '%s\n' "$_secret_tmpl" | "$_op_cmd" inject --account "$_personal_acct" 2>/dev/null) || {
   printf '[secret/env.sh] warning: %s inject failed; GH_TOKEN/TAVILY_API_KEY not set\n' "$_op_cmd" >&2
   _resolved=''
 }
@@ -35,4 +37,17 @@ if [ -n "$_resolved" ]; then
   eval "$_resolved"
   set +a
 fi
-unset _secret_tmpl _resolved _op_cmd _op_acct
+
+_work_tmpl='GITHUB_WORK_TOKEN={{ op://devcontainer/GITHUB_PERSONAL_ACCESS_TOKEN_KOHEI-MIKI-IM8/credential }}'
+_work_resolved=$(printf '%s\n' "$_work_tmpl" | "$_op_cmd" inject --account "$_work_acct" 2>/dev/null) || {
+  printf '[secret/env.sh] warning: %s inject failed (work); GITHUB_WORK_TOKEN not set\n' "$_op_cmd" >&2
+  _work_resolved=''
+}
+_work_resolved=$(printf '%s' "$_work_resolved" | tr -d '\r')
+if [ -n "$_work_resolved" ]; then
+  set -a
+  eval "$_work_resolved"
+  set +a
+fi
+
+unset _secret_tmpl _resolved _work_tmpl _work_resolved _op_cmd _personal_acct _work_acct

--- a/chezmoi/secret/secrets.env
+++ b/chezmoi/secret/secrets.env
@@ -1,2 +1,3 @@
 GH_TOKEN=op://Private/GitHubUsedUserPAT/credential
 TAVILY_API_KEY=op://Private/TavilyUsedUserPAT/credential
+GITHUB_WORK_TOKEN=op://devcontainer/GITHUB_PERSONAL_ACCESS_TOKEN_KOHEI-MIKI-IM8/credential


### PR DESCRIPTION
## Summary

- `secrets.env` に `GITHUB_WORK_TOKEN=op://devcontainer/GITHUB_PERSONAL_ACCESS_TOKEN_KOHEI-MIKI-IM8/credential` を追加
- `env.sh` に会社アカウント (`aimatecoltd.1password.com`) からの inject ブロックを追加

会社アカウントが未登録の環境では warning のみ出てスキップされる。

## Test plan

- [ ] 新規セットアップ環境で `chezmoi apply` 後に `GITHUB_WORK_TOKEN` が展開されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)