### PR TITLE
feat(nix): register sets.fonts to fonts.packages on NixOS

### DIFF
--- a/nix/modules/host/default.nix
+++ b/nix/modules/host/default.nix
@@ -11,6 +11,7 @@ let
     mkMerge
     types
     ;
+  sets = import ../../packages/sets.nix { inherit pkgs lib; };
 in
 {
   options.mySettings.wsl.dockerDesktopIntegration = mkOption {
@@ -37,7 +38,10 @@ in
       };
 
       nixpkgs.config.allowUnfree = true;
-      fonts.fontconfig.enable = true;
+      fonts = {
+        fontconfig.enable = true;
+        packages = sets.fonts;
+      };
       programs.zsh.enable = true;
 
       programs.git = {


### PR DESCRIPTION
## Summary
- NixOS の `fonts.packages` に `sets.fonts` (= MoralerspaceHWJPDOC) を登録
- Windows 側で使用している `Moralerspace Neon HWJPDOC` をシステム全体で利用可能にする
- `home.packages` 経由の配布に加え、システムレベルでも fontconfig がスキャンするよう一貫性を取る

## Test plan
- [ ] `sudo nixos-rebuild dry-build --flake ~/.dotfiles --impure` が成功する
- [ ] `nrs` 後に `fc-list | grep -i moralerspace` で Moralerspace 系フォントが表示される
- [ ] Warp/WezTerm で `Moralerspace Neon HWJPDOC` が正しく表示される