### PR TITLE
feat(nvim): auto-move :terminal to bottom via TermOpen autocmd

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/keymaps.lua
+++ b/chezmoi/dot_config/nvim/lua/config/keymaps.lua
@@ -68,3 +68,11 @@ map("t", "<C-h>", "<C-\\><C-n>:TmuxNavigateLeft<cr>", { desc = "Go to left windo
 map("t", "<C-j>", "<C-\\><C-n>:TmuxNavigateDown<cr>", { desc = "Go to lower window" })
 map("t", "<C-k>", "<C-\\><C-n>:TmuxNavigateUp<cr>", { desc = "Go to upper window" })
 map("t", "<C-l>", "<C-\\><C-n>:TmuxNavigateRight<cr>", { desc = "Go to right window" })
+
+-- Move any :terminal to the bottom automatically
+vim.api.nvim_create_autocmd("TermOpen", {
+    callback = function()
+        vim.cmd("wincmd J")
+        vim.cmd("resize 15")
+    end,
+})


### PR DESCRIPTION
## Summary
- `:terminal` コマンドで開いたターミナルを自動で画面下部に移動
- `TermOpen` autocmd で `wincmd J` + `resize 15` を実行
- `<leader>tt` の snacks terminal と同様に、全ターミナルが底部に配置される

## Test Plan
- [ ] `:terminal` を実行してターミナルが下部に開くことを確認
- [ ] `<leader>tt` の snacks terminal も引き続き下部で開くことを確認
- [ ] Claude pane (right) がターミナルに隠れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)