### PR TITLE
fix(nvim): make <leader>aa open a local Claude in a right split reliably

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -372,14 +372,23 @@ return {
             {
                 "<leader>aa",
                 function()
-                    require("sidekick.cli").toggle({ name = "claude" })
+                    -- external = true は他 tmux セッションで起動済みの CLI。
+                    -- 検出されると toggle 対象が曖昧になり画面に出ないので除外し、
+                    -- 常にローカルの claude を相手にする。
+                    require("sidekick.cli").toggle({
+                        name = "claude",
+                        focus = true,
+                        filter = function(state)
+                            return not state.external
+                        end,
+                    })
                 end,
-                desc = "Sidekick toggle Claude (default)",
+                desc = "Sidekick toggle Claude (local only)",
             },
             {
                 "<leader>as",
                 function()
-                    require("sidekick.cli").select()
+                    require("sidekick.cli").select({ focus = true })
                 end,
                 desc = "Sidekick select CLI",
             },
@@ -426,6 +435,8 @@ return {
             cli = {
                 win = {
                     layout = "right",
+                    -- split.width はターミナル幅より大きいと bottom にフォールバックする。
+                    -- デフォルト (80 cols) のままにしておき、必要なら手元で resize する。
                 },
                 mux = {
                     backend = "tmux",


### PR DESCRIPTION
## Summary
`<leader>aa` で Claude を開いても画面に出ない / bottom に出てしまう問題を 3 点まとめて修正。

## Root causes
1. **external mux session の干渉**: sidekick.nvim は `mux.enabled = false` でも他 tmux セッションで起動済みの CLI を「external state」として検出し、`toggle({ name = \"claude\" })` がそちらに attach してしまう (画面に出ず `Attached to claude` ステータスだけ残る)。
2. **focus が当たらない**: `toggle({ name = \"claude\" })` だけだとオープンしてもエディタ側にカーソルが残るため、開いていることに気づきにくい。
3. **split.width = 100 が逆効果**: ターミナル幅がそれより狭いと sidekick が bottom split に fallback する仕様だった。

## Changes
- `<leader>aa`: `filter = function(state) return not state.external end` でローカル claude のみを対象に
- `<leader>aa` / `<leader>as` に `focus = true` を追加
- `opts.cli.win.split` の幅指定を削除し、sidekick default (80 cols) に戻す

## Test plan
- [ ] coding-exam-prep (lifelog tmux で claude が走っている状態) で `<Space>aa` → ローカルの新規 claude が右ペインで開く
- [ ] 開いた直後にフォーカスが claude 側に当たっている
- [ ] `<Space>as` のリストには引き続き external 含めて表示される (こちらは選択用なので変更なし)