### PR TITLE
feat(wezterm): override cursor colors for CGA color scheme

### DIFF
--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -17,6 +17,17 @@ config.automatically_reload_config = true
 -- Color scheme (matches Windows Terminal's CGA built-in scheme).
 config.color_scheme = "CGA"
 
+-- Override cursor colors on top of CGA: the built-in CGA scheme uses the
+-- same grey (#AAAAAA) for cursor and foreground, which makes the cursor and
+-- IME composition text disappear against the prompt. Use bright CGA colors
+-- so the cursor (and IME compose state) stay visible.
+config.colors = {
+    cursor_bg = "#ffff55", -- CGA bright yellow
+    cursor_fg = "#000000",
+    cursor_border = "#ffff55",
+    compose_cursor = "#ff5555", -- CGA bright red during IME composition
+}
+
 -- Font settings
 config.font = wezterm.font("Moralerspace Neon HWJPDOC")
 config.font_size = 11.0


### PR DESCRIPTION
## Summary

- CGA built-in color scheme uses grey (`#AAAAAA`) for both cursor and foreground text, making the cursor and IME composition indicator invisible against the prompt
- Override with bright CGA palette colors: bright yellow cursor (`#ffff55`) and bright red compose cursor (`#ff5555`) during IME composition

## Test plan

- [ ] Open WezTerm — cursor is visible as bright yellow on CGA background
- [ ] Trigger IME composition (Japanese input) — compose cursor appears in red and is distinguishable

🤖 Generated with [Claude Code](https://claude.com/claude-code)