### PR TITLE
feat(wezterm): bind Ctrl+Shift+{+/-/0} to font size control

### DIFF
--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -100,20 +100,18 @@ config.keys = {
     { key = "Space", mods = "LEADER", action = act.QuickSelect },
     { key = "F11", action = act.ToggleFullScreen },
 
-    -- Disable all default font size bindings
+    -- Disable default font size bindings except Ctrl+Shift+{+/-/0}
     { key = "+", mods = "CTRL", action = act.DisableDefaultAssignment },
     { key = "-", mods = "CTRL", action = act.DisableDefaultAssignment },
     { key = "=", mods = "CTRL", action = act.DisableDefaultAssignment },
     { key = "0", mods = "CTRL", action = act.DisableDefaultAssignment },
-    { key = "+", mods = "CTRL|SHIFT", action = act.DisableDefaultAssignment },
-    { key = "-", mods = "CTRL|SHIFT", action = act.DisableDefaultAssignment },
     { key = "=", mods = "CTRL|SHIFT", action = act.DisableDefaultAssignment },
-    { key = "0", mods = "CTRL|SHIFT", action = act.DisableDefaultAssignment },
+    { key = "\\", mods = "CTRL|SHIFT", action = act.DisableDefaultAssignment },
 
-    -- Font size via LEADER (Ctrl+Space then +/-/0)
-    { key = "+", mods = "LEADER", action = act.IncreaseFontSize },
-    { key = "-", mods = "LEADER", action = act.DecreaseFontSize },
-    { key = "0", mods = "LEADER", action = act.ResetFontSize },
+    -- Font size via Ctrl+Shift+{+/-/0}
+    { key = "+", mods = "CTRL|SHIFT", action = act.IncreaseFontSize },
+    { key = "-", mods = "CTRL|SHIFT", action = act.DecreaseFontSize },
+    { key = "0", mods = "CTRL|SHIFT", action = act.ResetFontSize },
 
     -- Tab numbers
     { key = "1", mods = "LEADER", action = act.ActivateTab(0) },


### PR DESCRIPTION
## Summary

- Move font size keybindings from `LEADER+{+/-/0}` to `Ctrl+Shift+{+/-/0}` for more intuitive access
- Disable `Ctrl+Shift+\` which was triggering accidental zoom decrease on JIS keyboard
- Keep `Ctrl+Shift+=` disabled to avoid conflict

## Test plan

- [ ] `Ctrl+Shift++` increases font size
- [ ] `Ctrl+Shift+-` decreases font size
- [ ] `Ctrl+Shift+0` resets font size
- [ ] `Ctrl+Shift+\` does nothing (no accidental zoom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)