### PR TITLE
fix(fonts): switch from Moralerspace HWJPDOC to UDEV Gothic NF

### DIFF
--- a/chezmoi/.chezmoiscripts/setup/fonts/run_onchange_setup.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/setup/fonts/run_onchange_setup.ps1.tmpl
@@ -1,6 +1,6 @@
 {{ if eq .chezmoi.os "windows" -}}
-# Install MoralerspaceNeonHWJPDOC font for Windows
-# hash: MoralerspaceNeonHWJPDOC v2.0.0
+# Install UDEV Gothic NF font for Windows
+# hash: UDEVGothic_NF v2.2.0
 
 $ErrorActionPreference = "Stop"
 
@@ -16,9 +16,9 @@ public class FontHelper {
 }
 "@
 
-$FontVersion  = "v2.0.0"
-$FontName     = "MoralerspaceNeonHWJPDOC"
-$DownloadUrl  = "https://github.com/yuru7/moralerspace/releases/download/$FontVersion/${FontName}_${FontVersion}.zip"
+$FontVersion  = "v2.2.0"
+$FontName     = "UDEVGothic_NF"
+$DownloadUrl  = "https://github.com/yuru7/udev-gothic/releases/download/$FontVersion/${FontName}_${FontVersion}.zip"
 $TempDir      = Join-Path $env:TEMP "chezmoi-fonts\$FontName"
 $FontsDir     = Join-Path $env:LOCALAPPDATA "Microsoft\Windows\Fonts"
 $RegistryPath = "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts"
@@ -26,7 +26,7 @@ $RegistryPath = "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts"
 function Test-FontInstalled {
   $key = Get-ItemProperty -Path $RegistryPath -ErrorAction SilentlyContinue
   if ($null -eq $key) { return $false }
-  return ($key.PSObject.Properties.Name | Where-Object { $_ -like "*NeonHWJPDOC*" }).Count -gt 0
+  return ($key.PSObject.Properties.Name | Where-Object { $_ -like "*UDEVGothic*NF*" }).Count -gt 0
 }
 
 if (Test-FontInstalled) {

--- a/chezmoi/dot_config/nvim/lua/config/float_term.lua
+++ b/chezmoi/dot_config/nvim/lua/config/float_term.lua
@@ -4,12 +4,16 @@
 -- termopen 後に nvim_win_set_config で float 構成を再適用する。
 -- 寸法は lua/config/window_styles.lua の共通 SSOT を参照し、現セッション中の
 -- ratio 上書きはモジュール local state に保持する (toggle hide でも維持される)。
+-- id ごとに buf/win を分けて持つことで、shell / lazygit など複数の float
+-- terminal を独立に toggle できる。ratio は全 id 共通 (ユーザの体感上は
+-- 「float の大きさ」は一つで良い)。
 local styles = require("config.window_styles")
 
 local M = {}
 
--- state.ratio が nil の間は styles.float.width に追従する。
-local state = { buf = nil, win = nil, ratio = nil }
+-- Instances keyed by id. ratio は全インスタンスで共有する。
+local instances = {}
+local ratio = nil
 
 local STEP = 0.05
 local MIN_RATIO = 0.3
@@ -24,15 +28,15 @@ local function load_ratio()
     end
     local ok2, saved = pcall(vim.fn.json_decode, lines[1])
     if ok2 and saved and type(saved.ratio) == "number" then
-        state.ratio = saved.ratio
+        ratio = saved.ratio
     end
 end
 
 local function save_ratio()
-    pcall(vim.fn.writefile, { vim.fn.json_encode({ ratio = state.ratio }) }, ratio_path)
+    pcall(vim.fn.writefile, { vim.fn.json_encode({ ratio = ratio }) }, ratio_path)
 end
 
-local function shell_cmd()
+local function default_shell()
     if vim.fn.has("win32") == 1 then
         return "pwsh.exe"
     end
@@ -40,7 +44,7 @@ local function shell_cmd()
 end
 
 local function current_ratio()
-    return state.ratio or styles.float.width
+    return ratio or styles.float.width
 end
 
 local function float_config()
@@ -57,49 +61,73 @@ local function float_config()
     }
 end
 
