### PR TITLE
fix(nvim): use snacks built-in image module, fix WezTerm detection on Windows

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -247,21 +247,6 @@ return {
         },
     },
 
-    -- Image rendering via Kitty graphics protocol (used by snacks picker preview)
-    {
-        "3rd/image.nvim",
-        build = false,
-        opts = {
-            backend = "kitty",
-            processor = "magick_cli",
-            max_width_window_percentage = 100,
-            max_height_window_percentage = 80,
-            editor_only_render_when_focused = true,
-            hijack_file_patterns = { "*.png", "*.jpg", "*.jpeg", "*.gif", "*.webp", "*.bmp", "*.tiff" },
-            integrations = { markdown = { enabled = false } },
-        },
-    },
-
     -- UI utilities + lazygit float
     {
         "folke/snacks.nvim",
@@ -395,38 +380,6 @@ return {
                 },
             },
         },
-        init = function()
-            -- PDF: 先頭ページを PNG に変換して image.nvim で表示
-            -- Windows: ImageMagick + Ghostscript、Linux/WSL: pdftoppm (poppler)
-            -- VeryLazy 後に snacks.picker.preview が確実にロードされてからパッチ
-            vim.api.nvim_create_autocmd("User", {
-                pattern = "VeryLazy",
-                once = true,
-                callback = function()
-                    local ok, preview = pcall(require, "snacks.picker.preview")
-                    if not ok or not preview.file then
-                        return
-                    end
-                    local orig_file = preview.file
-                    preview.file = function(ctx)
-                        local file = ctx.item and (ctx.item.file or ctx.item.path or "")
-                        if file:match("%.pdf$") then
-                            local tmp = vim.fn.tempname()
-                            if vim.fn.has("win32") == 1 then
-                                vim.fn.system({ "magick", file .. "[0]", "-density", "150", tmp .. ".png" })
-                            else
-                                vim.fn.system({ "pdftoppm", "-png", "-r", "150", "-singlefile", file, tmp })
-                            end
-                            local patched = vim.tbl_deep_extend("force", ctx, {
-                                item = vim.tbl_extend("force", ctx.item, { file = tmp .. ".png" }),
-                            })
-                            return preview.image and preview.image(patched) or false
-                        end
-                        return orig_file(ctx)
-                    end
-                end,
-            })
-        end,
     },
 
     -- AI sidekick: AI CLI terminal (claude/codex/gemini/opencode)

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -54,6 +54,12 @@ config.leader = {
     timeout_milliseconds = 2000,
 }
 
+-- Force snacks.nvim to recognise WezTerm's Kitty graphics protocol support.
+-- Auto-detection can fail on Windows where TERM_PROGRAM may not propagate.
+config.set_environment_variables = {
+    SNACKS_WEZTERM = "true",
+}
+
 -- Alt key sends escape sequence for fzf Alt+C support
 config.send_composed_key_when_left_alt_is_pressed = false
 config.send_composed_key_when_right_alt_is_pressed = false

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -155,11 +155,6 @@ let
       winget = "ArtifexSoftware.GhostScript";
       category = "dev";
     };
-    poppler-utils = {
-      pkg = pkgs.poppler_utils;
-      winget = null; # Windows は ImageMagick + Ghostscript で代替
-      category = "dev";
-    };
 
     # ── terminal ──────────────────────────────────────────
     wezterm = {


### PR DESCRIPTION
## Summary

Fixes image preview not rendering in the snacks picker (raw binary was shown instead).

Root cause: `snacks.nvim` has its **own built-in image module** (`Snacks.image`) that directly implements the Kitty graphics protocol — it does **not** use the `3rd/image.nvim` plugin. On Windows, WezTerm's Kitty support is sometimes not auto-detected, causing `Snacks.image.supports_file()` to return false and the preview to fall back to raw file content.

### Changes

- **wezterm.lua**: Set `SNACKS_WEZTERM = "true"` via `set_environment_variables` — forces snacks to recognise WezTerm's Kitty graphics support even when auto-detection fails on Windows
- **init.lua**: Remove `3rd/image.nvim` plugin (not used by snacks) and remove the manual `snacks.picker.preview.file` patch (snacks handles image + PDF natively via ImageMagick)
- **sets.nix**: Remove `poppler-utils` (snacks uses ImageMagick + Ghostscript for PDF, not pdftoppm)

### Result

- PNG / JPG / GIF / WebP etc. → rendered inline in picker preview pane (Windows + WSL)
- PDF → first page converted via `magick` and rendered inline (Windows + WSL)

## Test plan

- [ ] Restart WezTerm so `SNACKS_WEZTERM=true` takes effect
- [ ] Open snacks picker, navigate to a PNG — preview pane renders the image
- [ ] Navigate to a PDF — first page renders as image
- [ ] Run `:checkhealth snacks` to confirm image support is detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
