### PR TITLE
chore(pkgs): remove Google.Antigravity from winget and nix sets

### DIFF
--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -546,7 +546,6 @@ lib.mapAttrs (_: names: resolve names) grouped
       "dprint.dprint"
       "hadolint.hadolint"
       "Google.Chrome"
-      "Google.Antigravity"
       "Microsoft.PowerToys"
       "Microsoft.VCRedist.2015+.x64"
       "Microsoft.VisualStudioCode"

--- a/scripts/powershell/tests/Integration.Tests.ps1
+++ b/scripts/powershell/tests/Integration.Tests.ps1
@@ -13,7 +13,6 @@ Describe 'Integration Verification - Windows Environment' {
 
     Context 'Dev Tools Installation' {
         It "should have <_> installed" -ForEach @(
-            'antigravity'
             'gh'
             'rg'
             'fd'

--- a/scripts/sh/tests/integration_test.sh
+++ b/scripts/sh/tests/integration_test.sh
@@ -20,11 +20,6 @@ COMMANDS=(
   "zoxide"
 )
 
-# Interop commands (Windows binaries exposed to WSL)
-INTEROP_COMMANDS=(
-  "antigravity"
-)
-
 FAILED=0
 
 check_command() {
@@ -39,12 +34,6 @@ check_command() {
 
 echo "ネイティブ/Nixpkgs ツールを確認中..."
 for cmd in "${COMMANDS[@]}"; do
-  check_command "$cmd"
-done
-
-echo ""
-echo "Windows 相互運用ツールを確認中..."
-for cmd in "${INTEROP_COMMANDS[@]}"; do
   check_command "$cmd"
 done
 

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -194,9 +194,6 @@
           "PackageIdentifier": "Google.Chrome"
         },
         {
-          "PackageIdentifier": "Google.Antigravity"
-        },
-        {
           "PackageIdentifier": "Microsoft.PowerToys"
         },
         {


### PR DESCRIPTION
## Summary

- `windows/winget/packages.json`: drop `Google.Antigravity`
- `nix/packages/sets.nix`: drop from winget catalog
- Integration tests: drop antigravity references (sh test had it as sole `INTEROP_COMMANDS` entry, removed whole section)

Package was not actually installed on Windows, so no uninstall step is required.

## Test plan

- [x] `task lint` passes (pre-commit + powershell tests + chezmoi template lint)