### PR TITLE
feat: Neovim improvements - VimLeave fix, Shift+Enter, lazygit integration

### DIFF
--- a/chezmoi/dot_claude/keybindings.json
+++ b/chezmoi/dot_claude/keybindings.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-keybindings.json",
+  "$docs": "https://code.claude.com/docs/en/keybindings",
+  "bindings": [
+    {
+      "context": "Chat",
+      "bindings": {
+        "shift+enter": "chat:newline"
+      }
+    }
+  ]
+}

--- a/chezmoi/dot_config/lazygit/config.yml
+++ b/chezmoi/dot_config/lazygit/config.yml
@@ -1,0 +1,11 @@
+os:
+  editPreset: "nvim-remote"
+  edit: >
+    nvr -cc "execute 'wincmd p | drop ' . fnameescape('{{filename}}')
+    | lua _G._SNACKS_LG_CLOSE()"
+  editAtLine: >
+    nvr -cc "execute 'wincmd p | drop ' . fnameescape('{{filename}}')
+    | {{line}} | lua _G._SNACKS_LG_CLOSE()"
+  editAtLineAndWait: >
+    nvr -cc "execute 'wincmd p | drop ' . fnameescape('{{filename}}')
+    | {{line}} | lua _G._SNACKS_LG_CLOSE()" --remote-wait-silent

--- a/chezmoi/dot_config/nvim/lua/config/options.lua
+++ b/chezmoi/dot_config/nvim/lua/config/options.lua
@@ -60,7 +60,7 @@ opt.backup = false
 -- shell is visible immediately after :q (fixes ghost-screen in WezTerm/WT)
 vim.api.nvim_create_autocmd("VimLeave", {
     callback = function()
-        io.write("\027[?1049l")
+        io.write("\027[?1049l\027[H\027[2J")
         io.flush()
     end,
 })

--- a/chezmoi/dot_config/nvim/lua/config/options.lua
+++ b/chezmoi/dot_config/nvim/lua/config/options.lua
@@ -55,3 +55,12 @@ opt.completeopt = "menu,menuone,noselect"
 -- Disable swap/backup
 opt.swapfile = false
 opt.backup = false
+
+-- Restore terminal on exit: explicitly switch off alternate screen so the
+-- shell is visible immediately after :q (fixes ghost-screen in WezTerm/WT)
+vim.api.nvim_create_autocmd("VimLeave", {
+    callback = function()
+        io.write("\027[?1049l")
+        io.flush()
+    end,
+})

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -198,12 +198,32 @@ return {
         },
     },
 
-    -- UI utilities (required by sidekick.nvim)
+    -- UI utilities + lazygit float
     {
         "folke/snacks.nvim",
         lazy = false,
         priority = 900,
-        opts = {},
+        keys = {
+            {
+                "<leader>gg",
+                function()
+                    _G.__snacks_last_lg = Snacks.lazygit.open()
+                    _G._SNACKS_LG_CLOSE = function()
+                        local lg = _G.__snacks_last_lg
+                        if lg and lg.close then
+                            pcall(lg.close, lg)
+                        end
+                        _G.__snacks_last_lg = nil
+                    end
+                end,
+                desc = "Lazygit",
+            },
+            { "<leader>gl", function() Snacks.lazygit.log() end,      desc = "Git log" },
+            { "<leader>gf", function() Snacks.lazygit.log_file() end, desc = "Git log (file)" },
+        },
+        opts = {
+            lazygit = { enabled = true },
+        },
     },
 
     -- AI sidekick: AI CLI terminal (claude/codex/gemini/opencode)

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -279,19 +279,18 @@ return {
                     backend = "tmux",
                     enabled = false,
                 },
-                tools = {
+                tools = vim.tbl_extend("force", {
                     aider = false,
                     amazon_q = false,
-                    claude = {
-                        cmd = { "env", "-u", "NVIM", "claude" },
-                    },
                     copilot = false,
                     crush = false,
                     cursor = false,
                     grok = false,
                     pi = false,
                     qwen = false,
-                },
+                }, vim.fn.has("unix") == 1 and {
+                    claude = { cmd = { "env", "-u", "NVIM", "claude" } },
+                } or {}),
             },
         },
     },

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -167,4 +167,6 @@ config.keys = {
     { key = "9", mods = "LEADER", action = act.ActivateTab(8) },
 }
 
+config.enable_scroll_back_on_alternate_screen = false
+
 return config

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -130,6 +130,11 @@ let
       winget = null;
       category = "dev";
     };
+    lazygit = {
+      pkg = pkgs.lazygit;
+      winget = "JesseDuffield.lazygit";
+      category = "dev";
+    };
 
     # ── terminal ──────────────────────────────────────────
     wezterm = {
@@ -157,6 +162,11 @@ let
     neovim = {
       pkg = pkgs.neovim;
       winget = "Neovim.Neovim";
+      category = "editors";
+    };
+    neovim-remote = {
+      pkg = pkgs.neovim-remote;
+      winget = null;
       category = "editors";
     };
     obsidian = {


### PR DESCRIPTION
## Summary

- fix(nvim): suppress Claude Code agents panel in Neovim via `env -u NVIM` on Unix
- fix(nvim): restore terminal on VimLeave to clear ghost screen in WezTerm
- feat: add Claude Code `shift+enter` keybinding for newline (`~/.claude/keybindings.json`)
- feat(nvim): add Snacks.nvim lazygit integration with `nvr` file-open
  - `<leader>gg` opens lazygit float, registers `_SNACKS_LG_CLOSE` global
  - `<leader>gl` / `<leader>gf` for git log
  - `~/.config/lazygit/config.yml` with nvr edit commands that close the float after opening a file
  - Added `lazygit` and `neovim-remote` to `nix/packages/sets.nix`

## Test plan

- [ ] Open Neovim via sidekick.nvim → confirm no agents panel appears
- [ ] `:qa` in Neovim → confirm terminal screen is restored in WezTerm
- [ ] `Shift+Enter` in Claude Code chat → confirm newline inserted
- [ ] `<leader>gg` in Neovim → confirm lazygit float opens
- [ ] Press `e` on a file in lazygit → confirm file opens in parent Neovim and float closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)