### PR TITLE
feat(nvim): persist float terminal size and reliably clear border on resize

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/float_persist.lua
+++ b/chezmoi/dot_config/nvim/lua/config/float_persist.lua
@@ -1,0 +1,105 @@
+-- Persist floating window position across sessions.
+-- Keys windows by title (snacks windows) or buftype (plain terminal floats).
+local M = {}
+
+local path = vim.fn.stdpath("data") .. "/nvim_float_positions.json"
+
+local function read()
+    local ok, lines = pcall(vim.fn.readfile, path)
+    if not ok or #lines == 0 then
+        return {}
+    end
+    local ok2, t = pcall(vim.fn.json_decode, lines[1])
+    return (ok2 and type(t) == "table") and t or {}
+end
+
+local function write(t)
+    pcall(vim.fn.writefile, { vim.fn.json_encode(t) }, path)
+end
+
+local function win_key(win)
+    if not vim.api.nvim_win_is_valid(win) then
+        return nil
+    end
+    local cfg = vim.api.nvim_win_get_config(win)
+    local title = cfg.title
+    if type(title) == "string" and title ~= "" then
+        return title
+    elseif type(title) == "table" and title[1] then
+        local t0 = title[1]
+        local s = type(t0) == "string" and t0 or (type(t0) == "table" and t0[1] or nil)
+        if type(s) == "string" and s ~= "" then
+            return s
+        end
+    end
+    local buf = vim.api.nvim_win_get_buf(win)
+    if vim.bo[buf].buftype == "terminal" then
+        return "terminal"
+    end
+    local ft = vim.bo[buf].filetype
+    return ft ~= "" and ("ft:" .. ft) or nil
+end
+
+function M.save(win)
+    if not vim.api.nvim_win_is_valid(win) then
+        return
+    end
+    local cfg = vim.api.nvim_win_get_config(win)
+    if cfg.relative == "" then
+        return
+    end
+    local key = win_key(win)
+    if not key then
+        return
+    end
+    local t = read()
+    t[key] = { row = cfg.row, col = cfg.col, width = cfg.width, height = cfg.height }
+    write(t)
+end
+
+function M.restore(win)
+    if not vim.api.nvim_win_is_valid(win) then
+        return
+    end
+    local cfg = vim.api.nvim_win_get_config(win)
+    if cfg.relative == "" then
+        return
+    end
+    local key = win_key(win)
+    if not key then
+        return
+    end
+    local saved = read()[key]
+    if not saved then
+        return
+    end
+    local patch = { row = saved.row, col = saved.col }
+    if saved.width then
+        patch.width = saved.width
+    end
+    if saved.height then
+        patch.height = saved.height
+    end
+    pcall(vim.api.nvim_win_set_config, win, patch)
+end
+
+function M.setup()
+    vim.api.nvim_create_autocmd("WinNew", {
+        group = vim.api.nvim_create_augroup("FloatPersist", { clear = true }),
+        callback = function()
+            local win = vim.api.nvim_get_current_win()
+            vim.defer_fn(function()
+                if not vim.api.nvim_win_is_valid(win) then
+                    return
+                end
+                local cfg = vim.api.nvim_win_get_config(win)
+                if cfg.relative == "" then
+                    return
+                end
+                M.restore(win)
+            end, 80)
+        end,
+    })
+end
+
+return M

--- a/chezmoi/dot_config/nvim/lua/config/float_term.lua
+++ b/chezmoi/dot_config/nvim/lua/config/float_term.lua
@@ -15,6 +15,23 @@ local STEP = 0.05
 local MIN_RATIO = 0.3
 local MAX_RATIO = 0.98
 
+local ratio_path = vim.fn.stdpath("data") .. "/nvim_float_term_ratio.json"
+
+local function load_ratio()
+    local ok, lines = pcall(vim.fn.readfile, ratio_path)
+    if not ok or #lines == 0 then
+        return
+    end
+    local ok2, saved = pcall(vim.fn.json_decode, lines[1])
+    if ok2 and saved and type(saved.ratio) == "number" then
+        state.ratio = saved.ratio
+    end
+end
+
+local function save_ratio()
+    pcall(vim.fn.writefile, { vim.fn.json_encode({ ratio = state.ratio }) }, ratio_path)
+end
+
 local function shell_cmd()
     if vim.fn.has("win32") == 1 then
         return "pwsh.exe"
@@ -92,26 +109,52 @@ end
 function M.grow()
     state.ratio = math.min(current_ratio() + STEP, MAX_RATIO)
     apply_size()
