### PR TITLE
fix(nvim): use terminal.open() and clear NVIM env for Windows lazygit

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -213,8 +213,13 @@ return {
                         return
                     end
                     if vim.fn.has("win32") == 1 then
-                        -- Windows: bypass Snacks.lazygit config injection entirely
-                        Snacks.terminal({ "lazygit" }, { cwd = root, win = { style = "lazygit" } })
+                        -- Windows: bypass Snacks.lazygit; use open() not toggle().
+                        -- Unset $NVIM so lazygit doesn't attempt nvim-remote at startup.
+                        Snacks.terminal.open({ "lazygit" }, {
+                            cwd = root,
+                            env = { NVIM = "" },
+                            win = { style = "lazygit" },
+                        })
                     else
                         _G.__snacks_last_lg = Snacks.lazygit.open({ cwd = root })
                         _G._SNACKS_LG_CLOSE = function()


### PR DESCRIPTION
## Summary

- Replace `Snacks.terminal(...)` (which calls `toggle()`) with `Snacks.terminal.open()` to avoid buffer-reuse that re-triggers `TermClose exit code 1`
- Add `env = { NVIM = "" }` to prevent lazygit from detecting nvim-remote mode on Windows where `nvr` is not available

## Test plan

- [ ] Press `<leader>gg` in Neovim on Windows — lazygit should open without `TermClose` error
- [ ] Press `<leader>gg` again after closing lazygit — should open a fresh terminal, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)