### PR TITLE
feat(nvim): share float window dimensions and add resize keymaps for float terminal

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/float_term.lua
+++ b/chezmoi/dot_config/nvim/lua/config/float_term.lua
@@ -1,9 +1,19 @@
--- Floating terminal toggle. snacks.terminal の position = "float" が機能しない /
--- vim.fn.termopen() が float window を split に書き換える環境への対策として、
--- 純粋 nvim API + termopen 後に nvim_win_set_config で float 構成を再適用する。
+-- Floating terminal toggle + dynamic resize.
+-- snacks.terminal の position = "float" が機能しない / vim.fn.termopen() が
+-- float window を split に書き換える環境への対策として、純粋 nvim API +
+-- termopen 後に nvim_win_set_config で float 構成を再適用する。
+-- 寸法は lua/config/window_styles.lua の共通 SSOT を参照し、現セッション中の
+-- ratio 上書きはモジュール local state に保持する (toggle hide でも維持される)。
+local styles = require("config.window_styles")
+
 local M = {}
 
-local state = { buf = nil, win = nil }
+-- state.ratio が nil の間は styles.float.width に追従する。
+local state = { buf = nil, win = nil, ratio = nil }
+
+local STEP = 0.05
+local MIN_RATIO = 0.3
+local MAX_RATIO = 0.98
 
 local function shell_cmd()
     if vim.fn.has("win32") == 1 then
@@ -12,17 +22,28 @@ local function shell_cmd()
     return vim.o.shell
 end
 
+local function current_ratio()
+    return state.ratio or styles.float.width
+end
+
 local function float_config()
-    local width = math.floor(vim.o.columns * 0.85)
-    local height = math.floor(vim.o.lines * 0.85)
+    local r = current_ratio()
+    local width = math.floor(vim.o.columns * r)
+    local height = math.floor(vim.o.lines * r)
     return {
         relative = "editor",
         row = math.floor((vim.o.lines - height) / 2),
         col = math.floor((vim.o.columns - width) / 2),
         width = width,
         height = height,
-        border = "rounded",
+        border = styles.float.border,
     }
+end
+
+local function apply_size()
+    if state.win and vim.api.nvim_win_is_valid(state.win) then
+        pcall(vim.api.nvim_win_set_config, state.win, float_config())
+    end
 end
 
 function M.toggle()
@@ -67,5 +88,26 @@ function M.toggle()
 
     vim.cmd("startinsert")
 end
+
+function M.grow()
+    state.ratio = math.min(current_ratio() + STEP, MAX_RATIO)
+    apply_size()
+end
+
+function M.shrink()
+    state.ratio = math.max(current_ratio() - STEP, MIN_RATIO)
+    apply_size()
+end
+
+function M.reset()
+    state.ratio = nil
+    apply_size()
+end
+
+-- 端末リサイズ時に開いている float terminal を新しい画面寸法に合わせて再配置。
+vim.api.nvim_create_autocmd("VimResized", {
+    group = vim.api.nvim_create_augroup("FloatTermResize", { clear = true }),
+    callback = apply_size,
+})
 
 return M

--- a/chezmoi/dot_config/nvim/lua/config/keymaps.lua
+++ b/chezmoi/dot_config/nvim/lua/config/keymaps.lua
@@ -49,6 +49,21 @@ map("n", "-", "<cmd>Oil<cr>", { desc = "Open parent directory" })
 -- Terminal mode
 map("t", "jk", "<C-\\><C-n>", { desc = "Exit terminal mode" })
 
+-- Float terminal resize (Alt+ 単キー)。nvim の terminal mode は prefix mapping
+-- が動作しにくいため、確実に届く single keystroke の Alt 系を採用。
+-- Shift キーが必要な記号 (`+` / `_`) を使うことで、視覚的にも拡大/縮小と
+-- 結びつきやすい。リセットは少なくとも今は keymap 化していない:
+-- `:lua require("config.float_term").reset()` で呼び出し可能。
+local function fterm_grow()
+    require("config.float_term").grow()
+end
+local function fterm_shrink()
+    require("config.float_term").shrink()
+end
+
+map({ "n", "t" }, "<M-+>", fterm_grow, { desc = "Float term: grow (+5%)" })
+map({ "n", "t" }, "<M-_>", fterm_shrink, { desc = "Float term: shrink (-5%)" })
+
 -- Telescope
 map("n", "<leader>ff", "<cmd>Telescope find_files<cr>", { desc = "Find files" })
 map("n", "<leader>fg", "<cmd>Telescope live_grep<cr>", { desc = "Live grep" })

--- a/chezmoi/dot_config/nvim/lua/config/window_styles.lua
+++ b/chezmoi/dot_config/nvim/lua/config/window_styles.lua
@@ -1,0 +1,16 @@
+-- Shared float window dimensions (SSOT).
+-- Reference this from any plugin / module that opens a floating window so
+-- that resizing happens in one place.
+local M = {}
+
+---@class config.WindowStyle.Float
+---@field width number   ratio of vim.o.columns (0..1)
+---@field height number  ratio of vim.o.lines   (0..1)
+---@field border string  vim window border style
+M.float = {
+    width = 0.85,
+    height = 0.85,
+    border = "rounded",
+}
+
+return M


### PR DESCRIPTION
## Summary
float window 寸法の SSOT を新設し、`<Space>tf` で開く float terminal を動的にリサイズできるようにする。

## Changes
- **lua/config/window_styles.lua** (新規)
  - `M.float = { width = 0.85, height = 0.85, border = "rounded" }` を export
  - 将来 telescope / sidekick float / snacks picker など他の float もここを参照する形に統一できる
- **lua/config/float_term.lua**
  - `window_styles` を参照
  - `M.grow()` / `M.shrink()` / `M.reset()` を追加 (5% step / 30%..98% / 0)
  - ratio は module local state に保持し、toggle hide/show で維持
  - `VimResized` autocmd でターミナル resize 時にも追従
- **lua/config/keymaps.lua**
  - `<M-+>` (Alt+Shift+;) で拡大、`<M-_>` (Alt+Shift+-) で縮小
  - nvim の terminal mode は prefix mapping が動作しにくいため単一 Alt+ 記号キーを採用
  - リセットは関数として残し keymap は付けない (`:lua require("config.float_term").reset()` で呼び出し可能)

## Test plan
- [ ] nvim 完全再起動
- [ ] `<Space>tf` で float terminal が画面 85% で開く
- [ ] `Alt+Shift+;` で 5% 拡大、連打で大きくなる
- [ ] `Alt+Shift+-` で 5% 縮小
- [ ] WezTerm/Windows Terminal をリサイズしても float が追従
- [ ] `window_styles.lua` の `width` を変えれば次回 toggle 時に新サイズで開く