### PR TITLE
feat(theme): unify all tools to Catppuccin Mocha

### DIFF
--- a/chezmoi/editors/cursor/extensions.json
+++ b/chezmoi/editors/cursor/extensions.json
@@ -18,6 +18,7 @@
     "yzhang.markdown-all-in-one",
     "alefragnani.project-manager",
     "ms-vscode.powershell",
+    "catppuccin.catppuccin-vsc",
     "tobiasalthoff.atom-material-theme",
     "ms-vscode-remote.remote-containers",
     "ms-vscode-remote.remote-ssh",

--- a/chezmoi/editors/cursor/settings.json
+++ b/chezmoi/editors/cursor/settings.json
@@ -65,7 +65,7 @@
   "editor.gotoLocation.multipleDefinitions": "gotoAndPeek",
   "editor.gotoLocation.multipleDeclarations": "gotoAndPeek",
   "editor.gotoLocation.multipleTypeDefinitions": "gotoAndPeek",
-  "workbench.colorTheme": "Default Dark Modern",
+  "workbench.colorTheme": "Catppuccin Mocha",
   "workbench.iconTheme": "material-icon-theme",
   "workbench.startupEditor": "newUntitledFile",
   "breadcrumbs.enabled": true,

--- a/chezmoi/editors/vscode/extensions.json
+++ b/chezmoi/editors/vscode/extensions.json
@@ -18,6 +18,7 @@
     "yzhang.markdown-all-in-one",
     "alefragnani.project-manager",
     "ms-vscode.powershell",
+    "catppuccin.catppuccin-vsc",
     "tobiasalthoff.atom-material-theme",
     "ms-vscode-remote.remote-containers",
     "ms-vscode-remote.remote-ssh",

--- a/chezmoi/editors/vscode/settings.json
+++ b/chezmoi/editors/vscode/settings.json
@@ -65,7 +65,7 @@
   "editor.gotoLocation.multipleDefinitions": "gotoAndPeek",
   "editor.gotoLocation.multipleDeclarations": "gotoAndPeek",
   "editor.gotoLocation.multipleTypeDefinitions": "gotoAndPeek",
-  "workbench.colorTheme": "Default Dark Modern",
+  "workbench.colorTheme": "Catppuccin Mocha",
   "workbench.iconTheme": "material-icon-theme",
   "workbench.startupEditor": "newUntitledFile",
   "breadcrumbs.enabled": true,

--- a/chezmoi/editors/zed/settings.json
+++ b/chezmoi/editors/zed/settings.json
@@ -2,7 +2,8 @@
   // Zed settings - uses JSONC format (comments allowed)
   // Extensions - auto-install listed extensions, unlisted ones are removed
   "auto_install_extensions": {
-    "github-theme": true,
+    "catppuccin": true,
+    "github-theme": false,
     "powershell": true,
     "dprint": true,
     "nix": true,
@@ -25,7 +26,11 @@
     "light": "Material Icon Theme",
     "dark": "Material Icon Theme"
   },
-  "theme": "GitHub Dark Dimmed",
+  "theme": {
+    "mode": "dark",
+    "dark": "Catppuccin Mocha",
+    "light": "Catppuccin Latte"
+  },
   "ui_font_size": 10,
   "buffer_font_size": 10,
   "buffer_font_family": "Moralerspace Neon HWJPDOC",

--- a/chezmoi/terminals/warp/settings.toml
+++ b/chezmoi/terminals/warp/settings.toml
@@ -31,4 +31,4 @@ font_size = 10.0
 
 [appearance.themes]
 system_theme = false
-theme_name = "Phenomenon"
+theme_name = "Catppuccin Mocha"


### PR DESCRIPTION
## Summary

- **Warp**: Phenomenon → Catppuccin Mocha
- **Zed**: GitHub Dark Dimmed → Catppuccin Mocha + `catppuccin` extension enabled, `github-theme` disabled
- **VS Code / Cursor**: Default Dark Modern → Catppuccin Mocha + `catppuccin.catppuccin-vsc` extension added

## Already unified (no change)
- WezTerm, Windows Terminal, Neovim: Catppuccin Mocha
- Codex: already set to Catppuccin

## Out of scope
- Claude Desktop: theme not configurable via config file (app UI only)

## Test plan

- [ ] Warp: restart Warp and confirm Catppuccin Mocha applied
- [ ] Zed: reopen Zed, extension auto-installs and theme switches
- [ ] VS Code / Cursor: install `catppuccin.catppuccin-vsc` extension and confirm theme