### PR TITLE
fix(starship): fix Nerd Font git branch icon width mismatch

### DIFF
--- a/chezmoi/cli/starship/starship.toml
+++ b/chezmoi/cli/starship/starship.toml
@@ -29,6 +29,7 @@ truncate_to_repo = true
 
 [git_branch]
 symbol = " "
+format = "on [$symbol$branch]($style) "
 
 [git_status]
 ahead = ""


### PR DESCRIPTION
## Summary

- Add explicit `format` to `[git_branch]` in `starship.toml`
- Without it, Starship used the default format which didn't account for the Nerd Font icon width, causing cursor position to be off by one column — last typed character appeared stuck on screen when deleted

## Test plan

- [ ] Open WSL terminal, type a command and delete characters — last character should disappear cleanly
- [ ] Verify git branch is still shown correctly in prompt (e.g. `on  main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)