### PR TITLE
feat(nvim): hide statusline to maximize code area

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/options.lua
+++ b/chezmoi/dot_config/nvim/lua/config/options.lua
@@ -2,9 +2,10 @@
 
 local opt = vim.opt
 
--- Line numbers
+-- Line numbers: relative on left, absolute on right
 opt.number = true
 opt.relativenumber = true
+opt.statuscolumn = "%{v:lnum}  %=%{v:relnum?printf('%3d', v:relnum):'   '} "
 
 -- Indentation
 opt.tabstop = 2
@@ -27,6 +28,11 @@ opt.sidescrolloff = 8
 opt.wrap = true
 opt.linebreak = true
 opt.breakindent = true
+
+-- Clear statusline (hide to gain code area; info moved to tmux/incline/modes)
+opt.laststatus = 0
+opt.statusline = "─"
+opt.fillchars:append({ stl = "─", stlnc = "─" })
 
 -- Split behavior
 opt.splitbelow = true


### PR DESCRIPTION
## Summary
- `chezmoi/dot_config/nvim/lua/config/options.lua` で statusline を非表示化
- `laststatus = 0` で表示自体を消し、`statusline`/`fillchars` を `─` に揃えて境界を目立たなくする
- statusline で表示していた情報は tmux / incline.nvim / modes.nvim に分散済みのため不要

## Test plan
- [ ] `chezmoi apply` 後に `nvim` を起動し、ウィンドウ下端に statusline が表示されないことを確認
- [ ] split を作って境界線が `─` で埋められて目立たないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)