### PR TITLE
fix(nvim): open lazygit as floating window on Windows

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/float_term.lua
+++ b/chezmoi/dot_config/nvim/lua/config/float_term.lua
@@ -94,6 +94,8 @@ function M.toggle(opts)
     opts = opts or {}
     local id = opts.id or "shell"
     local cmd = opts.cmd or default_shell()
+    local cwd = opts.cwd
+    local env = opts.env
     local inst = get(id)
 
     -- Already open → hide (buf は保持して次回再表示で resume できるように)。
@@ -103,9 +105,24 @@ function M.toggle(opts)
         return
     end
 
+    -- cwd / cmd / env が前回と違う場合は古い buffer を捨てて新規に作り直す。
+    -- 例: repo A で lazygit を開いて hide → repo B に移動して再 toggle、を
+    -- そのまま reuse すると A の lazygit プロセスが見えてしまう。
+    if
+        inst.buf
+        and vim.api.nvim_buf_is_valid(inst.buf)
+        and (not vim.deep_equal(inst.cmd, cmd) or inst.cwd ~= cwd or not vim.deep_equal(inst.env, env))
+    then
+        pcall(vim.api.nvim_buf_delete, inst.buf, { force = true })
+        inst.buf = nil
+    end
+
     local reuse = inst.buf and vim.api.nvim_buf_is_valid(inst.buf)
     if not reuse then
         inst.buf = vim.api.nvim_create_buf(false, true)
+        inst.cmd = cmd
+        inst.cwd = cwd
+        inst.env = env
     end
 
     local cfg = float_config()
@@ -114,10 +131,13 @@ function M.toggle(opts)
 
     if not reuse then
         vim.fn.termopen(cmd, {
-            cwd = opts.cwd,
-            env = opts.env,
+            cwd = cwd,
+            env = env,
             on_exit = function()
                 inst.buf = nil
+                inst.cmd = nil
+                inst.cwd = nil
+                inst.env = nil
                 if inst.win and vim.api.nvim_win_is_valid(inst.win) then
                     pcall(vim.api.nvim_win_close, inst.win, true)
                 end


### PR DESCRIPTION
## Summary
- Windows で `<leader>gg` / `<leader>gl` の lazygit が bottom split で開いていた問題を修正。snacks.nvim の `lazygit` style は実態が空 `{}` で float 設定が適用されず、さらに当環境では `termopen` が float window を split に書き換えるため、`Snacks.terminal.open` 経由では floating にできなかった。
- `config.float_term` を多インスタンス対応に拡張 (`opts.id` で shell / lazygit / lazygit-log を独立管理) し、`<leader>gg` / `<leader>gl` の Windows 分岐を `float_term.toggle` に置き換え。寸法は `config.window_styles` SSOT に追従し、`<M-+>` / `<M-_>` でリサイズも可能。
- 非 Windows パスは `Snacks.lazygit.open` を維持 (theme 連携のため)。

## Test plan
- [ ] Windows + WSL でそれぞれ Neovim を起動し `<leader>gg` で lazygit が `window_styles.lua` 準拠の floating window で開くこと
- [ ] `<leader>gg` 再押下で hide → 再押下で resume すること (id 別に buf 維持)
- [ ] `<leader>gl` で lazygit log が同様に floating で開くこと
- [ ] floating shell terminal (`<leader>tf`) が引き続き動作すること (後方互換)
- [ ] `<M-+>` / `<M-_>` で lazygit float のサイズが変わり、設定が永続化されること