### PR TITLE
feat(nvim): add t keymap in oil.nvim to open file in new tab

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -29,6 +29,7 @@ return {
             keymaps = {
                 ["\\"] = { "actions.select", opts = { vertical = true }, desc = "Open vsplit" },
                 ["s"] = { "actions.select", opts = { horizontal = true }, desc = "Open hsplit" },
+                ["t"] = { "actions.select", opts = { tab = true }, desc = "Open in new tab" },
             },
         },
         config = function(_, opts)


### PR DESCRIPTION
## Summary

- oil.nvim に `t` キーマップを追加し、新規タブでファイルを開けるようにした
- 統一キーバインドスキームの `t` = 新規タブ（tmux の `prefix+t` と同じ文字）に合わせた

## Keybindings (oil buffer)

| Key | Action |
|-----|--------|
| `t` | Open in new tab |
| `\` | Open in vertical split |
| `s` | Open in horizontal split |

## Test Plan

- [ ] oil バッファで `t` を押してファイルが新規タブで開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)