### PR TITLE
fix(windows): switch wezterm to nightly and guard pwsh profile for minimal env

### DIFF
--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -131,17 +131,20 @@ if ((Get-Command fzf -ErrorAction SilentlyContinue) -and (Get-Module PSReadLine)
 # Claude Code needs this env var to locate bash.exe on Windows.
 # Set it at session level so ALL child processes (node, pnpm, etc.) inherit it.
 if (-not $env:CLAUDE_CODE_GIT_BASH_PATH) {
-    foreach ($_candidate in @(
-        (Join-Path $env:LOCALAPPDATA "Programs\Git\bin\bash.exe"),
-        "C:\Program Files\Git\bin\bash.exe",
-        "C:\Program Files (x86)\Git\bin\bash.exe"
-    )) {
+    # Codex 等の最小環境で起動された場合 $env:LOCALAPPDATA が null になるため Join-Path がエラーになる。
+    $_candidates = [System.Collections.Generic.List[string]]::new()
+    if ($env:LOCALAPPDATA) {
+        $_candidates.Add((Join-Path $env:LOCALAPPDATA "Programs\Git\bin\bash.exe"))
+    }
+    $_candidates.Add("C:\Program Files\Git\bin\bash.exe")
+    $_candidates.Add("C:\Program Files (x86)\Git\bin\bash.exe")
+    foreach ($_candidate in $_candidates) {
         if (Test-Path -LiteralPath $_candidate -PathType Leaf) {
             $env:CLAUDE_CODE_GIT_BASH_PATH = $_candidate
             break
         }
     }
-    Remove-Variable _candidate -ErrorAction SilentlyContinue
+    Remove-Variable _candidate, _candidates -ErrorAction SilentlyContinue
 }
 
 # devcontainer: enter the project's devcontainer in a tmux session
@@ -208,6 +211,9 @@ function dotf {
 }
 
 # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)
-$_secretPs1 = Join-Path $HOME ".config\shell\secret.ps1"
-if (Test-Path $_secretPs1) { . $_secretPs1 }
-Remove-Variable _secretPs1
+# Codex 等の最小環境では $HOME が空文字列のため Join-Path がエラーになる。
+if ($HOME) {
+    $_secretPs1 = Join-Path $HOME ".config\shell\secret.ps1"
+    if (Test-Path $_secretPs1) { . $_secretPs1 }
+    Remove-Variable _secretPs1
+}

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -157,7 +157,7 @@
           "PackageIdentifier": "Warp.Warp"
         },
         {
-          "PackageIdentifier": "wez.wezterm"
+          "PackageIdentifier": "wez.wezterm.nightly"
         },
         {
           "PackageIdentifier": "ajeetdsouza.zoxide",


### PR DESCRIPTION
## Summary

- **winget**: `wez.wezterm` → `wez.wezterm.nightly`. Stable 20240203 (Feb 2024) has font descender clipping; fixed only in later nightlies (current nightly: 20260331).
- **Microsoft.PowerShell_profile.ps1**: guard `Join-Path` against null `\$env:LOCALAPPDATA` / `\$HOME`. Codex launches pwsh in a minimal env where these are unset, causing profile errors that stall startup (timeout at 12.5s).

## Test plan

- [x] WezTerm: descender clipping (g/j/p/y) gone on Windows after upgrading to nightly
- [x] Codex: starts without 'Cannot bind argument to parameter Path' errors
- [x] Normal pwsh sessions: profile still functions normally with all env vars set