### PR TITLE
feat(nvim/windows): snacks picker で画像プレビュー + telescope を完全置換

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run statix
         run: |
@@ -155,6 +157,8 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check formatting
         run: nix fmt -- --fail-on-change
@@ -174,12 +178,14 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check flake evaluation
         run: |
-          output=$(nix flake check --no-build 2>&1)
-          echo "$output"
-          if echo "$output" | grep -q "evaluation warning"; then
+          set -o pipefail
+          nix flake check --no-build 2>&1 | tee /tmp/nix-check.txt
+          if grep -q "evaluation warning" /tmp/nix-check.txt; then
             echo "ERROR: evaluation warnings found"
             exit 1
           fi

--- a/chezmoi/dot_config/nvim/lua/config/options.lua
+++ b/chezmoi/dot_config/nvim/lua/config/options.lua
@@ -70,6 +70,19 @@ opt.completeopt = "menu,menuone,noselect"
 opt.swapfile = false
 opt.backup = false
 
+-- Windows: ensure ImageMagick is in PATH for snacks image conversion.
+-- winget installs to a versioned dir (ImageMagick-7.x.x-…) that may not
+-- reach nvim when launched from a shell whose profile has not yet rebuilt
+-- PATH from the registry.
+if vim.fn.has("win32") == 1 and vim.fn.executable("magick") == 0 then
+    for _, dir in ipairs(vim.fn.glob("C:/Program Files/ImageMagick*", false, true)) do
+        if vim.fn.isdirectory(dir) == 1 then
+            vim.env.PATH = dir .. ";" .. vim.env.PATH
+            break
+        end
+    end
+end
+
 -- Restore terminal on exit: explicitly switch off alternate screen so the
 -- shell is visible immediately after :q (fixes ghost-screen in WezTerm/WT)
 vim.api.nvim_create_autocmd("VimLeave", {

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -98,42 +98,6 @@ return {
         end,
     },
 
-    -- Fuzzy finder
-    {
-        "nvim-telescope/telescope.nvim",
-        cmd = "Telescope",
-        keys = {
-            { "<leader>ff", "<cmd>Telescope find_files<cr>", desc = "Find files" },
-            { "<leader>fg", "<cmd>Telescope live_grep<cr>", desc = "Live grep" },
-            { "<leader>fb", "<cmd>Telescope buffers<cr>", desc = "Buffers" },
-            { "<leader>fq", "<cmd>Telescope ghq list<cr>", desc = "ghq repos" },
-        },
-        dependencies = {
-            "nvim-lua/plenary.nvim",
-            "nvim-telescope/telescope-ghq.nvim",
-        },
-        config = function(_, opts)
-            local actions = require("telescope.actions")
-            opts.defaults = vim.tbl_deep_extend("force", opts.defaults or {}, {
-                mappings = {
-                    i = {
-                        ["\\"] = actions.select_vertical,
-                        ["|"] = actions.select_vertical,
-                        ["-"] = actions.select_horizontal,
-                    },
-                    n = {
-                        ["\\"] = actions.select_vertical,
-                        ["|"] = actions.select_vertical,
-                        ["-"] = actions.select_horizontal,
-                    },
-                },
-            })
-            local telescope = require("telescope")
-            telescope.setup(opts)
-            telescope.load_extension("ghq")
-        end,
-    },
-
     -- Treesitter
     {
         "nvim-treesitter/nvim-treesitter",
@@ -266,8 +230,37 @@ return {
     {
         "folke/snacks.nvim",
         lazy = false,
-        priority = 900,
+        priority = 1000,
         keys = {
+            { "<leader>ff", function() Snacks.picker.files() end, desc = "Find files" },
+            { "<leader>fg", function() Snacks.picker.grep() end, desc = "Live grep" },
+            { "<leader>fb", function() Snacks.picker.buffers() end, desc = "Buffers" },
+            {
+                "<leader>fq",
+                function()
+                    if vim.fn.executable("ghq") == 0 then
+                        vim.notify("ghq not found", vim.log.levels.WARN)
+                        return
+                    end
+                    Snacks.picker.pick("ghq", {
+                        source = "proc",
+                        cmd = "ghq",
+                        args = { "list", "--full-path" },
+                        title = "ghq repos",
+                        transform = function(item)
+                            item.file = item.text
+                            return item
+                        end,
+                        confirm = function(picker, item)
+                            picker:close()
+                            if item and item.file then
+                                vim.cmd.cd(item.file)
+                            end
+                        end,
+                    })
+                end,
+                desc = "ghq repos",
+            },
             {
                 "<leader><leader>",
                 function()
@@ -372,7 +365,7 @@ return {
         opts = {
             lazygit = { enabled = true },
             terminal = { enabled = true },
-            image = { enabled = true },
+            image = { enabled = true, force = true, convert = { notify = true } },
             picker = {
                 enabled = true,
                 -- snacks picker から Alt+a で選択中の項目を sidekick の
@@ -396,7 +389,8 @@ return {
             },
         },
         init = function()
-            -- PDF: pdftoppm で先頭ページを PNG に変換して image.nvim で表示
+            -- PDF: 先頭ページを PNG に変換して image.nvim で表示
+            -- Windows: ImageMagick + Ghostscript、Linux/WSL: pdftoppm (poppler)
             -- VeryLazy 後に snacks.picker.preview が確実にロードされてからパッチ
             vim.api.nvim_create_autocmd("User", {
                 pattern = "VeryLazy",
@@ -411,7 +405,11 @@ return {
                         local file = ctx.item and (ctx.item.file or ctx.item.path or "")
                         if file:match("%.pdf$") then
                             local tmp = vim.fn.tempname()
-                            vim.fn.system({ "pdftoppm", "-png", "-r", "150", "-singlefile", file, tmp })
+                            if vim.fn.has("win32") == 1 then
+                                vim.fn.system({ "magick", file .. "[0]", "-density", "150", tmp .. ".png" })
+                            else
+                                vim.fn.system({ "pdftoppm", "-png", "-r", "150", "-singlefile", file, tmp })
+                            end
                             local patched = vim.tbl_deep_extend("force", ctx, {
                                 item = vim.tbl_extend("force", ctx.item, { file = tmp .. ".png" }),
                             })
@@ -568,13 +566,13 @@ return {
                     local map = function(keys, func, desc)
                         vim.keymap.set("n", keys, func, { buffer = bufnr, desc = desc })
                     end
-                    -- gd: LSP definition if supported, else telescope grep across files
+                    -- gd: LSP definition if supported, else snacks grep for word under cursor
                     map("gd", function()
                         local clients = vim.lsp.get_clients({ bufnr = bufnr, method = "textDocument/definition" })
                         if #clients > 0 then
                             vim.lsp.buf.definition()
                         else
-                            require("telescope.builtin").grep_string({ word_match = "-w" })
+                            Snacks.picker.grep_word()
                         end
                     end, "Go to definition")
                     map("gr", vim.lsp.buf.references, "References")

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -242,8 +242,7 @@ return {
                         vim.notify("ghq not found", vim.log.levels.WARN)
                         return
                     end
-                    Snacks.picker.pick("ghq", {
-                        source = "proc",
+                    Snacks.picker.pick("proc", {
                         cmd = "ghq",
                         args = { "list", "--full-path" },
                         title = "ghq repos",

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -232,9 +232,27 @@ return {
         lazy = false,
         priority = 1000,
         keys = {
-            { "<leader>ff", function() Snacks.picker.files() end, desc = "Find files" },
-            { "<leader>fg", function() Snacks.picker.grep() end, desc = "Live grep" },
-            { "<leader>fb", function() Snacks.picker.buffers() end, desc = "Buffers" },
+            {
+                "<leader>ff",
+                function()
+                    Snacks.picker.files()
+                end,
+                desc = "Find files",
+            },
+            {
+                "<leader>fg",
+                function()
+                    Snacks.picker.grep()
+                end,
+                desc = "Live grep",
+            },
+            {
+                "<leader>fb",
+                function()
+                    Snacks.picker.buffers()
+                end,
+                desc = "Buffers",
+            },
             {
                 "<leader>fq",
                 function()

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -156,7 +156,7 @@ let
       category = "dev";
     };
     poppler-utils = {
-      pkg = pkgs.poppler_utils;
+      pkg = pkgs.poppler-utils;
       winget = null; # Windows は ImageMagick + Ghostscript で代替
       category = "dev";
     };

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -147,12 +147,17 @@ let
     };
     imagemagick = {
       pkg = pkgs.imagemagick;
-      winget = null;
+      winget = "ImageMagick.ImageMagick";
+      category = "dev";
+    };
+    ghostscript = {
+      pkg = pkgs.ghostscript;
+      winget = "ArtifexSoftware.GhostScript";
       category = "dev";
     };
     poppler-utils = {
       pkg = pkgs.poppler_utils;
-      winget = null;
+      winget = null; # Windows は ImageMagick + Ghostscript で代替
       category = "dev";
     };
 

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -152,7 +152,7 @@ let
     };
     ghostscript = {
       pkg = pkgs.ghostscript;
-      winget = "ArtifexSoftware.GhostScript";
+      winget = null; # winget カタログ未収録 — Windows は https://ghostscript.com から手動インストール
       category = "dev";
     };
     poppler-utils = {

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -371,6 +371,11 @@ let
       winget = null;
       category = "lsp";
     };
+    stylua = {
+      pkg = pkgs.stylua;
+      winget = null;
+      category = "lsp";
+    };
     marksman = {
       pkg = pkgs.marksman;
       winget = null;

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -191,6 +191,9 @@
           "PackageIdentifier": "hadolint.hadolint"
         },
         {
+          "PackageIdentifier": "ImageMagick.ImageMagick"
+        },
+        {
           "PackageIdentifier": "Google.Chrome"
         },
         {


### PR DESCRIPTION
## 概要

- **ImageMagick PATH 修正**: `options.lua` に Windows 向け PATH 自動解決を追加。winget がバージョン付きディレクトリ（`ImageMagick-7.x.x-…`）にインストールするため、シェルプロファイルの PATH 再構築が nvim に届かない場合でも `magick` が見つかるようにした
- **Telescope 完全削除**: `telescope.nvim` / `telescope-ghq.nvim` を除去し、`<leader>ff/fg/fb/fq` を snacks picker に置き換え
- **snacks image 設定**: `force = true`（WezTerm Kitty プロトコル強制）、`convert.notify = true`（変換エラー可視化）、priority 900 → 1000
- **PDF プレビュー**: Windows は `magick`、Linux/WSL は `pdftoppm` で PNG 変換
- **nix packages**: ImageMagick の winget ID 追加・stylua をカタログに追加（Ghostscript は winget 未収録のため null）

## テスト項目

- [x] `<leader>ff` → snacks picker でファイル検索、PNG 選択時に画像プレビュー表示（動作確認済み）
- [x] `<leader>fg` → snacks picker live grep（`M.grep` ソース存在確認済み）
- [x] `<leader>fb` → snacks picker バッファ一覧（`M.buffers` ソース存在確認済み）
- [x] `<leader>fq` → ghq repos 一覧（`proc` ソースで `ghq list --full-path` を実行、`pick("proc",{...})` に修正済み）
- [x] `vim.fn.executable("magick")` → `1`（PATH fix 確認済み）
- [ ] `:checkhealth snacks` でエラーなし（要手動確認）

## 修正内容

- `pick("ghq", {source="proc",...})` → `pick("proc",{...})` に修正（第1引数が `opts.source` を上書きするバグ）
- `ghostscript.winget = "ArtifexSoftware.GhostScript"` → `null` に修正（winget カタログ未収録）

🤖 Generated with [Claude Code](https://claude.com/claude-code)