### PR TITLE
feat(nvim): enable word wrap with linebreak and breakindent

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/options.lua
+++ b/chezmoi/dot_config/nvim/lua/config/options.lua
@@ -24,7 +24,9 @@ opt.signcolumn = "yes"
 opt.cursorline = true
 opt.scrolloff = 8
 opt.sidescrolloff = 8
-opt.wrap = false
+opt.wrap = true
+opt.linebreak = true
+opt.breakindent = true
 
 -- Split behavior
 opt.splitbelow = true


### PR DESCRIPTION
## Summary
- `wrap = true` — ウィンドウ幅で自動折り返し
- `linebreak = true` — 単語境界で折り返し（途中で切らない）
- `breakindent = true` — 折り返し行のインデントを維持

## Test plan
- [ ] Neovim を再起動して長い行が自動折り返しされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)