### PR TITLE
fix(nvim): disable oil.nvim default C-h/C-l to allow TmuxNavigate

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -30,6 +30,8 @@ return {
                 ["\\"] = { "actions.select", opts = { vertical = true }, desc = "Open vsplit" },
                 ["s"] = { "actions.select", opts = { horizontal = true }, desc = "Open hsplit" },
                 ["t"] = { "actions.select", opts = { tab = true }, desc = "Open in new tab" },
+                ["<C-h>"] = false,
+                ["<C-l>"] = false,
             },
         },
         config = function(_, opts)


### PR DESCRIPTION
## Summary

- oil.nvim のデフォルトキーマップ `<C-h>`（水平分割）と `<C-l>`（refresh）を無効化
- global の `TmuxNavigateLeft` / `TmuxNavigateRight` が oil バッファ内でも動作するようになる

## Why

oil のバッファローカルキーマップが global の vim-tmux-navigator より優先されるため、
oil 内で `<C-h>` を押すと意図せずファイルが水平分割で開いていた。

## Test Plan

- [ ] oil バッファ内で `<C-h>` → 左の nvim window または tmux pane に移動
- [ ] oil バッファ内で `<C-l>` → 右の nvim window または tmux pane に移動

🤖 Generated with [Claude Code](https://claude.com/claude-code)