### PR TITLE
revert(wezterm): restore custom_block_glyphs default to keep TUI borders intact

### DIFF
--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -23,11 +23,6 @@ config.font_size = 11.0
 config.line_height = 1.15
 config.cell_width = 1.0
 
--- Use the font's own Powerline / box-drawing glyphs instead of WezTerm's
--- built-in renderings; the built-ins are vertically centered differently than
--- Moralerspace's Nerd Font glyphs, which makes starship's separators jitter.
-config.custom_block_glyphs = false
-
 -- WebGpu renders text more sharply than the legacy OpenGL front end on Windows.
 config.front_end = "WebGpu"
 


### PR DESCRIPTION
## Summary
- PR #257 で追加した `config.custom_block_glyphs = false` を撤回し、default (`true`) に戻す

## Why
`custom_block_glyphs` は **罫線文字 (U+2500-U+259F) と Powerline 文字 (U+E0B0-U+E0B7) の両方** を制御するオプションで、個別制御はできない。
`false` にすると Powerline 三角のジグザグは解消するが、副作用として Claude Code などの TUI 枠線がフォント側のメトリクスで描画され、セル境界で繋がらず崩れる。
TUI 崩れの方が体感ダメージが大きいため default に戻す。

## Trade-off
| 設定 | 罫線 (TUI 枠) | Powerline 三角 |
|------|-------------|----------------|
| `true` (本PR) | ◎ 綺麗 | △ ジグザグ |
| `false` (PR #257) | ✗ 崩れる | ◎ 揃う |

## Test plan
- [ ] WezTerm 再フォーカス後、Claude Code を起動して枠線が綺麗に繋がること
- [ ] 通常のシェル/nvim 表示に問題がないこと