### PR TITLE
fix(nvim): stop oil-related E5108 errors and add snacks <-> sidekick bridge

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/osc7.lua
+++ b/chezmoi/dot_config/nvim/lua/config/osc7.lua
@@ -15,8 +15,11 @@ function M.sync_cwd_to_terminal()
     if vim.bo.filetype == "oil" then
         local ok, oil = pcall(require, "oil")
         if ok then
-            local oil_dir = oil.get_current_dir()
-            if oil_dir and oil_dir ~= "" then
+            -- Windows のドライブ root (C:\) など、oil の get_current_dir が
+            -- 内部で `attempt to index local 'drive' (a nil value)` を投げる
+            -- ケースがあるため pcall で吸収し、フォールバックで getcwd() を使う。
+            local got_dir, oil_dir = pcall(oil.get_current_dir)
+            if got_dir and oil_dir and oil_dir ~= "" then
                 emit_osc7(oil_dir)
                 return
             end

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -49,21 +49,11 @@ return {
                     end
                 end,
             })
-            -- WSL の /mnt/ (9p) では inotify が発火しないため
-            -- watch_for_changes (fs_event ベース) が機能しない。
-            -- フォーカス復帰時に限って手動 refresh で代替する。
-            -- BufEnter は使わない: oil 自身の `-` ナビゲーションで新 buffer を
-            -- 開くたびに refresh が走ると buffer が空になるため。
-            vim.api.nvim_create_autocmd("FocusGained", {
-                group = vim.api.nvim_create_augroup("OilRefreshFallback", { clear = true }),
-                callback = function()
-                    if vim.bo.filetype == "oil" then
-                        pcall(function()
-                            require("oil.actions").refresh.callback()
-                        end)
-                    end
-                end,
-            })
+            -- (削除: PR #263 で入れた FocusGained refresh は user の select 操作と
+            -- 衝突して `cache.lua:138: Entry X missing parent url` を起こす race
+            -- condition があったため撤回。WSL /mnt の外部変更反映は手動 `<C-l>`
+            -- (oil default の refresh) で対応する。)
+
             -- wmic was removed in Windows 11; patch drive listing to use PowerShell.
             if vim.fn.has("win32") == 1 and vim.fn.executable("wmic") == 0 then
                 local files = require("oil.adapters.files")
@@ -351,7 +341,27 @@ return {
         opts = {
             lazygit = { enabled = true },
             terminal = { enabled = true },
-            picker = { enabled = true },
+            picker = {
+                enabled = true,
+                -- snacks picker から Alt+a で選択中の項目を sidekick の
+                -- 現在の AI CLI セッションに送る (ファイルパス / grep ヒット /
+                -- 複数選択 / 位置情報まで自動付与される)。
+                actions = {
+                    sidekick_send = function(...)
+                        return require("sidekick.cli.picker.snacks").send(...)
+                    end,
+                },
+                win = {
+                    input = {
+                        keys = {
+                            ["<a-a>"] = {
+                                "sidekick_send",
+                                mode = { "n", "i" },
+                            },
+                        },
+                    },
+                },
+            },
         },
     },
 


### PR DESCRIPTION
## Summary
oil 由来の `E5108` エラーを 2 件止めつつ、snacks picker から sidekick CLI に送れる橋渡しを追加。

## Changes
- **osc7.lua**: `oil.get_current_dir()` を `pcall` で wrap。Windows のドライブ root (`C:\`) などで oil が内部 `fs.lua:90` で `attempt to index local 'drive' (a nil value)` を投げるケースを吸収し、フォールバックで `vim.fn.getcwd()` を使う。これで BufEnter autocmd が落ちなくなる
- **oil の FocusGained refresh autocmd を撤回**: PR #263 で追加したもの。user の select 操作と非同期で衝突し `cache.lua:138: Entry X missing parent url` を起こす race condition があった。WSL `/mnt/` の外部変更反映は手動 `<C-l>` で対応する方針に戻す
- **snacks の picker.actions.sidekick_send + `<a-a>` キーマップを追加**: picker 選択中の項目 (ファイルパス / grep ヒット / 複数選択 / 位置情報) を現在の sidekick AI CLI に直接送れる

## Test plan
- [ ] Windows nvim で `D:\ruru\dotfiles` を oil で開き `../` でドライブ root へ移動 → エラーなし
- [ ] oil で `<CR>` (select) を連打しても `Entry X missing parent url` が出ない
- [ ] snacks picker (例: `<leader>fg` grep) を開いて項目を選択し `<a-a>` → sidekick CLI に送信される