### PR TITLE
feat(nvim): add | as alias for vsplit in oil.nvim and telescope

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -28,6 +28,7 @@ return {
             },
             keymaps = {
                 ["\\"] = { "actions.select", opts = { vertical = true }, desc = "Open vsplit" },
+                ["|"] = { "actions.select", opts = { vertical = true }, desc = "Open vsplit" },
                 ["s"] = { "actions.select", opts = { horizontal = true }, desc = "Open hsplit" },
                 ["t"] = { "actions.select", opts = { tab = true }, desc = "Open in new tab" },
                 ["<C-h>"] = false,
@@ -109,10 +110,12 @@ return {
                 mappings = {
                     i = {
                         ["\\"] = actions.select_vertical,
+                        ["|"] = actions.select_vertical,
                         ["-"] = actions.select_horizontal,
                     },
                     n = {
                         ["\\"] = actions.select_vertical,
+                        ["|"] = actions.select_vertical,
                         ["-"] = actions.select_horizontal,
                     },
                 },

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -30,6 +30,8 @@ return {
                 ["\\"] = { "actions.select", opts = { vertical = true }, desc = "Open vsplit" },
                 ["s"] = { "actions.select", opts = { horizontal = true }, desc = "Open hsplit" },
                 ["t"] = { "actions.select", opts = { tab = true }, desc = "Open in new tab" },
+                ["<C-h>"] = false,
+                ["<C-l>"] = false,
             },
         },
         config = function(_, opts)


### PR DESCRIPTION
## Summary

- oil.nvim と telescope で `|`（パイプ）を `\`（バックスラッシュ）の vsplit エイリアスとして追加
- JIS キーボードでは `\` と `|` が別キーのため両方対応

## Keybindings (after this PR)

| Key | oil.nvim | telescope |
|-----|----------|-----------|
| `\` or `\|` | vsplit | vsplit |
| `s` | hsplit | — |
| `-` | parent dir | hsplit |
| `t` | new tab | — |

## Test Plan

- [ ] oil バッファで `|` → ファイルが垂直分割で開く
- [ ] telescope で `|` → 結果が垂直分割で開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)