### PR TITLE
style(terminals): align WezTerm and Windows Terminal on CGA scheme

### DIFF
--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -14,72 +14,19 @@ config.term = "wezterm"
 
 config.automatically_reload_config = true
 
--- Color scheme
-config.color_schemes = {
-    ["gruvbox-custom"] = {
-        ansi = {
-            "#1d2021",
-            "#fb4934",
-            "#b8bb26",
-            "#fabd2f",
-            "#83a598",
-            "#d3869b",
-            "#8ec07c",
-            "#d5c4a1",
-        },
-        brights = {
-            "#665c54",
-            "#fb4934",
-            "#b8bb26",
-            "#fabd2f",
-            "#83a598",
-            "#d3869b",
-            "#8ec07c",
-            "#fbf1c7",
-        },
-        background = "#1d2021",
-        foreground = "#ebdbb2",
-        cursor_bg = "#ebdbb2",
-        cursor_fg = "#1d2021",
-        selection_bg = "#504945",
-        selection_fg = "#ebdbb2",
-        split = "#665c54",
-        compose_cursor = "#fe8019",
-        scrollbar_thumb = "#3c3836",
-        tab_bar = {
-            background = "#1d2021",
-            inactive_tab_edge = "#3c3836",
-            active_tab = {
-                bg_color = "#3c3836",
-                fg_color = "#ebdbb2",
-            },
-            inactive_tab = {
-                bg_color = "#1d2021",
-                fg_color = "#665c54",
-            },
-            inactive_tab_hover = {
-                bg_color = "#3c3836",
-                fg_color = "#ebdbb2",
-            },
-            new_tab = {
-                bg_color = "#1d2021",
-                fg_color = "#665c54",
-            },
-            new_tab_hover = {
-                bg_color = "#3c3836",
-                fg_color = "#ebdbb2",
-            },
-        },
-    },
-}
-
-config.color_scheme = "gruvbox-custom"
+-- Color scheme (matches Windows Terminal's CGA built-in scheme).
+config.color_scheme = "CGA"
 
 -- Font settings
 config.font = wezterm.font("Moralerspace Neon HWJPDOC")
 config.font_size = 11.0
 config.line_height = 1.15
 config.cell_width = 1.0
+
+-- Use the font's own Powerline / box-drawing glyphs instead of WezTerm's
+-- built-in renderings; the built-ins are vertically centered differently than
+-- Moralerspace's Nerd Font glyphs, which makes starship's separators jitter.
+config.custom_block_glyphs = false
 
 -- WebGpu renders text more sharply than the legacy OpenGL front end on Windows.
 config.front_end = "WebGpu"

--- a/chezmoi/terminals/windows-terminal/settings.json
+++ b/chezmoi/terminals/windows-terminal/settings.json
@@ -248,7 +248,7 @@
       },
       "useAcrylic": true,
       "opacity": 85,
-      "colorScheme": "One Half Dark",
+      "colorScheme": "CGA",
       "cursorShape": "bar",
       "padding": "8, 8, 8, 8"
     },


### PR DESCRIPTION
## Summary
- WezTerm の color scheme を `gruvbox-custom` → built-in **CGA** に変更し、不要になったカスタムスキーム定義 (約 55 行) を削除
- Windows Terminal の `defaults.colorScheme` も `One Half Dark` → **CGA** に変更し、両ターミナルで配色を統一
- WezTerm に `custom_block_glyphs = false` を追加し、罫線 / Powerline 三角を WezTerm 内蔵描画ではなく Moralerspace v2.0.0 内蔵の Nerd Font グリフで描画させてベースラインの揺らぎを抑制

## Why
- スクリーンショット比較で Windows Terminal の CGA 配色のほうが視認性が良かったため WezTerm 側を寄せた
- starship プロンプトの Powerline セパレータが WezTerm の `custom_block_glyphs` 内蔵描画と垂直中心がずれていてジグザグに見えていた

## Test plan
- [ ] WezTerm を再フォーカス (auto-reload) して CGA 配色が反映されること
- [ ] Windows Terminal の defaults プロファイルも CGA に変わること
- [ ] starship プロンプトの三角形セパレータが一直線に並ぶこと