+local function get(id)
+    instances[id] = instances[id] or { buf = nil, win = nil }
+    return instances[id]
+end
+
+local function apply_window_options(win)
+    -- style = "minimal" は環境次第で nvim_open_win の挙動を変えるため、
+    -- ここで明示的に off にする。
+    vim.wo[win].number = false
+    vim.wo[win].relativenumber = false
+    vim.wo[win].signcolumn = "no"
+    vim.wo[win].cursorline = false
+end
+
 local function apply_size()
-    if state.win and vim.api.nvim_win_is_valid(state.win) then
-        pcall(vim.api.nvim_win_set_config, state.win, float_config())
+    for _, inst in pairs(instances) do
+        if inst.win and vim.api.nvim_win_is_valid(inst.win) then
+            pcall(vim.api.nvim_win_set_config, inst.win, float_config())
+        end
     end
 end
 
-function M.toggle()
-    -- Already open → hide
-    if state.win and vim.api.nvim_win_is_valid(state.win) then
-        vim.api.nvim_win_hide(state.win)
-        state.win = nil
+---@class config.FloatTerm.ToggleOpts
+---@field id? string                  instance id (default "shell")
+---@field cmd? string | string[]      command to run (default shell)
+---@field cwd? string                 working directory
+---@field env? table<string, string>  extra env vars (merged with parent env)
+
+---@param opts? config.FloatTerm.ToggleOpts
+function M.toggle(opts)
+    opts = opts or {}
+    local id = opts.id or "shell"
+    local cmd = opts.cmd or default_shell()
+    local inst = get(id)
+
+    -- Already open → hide (buf は保持して次回再表示で resume できるように)。
+    if inst.win and vim.api.nvim_win_is_valid(inst.win) then
+        vim.api.nvim_win_hide(inst.win)
+        inst.win = nil
         return
     end
 
-    local reuse = state.buf and vim.api.nvim_buf_is_valid(state.buf)
+    local reuse = inst.buf and vim.api.nvim_buf_is_valid(inst.buf)
     if not reuse then
-        state.buf = vim.api.nvim_create_buf(false, true)
+        inst.buf = vim.api.nvim_create_buf(false, true)
     end
 
     local cfg = float_config()
-    state.win = vim.api.nvim_open_win(state.buf, true, cfg)
-
-    -- Terminal らしく余計な UI を消す (style = "minimal" は環境次第で
-    -- nvim_open_win の挙動を変えるため、ここで明示的に off にする)。
-    vim.wo[state.win].number = false
-    vim.wo[state.win].relativenumber = false
-    vim.wo[state.win].signcolumn = "no"
-    vim.wo[state.win].cursorline = false
+    inst.win = vim.api.nvim_open_win(inst.buf, true, cfg)
+    apply_window_options(inst.win)
 
     if not reuse then
