### PR TITLE
fix(nvim): disable snacks lazygit configure on Windows

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -230,7 +230,12 @@ return {
             { "<leader>gf", function() Snacks.lazygit.log_file() end, desc = "Git log (file)" },
         },
         opts = {
-            lazygit = { enabled = true },
+            lazygit = {
+                enabled = true,
+                -- On Windows, snacks config injection (editPreset=nvim-remote) causes
+                -- lazygit to exit with code 1. Disable on Windows; Unix handles nvr fine.
+                configure = vim.fn.has("win32") == 0,
+            },
         },
     },
 


### PR DESCRIPTION
snacks が lazygit に editPreset=nvim-remote を注入するが、Windows では nvr が存在せず exit 1 になる。win32 では configure=false にして snacks のコンフィグ注入を無効化。