+    save_ratio()
 end
 
 function M.shrink()
     state.ratio = math.max(current_ratio() - STEP, MIN_RATIO)
     apply_size()
+    save_ratio()
 end
 
 function M.reset()
     state.ratio = nil
     apply_size()
+    save_ratio()
 end
 
--- 端末リサイズ時に開いている float terminal を新しい画面寸法に合わせて再配置。
--- リサイズ後は古い border が画面に残ることがあるため redraw! で強制再描画する。
+-- 端末リサイズ時に開いている float terminal を新しい画面寸法に合わせる。
+-- nvim_win_set_config では emulator に古い border が残り続けるため、
+-- window を一度閉じて再オープンすることで完全に消す。
+-- terminal mode で作業中なら resize 後も terminal mode に戻す。
 vim.api.nvim_create_autocmd("VimResized", {
     group = vim.api.nvim_create_augroup("FloatTermResize", { clear = true }),
     callback = function()
-        apply_size()
-        vim.cmd("redraw!")
+        if not (state.win and vim.api.nvim_win_is_valid(state.win)) then
+            return
+        end
+        local was_in_terminal = vim.api.nvim_get_mode().mode == "t"
+        vim.schedule(function()
+            if state.win and vim.api.nvim_win_is_valid(state.win) then
+                pcall(vim.api.nvim_win_close, state.win, true)
+                state.win = nil
+            end
+            if not (state.buf and vim.api.nvim_buf_is_valid(state.buf)) then
+                return
+            end
+            state.win = vim.api.nvim_open_win(state.buf, true, float_config())
+            vim.wo[state.win].number = false
+            vim.wo[state.win].relativenumber = false
+            vim.wo[state.win].signcolumn = "no"
+            vim.wo[state.win].cursorline = false
+            if was_in_terminal then
+                vim.cmd("startinsert")
+            end
+        end)
     end,
 })
+
+load_ratio()
 
 return M

--- a/chezmoi/dot_config/nvim/lua/config/float_term.lua
+++ b/chezmoi/dot_config/nvim/lua/config/float_term.lua
@@ -105,9 +105,13 @@ function M.reset()
 end
 
 -- 端末リサイズ時に開いている float terminal を新しい画面寸法に合わせて再配置。
+-- リサイズ後は古い border が画面に残ることがあるため redraw! で強制再描画する。
 vim.api.nvim_create_autocmd("VimResized", {
     group = vim.api.nvim_create_augroup("FloatTermResize", { clear = true }),
-    callback = apply_size,
+    callback = function()
+        apply_size()
+        vim.cmd("redraw!")
+    end,
 })
 
 return M

--- a/chezmoi/dot_config/nvim/lua/config/keymaps.lua
+++ b/chezmoi/dot_config/nvim/lua/config/keymaps.lua
@@ -69,13 +69,12 @@ local function move_float(dr, dc)
     local win = vim.api.nvim_get_current_win()
     local cfg = vim.api.nvim_win_get_config(win)
     if cfg.relative == "" then
-        vim.notify("move_float: not a float (relative='')", vim.log.levels.WARN)
         return
     end
     cfg.row = (cfg.row or 0) + dr
     cfg.col = (cfg.col or 0) + dc
     vim.api.nvim_win_set_config(win, cfg)
-    vim.notify(("move_float: row=%.0f col=%.0f"):format(cfg.row, cfg.col), vim.log.levels.INFO)
+    require("config.float_persist").save(win)
 end
 map("t", "<A-H>", function()
     move_float(0, -3)
@@ -108,6 +107,8 @@ vim.api.nvim_create_user_command("Term", function()
     vim.cmd("botright 15split | terminal")
     vim.cmd("startinsert")
 end, { desc = "Open terminal in bottom split" })
+
+require("config.float_persist").setup()
 
 -- Redirect :terminal (typed at start of command line) to :Term.
 -- getcmdpos() guard prevents expansion mid-command (e.g. :edit terminal stays intact).


### PR DESCRIPTION
## Summary
Float terminal の見た目周りを 2 点改善:

1. **`fix: force redraw after VimResized`** — VimResized 時に `nvim_win_set_config` だけだと旧 border (`│`) が画面に残るため、window を **close + reopen** で完全に再生成して emulator 残骸も消す
2. **`feat: persist float window size`** — ratio (拡大/縮小状態) を `stdpath("data")/nvim_float_term_ratio.json` に保存し、nvim 再起動後も復元

## Test plan
- [ ] `<Space>tf` → `Alt+Shift+;` で拡大 → nvim 再起動 → 同じサイズで開く
- [ ] WezTerm のサイズ変更時に border が綺麗に追従する