### PR TITLE
fix(git): add safe.directory = * on Windows for cross-account ownership

### DIFF
--- a/chezmoi/dot_gitconfig.tmpl
+++ b/chezmoi/dot_gitconfig.tmpl
@@ -58,6 +58,7 @@
 {{- if eq .chezmoi.os "windows" }}
 [safe]
   directory = D:/ruru/dotfiles
+  directory = *
 {{- end }}
 
 [ghq]

--- a/chezmoi/dot_gitconfig.tmpl
+++ b/chezmoi/dot_gitconfig.tmpl
@@ -57,7 +57,6 @@
 
 {{- if eq .chezmoi.os "windows" }}
 [safe]
-  directory = D:/ruru/dotfiles
   directory = *
 {{- end }}
 


### PR DESCRIPTION
## Summary

- Work (AzureAD) and personal (local) accounts own repos on the same machine
- git's ownership check blocks lazygit/git in repos owned by the other account
- `safe.directory = *` disables the check on Windows where this is expected

## Test plan

- [ ] Open lazygit (`<leader>gg`) in a repo under `D:/ruru/` owned by the other account — no ownership error

🤖 Generated with [Claude Code](https://claude.com/claude-code)