### PR TITLE
feat(pkgs): add gwq custom nix derivation for git worktree management

### DIFF
--- a/nix/packages/gwq/default.nix
+++ b/nix/packages/gwq/default.nix
@@ -1,0 +1,23 @@
+{ pkgs, ... }:
+pkgs.buildGoModule {
+  pname = "gwq";
+  version = "0.1.1";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "d-kuro";
+    repo = "gwq";
+    rev = "v0.1.1";
+    sha256 = "044cjn57373zsz0v283012masgiibjwv1fhzqz7pfnl3ncariw1i";
+  };
+
+  vendorHash = "sha256-4K01Xf1EXl/NVX1loQ76l1bW8QglBAQdvlZSo7J4NPI=";
+
+  doCheck = false;
+
+  meta = {
+    description = "Manage git worktrees like ghq manages repositories";
+    homepage = "https://github.com/d-kuro/gwq";
+    license = pkgs.lib.licenses.mit;
+    mainProgram = "gwq";
+  };
+}

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -115,6 +115,11 @@ let
       winget = "x-motemen.ghq";
       category = "dev";
     };
+    gwq = {
+      pkg = import ./gwq/default.nix { inherit pkgs; };
+      winget = null;
+      category = "dev";
+    };
     uv = {
       pkg = pkgs.uv;
       winget = "astral-sh.uv";


### PR DESCRIPTION
## Summary

- `nix/packages/gwq/default.nix` を新規追加 (`buildGoModule` で d-kuro/gwq v0.1.1 をビルド)
- `nix/packages/sets.nix` の dev カテゴリに gwq を追加 (winget = null, NixOS 専用)

## Test plan

- [x] `nix build .#gwq` で正常ビルド確認
- [x] NixOS WSL で `gwq --version` が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)