### PR TITLE
feat(windows): add typescript-language-server to pnpm global packages

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -26,6 +26,7 @@ return {
                 conceallevel = 3,
                 concealcursor = "nvic",
             },
+            watch_for_changes = true,
             keymaps = {
                 ["\\"] = { "actions.select", opts = { vertical = true }, desc = "Open vsplit" },
                 ["|"] = { "actions.select", opts = { vertical = true }, desc = "Open vsplit" },

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -415,6 +415,8 @@ lib.mapAttrs (_: names: resolve names) grouped
     "@tobilu/qmd"
     "@prisma/language-server"
     "@agentclientprotocol/claude-agent-acp"
+    "typescript-language-server"
+    "typescript"
   ];
 
   # Post-install verification commands for pnpm packages.

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -434,6 +434,14 @@ lib.mapAttrs (_: names: resolve names) grouped
       command = "gemini";
       args = [ "--version" ];
     };
+    "typescript-language-server" = {
+      command = "typescript-language-server";
+      args = [ "--version" ];
+    };
+    "typescript" = {
+      command = "tsc";
+      args = [ "--version" ];
+    };
     "@agentclientprotocol/claude-agent-acp" = {
       command = "claude-agent-acp";
       args = [ "--version" ];

--- a/windows/pnpm/packages.json
+++ b/windows/pnpm/packages.json
@@ -24,13 +24,6 @@
       }
     },
     {
-      "name": "@google/gemini-cli",
-      "verifyCommand": {
-        "args": ["--version"],
-        "command": "gemini"
-      }
-    },
-    {
       "name": "typescript-language-server",
       "verifyCommand": {
         "args": ["--version"],
@@ -42,6 +35,13 @@
       "verifyCommand": {
         "args": ["--version"],
         "command": "tsc"
+      }
+    },
+    {
+      "name": "@google/gemini-cli",
+      "verifyCommand": {
+        "args": ["--version"],
+        "command": "gemini"
       }
     }
   ]

--- a/windows/pnpm/packages.json
+++ b/windows/pnpm/packages.json
@@ -29,6 +29,20 @@
         "args": ["--version"],
         "command": "gemini"
       }
+    },
+    {
+      "name": "typescript-language-server",
+      "verifyCommand": {
+        "args": ["--version"],
+        "command": "typescript-language-server"
+      }
+    },
+    {
+      "name": "typescript",
+      "verifyCommand": {
+        "args": ["--version"],
+        "command": "tsc"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

- `pnpmGlobal` に `typescript-language-server` と `typescript` を追加
- Windows 側の nvim で `ts_ls` が動作するようになる
- WSL 側は `nix/packages/sets.nix` の nix パッケージとして対応済み

## Test Plan

- [ ] Windows の nvim で `.tsx` ファイルを開き `:LspInfo` で `ts_ls` が attached されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)