### PR TITLE
feat(nvim): hide oil.nvim entry IDs in insert mode via conceallevel

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/keymaps.lua
+++ b/chezmoi/dot_config/nvim/lua/config/keymaps.lua
@@ -55,3 +55,16 @@ map("n", "<leader>fg", "<cmd>Telescope live_grep<cr>", { desc = "Live grep" })
 map("n", "<leader>fb", "<cmd>Telescope buffers<cr>", { desc = "Buffers" })
 map("n", "<leader>fh", "<cmd>Telescope help_tags<cr>", { desc = "Help tags" })
 map("n", "<leader>fr", "<cmd>Telescope oldfiles<cr>", { desc = "Recent files" })
+
+-- Unified window management (same characters as tmux/terminal layers)
+map("n", "<leader>\\", "<cmd>vsplit<cr>", { desc = "Vertical split" })
+map("n", "<leader>-", "<cmd>split<cr>", { desc = "Horizontal split" })
+map("n", "<leader>x", "<cmd>q<cr>", { desc = "Close window" })
+map("n", "<leader>h", "<cmd>bprevious<cr>", { desc = "Prev buffer" })
+map("n", "<leader>l", "<cmd>bnext<cr>", { desc = "Next buffer" })
+
+-- Terminal mode: pass C-h/j/k/l through to tmux via vim-tmux-navigator
+map("t", "<C-h>", "<C-\\><C-n><C-w>h", { desc = "Go to left window" })
+map("t", "<C-j>", "<C-\\><C-n><C-w>j", { desc = "Go to lower window" })
+map("t", "<C-k>", "<C-\\><C-n><C-w>k", { desc = "Go to upper window" })
+map("t", "<C-l>", "<C-\\><C-n><C-w>l", { desc = "Go to right window" })

--- a/chezmoi/dot_config/nvim/lua/config/keymaps.lua
+++ b/chezmoi/dot_config/nvim/lua/config/keymaps.lua
@@ -63,8 +63,8 @@ map("n", "<leader>x", "<cmd>q<cr>", { desc = "Close window" })
 map("n", "<leader>h", "<cmd>bprevious<cr>", { desc = "Prev buffer" })
 map("n", "<leader>l", "<cmd>bnext<cr>", { desc = "Next buffer" })
 
--- Terminal mode: pass C-h/j/k/l through to tmux via vim-tmux-navigator
-map("t", "<C-h>", "<C-\\><C-n><C-w>h", { desc = "Go to left window" })
-map("t", "<C-j>", "<C-\\><C-n><C-w>j", { desc = "Go to lower window" })
-map("t", "<C-k>", "<C-\\><C-n><C-w>k", { desc = "Go to upper window" })
-map("t", "<C-l>", "<C-\\><C-n><C-w>l", { desc = "Go to right window" })
+-- Terminal mode: use TmuxNavigate so boundary-crossing to tmux panes works
+map("t", "<C-h>", "<C-\\><C-n>:TmuxNavigateLeft<cr>", { desc = "Go to left window" })
+map("t", "<C-j>", "<C-\\><C-n>:TmuxNavigateDown<cr>", { desc = "Go to lower window" })
+map("t", "<C-k>", "<C-\\><C-n>:TmuxNavigateUp<cr>", { desc = "Go to upper window" })
+map("t", "<C-l>", "<C-\\><C-n>:TmuxNavigateRight<cr>", { desc = "Go to right window" })

--- a/chezmoi/dot_config/nvim/lua/config/keymaps.lua
+++ b/chezmoi/dot_config/nvim/lua/config/keymaps.lua
@@ -2,7 +2,7 @@
 
 local map = vim.keymap.set
 
