### PR TITLE
fix(nvim): gate sidekick mux.enabled on tmux being executable

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -426,7 +426,10 @@ return {
             cli = {
                 mux = {
                     backend = "tmux",
-                    enabled = true,
+                    -- tmux が PATH にある時のみ有効化。Windows ネイティブ nvim や
+                    -- tmux 未インストール環境では terminal backend にフォールバック
+                    -- する (= sidekick の session/init.lua:124-128 と同じ判定)。
+                    enabled = vim.fn.executable("tmux") == 1,
                 },
                 tools = vim.fn.has("unix") == 1 and {
                     claude = { cmd = { "env", "-u", "NVIM", "claude" } },


### PR DESCRIPTION
## Summary
PR #266 で `cli.mux.enabled = true` に固定したところ、tmux が PATH にない環境 (Windows native nvim 等) で `<leader>aa` を叩くと:

```
unknown backend: tmux
sidekick/cli/session/init.lua:83: in function 'new'
sidekick/cli/state.lua:185: in function 'attach'
```

で失敗するようになっていたため、`vim.fn.executable("tmux") == 1` で動的に切り替えるよう修正。

## Why
`sidekick.nvim/lua/sidekick/cli/session/init.lua:124-128` でも同じ判定で tmux backend を register しているので、設定側もそれに合わせる:

```lua
local session_backends = { tmux = "sidekick.cli.session.tmux", zellij = "sidekick.cli.session.zellij" }
for name, mod in pairs(session_backends) do
    if vim.fn.executable(name) == 1 then
        M.register(name, require(mod))
    end
end
```

tmux がない環境では terminal backend に自動フォールバックする。

## Test plan
- [ ] WSL nvim で `<Space>aa` → tmux session 経由で Claude が起動
- [ ] Windows native nvim で `<Space>aa` → terminal backend で起動、エラーが出ない