### PR TITLE
feat(nvim+tmux): add incline.nvim floating file info and tmux top statusbar with Nerd Font icons

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -624,4 +624,96 @@ return {
             })
         end,
     },
+
+    -- Floating file info per window
+    {
+        "b0o/incline.nvim",
+        event = "BufReadPost",
+        dependencies = { "nvim-tree/nvim-web-devicons" },
+        config = function()
+            local devicons = require("nvim-web-devicons")
+            local c = {
+                bg = "#1e1e2e",
+                fg = "#cdd6f4",
+                dim = "#585b70",
+                error = "#f38ba8",
+                warn = "#fab387",
+                info = "#89b4fa",
+            }
+            local generic_set = {}
+            for _, n in ipairs({
+                "init.lua",
+                "init.vim",
+                "init.ts",
+                "init.js",
+                "index.ts",
+                "index.js",
+                "index.tsx",
+                "index.jsx",
+                "main.rs",
+                "main.go",
+                "main.py",
+                "main.c",
+                "main.cpp",
+                "mod.rs",
+                "lib.rs",
+            }) do
+                generic_set[n] = true
+            end
+
+            require("incline").setup({
+                window = {
+                    padding = 1,
+                    margin = { horizontal = 1, vertical = 0 },
+                    placement = { horizontal = "right", vertical = "bottom" },
+                },
+                render = function(props)
+                    local bufnr = props.buf
+                    local focused = props.focused
+                    local fname = vim.api.nvim_buf_get_name(bufnr)
+                    local tail = fname ~= "" and vim.fn.fnamemodify(fname, ":t") or "[No Name]"
+                    local name = tail
+                    if generic_set[tail] then
+                        local parent = vim.fn.fnamemodify(fname, ":h:t")
+                        if parent ~= "" and parent ~= "." then
+                            name = parent .. "/" .. tail
+                        end
+                    end
+
+                    local icon, icon_color =
+                        devicons.get_icon_color(tail, vim.fn.fnamemodify(fname, ":e"), { default = true })
+                    local modified = vim.bo[bufnr].modified
+
+                    local result = {}
+                    if focused then
+                        local diag_specs = {
+                            { vim.diagnostic.severity.ERROR, "⊘", c.error },
+                            { vim.diagnostic.severity.WARN, "△", c.warn },
+                            { vim.diagnostic.severity.INFO, "⊙", c.info },
+                        }
+                        local any = false
+                        for _, spec in ipairs(diag_specs) do
+                            local count = #vim.diagnostic.get(bufnr, { severity = spec[1] })
+                            if count > 0 then
+                                result[#result + 1] = { spec[2] .. " " .. count .. " ", guifg = spec[3] }
+                                any = true
+                            end
+                        end
+                        if any then
+                            result[#result + 1] = { "| ", guifg = c.dim }
+                        end
+                    end
+
+                    result[#result + 1] = { icon .. " ", guifg = focused and icon_color or c.dim }
+                    result[#result + 1] = { name, guifg = focused and c.fg or c.dim }
+                    if modified then
+                        result[#result + 1] = { " ●", guifg = c.warn }
+                    end
+
+                    result.guibg = c.bg
+                    return result
+                end,
+            })
+        end,
+    },
 }

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -628,7 +628,7 @@ return {
     -- Floating file info per window
     {
         "b0o/incline.nvim",
-        event = "BufReadPost",
+        event = { "BufReadPost", "BufNewFile" },
         dependencies = { "nvim-tree/nvim-web-devicons" },
         config = function()
             local devicons = require("nvim-web-devicons")

--- a/chezmoi/dot_tmux.conf
+++ b/chezmoi/dot_tmux.conf
@@ -45,18 +45,20 @@ bind -r h previous-window
 bind r source-file ~/.tmux.conf \; display-message "tmux.conf reloaded"
 
 # ステータスバー
-set -g status-position bottom
+set -g status-position top
 set -g status-style 'bg=#1e1e2e fg=#cdd6f4'
 set -g status-interval 2
-set -g status-left-length 80
+set -g status-left-length 100
+set -g status-right-length 0
+set -g status-justify left
 
-# 左: □ session | ○ repo | ⎇ branch
-set -g status-left '#[fg=#89b4fa,bold] □ #S #[fg=#585b70,nobold] | #[fg=#a6e3a1]○ #(cd #{pane_current_path} && git rev-parse --show-toplevel 2>/dev/null | xargs basename 2>/dev/null) #[fg=#585b70] | #[fg=#f38ba8]⎇ #(cd #{pane_current_path} && git branch --show-current 2>/dev/null) '
+# 左: 󰉋 session   repo  󰘬 branch  (Nerd Font icons)
+set -g status-left '#[fg=#89b4fa,bold]󰉋 #S  #[fg=#a6e3a1] #(cd #{pane_current_path} && git rev-parse --show-toplevel 2>/dev/null | xargs basename 2>/dev/null)  #[fg=#f38ba8]󰘬 #(cd #{pane_current_path} && git branch --show-current 2>/dev/null)  '
 
-# ウィンドウリスト
+# ウィンドウリスト (区切りなし、スペースのみ)
 setw -g window-status-format         '#[fg=#585b70] #I #W '
 setw -g window-status-current-format '#[fg=#cdd6f4,bold] #I #W '
-set -g window-status-separator       '#[fg=#585b70] | '
+set -g window-status-separator       ''
 
-# 右: 時刻のみ
-set -g status-right '#[fg=#585b70] %H:%M '
+# 右: 空
+set -g status-right ''


### PR DESCRIPTION
## Summary

- **incline.nvim**: floating per-window file info in bottom-right corner
  - File type icon via nvim-web-devicons
  - Orange `●` indicator for unsaved buffers
  - LSP diagnostics with Catppuccin colors: `⊘ N` error, `△ N` warn, `⊙ N` info
  - Inactive windows dim all elements
  - Generic filenames (init.lua, index.ts, etc.) show parent dir (e.g. `lsp/init.lua`)
- **tmux statusbar**: moved to top with Nerd Font icons (󰉋  󰘬)

## Test plan

- [ ] Open Neovim with multiple splits — incline floats appear bottom-right of each window
- [ ] Modify a buffer without saving — orange `●` appears
- [ ] Introduce a lint error — `⊘ N` shown in red on the active window
- [ ] Switch focus to another window — that window's incline dims
- [ ] Open `lua/lsp/init.lua` — incline shows `lsp/init.lua` not just `init.lua`
- [ ] Verify tmux statusbar appears at top with Nerd Font icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)