### PR TITLE
feat(nvim): add <leader>tf to toggle a floating terminal

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/float_term.lua
+++ b/chezmoi/dot_config/nvim/lua/config/float_term.lua
@@ -1,0 +1,71 @@
+-- Floating terminal toggle. snacks.terminal の position = "float" が機能しない /
+-- vim.fn.termopen() が float window を split に書き換える環境への対策として、
+-- 純粋 nvim API + termopen 後に nvim_win_set_config で float 構成を再適用する。
+local M = {}
+
+local state = { buf = nil, win = nil }
+
+local function shell_cmd()
+    if vim.fn.has("win32") == 1 then
+        return "pwsh.exe"
+    end
+    return vim.o.shell
+end
+
+local function float_config()
+    local width = math.floor(vim.o.columns * 0.85)
+    local height = math.floor(vim.o.lines * 0.85)
+    return {
+        relative = "editor",
+        row = math.floor((vim.o.lines - height) / 2),
+        col = math.floor((vim.o.columns - width) / 2),
+        width = width,
+        height = height,
+        border = "rounded",
+    }
+end
+
+function M.toggle()
+    -- Already open → hide
+    if state.win and vim.api.nvim_win_is_valid(state.win) then
+        vim.api.nvim_win_hide(state.win)
+        state.win = nil
+        return
+    end
+
+    local reuse = state.buf and vim.api.nvim_buf_is_valid(state.buf)
+    if not reuse then
+        state.buf = vim.api.nvim_create_buf(false, true)
+    end
+
+    local cfg = float_config()
+    state.win = vim.api.nvim_open_win(state.buf, true, cfg)
+
+    -- Terminal らしく余計な UI を消す (style = "minimal" は環境次第で
+    -- nvim_open_win の挙動を変えるため、ここで明示的に off にする)。
+    vim.wo[state.win].number = false
+    vim.wo[state.win].relativenumber = false
+    vim.wo[state.win].signcolumn = "no"
+    vim.wo[state.win].cursorline = false
+
+    if not reuse then
+        vim.fn.termopen(shell_cmd(), {
+            on_exit = function()
+                state.buf = nil
+                if state.win and vim.api.nvim_win_is_valid(state.win) then
+                    pcall(vim.api.nvim_win_close, state.win, true)
+                end
+                state.win = nil
+            end,
+        })
+        -- termopen が float window を split に変換するケースに備えて
+        -- float config を再適用する。
+        if state.win and vim.api.nvim_win_is_valid(state.win) then
+            pcall(vim.api.nvim_win_set_config, state.win, cfg)
+        end
+    end
+
+    vim.cmd("startinsert")
+end
+
+return M

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -337,6 +337,16 @@ return {
                 mode = { "n", "t" },
                 desc = "Toggle bottom terminal",
             },
+            {
+                "<leader>tf",
+                function()
+                    -- snacks.terminal の position = "float" が bottom に化ける問題
+                    -- を避けるため、純粋 nvim API で実装した自前 float terminal を使う。
+                    require("config.float_term").toggle()
+                end,
+                mode = { "n", "t" },
+                desc = "Toggle floating terminal",
+            },
         },
         opts = {
             lazygit = { enabled = true },


### PR DESCRIPTION
## Summary
`<Space>tf` で画面中央に floating terminal を toggle するキーマップを追加。snacks.terminal は使わず純粋 nvim API で自前実装。

## Why custom implementation
- `Snacks.terminal.toggle(cmd, { win = { position = "float" } })` を試したが `position = "bottom"` に化ける挙動
- 純粋 `vim.api.nvim_open_win({ relative = "editor", ... })` も `vim.fn.termopen()` を呼ぶと内部で **`split = "left"` に書き換わる**ことを確認 (ユーザー環境)
- そこで **`nvim_win_set_config` で termopen 後に float 構成を再適用**することで安定動作

## Changes
- **lua/config/float_term.lua** (新規)
  - `nvim_open_win` で float window を作成 (`relative = "editor"`, 画面 85% サイズ, 中央, 丸角枠)
  - `vim.fn.termopen` で pwsh.exe (Windows) / vim.o.shell (Unix) を起動
  - termopen 後に `nvim_win_set_config` で float 構成を再適用 (split 化への対策)
  - `number = false`, `signcolumn = "no"`, `cursorline = false` で terminal らしく
  - `on_exit` で state cleanup
- **plugins/init.lua**
  - `<leader>tf` キーマップを追加し `require("config.float_term").toggle()` を呼ぶ
  - `<leader>tt` (bottom terminal, snacks) と独立 session

## Test plan
- [ ] nvim 完全再起動後、`<Space>tf` で画面中央に丸角 float terminal が出る
- [ ] もう一度 `<Space>tf` で hide、再度押すと同じ session が再表示
- [ ] `<Space>tt` (bottom) と共存
- [ ] shell exit 時に float window も自動 close