### PR TITLE
fix(nvim): open :terminal as bottom split instead of full-screen takeover

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/keymaps.lua
+++ b/chezmoi/dot_config/nvim/lua/config/keymaps.lua
@@ -69,10 +69,23 @@ map("t", "<C-j>", "<C-\\><C-n>:TmuxNavigateDown<cr>", { desc = "Go to lower wind
 map("t", "<C-k>", "<C-\\><C-n>:TmuxNavigateUp<cr>", { desc = "Go to upper window" })
 map("t", "<C-l>", "<C-\\><C-n>:TmuxNavigateRight<cr>", { desc = "Go to right window" })
 
--- Move any :terminal to the bottom automatically
+-- Open terminal in a 15-line split at the bottom
+vim.api.nvim_create_user_command("Term", function()
+    vim.cmd("botright 15split | terminal")
+    vim.cmd("startinsert")
+end, { desc = "Open terminal in bottom split" })
+
+-- Redirect :terminal (typed at start of command line) to :Term.
+-- getcmdpos() guard prevents expansion mid-command (e.g. :edit terminal stays intact).
+vim.cmd([[cabbrev <expr> terminal (getcmdtype() == ':' && getcmdpos() <= 9) ? 'Term' : 'terminal']])
+
+-- If a terminal opens alongside other windows (plugins, scripted :terminal),
+-- snap it to the bottom. Single-window case is handled by :Term above.
 vim.api.nvim_create_autocmd("TermOpen", {
     callback = function()
-        vim.cmd("wincmd J")
-        vim.cmd("resize 15")
+        if vim.fn.winnr("$") > 1 then
+            vim.cmd("wincmd J")
+            vim.cmd("resize 15")
+        end
     end,
 })

--- a/chezmoi/dot_tmux.conf
+++ b/chezmoi/dot_tmux.conf
@@ -41,6 +41,9 @@ bind t new-window
 bind -r l next-window
 bind -r h previous-window
 
+# 設定リロード
+bind r source-file ~/.tmux.conf \; display-message "tmux.conf reloaded"
+
 # ステータスバー
 set -g status-position bottom
 set -g status-style 'bg=#1e1e2e fg=#cdd6f4'


### PR DESCRIPTION
## Summary
- `:terminal` を入力すると全画面ターミナルになっていた問題を修正
- `botright 15split | terminal` で下部 15 行のスプリットに開く
- Vim wiki 推奨の `cabbrev <expr>` + `getcmdpos()` ガードで誤爆防止（`:edit terminal` などは影響なし）
- TermOpen autocmd は複数ウィンドウ時のみ `wincmd J` 適用（単独ウィンドウは `:Term` 側で対応）

## Why
`:terminal` は現在のウィンドウバッファを置き換えるため、単独ウィンドウだと全画面ターミナルになる。TermOpen の `wincmd J` は他ウィンドウが無いと no-op。

`termwrapper.nvim` のデフォルト (`belowright 13split`) や Vim wiki の cabbrev `<expr>` パターンに倣った実装。

## Test Plan
- [ ] 単独ウィンドウで `:terminal` を実行 → 下部 15 行のスプリットで開くこと
- [ ] 既存スプリットがある状態で `:terminal` → 下部に配置されること
- [ ] `:Term` 直接呼び出しでも同じ挙動になること
- [ ] `:edit terminal_test.txt` のように mid-command で `terminal` を含む場合は展開されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)