### PR TITLE
feat(nvim): add bottom terminal toggle and restore sidekick to right

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -294,9 +294,20 @@ return {
                 end,
                 desc = "Git log (file)",
             },
+            {
+                "<leader>tt",
+                function()
+                    Snacks.terminal.toggle(nil, {
+                        win = { position = "bottom", height = 0.3 },
+                    })
+                end,
+                mode = { "n", "t" },
+                desc = "Toggle bottom terminal",
+            },
         },
         opts = {
             lazygit = { enabled = true },
+            terminal = { enabled = true },
         },
     },
 
@@ -369,7 +380,7 @@ return {
         },
         opts = {
             win = {
-                layout = "float",
+                layout = "right",
             },
             cli = {
                 mux = {

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -368,6 +368,9 @@ return {
             },
         },
         opts = {
+            win = {
+                layout = "float",
+            },
             cli = {
                 mux = {
                     backend = "tmux",


### PR DESCRIPTION
## Summary

- `<leader>tt` で下部ターミナルをトグル（画面高さ 30%、snacks.nvim 使用）
- sidekick の layout を float → right に戻す
- ターミナルを bottom に固定することで Claude (right) が隠れなくなる

## Layout

```
┌─────────────────────────┬────────────┐
│        コード           │   Claude   │
│                         │  (right)   │
├─────────────────────────┴────────────┤
│  ターミナル (leader+tt でトグル)      │
└──────────────────────────────────────┘
```

## Test Plan

- [ ] `<leader>tt` でボトムターミナルが開閉する
- [ ] ターミナルを開いても Claude pane が隠れない
- [ ] ターミナル内でも `<leader>tt` で閉じられる

🤖 Generated with [Claude Code](https://claude.com/claude-code)