### PR TITLE
fix(pwsh): set SNACKS_WEZTERM=true in PowerShell profile

### DIFF
--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -8,6 +8,9 @@ if ($env:VSCODE_PID -or $env:VSCODE_INJECTION) { return }
 # Windows Terminal with "elevate: true" may not inherit User-scope PATH entries.
 $env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [Environment]::GetEnvironmentVariable("PATH", "User")
 
+# Tell snacks.nvim to use WezTerm's Kitty graphics protocol for image preview.
+$env:SNACKS_WEZTERM = "true"
+
 # Aliases
 if (Get-Command rg -ErrorAction SilentlyContinue) {
     Set-Alias -Name grep -Value rg -Scope Global


### PR DESCRIPTION
## Summary

- Add `$env:SNACKS_WEZTERM = "true"` to PowerShell profile after PATH rebuild
- Ensures snacks.nvim detects WezTerm's Kitty graphics protocol for image preview
- Fixes case where current WezTerm session started before `wezterm.lua` `set_environment_variables` was applied

## Why

Auto-detection of WezTerm's Kitty graphics support can fail on Windows when `TERM_PROGRAM` doesn't propagate into child processes. `wezterm.lua` already sets `SNACKS_WEZTERM=true` via `set_environment_variables`, but existing sessions miss it until WezTerm is restarted. The PowerShell profile ensures any new `pwsh` session (new tab) gets the env var immediately.

## Test plan

- [ ] Open a new PowerShell tab in WezTerm (no WezTerm restart needed)
- [ ] Start nvim and open snacks picker (e.g. `<leader>ff`)
- [ ] Navigate to a PNG or PDF file — preview pane should render the image
- [ ] Run `:checkhealth snacks` → image section should show WezTerm detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)