### PR TITLE
fix(git): configure per-directory GitHub credentials on Windows

### DIFF
--- a/chezmoi/dot_gitconfig-work.tmpl
+++ b/chezmoi/dot_gitconfig-work.tmpl
@@ -1,6 +1,7 @@
-# Loaded by ~/.gitconfig via [includeIf "hasconfig:remote.*.url:git@github-work:**"].
-# Overrides [user.*] fields when the current repo's remote uses the github-work
-# SSH host alias (defined in ~/.ssh/config, see chezmoi/ssh/config.tmpl).
+# Loaded by ~/.gitconfig via:
+#   - [includeIf "hasconfig:remote.*.url:git@github-work:**"] (SSH work repos)
+#   - [includeIf "gitdir/i:D:/my_programing/"] (Windows work repos by directory)
+# Overrides [user.*] and [credential.*] fields for work repos.
 #
 # Identity source: chezmoi/.chezmoidata/personal.yaml (git.work).
 {{- $git := (get . "git" | default (dict)) }}
@@ -9,3 +10,6 @@
   name = {{ get $work "name" | default "Work User" | quote }}
   email = {{ get $work "email" | default "work@example.com" | quote }}
   signingkey = {{ get $work "signingkey" | default "~/.ssh/github_work.pub" | quote }}
+
+[credential "https://github.com"]
+  username = kohei-miki-im8

--- a/chezmoi/dot_gitconfig.tmpl
+++ b/chezmoi/dot_gitconfig.tmpl
@@ -37,7 +37,10 @@
   sshCommand = ssh
 {{- end }}
 
-{{- if ne .chezmoi.os "windows" }}
+{{- if eq .chezmoi.os "windows" }}
+[credential "https://github.com"]
+  username = rurusasu
+{{- else }}
 [credential "https://github.com"]
   helper = "!gh auth git-credential"
 [credential "https://gist.github.com"]
@@ -58,6 +61,9 @@
 {{- if eq .chezmoi.os "windows" }}
 [safe]
   directory = *
+
+[includeIf "gitdir/i:D:/my_programing/"]
+  path = ~/.gitconfig-work
 {{- end }}
 
 [ghq]


### PR DESCRIPTION
## Summary

- `D:/ruru/` → `rurusasu` (personal, default)
- `D:/my_programing/` → `kohei-miki-im8` (work, via `includeIf gitdir/i:`)
- Suppresses GCM "Select an account" picker when running git/lazygit

## Test plan

- [ ] Open lazygit in `D:/ruru/` repo — no account picker, uses `rurusasu`
- [ ] Open lazygit in `D:/my_programing/` repo — no account picker, uses `kohei-miki-im8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)