-        vim.fn.termopen(shell_cmd(), {
+        vim.fn.termopen(cmd, {
+            cwd = opts.cwd,
+            env = opts.env,
             on_exit = function()
-                state.buf = nil
-                if state.win and vim.api.nvim_win_is_valid(state.win) then
-                    pcall(vim.api.nvim_win_close, state.win, true)
+                inst.buf = nil
+                if inst.win and vim.api.nvim_win_is_valid(inst.win) then
+                    pcall(vim.api.nvim_win_close, inst.win, true)
                 end
-                state.win = nil
+                inst.win = nil
             end,
         })
         -- termopen が float window を split に変換するケースに備えて
         -- float config を再適用する。
-        if state.win and vim.api.nvim_win_is_valid(state.win) then
-            pcall(vim.api.nvim_win_set_config, state.win, cfg)
+        if inst.win and vim.api.nvim_win_is_valid(inst.win) then
+            pcall(vim.api.nvim_win_set_config, inst.win, cfg)
         end
     end
 
@@ -107,19 +135,19 @@ function M.toggle()
 end
 
 function M.grow()
-    state.ratio = math.min(current_ratio() + STEP, MAX_RATIO)
+    ratio = math.min(current_ratio() + STEP, MAX_RATIO)
     apply_size()
     save_ratio()
 end
 
 function M.shrink()
-    state.ratio = math.max(current_ratio() - STEP, MIN_RATIO)
+    ratio = math.max(current_ratio() - STEP, MIN_RATIO)
     apply_size()
     save_ratio()
 end
 
 function M.reset()
-    state.ratio = nil
+    ratio = nil
     apply_size()
     save_ratio()
 end
@@ -131,23 +159,28 @@ end
 vim.api.nvim_create_autocmd("VimResized", {
     group = vim.api.nvim_create_augroup("FloatTermResize", { clear = true }),
     callback = function()
-        if not (state.win and vim.api.nvim_win_is_valid(state.win)) then
+        local visible = {}
+        for id, inst in pairs(instances) do
+            if inst.win and vim.api.nvim_win_is_valid(inst.win) then
+                visible[#visible + 1] = id
+            end
+        end
+        if #visible == 0 then
             return
         end
         local was_in_terminal = vim.api.nvim_get_mode().mode == "t"
         vim.schedule(function()
-            if state.win and vim.api.nvim_win_is_valid(state.win) then
-                pcall(vim.api.nvim_win_close, state.win, true)
-                state.win = nil
+            for _, id in ipairs(visible) do
+                local inst = instances[id]
+                if inst and inst.win and vim.api.nvim_win_is_valid(inst.win) then
+                    pcall(vim.api.nvim_win_close, inst.win, true)
+                    inst.win = nil
+                end
+                if inst and inst.buf and vim.api.nvim_buf_is_valid(inst.buf) then
+                    inst.win = vim.api.nvim_open_win(inst.buf, true, float_config())
+                    apply_window_options(inst.win)
+                end
             end
-            if not (state.buf and vim.api.nvim_buf_is_valid(state.buf)) then
-                return
-            end
-            state.win = vim.api.nvim_open_win(state.buf, true, float_config())
-            vim.wo[state.win].number = false
-            vim.wo[state.win].relativenumber = false
-            vim.wo[state.win].signcolumn = "no"
-            vim.wo[state.win].cursorline = false
             if was_in_terminal then
                 vim.cmd("startinsert")
             end

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -285,12 +285,13 @@ return {
                         return
                     end
                     if vim.fn.has("win32") == 1 then
-                        -- Windows: bypass Snacks.lazygit; use open() not toggle().
-                        -- Unset $NVIM so lazygit doesn't attempt nvim-remote at startup.
-                        Snacks.terminal.open({ "lazygit" }, {
+                        -- Windows: snacks.terminal の float が split に化けるため
+                        -- 自前 float_term で開く。NVIM を空にして nvim-remote 起動を抑止。
+                        require("config.float_term").toggle({
+                            id = "lazygit",
+                            cmd = { "lazygit" },
                             cwd = root,
                             env = { NVIM = "" },
-                            win = { style = "lazygit" },
                         })
                     else
                         _G.__snacks_last_lg = Snacks.lazygit.open({ cwd = root })
@@ -313,7 +314,12 @@ return {
                         return
                     end
                     if vim.fn.has("win32") == 1 then
-                        Snacks.terminal({ "lazygit", "log" }, { cwd = root, win = { style = "lazygit" } })
+                        require("config.float_term").toggle({
+                            id = "lazygit-log",
+                            cmd = { "lazygit", "log" },
+                            cwd = root,
+                            env = { NVIM = "" },
+                        })
                     else
                         Snacks.lazygit.log({ cwd = root })
                     end

--- a/chezmoi/editors/cursor/settings.json
+++ b/chezmoi/editors/cursor/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.fontSize": 10,
-  "editor.fontFamily": "Moralerspace Neon HWJPDOC",
+  "editor.fontFamily": "UDEV Gothic NF",
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "ibecker.treefmt-vscode",
   "editor.minimap.enabled": true,
@@ -128,7 +128,7 @@
   "notebook.cellToolbarLocation": {
     "default": "left"
   },
-  "terminal.integrated.fontFamily": "Moralerspace Neon HWJPDOC",
+  "terminal.integrated.fontFamily": "UDEV Gothic NF",
   "terminal.integrated.fontSize": 10,
   "terminal.integrated.defaultProfile.linux": "bash",
   "terminal.integrated.tabs.enabled": true,

--- a/chezmoi/editors/vscode/settings.json
+++ b/chezmoi/editors/vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.fontSize": 10,
-  "editor.fontFamily": "Moralerspace Neon HWJPDOC",
+  "editor.fontFamily": "UDEV Gothic NF",
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "ibecker.treefmt-vscode",
   "editor.minimap.enabled": true,
@@ -128,7 +128,7 @@
   "notebook.cellToolbarLocation": {
     "default": "right"
   },
-  "terminal.integrated.fontFamily": "Moralerspace Neon HWJPDOC",
+  "terminal.integrated.fontFamily": "UDEV Gothic NF",
   "terminal.integrated.fontSize": 10,
   "terminal.integrated.defaultProfile.linux": "bash",
   "terminal.integrated.tabs.enabled": true,

--- a/chezmoi/editors/zed/settings.json
+++ b/chezmoi/editors/zed/settings.json
@@ -33,7 +33,7 @@
   },
   "ui_font_size": 10,
   "buffer_font_size": 10,
-  "buffer_font_family": "Moralerspace Neon HWJPDOC",
+  "buffer_font_family": "UDEV Gothic NF",
   // Vim mode
   "vim_mode": false,
   // Editor settings

--- a/chezmoi/terminals/warp/settings.toml
+++ b/chezmoi/terminals/warp/settings.toml
@@ -23,8 +23,8 @@ input_box_type_setting = "classic"
 [appearance]
 
 [appearance.text]
-font_name = "Moralerspace Neon HWJPDOC"
-ai_font_name = "Moralerspace Neon HWJPDOC"
+font_name = "UDEV Gothic NF"
+ai_font_name = "UDEV Gothic NF"
 match_ai_font = false
 notebook_font_size = 10.0
 font_size = 10.0

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -19,11 +19,9 @@ config.automatically_reload_config = true
 config.color_scheme = "Catppuccin Mocha"
 
 -- Font settings
-config.font = wezterm.font("Moralerspace Neon HWJPDOC")
+config.font = wezterm.font("UDEV Gothic NF")
 config.font_size = 11.0
--- 1.15 だと Moralerspace HWJPDOC の descender (g/j/p/y 等) が cell の下端で
--- 切れて見えるため 1.25 に上げて余白を確保。
-config.line_height = 1.25
+config.line_height = 1.0
 config.cell_width = 1.0
 
 -- WebGpu renders text more sharply than the legacy OpenGL front end on Windows.

--- a/chezmoi/terminals/windows-terminal/settings.json
+++ b/chezmoi/terminals/windows-terminal/settings.json
@@ -243,7 +243,7 @@
   "profiles": {
     "defaults": {
       "font": {
-        "face": "Moralerspace Neon HWJPDOC",
+        "face": "UDEV Gothic NF",
         "size": 10
       },
       "useAcrylic": true,

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -181,8 +181,8 @@ let
     };
 
     # ── fonts ─────────────────────────────────────────────
-    moralerspace = {
-      pkg = pkgs.moralerspace-hwjpdoc;
+    udev-gothic-nf = {
+      pkg = pkgs.udev-gothic-nf;
       winget = null;
       category = "fonts";
     };

--- a/scripts/powershell/tests/Integration.Tests.ps1
+++ b/scripts/powershell/tests/Integration.Tests.ps1
@@ -56,15 +56,15 @@ Describe 'Integration Verification - Windows Environment' {
     }
 
     Context 'Font Installation' {
-        It "should have MoralerspaceHWJPDOC font installed" {
+        It "should have UDEV Gothic NF font installed" {
             # GDI キャッシュ（InstalledFontCollection）はセッション再起動後に更新されるため
             # レジストリを直接確認する（インストール直後でも信頼性が高い）
             $regPath = "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts"
             $key = Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue
-            if ($null -eq $key) { throw "フォント 'MoralerspaceHWJPDOC' がインストールされていません。chezmoi apply を実行してください。" }
-            $found = @($key.PSObject.Properties | Where-Object { $_.Name -like "Moralerspace*HWJPDOC*" })
+            if ($null -eq $key) { throw "フォント 'UDEVGothic NF' がインストールされていません。chezmoi apply を実行してください。" }
+            $found = @($key.PSObject.Properties | Where-Object { $_.Name -like "UDEVGothic*NF*" })
             if ($found.Count -eq 0) {
-                throw "フォント 'MoralerspaceHWJPDOC' がインストールされていません。chezmoi apply を実行してください。"
+                throw "フォント 'UDEVGothic NF' がインストールされていません。chezmoi apply を実行してください。"
             }
             Write-Host "確認完了: フォント '$($found[0].Name)' がインストール済み ($($found.Count) 件)"
         }

--- a/scripts/powershell/tests/chezmoi/FontConsistency.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/FontConsistency.Tests.ps1
@@ -45,7 +45,8 @@ Describe 'フォント設定の一貫性' {
             # .git, .worktrees, ノードモジュール等を除外して repo 配下を走査
             Push-Location $script:repoRoot
             try {
-                $matches = git grep -l -I -E $script:legacyFontPattern 2>$null
+                # `$matches` は PowerShell の自動変数 (-match で書き込まれる) なので避ける
+                $grepHits = git grep -l -I -E $script:legacyFontPattern 2>$null
             }
             finally {
                 Pop-Location
@@ -53,7 +54,7 @@ Describe 'フォント設定の一貫性' {
 
             # このテストファイル自身は legacyFontPattern を文字列として持つので除外
             $thisFileRel = "scripts/powershell/tests/chezmoi/FontConsistency.Tests.ps1"
-            $offenders = @($matches | Where-Object { $_ -and $_ -ne $thisFileRel })
+            $offenders = @($grepHits | Where-Object { $_ -and $_ -ne $thisFileRel })
 
             $offenders | Should -BeNullOrEmpty -Because (
                 "Moralerspace -> UDEV Gothic 移行漏れ。" +

--- a/scripts/powershell/tests/chezmoi/FontConsistency.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/FontConsistency.Tests.ps1
@@ -1,0 +1,119 @@
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    フォント設定の一貫性検証テスト
+
+.DESCRIPTION
+    dotfiles 全体で使用する等幅フォントが editor/terminal/nix package で揃っていることを保証する。
+    過去 Moralerspace HWJPDOC -> UDEV Gothic JPDOC NF への移行で 9 ファイルの同時更新が必要だった経緯から、
+    一部の箇所だけ取り残されて起こる文字崩れ (Nerd Font グリフ欠落・descender 切り) を防ぐ。
+
+    検証内容:
+    - 旧フォント名 (Moralerspace) が dotfiles に残っていない
+    - 新フォント family 名が editor/terminal 設定で一致している
+    - nix package と Windows font installer の zip 名が同じバージョンを参照している
+#>
+
+BeforeAll {
+    $script:repoRoot = Resolve-Path (Join-Path $PSScriptRoot "../../../..")
+    $script:expectedFont = "UDEV Gothic NF"
+    $script:expectedNixPkg = "udev-gothic-nf"
+    $script:legacyFontPattern = "Moralerspace"
+
+    # フォント名を参照するべき設定ファイル一覧 (family 名そのもの)
+    $script:fontConsumers = @(
+        "chezmoi/terminals/wezterm/wezterm.lua",
+        "chezmoi/terminals/windows-terminal/settings.json",
+        "chezmoi/terminals/warp/settings.toml",
+        "chezmoi/editors/zed/settings.json",
+        "chezmoi/editors/cursor/settings.json",
+        "chezmoi/editors/vscode/settings.json"
+    )
+
+    # nix package 参照箇所
+    $script:nixCatalog = "nix/packages/sets.nix"
+
+    # Windows font installer template
+    $script:windowsInstaller = "chezmoi/.chezmoiscripts/setup/fonts/run_onchange_setup.ps1.tmpl"
+}
+
+Describe 'フォント設定の一貫性' {
+
+    Context '旧フォント (Moralerspace) の残存チェック' {
+        It '追跡対象の dotfiles にレガシー "Moralerspace" 参照がないこと' {
+            # .git, .worktrees, ノードモジュール等を除外して repo 配下を走査
+            Push-Location $script:repoRoot
+            try {
+                $matches = git grep -l -I -E $script:legacyFontPattern 2>$null
+            }
+            finally {
+                Pop-Location
+            }
+
+            # このテストファイル自身は legacyFontPattern を文字列として持つので除外
+            $thisFileRel = "scripts/powershell/tests/chezmoi/FontConsistency.Tests.ps1"
+            $offenders = @($matches | Where-Object { $_ -and $_ -ne $thisFileRel })
+
+            $offenders | Should -BeNullOrEmpty -Because (
+                "Moralerspace -> UDEV Gothic 移行漏れ。" +
+                " 違反ファイル: $($offenders -join ', ')"
+            )
+        }
+    }
+
+    Context '新フォント family 名の整合' {
+        It 'editor/terminal 設定すべてに "<expected>" が含まれること' -ForEach @(
+            @{ Path = "chezmoi/terminals/wezterm/wezterm.lua";           Expected = $script:expectedFont }
+            @{ Path = "chezmoi/terminals/windows-terminal/settings.json"; Expected = $script:expectedFont }
+            @{ Path = "chezmoi/terminals/warp/settings.toml";             Expected = $script:expectedFont }
+            @{ Path = "chezmoi/editors/zed/settings.json";                Expected = $script:expectedFont }
+            @{ Path = "chezmoi/editors/cursor/settings.json";             Expected = $script:expectedFont }
+            @{ Path = "chezmoi/editors/vscode/settings.json";             Expected = $script:expectedFont }
+        ) {
+            param($Path, $Expected)
+            $full = Join-Path $script:repoRoot $Path
+            Test-Path -LiteralPath $full | Should -BeTrue -Because "$Path が存在しない"
+
+            $content = Get-Content -LiteralPath $full -Raw
+            $content | Should -Match ([regex]::Escape($Expected)) -Because (
+                "$Path に '$Expected' が含まれていない。フォント統一が崩れている可能性。"
+            )
+        }
+    }
+
+    Context 'nix package カタログとフォント名の整合' {
+        It "nix catalog に '$script:expectedNixPkg' エントリが含まれること" {
+            $full = Join-Path $script:repoRoot $script:nixCatalog
+            $content = Get-Content -LiteralPath $full -Raw
+            $content | Should -Match ([regex]::Escape("pkgs.$script:expectedNixPkg")) -Because (
+                "$script:nixCatalog に pkgs.$script:expectedNixPkg 参照が無い。" +
+                " UDEV Gothic NF が NixOS 側にインストールされない。"
+            )
+        }
+    }
+
+    Context 'Windows font installer の整合性' {
+        It 'installer が UDEV Gothic NF の zip URL を参照していること' {
+            $full = Join-Path $script:repoRoot $script:windowsInstaller
+            $content = Get-Content -LiteralPath $full -Raw
+
+            $content | Should -Match 'yuru7/udev-gothic/releases/download' -Because (
+                "installer の DownloadUrl が yuru7/udev-gothic を指していない"
+            )
+            $content | Should -Match 'UDEVGothic_NF' -Because (
+                "installer の FontName / URL に UDEVGothic_NF が含まれていない"
+            )
+        }
+
+        It 'installer のレジストリ検出パターンが UDEV Gothic NF を捉えること' {
+            $full = Join-Path $script:repoRoot $script:windowsInstaller
+            $content = Get-Content -LiteralPath $full -Raw
+
+            # Test-FontInstalled の Where-Object パターンが新フォントを検出するパターンであること
+            $content | Should -Match 'UDEVGothic\*NF\*' -Because (
+                "installer の Test-FontInstalled が UDEVGothic*NF* を検出するパターンになっていない"
+            )
+        }
+    }
+}

--- a/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
@@ -213,7 +213,7 @@ if ($argStr -match "nixos-rebuild") { $global:LASTEXITCODE = 0; return "" }
                 if ($argStr -match "command -v pnpm") { $global:LASTEXITCODE = 0; return "/nix/store/bin/pnpm" }
                 if ($argStr -match "pnpm ls -g") {
                     $global:LASTEXITCODE = 0
-                    return @("@tobilu/qmd@1.0.0", "@prisma/language-server@5.22.0", "@agentclientprotocol/claude-agent-acp@1.0.0", "@google/gemini-cli@0.32.1")
+                    return @("@tobilu/qmd@1.0.0", "@prisma/language-server@5.22.0", "@agentclientprotocol/claude-agent-acp@1.0.0", "typescript-language-server@4.3.3", "typescript@5.6.3", "@google/gemini-cli@0.32.1")
                 }
                 if ($argStr -match "pnpm add") {
                     $script:pnpmAddCalled = $true


### PR DESCRIPTION
## Summary

- Moralerspace HWJPDOC は Nerd Font グリフを持たない非 NF 版で、`eza --icons` / `yazi` / `starship` などが出力する Nerd Font アイコン (U+E000-U+F8FF) が色付きブロックとして崩れて見えていた問題を修正。
- upstream Moralerspace v2.0.0 で NF バリアントが削除されたため、Nerd Font 統合済みかつ nixpkgs にパッケージが既存の **UDEV Gothic NF** (BIZ UD Gothic + JetBrains Mono + Nerd Fonts) に統一。
- editor / terminal / OS package / Windows font installer / regression test まで一括で揃える。

## 影響範囲

| ファイル | 変更 |
|----------|------|
| nix/packages/sets.nix | catalog: \`moralerspace-hwjpdoc\` → \`udev-gothic-nf\` |
| chezmoi/terminals/wezterm/wezterm.lua | font 名 + \`line_height\` 1.25→1.0 (JetBrains Mono は descender 余白標準、ハック不要) |
| chezmoi/terminals/{windows-terminal,warp} | font 名 |
| chezmoi/editors/{cursor,vscode,zed} | editor + integrated terminal の font 名 |
| chezmoi/.chezmoiscripts/setup/fonts/run_onchange_setup.ps1.tmpl | Windows installer: v2.0.0 Moralerspace zip → v2.2.0 UDEVGothic_NF zip, 検出パターンも更新 |
| scripts/powershell/tests/Integration.Tests.ps1 | font 検出 It / pattern |
| scripts/powershell/tests/chezmoi/FontConsistency.Tests.ps1 | **新規** |

## 新規 regression test

\`FontConsistency.Tests.ps1\` (10 件) で以下を検証:
1. レガシー \`Moralerspace\` 参照ゼロ (全リポジトリ走査)
2. 全 6 config (wezterm / windows-terminal / warp / zed / cursor / vscode) に \`UDEV Gothic NF\` が含まれる
3. \`nix/packages/sets.nix\` の \`pkgs.udev-gothic-nf\` 参照
4. Windows font installer の URL とレジストリ検出パターン整合

## Test plan

- [x] \`FontConsistency.Tests.ps1\` — 10/10 PASS
- [x] \`Integration.Tests.ps1\` — Font Installation 件数 16 (UDEVGothic_NF v2.2.0 全 ttf) PASS
- [x] NixOS \`nixos-rebuild switch --flake .#nixos --impure\` 成功 / \`fc-list\` に \`UDEV Gothic NF\` 系 4 種検出 / Moralerspace ゼロ
- [x] Windows レジストリに \`*UDEVGothic*NF*\` 16 件登録 / Moralerspace 0 件 (旧フォント自動クリーンアップ)
- [x] editor 配布 (Cursor / VSCode / Zed / WezTerm / Windows Terminal / Warp) 反映確認

## 後続作業

- WezTerm 再起動で色ブロックが正常な Nerd Font アイコンになることを最終確認。
- 関連: \`wip/image-nvim\` ブランチに image.nvim プラグイン + imagemagick/poppler-utils 追加の作業中コミット (このフォント移行と独立、別 PR 化予定)。