### PR TITLE
feat(tmux): align session/repo/branch + window list to top-right

### DIFF
--- a/chezmoi/dot_tmux.conf
+++ b/chezmoi/dot_tmux.conf
@@ -44,21 +44,21 @@ bind -r h previous-window
 # 設定リロード
 bind r source-file ~/.tmux.conf \; display-message "tmux.conf reloaded"
 
-# ステータスバー
+# ステータスバー: 右上に session/repo/branch + ウィンドウリストを集約
 set -g status-position top
 set -g status-style 'bg=#1e1e2e fg=#cdd6f4'
 set -g status-interval 2
-set -g status-left-length 100
-set -g status-right-length 0
+set -g status-left-length 0
+set -g status-right-length 300
 set -g status-justify left
 
-# 左: 󰉋 session   repo  󰘬 branch  (Nerd Font icons)
-set -g status-left '#[fg=#89b4fa,bold]󰉋 #S  #[fg=#a6e3a1] #(cd #{pane_current_path} && git rev-parse --show-toplevel 2>/dev/null | xargs basename 2>/dev/null)  #[fg=#f38ba8]󰘬 #(cd #{pane_current_path} && git branch --show-current 2>/dev/null)  '
+# 左側は空
+set -g status-left ''
 
-# ウィンドウリスト (区切りなし、スペースのみ)
-setw -g window-status-format         '#[fg=#585b70] #I #W '
-setw -g window-status-current-format '#[fg=#cdd6f4,bold] #I #W '
-set -g window-status-separator       ''
+# デフォルトのウィンドウリストは非表示 (status-right で W ループ描画)
+setw -g window-status-format ''
+setw -g window-status-current-format ''
+set -g window-status-separator ''
 
-# 右: 空
-set -g status-right ''
+# 右上: 󰉋 session   repo  󰘬 branch  windows...
+set -g status-right '#[fg=#89b4fa,bold]󰉋 #S  #[fg=#a6e3a1] #(cd #{pane_current_path} && git rev-parse --show-toplevel 2>/dev/null | xargs basename 2>/dev/null)  #[fg=#f38ba8]󰘬 #(cd #{pane_current_path} && git branch --show-current 2>/dev/null) #{W:#{?window_active,#[fg=#cdd6f4\,bold] #{window_index} #{window_name} ,#[fg=#585b70] #{window_index} #{window_name} }}'


### PR DESCRIPTION
## Summary
- ステータスバーの内容を画面右上に集約
- `#{W:...}` でウィンドウリストを `status-right` 内に描画し、`session → repo → branch → windows` の順を維持
- デフォルトの window list は非表示にして status-right に統一

## Why
画像 (reference) と同じ右上配置にするため。`status-justify right` だけでは `status-right` がウィンドウリストの後に来てしまい、`[windows] [session info]` の逆順になる。`#{W:condition,format}` でループ描画することで一括して右寄せできる。

## Test Plan
- [ ] tmux 再起動 or `prefix + r` で reload
- [ ] 上部ステータスバーが空白なし・右端に `󰉋 session   repo  󰘬 branch  [windows]` の順で表示されること
- [ ] アクティブなウィンドウのみ bold + light foreground、他は dim 表示
- [ ] ウィンドウを追加/切り替えてもレイアウト崩れがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)