### PR TITLE
fix(git): guard work credential username behind Windows-only condition

### DIFF
--- a/chezmoi/dot_gitconfig-work.tmpl
+++ b/chezmoi/dot_gitconfig-work.tmpl
@@ -11,5 +11,7 @@
   email = {{ get $work "email" | default "work@example.com" | quote }}
   signingkey = {{ get $work "signingkey" | default "~/.ssh/github_work.pub" | quote }}
 
+{{- if eq .chezmoi.os "windows" }}
 [credential "https://github.com"]
   username = kohei-miki-im8
+{{- end }}


### PR DESCRIPTION
## Summary

- `username = kohei-miki-im8` in `dot_gitconfig-work.tmpl` was unguarded
- WSL/Linux uses `gh auth git-credential` and doesn't need this hint
- Wrap in `{{- if eq .chezmoi.os "windows" }}` for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)