### PR TITLE
feat(wsl): set BROWSER=explorer.exe; update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779507042,
-        "narHash": "sha256-7wOwi8B6D0BYsieZCnHZZj2sNUzgJhLoIVSfkwB7lxQ=",
+        "lastModified": 1779726696,
+        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "509ed3c603349a9d43de9e2ae6613baea6bd5b34",
+        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1779357205,
-        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {

--- a/nix/home/wsl/users.nix
+++ b/nix/home/wsl/users.nix
@@ -36,6 +36,7 @@
 
       home.sessionVariables = {
         _ZO_EXCLUDE_DIRS = "/mnt/wsl/*:/mnt/wslg/*";
+        BROWSER = "explorer.exe";
         # fcitx5 GTK_IM_MODULE bridge: Warp runs in Wayland mode but reads these
         # env vars to delegate key events to the fcitx5 daemon via the GTK IM module.
         GTK_IM_MODULE = "fcitx";


### PR DESCRIPTION
## Summary

- `nix/home/wsl/users.nix`: `BROWSER = "explorer.exe"` を追加 — WSL 内のツール (`claude /login` 等) が Windows のデフォルトブラウザで URL を自動オープン
- `flake.lock`: nixpkgs・home-manager を最新化、workmux はビルド失敗のため旧バージョンに固定
  - nixpkgs: `f83fc3c` → `64c08a7` (2026-05-21 → 2026-05-23)
  - home-manager: `509ed3c` → `1a95e2e` (2026-05-23 → 2026-05-25)
  - workmux: `dfcd9b0` に固定 (最新 `d3f7930` は `ansi-to-tui` crate が 403 でビルド不可)

🤖 Generated with [Claude Code](https://claude.com/claude-code)