### PR TITLE
fix(nvim/windows): use pdftoppm (Poppler) for PDF preview

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/options.lua
+++ b/chezmoi/dot_config/nvim/lua/config/options.lua
@@ -70,15 +70,25 @@ opt.completeopt = "menu,menuone,noselect"
 opt.swapfile = false
 opt.backup = false
 
--- Windows: ensure ImageMagick is in PATH for snacks image conversion.
--- winget installs to a versioned dir (ImageMagick-7.x.x-…) that may not
--- reach nvim when launched from a shell whose profile has not yet rebuilt
--- PATH from the registry.
-if vim.fn.has("win32") == 1 and vim.fn.executable("magick") == 0 then
-    for _, dir in ipairs(vim.fn.glob("C:/Program Files/ImageMagick*", false, true)) do
-        if vim.fn.isdirectory(dir) == 1 then
-            vim.env.PATH = dir .. ";" .. vim.env.PATH
-            break
+-- Windows: ensure ImageMagick and Poppler are in PATH for snacks image/PDF conversion.
+-- winget installs to versioned dirs that may not reach nvim when launched from a shell
+-- whose profile has not yet rebuilt PATH from the registry.
+if vim.fn.has("win32") == 1 then
+    if vim.fn.executable("magick") == 0 then
+        for _, dir in ipairs(vim.fn.glob("C:/Program Files/ImageMagick*", false, true)) do
+            if vim.fn.isdirectory(dir) == 1 then
+                vim.env.PATH = dir .. ";" .. vim.env.PATH
+                break
+            end
+        end
+    end
+    if vim.fn.executable("pdftoppm") == 0 then
+        local pattern = vim.fn.expand("$LOCALAPPDATA") .. "/Microsoft/WinGet/Packages/oschwartz10612.Poppler*/Library/bin"
+        for _, dir in ipairs(vim.fn.glob(pattern, false, true)) do
+            if vim.fn.isdirectory(dir) == 1 then
+                vim.env.PATH = dir .. ";" .. vim.env.PATH
+                break
+            end
         end
     end
 end

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -407,13 +407,17 @@ return {
                         local file = ctx.item and (ctx.item.file or ctx.item.path or "")
                         if file:match("%.pdf$") then
                             local tmp = vim.fn.tempname()
-                            if vim.fn.has("win32") == 1 then
-                                vim.fn.system({ "magick", file .. "[0]", "-density", "150", tmp .. ".png" })
-                            else
+                            if vim.fn.executable("pdftoppm") == 1 then
                                 vim.fn.system({ "pdftoppm", "-png", "-r", "150", "-singlefile", file, tmp })
+                                tmp = tmp .. ".png"
+                            elseif vim.fn.has("win32") == 1 then
+                                vim.notify("PDF preview requires poppler (pdftoppm). Install via: winget install oschwartz10612.Poppler", vim.log.levels.WARN)
+                                return orig_file(ctx)
+                            else
+                                return orig_file(ctx)
                             end
                             local patched = vim.tbl_deep_extend("force", ctx, {
-                                item = vim.tbl_extend("force", ctx.item, { file = tmp .. ".png" }),
+                                item = vim.tbl_extend("force", ctx.item, { file = tmp }),
                             })
                             return preview.image and preview.image(patched) or false
                         end

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -157,7 +157,7 @@ let
     };
     poppler-utils = {
       pkg = pkgs.poppler-utils;
-      winget = null; # Windows は ImageMagick + Ghostscript で代替
+      winget = "oschwartz10612.Poppler";
       category = "dev";
     };
 

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -194,6 +194,9 @@
           "PackageIdentifier": "ImageMagick.ImageMagick"
         },
         {
+          "PackageIdentifier": "oschwartz10612.Poppler"
+        },
+        {
           "PackageIdentifier": "Google.Chrome"
         },
         {


### PR DESCRIPTION
## 概要

- ImageMagick は PDF 変換に Ghostscript (`gswin64c.exe`) を必要とするが未インストールのためエラー
- Poppler (`pdftoppm`) に切り替え。winget で管理可能 (`oschwartz10612.Poppler`)
- Windows でも `pdftoppm` が優先されるよう統一

## 変更内容

- `sets.nix`: `poppler-utils.winget = "oschwartz10612.Poppler"` に変更
- `packages.json`: `oschwartz10612.Poppler` を追加
- `options.lua`: Poppler の winget インストール先を動的に PATH 追加
- `init.lua`: 全プラットフォームで `pdftoppm` を使用、未インストール時は警告表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)