### PR TITLE
feat(shell): add dotf function across zsh/bash/PowerShell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@
 ## 実行コマンド
 
 ```bash
+# dotfiles 反映（NixOS + Windows 両方）
+dotf chezmoi        # task chezmoi の短縮形
+
 # WSL/NixOS
 nrs
 sudo nixos-rebuild dry-build --flake ~/.dotfiles --impure
@@ -25,6 +28,7 @@ nix fmt
 
 ```powershell
 # Windows
+dotf chezmoi        # task chezmoi の短縮形
 pwsh -File scripts/powershell/install.ps1
 task test:powershell
 task lint:all

--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -200,6 +200,13 @@ function tm {
     }
 }
 
+# dotf: run task from dotfiles root without changing cwd
+function dotf {
+    $dotfilesDir = Split-Path -Parent (chezmoi source-path)
+    Push-Location $dotfilesDir
+    try { task @args } finally { Pop-Location }
+}
+
 # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)
 $_secretPs1 = Join-Path $HOME ".config\shell\secret.ps1"
 if (Test-Path $_secretPs1) { . $_secretPs1 }

--- a/chezmoi/shells/bashrc
+++ b/chezmoi/shells/bashrc
@@ -174,5 +174,8 @@ dcnvim() {
     '
 }
 
+# dotf: run task from dotfiles root without changing cwd
+dotf() { (cd ~/.dotfiles && task "$@"); }
+
 # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)
 [[ -f "$HOME/.config/shell/secret.sh" ]] && source "$HOME/.config/shell/secret.sh"

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -179,6 +179,9 @@ in
         fi
       }
 
+      # dotf: run task from dotfiles root without changing cwd
+      dotf() { (cd ~/.dotfiles && task "$@") }
+
       # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)
       [[ -f "$HOME/.config/shell/secret.sh" ]] && source "$HOME/.config/shell/secret.sh"
     '';


### PR DESCRIPTION
## Summary

- zsh (nix/home/common.nix)、bash (chezmoi/shells/bashrc)、PowerShell の全シェルに `dotf` 関数を追加
- `dotf chezmoi` で NixOS + Windows 両方に chezmoi apply、`dotf commit -- "msg"` でコミット等が可能
- cwd を変えずに実行（subshell / Push-Location を使用）
- CLAUDE.md / AGENTS.md に `dotf chezmoi` を追記

## Usage

```sh
dotf chezmoi        # dotfiles を両環境に反映
dotf commit -- "msg"  # task commit の短縮形
dotf lint:all       # lint 実行
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)