### PR TITLE
chore: update chezmoi task to apply NixOS + Windows with --force

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -121,12 +121,10 @@ tasks:
       - pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/install.ps1
 
   chezmoi:
-    desc: Apply chezmoi dotfiles (WSL + Windows)
+    desc: Apply chezmoi dotfiles (NixOS + Windows)
     cmds:
-      - chezmoi apply --source {{.TASKFILE_DIR}}/chezmoi
-      - |
-        WIN_PATH=$(wslpath -w "{{.TASKFILE_DIR}}/chezmoi")
-        powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "chezmoi apply --source '$WIN_PATH'"
+      - wsl -d NixOS -- chezmoi apply --force
+      - chezmoi apply --force
 
   # ===========================================
   # Docker


### PR DESCRIPTION
## Summary

- `task chezmoi` で NixOS (WSL) と Windows の両方に `chezmoi apply --force` を実行するよう更新
- interactive prompt を避けるため `--force` を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)