### PR TITLE
fix(nvim): set sidekick cli.mux.enabled = false to use terminal backend

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -426,10 +426,7 @@ return {
             cli = {
                 mux = {
                     backend = "tmux",
-                    -- tmux が PATH にある時のみ有効化。Windows ネイティブ nvim や
-                    -- tmux 未インストール環境では terminal backend にフォールバック
-                    -- する (= sidekick の session/init.lua:124-128 と同じ判定)。
-                    enabled = vim.fn.executable("tmux") == 1,
+                    enabled = false,
                 },
                 tools = vim.fn.has("unix") == 1 and {
                     claude = { cmd = { "env", "-u", "NVIM", "claude" } },


### PR DESCRIPTION
## Summary
PR #267 で `mux.enabled = vim.fn.executable(\"tmux\") == 1` という動的判定にしたが、tmux がある WSL nvim でも `unknown backend: tmux` エラーが解消しなかったため、一昨日まで安定して動いていた **`enabled = false` (= terminal backend)** に戻す。

## Why
- sidekick 内部の backend register タイミング (`session/init.lua:M.setup()` が遅延 setup される) と、`mux.enabled = true` を受けた `M.new()` の assert が噛み合わないと推測
- worktree + tmux でのセッション管理は引き続き **nvim 外で自前** に行う方針 (`user_nvim_workflow.md` の従来運用に戻る)

## Test plan
- [ ] WSL nvim を再起動して `<Space>aa` → エラーなく Claude が起動
- [ ] Windows native nvim でも同様にエラーが出ない
- [ ] WinNew autocmd workaround で右 pane に強制移動される (PR #266 由来)