### PR TITLE
feat(nvim): add TypeScript/TSX support via LSP and treesitter

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -140,6 +140,8 @@ return {
                 "python",
                 "typescript",
                 "javascript",
+                "tsx",
+                "jsx",
                 "json",
                 "yaml",
                 "toml",
@@ -543,6 +545,7 @@ return {
                         },
                     },
                 },
+                ts_ls = {},
                 marksman = {},
                 ruff = {},
                 ty = {

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -371,6 +371,11 @@ let
       winget = "oxc-project.oxlint";
       category = "lsp";
     };
+    typescript-language-server = {
+      pkg = pkgs.typescript-language-server;
+      winget = null;
+      category = "lsp";
+    };
   };
 
   # Group package names by category


### PR DESCRIPTION
## Summary

- treesitter `ensure_installed` に `tsx` / `jsx` パーサーを追加（シンタックスハイライト改善）
- LSP サーバーリストに `ts_ls`（typescript-language-server）を追加
- `nix/packages/sets.nix` に `typescript-language-server` を追加

## Before / After

| 機能 | Before | After |
|------|--------|-------|
| TSX シンタックスハイライト | 薄い（typescript パーサーのみ） | tsx パーサーで正確に色付け |
| 型チェック・補完・hover | なし | ts_ls で対応 |
| linting | oxlint のみ | oxlint + ts_ls 並走 |

## Test Plan

- [ ] `.tsx` ファイルを開いて色付けが改善されることを確認
- [ ] `:LspInfo` で `ts_ls` が attached されていることを確認
- [ ] hover (`K`) / go-to-def (`gd`) が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)