### PR TITLE
feat(tmux): add tmux config and fix wezterm invalid field

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -224,7 +224,9 @@ return {
                         _G.__snacks_last_lg = Snacks.lazygit.open({ cwd = root })
                         _G._SNACKS_LG_CLOSE = function()
                             local lg = _G.__snacks_last_lg
-                            if lg and lg.close then pcall(lg.close, lg) end
+                            if lg and lg.close then
+                                pcall(lg.close, lg)
+                            end
                             _G.__snacks_last_lg = nil
                         end
                     end
@@ -235,7 +237,9 @@ return {
                 "<leader>gl",
                 function()
                     local root = Snacks.git.get_root()
-                    if not root then return end
+                    if not root then
+                        return
+                    end
                     if vim.fn.has("win32") == 1 then
                         Snacks.terminal({ "lazygit", "log" }, { cwd = root, win = { style = "lazygit" } })
                     else
@@ -244,7 +248,13 @@ return {
                 end,
                 desc = "Git log",
             },
-            { "<leader>gf", function() Snacks.lazygit.log_file() end, desc = "Git log (file)" },
+            {
+                "<leader>gf",
+                function()
+                    Snacks.lazygit.log_file()
+                end,
+                desc = "Git log (file)",
+            },
         },
         opts = {
             lazygit = { enabled = true },

--- a/chezmoi/dot_tmux.conf
+++ b/chezmoi/dot_tmux.conf
@@ -1,0 +1,42 @@
+# prefix: C-a
+unbind C-b
+set -g prefix C-a
+bind C-a send-prefix
+
+# 256 color + true color
+set -g default-terminal "tmux-256color"
+set -ga terminal-overrides ",*:Tc"
+
+# インデックスを 1 始まりに
+set -g base-index 1
+setw -g pane-base-index 1
+
+# マウス有効
+set -g mouse on
+
+# ウィンドウ番号の自動振り直し
+set -g renumber-windows on
+
+# ペイン分割を直感的なキーに
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+unbind '"'
+unbind %
+
+# vim-tmux-navigator
+is_vim="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
+bind-key -n C-h if-shell "$is_vim" 'send-keys C-h' 'select-pane -L'
+bind-key -n C-j if-shell "$is_vim" 'send-keys C-j' 'select-pane -D'
+bind-key -n C-k if-shell "$is_vim" 'send-keys C-k' 'select-pane -U'
+bind-key -n C-l if-shell "$is_vim" 'send-keys C-l' 'select-pane -R'
+
+# コピーモードを vi キーに
+setw -g mode-keys vi
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
+
+# ステータスバー
+set -g status-position bottom
+set -g status-style 'bg=#2d2d2d fg=#cccccc'
+set -g status-left '#[fg=#88c0d0,bold] #S '
+set -g status-right '#[fg=#88c0d0] %H:%M %Y-%m-%d '

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -167,6 +167,4 @@ config.keys = {
     { key = "9", mods = "LEADER", action = act.ActivateTab(8) },
 }
 
-config.enable_scroll_back_on_alternate_screen = false
-
 return config

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -6,63 +6,49 @@
         {
           "PackageIdentifier": "AgileBits.1Password.CLI",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "op"
           }
         },
         {
           "PackageIdentifier": "twpayne.chezmoi",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "chezmoi"
           }
         },
         {
           "PackageIdentifier": "direnv.direnv",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "direnv"
           }
         },
         {
           "PackageIdentifier": "eza-community.eza",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "eza"
           }
         },
         {
           "PackageIdentifier": "sharkdp.fd",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "fd"
           }
         },
         {
           "PackageIdentifier": "junegunn.fzf",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "fzf"
           }
         },
         {
           "PackageIdentifier": "GitHub.cli",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "gh"
           }
         },
@@ -72,36 +58,28 @@
         {
           "PackageIdentifier": "Git.Git",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "git"
           }
         },
         {
           "PackageIdentifier": "GoLang.Go",
           "verifyCommand": {
-            "args": [
-              "version"
-            ],
+            "args": ["version"],
             "command": "go"
           }
         },
         {
           "PackageIdentifier": "Task.Task",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "task"
           }
         },
         {
           "PackageIdentifier": "Google.CloudSDK",
           "verifyCommand": {
-            "args": [
-              "version"
-            ],
+            "args": ["version"],
             "command": "gcloud"
           }
         },
@@ -114,18 +92,14 @@
         {
           "PackageIdentifier": "Neovim.Neovim",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "nvim"
           }
         },
         {
           "PackageIdentifier": "OpenJS.NodeJS.LTS",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "node"
           }
         },
@@ -141,27 +115,21 @@
         {
           "PackageIdentifier": "Microsoft.PowerShell",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "pwsh"
           }
         },
         {
           "PackageIdentifier": "Python.Python.3.13",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "python"
           }
         },
         {
           "PackageIdentifier": "BurntSushi.ripgrep.MSVC",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "rg"
           }
         },
@@ -171,9 +139,7 @@
         {
           "PackageIdentifier": "Starship.Starship",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "starship"
           }
         },
@@ -183,9 +149,7 @@
         {
           "PackageIdentifier": "astral-sh.uv",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "uv"
           }
         },
@@ -198,9 +162,7 @@
         {
           "PackageIdentifier": "ajeetdsouza.zoxide",
           "verifyCommand": {
-            "args": [
-              "--version"
-            ],
+            "args": ["--version"],
             "command": "zoxide"
           }
         },


### PR DESCRIPTION
## Summary

- `chezmoi/dot_tmux.conf` を新規追加（prefix `C-a`、vim-tmux-navigator、vi コピーモード、マウス有効）
- `wezterm.lua` から存在しないフィールド `enable_scroll_back_on_alternate_screen` を削除

## Test plan

- [ ] WSL で `tmux` 起動後 `~/.tmux.conf` が読み込まれること
- [ ] WezTerm 起動時にエラーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)