### PR TITLE
fix(nvim): raise snacks priority to 1000 and install ImageMagick

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -251,7 +251,7 @@ return {
     {
         "folke/snacks.nvim",
         lazy = false,
-        priority = 900,
+        priority = 1000,
         keys = {
             {
                 "<leader><leader>",


### PR DESCRIPTION
## Summary

- snacks.nvim priority: 900 → 1000（`:checkhealth snacks` の警告対応）
- ImageMagick を winget でインストール済み（`sets.nix` には既に記載済み）
  → snacks image の `identify` ステップが PNG ファイルに対して実行可能になる

## 背景

`:checkhealth snacks` で以下の問題を検出：
- `magick` が見つからない → PNG 変換の identify ステップが失敗し画像プレビュー不可
- priority < 1000 の警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)