### PR TITLE
feat(nvim): add modes.nvim for mode-aware cursorline color

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -167,6 +167,26 @@ return {
         opts = {},
     },
 
+    -- Mode indicator via cursorline background color
+    {
+        "mvllow/modes.nvim",
+        event = "ModeChanged",
+        opts = {
+            colors = {
+                copy = "#f9e2af",
+                delete = "#f38ba8",
+                insert = "#89dceb",
+                visual = "#cba6f7",
+            },
+            line_opacity = {
+                copy = 0.4,
+                delete = 0.4,
+                insert = 0.4,
+                visual = 0.4,
+            },
+        },
+    },
+
     -- Which-key
     {
         "folke/which-key.nvim",


### PR DESCRIPTION
## Summary

- Add `mvllow/modes.nvim` to show current Vim mode via cursorline background color
- Colors from Catppuccin Mocha palette at 40% opacity — subtle enough to not distract
  - Insert: sky (`#89dceb`)
  - Visual: mauve (`#cba6f7`)
  - Copy (yank): yellow (`#f9e2af`)
  - Delete: red (`#f38ba8`)

## Test plan

- [ ] Enter insert mode — cursorline tints sky blue
- [ ] Enter visual mode — cursorline tints mauve
- [ ] Yank (`yy`) — cursorline briefly tints yellow
- [ ] Delete (`dd`) — cursorline briefly tints red

🤖 Generated with [Claude Code](https://claude.com/claude-code)