### PR TITLE
fix(nvim): sidekick to tmux mux backend + WinNew autocmd right-pane workaround

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -372,19 +372,9 @@ return {
             {
                 "<leader>aa",
                 function()
-                    -- show() は attach: true, show: true で呼ぶので、
-                    -- 既存があれば再表示、なければ spawn して right split で開く。
-                    -- toggle() は terminal が無いと早期 return するため新規起動できない。
-                    -- external を除外して他 tmux セッションの Claude に誤 attach しない。
-                    require("sidekick.cli").show({
-                        name = "claude",
-                        focus = true,
-                        filter = function(state)
-                            return not state.external
-                        end,
-                    })
+                    require("sidekick.cli").toggle({ name = "claude", focus = true })
                 end,
-                desc = "Sidekick show Claude (right pane)",
+                desc = "Sidekick toggle Claude",
             },
             {
                 "<leader>as",
@@ -434,29 +424,37 @@ return {
         },
         opts = {
             cli = {
-                win = {
-                    layout = "right",
-                    -- split.width はターミナル幅より大きいと bottom にフォールバックする。
-                    -- デフォルト (80 cols) のままにしておき、必要なら手元で resize する。
-                },
                 mux = {
                     backend = "tmux",
-                    enabled = false,
+                    enabled = true,
                 },
-                tools = vim.tbl_extend("force", {
-                    aider = false,
-                    amazon_q = false,
-                    copilot = false,
-                    crush = false,
-                    cursor = false,
-                    grok = false,
-                    pi = false,
-                    qwen = false,
-                }, vim.fn.has("unix") == 1 and {
+                tools = vim.fn.has("unix") == 1 and {
                     claude = { cmd = { "env", "-u", "NVIM", "claude" } },
-                } or {}),
+                } or nil,
             },
         },
+        config = function(_, opts)
+            require("sidekick").setup(opts)
+            -- sidekick の default cli.win.layout = "right" でも環境次第で
+            -- bottom split に化けるため、CLI window が現れたら強制的に最右
+            -- vsplit に移動する workaround。本来不要だが暫定で入れる。
+            vim.api.nvim_create_autocmd("WinNew", {
+                group = vim.api.nvim_create_augroup("SidekickForceRight", { clear = true }),
+                callback = function()
+                    vim.schedule(function()
+                        for _, win in ipairs(vim.api.nvim_list_wins()) do
+                            if vim.api.nvim_win_is_valid(win) and vim.w[win].sidekick_cli then
+                                pcall(function()
+                                    vim.api.nvim_set_current_win(win)
+                                    vim.cmd("wincmd L")
+                                end)
+                                return
+                            end
+                        end
+                    end)
+                end,
+            })
+        end,
     },
 
     -- Tmux pane navigation (C-h/j/k/l shared with nvim windows)


### PR DESCRIPTION
## Summary
sidekick.nvim で Claude を `<Space>aa` で開いた時に右 pane に出るよう修正。これまでの試行錯誤を整理してまとめる。

## Changes
- `<leader>aa` は素直に `toggle({ name = "claude", focus = true })` のみ。`show()` + `filter = function` は API 不一致で **E5108** を起こすため撤回
- `cli.mux.enabled = true` / `backend = "tmux"` に変更し、Claude を tmux session 経由で起動
- `cli.tools` の `aider = false` 等のデバイス別 disable 列挙は削除 (default に任せる)、unix のみ `claude = { cmd = { "env", "-u", "NVIM", "claude" } }` を override
- `config = function` で **WinNew autocmd** を仕込み、sidekick CLI window (`w:sidekick_cli` マーカー付き) が現れたら `wincmd L` で最右 vsplit に強制移動

## Why workaround is needed
sidekick の default `cli.win.layout = "right"` でも環境次第で bottom split に化ける症状を確認。`split.width` / `height` の調整、`opts` 完全削除など複数試したが効果なし、`opts` を完全に空にした default 動作でも bottom 化。本来 sidekick / Neovim 側で解消されるべき問題なので、暫定 workaround として autocmd で右に強制移動する。

## Test plan
- [ ] nvim 再起動後、`<Space>aa` で Claude が右 pane に開く
- [ ] フォーカスも Claude 側に当たる
- [ ] tmux mux 経由で起動するので、 nvim を閉じても Claude session は tmux 上に残る