### PR TITLE
feat(nvim): add vim-tmux-navigator for seamless pane navigation

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -350,6 +350,12 @@ return {
         },
     },
 
+    -- Tmux pane navigation (C-h/j/k/l shared with nvim windows)
+    {
+        "christoomey/vim-tmux-navigator",
+        event = "VeryLazy",
+    },
+
     -- Devcontainer
     {
         "erichlf/devcontainer-cli.nvim",


### PR DESCRIPTION
## Summary

- `christoomey/vim-tmux-navigator` を追加
- `C-h/j/k/l` で nvim ウィンドウと tmux ペインをシームレスに移動可能に

## Test plan

- [ ] WSL で nvim を起動し `:Lazy sync` でインストール
- [ ] tmux 内で nvim を開き `C-h/j/k/l` でペイン間移動できること
- [ ] nvim のウィンドウ分割時も `C-h/j/k/l` で移動できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)