### PR TITLE
fix(nvim+wezterm): raise line_height, switch float border to single, enable mouse, add float move keymaps

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/keymaps.lua
+++ b/chezmoi/dot_config/nvim/lua/config/keymaps.lua
@@ -64,12 +64,31 @@ end
 map({ "n", "t" }, "<M-+>", fterm_grow, { desc = "Float term: grow (+5%)" })
 map({ "n", "t" }, "<M-_>", fterm_shrink, { desc = "Float term: shrink (-5%)" })
 
--- Telescope
-map("n", "<leader>ff", "<cmd>Telescope find_files<cr>", { desc = "Find files" })
-map("n", "<leader>fg", "<cmd>Telescope live_grep<cr>", { desc = "Live grep" })
-map("n", "<leader>fb", "<cmd>Telescope buffers<cr>", { desc = "Buffers" })
-map("n", "<leader>fh", "<cmd>Telescope help_tags<cr>", { desc = "Help tags" })
-map("n", "<leader>fr", "<cmd>Telescope oldfiles<cr>", { desc = "Recent files" })
+-- Move floating window (Alt+Shift+HJKL)
+local function move_float(dr, dc)
+    local win = vim.api.nvim_get_current_win()
+    local cfg = vim.api.nvim_win_get_config(win)
+    if cfg.relative == "" then
+        vim.notify("move_float: not a float (relative='')", vim.log.levels.WARN)
+        return
+    end
+    cfg.row = (cfg.row or 0) + dr
+    cfg.col = (cfg.col or 0) + dc
+    vim.api.nvim_win_set_config(win, cfg)
+    vim.notify(("move_float: row=%.0f col=%.0f"):format(cfg.row, cfg.col), vim.log.levels.INFO)
+end
+map("t", "<A-H>", function()
+    move_float(0, -3)
+end, { desc = "Float: move left" })
+map("t", "<A-J>", function()
+    move_float(3, 0)
+end, { desc = "Float: move down" })
+map("t", "<A-K>", function()
+    move_float(-3, 0)
+end, { desc = "Float: move up" })
+map("t", "<A-L>", function()
+    move_float(0, 3)
+end, { desc = "Float: move right" })
 
 -- Unified window management (same characters as tmux/terminal layers)
 map("n", "<leader>\\", "<cmd>vsplit<cr>", { desc = "Vertical split" })

--- a/chezmoi/dot_config/nvim/lua/config/options.lua
+++ b/chezmoi/dot_config/nvim/lua/config/options.lua
@@ -19,6 +19,9 @@ opt.smartcase = true
 opt.hlsearch = true
 opt.incsearch = true
 
+-- Mouse: enable in all modes so floating windows can be dragged by title bar
+opt.mouse = "a"
+
 -- UI
 opt.termguicolors = true
 opt.signcolumn = "yes"

--- a/chezmoi/dot_config/nvim/lua/config/window_styles.lua
+++ b/chezmoi/dot_config/nvim/lua/config/window_styles.lua
@@ -10,7 +10,9 @@ local M = {}
 M.float = {
     width = 0.85,
     height = 0.85,
-    border = "rounded",
+    -- "rounded" (╭╮╰╯) は line_height > 1 の WezTerm で行間に隙間が
+    -- 出て border がガタつくため、cell 連続性が安定する "single" を採用。
+    border = "single",
 }
 
 return M

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -21,7 +21,9 @@ config.color_scheme = "Catppuccin Mocha"
 -- Font settings
 config.font = wezterm.font("Moralerspace Neon HWJPDOC")
 config.font_size = 11.0
-config.line_height = 1.15
+-- 1.15 だと Moralerspace HWJPDOC の descender (g/j/p/y 等) が cell の下端で
+-- 切れて見えるため 1.25 に上げて余白を確保。
+config.line_height = 1.25
 config.cell_width = 1.0
 
 -- WebGpu renders text more sharply than the legacy OpenGL front end on Windows.

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -107,6 +107,7 @@ config.keys = {
     { key = "0", mods = "CTRL", action = act.DisableDefaultAssignment },
     { key = "=", mods = "CTRL|SHIFT", action = act.DisableDefaultAssignment },
     { key = "\\", mods = "CTRL|SHIFT", action = act.DisableDefaultAssignment },
+    { key = "w", mods = "CTRL|SHIFT", action = act.DisableDefaultAssignment },
 
     -- Font size via Ctrl+Shift+{+/-/0}
     { key = "+", mods = "CTRL|SHIFT", action = act.IncreaseFontSize },


### PR DESCRIPTION
## Summary
WezTerm の `line_height` を上げて Moralerspace HWJPDOC の descender 切れを解消し、その副作用で float window の border が崩れる問題を border 種別変更で吸収。あわせてマウス有効化と float 移動キーを追加。

## Changes
- **wezterm.lua**: `line_height = 1.15` → **1.25** (CJK 推奨レンジ 1.2-1.4 の真ん中、descender 用余白を確保)
- **window_styles.lua**: float `border = "rounded"` → **"single"** (line_height > 1 だと rounded コーナーが行間で繋がらずガタつくため)
- **options.lua**: `mouse = "a"` を追加 (floating window タイトルバーでドラッグ移動できるように)
- **keymaps.lua**:
  - `<A-S-H/J/K/L>` で float window を移動 (terminal mode)
  - 古い `<leader>f*` の Telescope keymap は plugin spec 側 `keys = {...}` と重複していたので削除

## Test plan
- [ ] `<Space>tf` で float terminal を開き、descender (g/j/p/y) が削れていないこと
- [ ] float terminal の border (`│┌┐└┘─`) が連続していてガタつかないこと
- [ ] マウスで float タイトルバーをドラッグして移動できること
- [ ] `Alt+Shift+L` 等で float をキーボードからも移動できること