### PR TITLE
fix(wezterm): tune font rendering for Moralerspace HWJPDOC

### DIFF
--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -77,7 +77,12 @@ config.color_scheme = "gruvbox-custom"
 
 -- Font settings
 config.font = wezterm.font("Moralerspace Neon HWJPDOC")
-config.font_size = 10.0
+config.font_size = 11.0
+config.line_height = 1.15
+config.cell_width = 1.0
+
+-- WebGpu renders text more sharply than the legacy OpenGL front end on Windows.
+config.front_end = "WebGpu"
 
 -- IME support
 config.use_ime = true


### PR DESCRIPTION
## Summary
- `font_size` を 10 → **11** に拡大
- `line_height = 1.15`, `cell_width = 1.0` を明示
- `front_end = "WebGpu"` で Windows のテキストレンダリングをよりシャープに
- `window_background_opacity = 0.85` の透過を維持するため、`freetype_load_target` は default (Normal) のままにし、HorizontalLcd は採用していない

## Why
Windows Terminal と比べると WezTerm 側のフォントが小さく / 詰まって見えていた問題に対する調整。Moralerspace (Monaspace 派生) は texture healing 経由で calt が効くが、明示変更すると逆にベースラインがガタつくため、harfbuzz_features や freetype_load_flags は触らずデフォルトに任せる方針。

## Test plan
- [ ] WezTerm を再フォーカスして自動再読み込みされる (`automatically_reload_config = true`)
- [ ] `nvim` 起動画面で文字のベースラインがガタつかないこと
- [ ] starship プロンプトの Nerd Font アイコンも崩れないこと

## References
- [WezTerm Discussion #5791 — Monaspace rendering](https://github.com/wezterm/wezterm/discussions/5791)
- [WezTerm Issue #6785 — baseline inconsistent](https://github.com/wezterm/wezterm/issues/6785)