### PR TITLE
fix(nvim): remove lualine to honor laststatus=0

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -160,23 +160,6 @@ return {
         end,
     },
 
-    -- Status line
-    {
-        "nvim-lualine/lualine.nvim",
-        event = "VeryLazy",
-        opts = {
-            options = {
-                theme = "gruvbox",
-                component_separators = "|",
-                section_separators = "",
-            },
-            sections = {
-                lualine_b = { "branch", "diff", "diagnostics" },
-                lualine_c = { { "filename", path = 1 } },
-            },
-        },
-    },
-
     -- Git signs
     {
         "lewis6991/gitsigns.nvim",


### PR DESCRIPTION
## Summary
- #249 で `laststatus = 0` を設定したが lualine.nvim が statusline を再描画していたため非表示にならなかった
- lualine.nvim の lazy 設定ブロックを `plugins/init.lua` から削除
- statusline 情報は tmux / incline.nvim / modes.nvim に分散済み

## Test plan
- [ ] `chezmoi apply` 後に `nvim` を起動し、画面下端の statusline が表示されないことを確認
- [ ] `:Lazy` で lualine.nvim が一覧にないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)