--- Better window navigation
+-- Better window navigation (overridden by vim-tmux-navigator with TmuxNavigate* at startup)
 map("n", "<C-h>", "<C-w>h", { desc = "Go to left window" })
 map("n", "<C-j>", "<C-w>j", { desc = "Go to lower window" })
 map("n", "<C-k>", "<C-w>k", { desc = "Go to upper window" })

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -353,7 +353,7 @@ return {
     -- Tmux pane navigation (C-h/j/k/l shared with nvim windows)
     {
         "christoomey/vim-tmux-navigator",
-        event = "VeryLazy",
+        cmd = { "TmuxNavigateLeft", "TmuxNavigateDown", "TmuxNavigateUp", "TmuxNavigateRight" },
     },
 
     -- Devcontainer

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -25,6 +25,12 @@ return {
         },
         config = function(_, opts)
             require("oil").setup(opts)
+            vim.api.nvim_create_autocmd("FileType", {
+                pattern = "oil",
+                callback = function()
+                    vim.opt_local.conceallevel = 2
+                end,
+            })
             -- wmic was removed in Windows 11; patch drive listing to use PowerShell.
             if vim.fn.has("win32") == 1 and vim.fn.executable("wmic") == 0 then
                 local files = require("oil.adapters.files")

--- a/chezmoi/dot_tmux.conf
+++ b/chezmoi/dot_tmux.conf
@@ -35,6 +35,12 @@ setw -g mode-keys vi
 bind-key -T copy-mode-vi v send-keys -X begin-selection
 bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
 
+# ウィンドウ管理（統一キーバインド: x=閉じる t=新規 h/l=前後）
+bind x kill-pane
+bind t new-window
+bind l next-window
+bind h previous-window
+
 # ステータスバー
 set -g status-position bottom
 set -g status-style 'bg=#2d2d2d fg=#cccccc'

--- a/chezmoi/dot_tmux.conf
+++ b/chezmoi/dot_tmux.conf
@@ -38,8 +38,8 @@ bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
 # ウィンドウ管理（統一キーバインド: x=閉じる t=新規 h/l=前後）
 bind x kill-pane
 bind t new-window
-bind l next-window
-bind h previous-window
+bind -r l next-window
+bind -r h previous-window
 
 # ステータスバー
 set -g status-position bottom

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -138,7 +138,7 @@ config.keys = {
     { key = "UpArrow", mods = "CTRL|ALT", action = act.AdjustPaneSize({ "Up", 5 }) },
     { key = "RightArrow", mods = "CTRL|ALT", action = act.AdjustPaneSize({ "Right", 5 }) },
 
-    -- Tab management (Ctrl+Alt+T, also Leader)
+    -- Tab management (Ctrl+Alt+T or Leader+t=new, Leader+x=close, Ctrl+Tab=nav)
     { key = "t", mods = "CTRL|ALT", action = act.SpawnTab("CurrentPaneDomain") },
     { key = "t", mods = "LEADER", action = act.SpawnTab("CurrentPaneDomain") },
     { key = "x", mods = "LEADER", action = act.CloseCurrentTab({ confirm = true }) },

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -142,8 +142,8 @@ config.keys = {
     { key = "t", mods = "CTRL|ALT", action = act.SpawnTab("CurrentPaneDomain") },
     { key = "t", mods = "LEADER", action = act.SpawnTab("CurrentPaneDomain") },
     { key = "x", mods = "LEADER", action = act.CloseCurrentTab({ confirm = true }) },
-    { key = "l", mods = "LEADER", action = act.ActivateTabRelative(1) },
-    { key = "h", mods = "LEADER", action = act.ActivateTabRelative(-1) },
+    { key = "Tab", mods = "CTRL", action = act.ActivateTabRelative(1) },
+    { key = "Tab", mods = "CTRL|SHIFT", action = act.ActivateTabRelative(-1) },
 
     -- Misc
     { key = "[", mods = "LEADER", action = act.ActivateCopyMode },


### PR DESCRIPTION
## Summary
- oil.nvim のバッファで INSERT モード中に表示される内部エントリID（`/121` など）を非表示にする
- `FileType oil` autocmd で `conceallevel=2` をローカル設定として追加

## Test plan
- [ ] `nvim` を起動して `-` キーで oil バッファを開く
- [ ] `o` や `i` で INSERT モードに入り、entry ID が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)