### PR TITLE
fix(nvim): add force=true to snacks image config

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -357,7 +357,7 @@ return {
         opts = {
             lazygit = { enabled = true },
             terminal = { enabled = true },
-            image = { enabled = true },
+            image = { enabled = true, force = true },
             picker = {
                 enabled = true,
                 -- snacks picker から Alt+a で選択中の項目を sidekick の


### PR DESCRIPTION
## Summary

- `image = { enabled = true, force = true }` を snacks opts に追加
- `force = true` は `supports_terminal()` チェックをスキップし、ターミナル検出失敗に関わらず画像レンダリングを試みる
- WezTerm は Kitty Graphics Protocol をサポートしているため安全

## 背景

`SNACKS_WEZTERM=true` の env var が nvim プロセスに届いていない場合、`supports_terminal()` が false を返し、画像の代わりにバイナリ内容が表示される。`force = true` でこの問題を回避する。

## Test plan

- [ ] nvim を再起動して `:source %` または `:Lazy reload snacks.nvim`
- [ ] スナックスファイルピッカーを開いて PNG ファイルに移動
- [ ] プレビューペインに画像が表示されることを確認
- [ ] `:checkhealth snacks` で画像サポートの状態を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)