### PR TITLE
feat(terminal): unify font size keybinds and enable wezterm hot reload

### DIFF
--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -12,6 +12,8 @@ end
 -- Terminal type (enables undercurl, colored underlines, etc.)
 config.term = "wezterm"
 
+config.automatically_reload_config = true
+
 -- Color scheme
 config.color_schemes = {
     ["gruvbox-custom"] = {
@@ -150,10 +152,10 @@ config.keys = {
     { key = "Space", mods = "LEADER", action = act.QuickSelect },
     { key = "F11", action = act.ToggleFullScreen },
 
-    -- Font size
-    { key = "+", mods = "CTRL", action = act.IncreaseFontSize },
-    { key = "-", mods = "CTRL", action = act.DecreaseFontSize },
-    { key = "0", mods = "CTRL", action = act.ResetFontSize },
+    -- Font size (CTRL|SHIFT to avoid conflict with tmux C-a -)
+    { key = "+", mods = "CTRL|SHIFT", action = act.IncreaseFontSize },
+    { key = "-", mods = "CTRL|SHIFT", action = act.DecreaseFontSize },
+    { key = "0", mods = "CTRL|SHIFT", action = act.ResetFontSize },
 
     -- Tab numbers
     { key = "1", mods = "LEADER", action = act.ActivateTab(0) },

--- a/chezmoi/terminals/windows-terminal/settings.json
+++ b/chezmoi/terminals/windows-terminal/settings.json
@@ -108,6 +108,30 @@
     {
       "command": "unbound",
       "keys": "alt+z"
+    },
+    {
+      "command": "unbound",
+      "keys": "ctrl+plus"
+    },
+    {
+      "command": "unbound",
+      "keys": "ctrl+minus"
+    },
+    {
+      "command": "unbound",
+      "keys": "ctrl+0"
+    },
+    {
+      "command": { "action": "adjustFontSize", "delta": 1 },
+      "id": "User.increaseFontSize"
+    },
+    {
+      "command": { "action": "adjustFontSize", "delta": -1 },
+      "id": "User.decreaseFontSize"
+    },
+    {
+      "command": "resetFontSize",
+      "id": "User.resetFontSize"
     }
   ],
   "copyFormatting": "none",
@@ -197,6 +221,18 @@
     {
       "id": "User.resizePane.down",
       "keys": "ctrl+alt+down"
+    },
+    {
+      "id": "User.increaseFontSize",
+      "keys": "ctrl+shift+plus"
+    },
+    {
+      "id": "User.decreaseFontSize",
+      "keys": "ctrl+shift+minus"
+    },
+    {
+      "id": "User.resetFontSize",
+      "keys": "ctrl+shift+0"
     }
   ],
   "newTabMenu": [


### PR DESCRIPTION
## Summary

- フォントサイズ操作を `Ctrl+Shift++/-/0` に統一（WezTerm・Windows Terminal）
  - tmux の `C-a -` と `Ctrl+-` が競合するため変更
- WezTerm に `automatically_reload_config = true` を追加（設定変更の即時反映）

## Test plan

- [ ] WezTerm で `Ctrl+Shift++/-/0` によるフォントサイズ変更が動作すること
- [ ] Windows Terminal で `Ctrl+Shift++/-/0` によるフォントサイズ変更が動作すること
- [ ] tmux 内で `C-a -` がペイン横分割として動作すること
- [ ] `wezterm.lua` 保存時に WezTerm が自動リロードされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)