### PR TITLE
style: unify terminals and Neovim on Catppuccin Mocha

### DIFF
--- a/chezmoi/dot_config/nvim/init.lua
+++ b/chezmoi/dot_config/nvim/init.lua
@@ -34,7 +34,7 @@ require("config.osc7").setup()
 -- Load plugins
 require("lazy").setup("plugins", {
     defaults = { lazy = true },
-    install = { colorscheme = { "kanagawa" } },
+    install = { colorscheme = { "catppuccin" } },
     checker = { enabled = false },
     performance = {
         rtp = {

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -3,11 +3,13 @@
 return {
     -- Colorscheme
     {
-        "rebelot/kanagawa.nvim",
+        "catppuccin/nvim",
+        name = "catppuccin",
         lazy = false,
         priority = 1000,
         config = function()
-            vim.cmd.colorscheme("kanagawa-dragon")
+            require("catppuccin").setup({ flavour = "mocha" })
+            vim.cmd.colorscheme("catppuccin-mocha")
         end,
     },
 

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -14,19 +14,9 @@ config.term = "wezterm"
 
 config.automatically_reload_config = true
 
--- Color scheme (matches Windows Terminal's CGA built-in scheme).
-config.color_scheme = "CGA"
-
--- Override cursor colors on top of CGA: the built-in CGA scheme uses the
--- same grey (#AAAAAA) for cursor and foreground, which makes the cursor and
--- IME composition text disappear against the prompt. Use bright CGA colors
--- so the cursor (and IME compose state) stay visible.
-config.colors = {
-    cursor_bg = "#ffff55", -- CGA bright yellow
-    cursor_fg = "#000000",
-    cursor_border = "#ffff55",
-    compose_cursor = "#ff5555", -- CGA bright red during IME composition
-}
+-- Color scheme: Catppuccin Mocha (shared with Windows Terminal and Neovim).
+-- The scheme defines its own cursor/selection colors so no override is needed.
+config.color_scheme = "Catppuccin Mocha"
 
 -- Font settings
 config.font = wezterm.font("Moralerspace Neon HWJPDOC")

--- a/chezmoi/terminals/windows-terminal/settings.json
+++ b/chezmoi/terminals/windows-terminal/settings.json
@@ -248,7 +248,7 @@
       },
       "useAcrylic": true,
       "opacity": 85,
-      "colorScheme": "CGA",
+      "colorScheme": "Catppuccin Mocha",
       "cursorShape": "bar",
       "padding": "8, 8, 8, 8"
     },
@@ -268,7 +268,7 @@
         "backgroundImage": "desktopWallpaper",
         "backgroundImageOpacity": 0.25,
         "backgroundImageStretchMode": "uniformToFill",
-        "colorScheme": "CGA",
+        "colorScheme": "Catppuccin Mocha",
         "opacity": 25
       },
       {
@@ -285,6 +285,30 @@
       }
     ]
   },
-  "schemes": [],
+  "schemes": [
+    {
+      "name": "Catppuccin Mocha",
+      "cursorColor": "#F5E0DC",
+      "selectionBackground": "#585B70",
+      "background": "#1E1E2E",
+      "foreground": "#CDD6F4",
+      "black": "#45475A",
+      "red": "#F38BA8",
+      "green": "#A6E3A1",
+      "yellow": "#F9E2AF",
+      "blue": "#89B4FA",
+      "purple": "#F5C2E7",
+      "cyan": "#94E2D5",
+      "white": "#BAC2DE",
+      "brightBlack": "#585B70",
+      "brightRed": "#F38BA8",
+      "brightGreen": "#A6E3A1",
+      "brightYellow": "#F9E2AF",
+      "brightBlue": "#89B4FA",
+      "brightPurple": "#F5C2E7",
+      "brightCyan": "#94E2D5",
+      "brightWhite": "#A6ADC8"
+    }
+  ],
   "themes": []
 }


### PR DESCRIPTION
## Summary
WezTerm / Windows Terminal / Neovim を **Catppuccin Mocha** に統一する。

## Why
CGA は彩度が高めかつ built-in scheme が cursor 色を定義していないため、IME composition 中の視認性が悪く長時間コーディングに不向きだった。
ターミナル配色ベストプラクティス調査 (#258 後の検討) より、`Catppuccin Mocha` は次の理由で最適と判断:

- **目に優しいパステル系** で長時間コーディング向け
- **cursor / selection 色が scheme 内で定義済み** → IME compose 中も視認性 OK
- WezTerm / Windows Terminal / Neovim 全てに公式サポートあり (built-in or 公式プラグイン)

## Changes
- **WezTerm**: `color_scheme = "Catppuccin Mocha"` に変更、CGA 用 `config.colors` cursor override を削除
- **Windows Terminal**: `defaults` と Administrator profile の `colorScheme` を Catppuccin Mocha に変更、`schemes` 配列に公式 Catppuccin Mocha 定義を追加
- **Neovim**: `rebelot/kanagawa.nvim` → `catppuccin/nvim` (flavour=mocha)、lazy.nvim `install.colorscheme` も catppuccin に変更

## Test plan
- [ ] WezTerm が auto-reload で Catppuccin Mocha に切り替わる
- [ ] Windows Terminal (PowerShell / WSL / Administrator) すべてが Catppuccin Mocha 表示
- [ ] Neovim を再起動して lazy.nvim が catppuccin/nvim を自動インストールし、`catppuccin-mocha` colorscheme が適用される
- [ ] IME (かな入力) 中もカーソル位置がはっきり見える

## References
- [Catppuccin Mocha for Windows Terminal (公式)](https://github.com/catppuccin/windows-terminal)
- [catppuccin/nvim](https://github.com/catppuccin/nvim)
- [WezTerm built-in color schemes](https://wezterm.org/colorschemes/c/index.html#catppuccin-mocha)