### PR TITLE
feat(nvim): cross-platform image/PDF preview (Windows + WSL)

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -396,7 +396,8 @@ return {
             },
         },
         init = function()
-            -- PDF: pdftoppm で先頭ページを PNG に変換して image.nvim で表示
+            -- PDF: 先頭ページを PNG に変換して image.nvim で表示
+            -- Windows: ImageMagick + Ghostscript、Linux/WSL: pdftoppm (poppler)
             -- VeryLazy 後に snacks.picker.preview が確実にロードされてからパッチ
             vim.api.nvim_create_autocmd("User", {
                 pattern = "VeryLazy",
@@ -411,7 +412,11 @@ return {
                         local file = ctx.item and (ctx.item.file or ctx.item.path or "")
                         if file:match("%.pdf$") then
                             local tmp = vim.fn.tempname()
-                            vim.fn.system({ "pdftoppm", "-png", "-r", "150", "-singlefile", file, tmp })
+                            if vim.fn.has("win32") == 1 then
+                                vim.fn.system({ "magick", file .. "[0]", "-density", "150", tmp .. ".png" })
+                            else
+                                vim.fn.system({ "pdftoppm", "-png", "-r", "150", "-singlefile", file, tmp })
+                            end
                             local patched = vim.tbl_deep_extend("force", ctx, {
                                 item = vim.tbl_extend("force", ctx.item, { file = tmp .. ".png" }),
                             })

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -147,12 +147,17 @@ let
     };
     imagemagick = {
       pkg = pkgs.imagemagick;
-      winget = null;
+      winget = "ImageMagick.ImageMagick";
+      category = "dev";
+    };
+    ghostscript = {
+      pkg = pkgs.ghostscript;
+      winget = "ArtifexSoftware.GhostScript";
       category = "dev";
     };
     poppler-utils = {
       pkg = pkgs.poppler_utils;
-      winget = null;
+      winget = null; # Windows は ImageMagick + Ghostscript で代替
       category = "dev";
     };
 


### PR DESCRIPTION
## Summary

Cross-platform extension of #282 (image/PDF preview in snacks picker).

- **imagemagick**: add `winget = "ImageMagick.ImageMagick"` — now installed on Windows too
- **ghostscript**: new entry with `winget = "ArtifexSoftware.GhostScript"` — required by ImageMagick for PDF rendering on Windows
- **poppler-utils**: keep `winget = null` (Linux/WSL only — Windows uses ImageMagick + GS instead)
- **PDF previewer**: platform branch in `snacks.picker.preview.file` patch
  - Windows: `magick file.pdf[0] -density 150 tmp.png`
  - Linux/WSL: `pdftoppm -png -r 150 -singlefile file tmp`

## Test plan

- [ ] Windows: `winget install ImageMagick.ImageMagick ArtifexSoftware.GhostScript`, open snacks picker, navigate to a PDF — first page renders as image
- [ ] WSL/NixOS: existing `pdftoppm` path unchanged; `nix profile upgrade` picks up ghostscript if needed
- [ ] Image files (png/jpg etc.) continue to render inline on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
