### PR TITLE
fix(nvim): use sidekick.cli.show() for <leader>aa to reliably open Claude

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -375,7 +375,14 @@ return {
                     -- show() は attach: true, show: true で呼ぶので、
                     -- 既存があれば再表示、なければ spawn して right split で開く。
                     -- toggle() は terminal が無いと早期 return するため新規起動できない。
-                    require("sidekick.cli").show({ name = "claude", focus = true })
+                    -- external を除外して他 tmux セッションの Claude に誤 attach しない。
+                    require("sidekick.cli").show({
+                        name = "claude",
+                        focus = true,
+                        filter = function(state)
+                            return not state.external
+                        end,
+                    })
                 end,
                 desc = "Sidekick show Claude (right pane)",
             },

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -372,18 +372,12 @@ return {
             {
                 "<leader>aa",
                 function()
-                    -- external = true は他 tmux セッションで起動済みの CLI。
-                    -- 検出されると toggle 対象が曖昧になり画面に出ないので除外し、
-                    -- 常にローカルの claude を相手にする。
-                    require("sidekick.cli").toggle({
-                        name = "claude",
-                        focus = true,
-                        filter = function(state)
-                            return not state.external
-                        end,
-                    })
+                    -- show() は attach: true, show: true で呼ぶので、
+                    -- 既存があれば再表示、なければ spawn して right split で開く。
+                    -- toggle() は terminal が無いと早期 return するため新規起動できない。
+                    require("sidekick.cli").show({ name = "claude", focus = true })
                 end,
-                desc = "Sidekick toggle Claude (local only)",
+                desc = "Sidekick show Claude (right pane)",
             },
             {
                 "<leader>as",


### PR DESCRIPTION
## Summary

- Replace `sidekick.cli.toggle()` with `sidekick.cli.show()` for the `<leader>aa` keybind
- `toggle()` returns early when no terminal exists and cannot spawn a new Claude pane from scratch
- `show()` always attaches to an existing session or spawns a new one, so the first press reliably opens the right-pane Claude session

## Test plan

- [ ] Press `<leader>aa` with no existing Claude pane — Claude opens in right split
- [ ] Press `<leader>aa` again — focuses the existing Claude pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)