### PR TITLE
fix(nvim): enable jk to exit terminal mode in sidekick

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/keymaps.lua
+++ b/chezmoi/dot_config/nvim/lua/config/keymaps.lua
@@ -46,6 +46,9 @@ map("n", "<leader>e", vim.diagnostic.open_float, { desc = "Show diagnostic" })
 -- File explorer
 map("n", "-", "<cmd>Oil<cr>", { desc = "Open parent directory" })
 
+-- Terminal mode
+map("t", "jk", "<C-\\><C-n>", { desc = "Exit terminal mode" })
+
 -- Telescope
 map("n", "<leader>ff", "<cmd>Telescope find_files<cr>", { desc = "Find files" })
 map("n", "<leader>fg", "<cmd>Telescope live_grep<cr>", { desc = "Live grep" })

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -187,7 +187,7 @@ return {
     -- Terminal-mode escape: jk → Normal-mode (faster than <C-\><C-n>)
     {
         "max397574/better-escape.nvim",
-        event = "InsertEnter",
+        event = { "InsertEnter", "TermOpen" },
         opts = {
             timeout = 100,
             default_mappings = false,


### PR DESCRIPTION
## Summary

- better-escape.nvim の `event` に `TermOpen` を追加し、ターミナル起動時にロードされるように修正
- `keymaps.lua` に直接 `tnoremap jk <C-\><C-n>` を追加（better-escape のタイムアウト方式はraw TUIでは機能しないため）

## Test plan

- [ ] sidekick で Claude Code を開く
- [ ] `jk` で `-- TERMINAL --` から `NORMAL` モードに戻れることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)