### PR TITLE
feat(nvim): refresh oil on FocusGained to work around WSL /mnt inotify gap

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -49,6 +49,21 @@ return {
                     end
                 end,
             })
+            -- WSL の /mnt/ (9p) では inotify が発火しないため
+            -- watch_for_changes (fs_event ベース) が機能しない。
+            -- フォーカス復帰時に限って手動 refresh で代替する。
+            -- BufEnter は使わない: oil 自身の `-` ナビゲーションで新 buffer を
+            -- 開くたびに refresh が走ると buffer が空になるため。
+            vim.api.nvim_create_autocmd("FocusGained", {
+                group = vim.api.nvim_create_augroup("OilRefreshFallback", { clear = true }),
+                callback = function()
+                    if vim.bo.filetype == "oil" then
+                        pcall(function()
+                            require("oil.actions").refresh.callback()
+                        end)
+                    end
+                end,
+            })
             -- wmic was removed in Windows 11; patch drive listing to use PowerShell.
             if vim.fn.has("win32") == 1 and vim.fn.executable("wmic") == 0 then
                 local files = require("oil.adapters.files")


### PR DESCRIPTION
## Summary
WSL の `/mnt/` (9p ファイルシステム) は inotify イベントを発火しないため、`oil.nvim` の `watch_for_changes = true` (libuv fs_event ベース) が機能しない。`FocusGained` で oil バッファに居る時のみ `oil.actions.refresh` を呼ぶ fallback を追加。

## Why
WSL から `/mnt/d/ruru/dotfiles` 等を開いて作業しているため、他ターミナルでファイル追加・削除しても oil 表示が古いままだった。

## Design notes
- **`BufEnter` は使わない**: oil 自身の `-` ナビゲーションで新 buffer を開くたびに `refresh` が走り、buffer が一時的に空になる副作用があるため。
- `pcall` で oil API 変更に対する耐性を持たせる
- oil バッファ以外では何もしない (filetype チェック)

## Test plan
- [ ] `:Lazy reload oil.nvim` or nvim 再起動
- [ ] WSL nvim で `/mnt/d/ruru/dotfiles` を oil で開く → 表示される
- [ ] `-` で親ディレクトリへ移動 → 表示される (空にならない)
- [ ] 別ターミナルで同じディレクトリにファイル追加 → nvim にフォーカス戻すと表示更新