### PR TITLE
fix(nvim): move sidekick layout under cli.win so right split actually takes effect

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -408,10 +408,10 @@ return {
             },
         },
         opts = {
-            win = {
-                layout = "right",
-            },
             cli = {
+                win = {
+                    layout = "right",
+                },
                 mux = {
                     backend = "tmux",
                     enabled = false,


### PR DESCRIPTION
## Summary
sidekick.nvim の正しいキーパスは **`opts.cli.win.layout`** で、`opts.win.layout` は認識されない。今までトップレベルに置いていたため設定が無視され、Claude などの CLI が bottom split で開いていた。`cli.win.layout = \"right\"` に修正。

## Why
Sidekick から Claude を起動すると右ペインに開くという既存の運用に戻すため。

## Test plan
- [ ] nvim 再起動 (または `:Lazy reload sidekick.nvim`) 後、`<leader>aa` で Claude を起動して **右ペイン** に開くこと
- [ ] `<leader>as` で他の CLI を選んでも右ペインに開くこと

## References
- [folke/sidekick.nvim README](https://github.com/folke/sidekick.nvim)