### PR TITLE
feat(nvim): replace gruvbox with kanagawa-dragon colorscheme

### DIFF
--- a/chezmoi/dot_config/nvim/init.lua
+++ b/chezmoi/dot_config/nvim/init.lua
@@ -34,7 +34,7 @@ require("config.osc7").setup()
 -- Load plugins
 require("lazy").setup("plugins", {
     defaults = { lazy = true },
-    install = { colorscheme = { "gruvbox" } },
+    install = { colorscheme = { "kanagawa" } },
     checker = { enabled = false },
     performance = {
         rtp = {

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -3,11 +3,11 @@
 return {
     -- Colorscheme
     {
-        "ellisonleao/gruvbox.nvim",
+        "rebelot/kanagawa.nvim",
         lazy = false,
         priority = 1000,
         config = function()
-            vim.cmd.colorscheme("gruvbox")
+            vim.cmd.colorscheme("kanagawa-dragon")
         end,
     },
 


### PR DESCRIPTION
## Summary

- Replace `ellisonleao/gruvbox.nvim` with `rebelot/kanagawa.nvim`
- Use `kanagawa-dragon` variant (dark, muted tones)
- Update lazy.nvim install fallback colorscheme

🤖 Generated with [Claude Code](https://claude.com/claude-code)