### PR TITLE
feat(tmux): add git repo/branch info to statusline with minimal design

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/keymaps.lua
+++ b/chezmoi/dot_config/nvim/lua/config/keymaps.lua
@@ -68,3 +68,11 @@ map("t", "<C-h>", "<C-\\><C-n>:TmuxNavigateLeft<cr>", { desc = "Go to left windo
 map("t", "<C-j>", "<C-\\><C-n>:TmuxNavigateDown<cr>", { desc = "Go to lower window" })
 map("t", "<C-k>", "<C-\\><C-n>:TmuxNavigateUp<cr>", { desc = "Go to upper window" })
 map("t", "<C-l>", "<C-\\><C-n>:TmuxNavigateRight<cr>", { desc = "Go to right window" })
+
+-- Move any :terminal to the bottom automatically
+vim.api.nvim_create_autocmd("TermOpen", {
+    callback = function()
+        vim.cmd("wincmd J")
+        vim.cmd("resize 15")
+    end,
+})

--- a/chezmoi/dot_tmux.conf
+++ b/chezmoi/dot_tmux.conf
@@ -43,6 +43,17 @@ bind -r h previous-window
 
 # ステータスバー
 set -g status-position bottom
-set -g status-style 'bg=#2d2d2d fg=#cccccc'
-set -g status-left '#[fg=#88c0d0,bold] #S '
-set -g status-right '#[fg=#88c0d0] %H:%M %Y-%m-%d '
+set -g status-style 'bg=#1e1e2e fg=#cdd6f4'
+set -g status-interval 2
+set -g status-left-length 80
+
+# 左: □ session | ○ repo | ⎇ branch
+set -g status-left '#[fg=#89b4fa,bold] □ #S #[fg=#585b70,nobold] | #[fg=#a6e3a1]○ #(cd #{pane_current_path} && git rev-parse --show-toplevel 2>/dev/null | xargs basename 2>/dev/null) #[fg=#585b70] | #[fg=#f38ba8]⎇ #(cd #{pane_current_path} && git branch --show-current 2>/dev/null) '
+
+# ウィンドウリスト
+setw -g window-status-format         '#[fg=#585b70] #I #W '
+setw -g window-status-current-format '#[fg=#cdd6f4,bold] #I #W '
+set -g window-status-separator       '#[fg=#585b70] | '
+
+# 右: 時刻のみ
+set -g status-right '#[fg=#585b70] %H:%M '


### PR DESCRIPTION
## Summary
- tmux statusline に session・git リポジトリ名・ブランチ名をミニマルに表示
- `□ session | ○ repo | ⎇ branch` フォーマット
- カラーテーマを Catppuccin Mocha ベースに更新
- `status-interval 2` で2秒ごとに自動更新

## Test plan
- [ ] tmux を再起動して statusline の表示を確認
- [ ] git リポジトリ内のディレクトリで repo 名・branch 名が表示されることを確認
- [ ] git リポジトリ外では空欄になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)