### PR TITLE
fix(nvim): PDF preview - use pdftoppm on all platforms, clear _path cache

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/options.lua
+++ b/chezmoi/dot_config/nvim/lua/config/options.lua
@@ -70,15 +70,26 @@ opt.completeopt = "menu,menuone,noselect"
 opt.swapfile = false
 opt.backup = false
 
--- Windows: ensure ImageMagick is in PATH for snacks image conversion.
--- winget installs to a versioned dir (ImageMagick-7.x.x-…) that may not
--- reach nvim when launched from a shell whose profile has not yet rebuilt
--- PATH from the registry.
-if vim.fn.has("win32") == 1 and vim.fn.executable("magick") == 0 then
-    for _, dir in ipairs(vim.fn.glob("C:/Program Files/ImageMagick*", false, true)) do
-        if vim.fn.isdirectory(dir) == 1 then
-            vim.env.PATH = dir .. ";" .. vim.env.PATH
-            break
+-- Windows: ensure ImageMagick and Poppler are in PATH for snacks image/PDF conversion.
+-- winget installs to versioned dirs that may not reach nvim when launched from a shell
+-- whose profile has not yet rebuilt PATH from the registry.
+if vim.fn.has("win32") == 1 then
+    if vim.fn.executable("magick") == 0 then
+        for _, dir in ipairs(vim.fn.glob("C:/Program Files/ImageMagick*", false, true)) do
+            if vim.fn.isdirectory(dir) == 1 then
+                vim.env.PATH = dir .. ";" .. vim.env.PATH
+                break
+            end
+        end
+    end
+    if vim.fn.executable("pdftoppm") == 0 then
+        -- WinGet installs Poppler as: oschwartz10612.Poppler_.../poppler-X.Y.Z/Library/bin
+        local pattern = vim.fn.expand("$LOCALAPPDATA") .. "/Microsoft/WinGet/Packages/oschwartz10612.Poppler*/*/Library/bin"
+        for _, dir in ipairs(vim.fn.glob(pattern, false, true)) do
+            if vim.fn.isdirectory(dir) == 1 then
+                vim.env.PATH = dir .. ";" .. vim.env.PATH
+                break
+            end
         end
     end
 end

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -367,7 +367,14 @@ return {
         opts = {
             lazygit = { enabled = true },
             terminal = { enabled = true },
-            image = { enabled = true, force = true, convert = { notify = true } },
+            image = {
+                enabled = true,
+                force = true,
+                convert = { notify = true },
+                -- "pdf" を除外: picker では monkey-patch が pdftoppm で処理するため
+                -- snacks 自身の magick/Ghostscript パイプラインが走らないようにする
+                formats = { "png", "jpg", "jpeg", "gif", "bmp", "webp", "tiff", "heic", "avif", "mp4", "mov", "avi", "mkv", "webm", "icns" },
+            },
             picker = {
                 enabled = true,
                 -- snacks picker から Alt+a で選択中の項目を sidekick の
@@ -412,7 +419,7 @@ return {
                                     "PDF preview requires poppler (pdftoppm). Install via: winget install oschwartz10612.Poppler",
                                     vim.log.levels.WARN
                                 )
-                                return orig_file(ctx)
+                                return false
                             end
                             local tmp = vim.fn.tempname()
                             vim.fn.system({ "pdftoppm", "-png", "-r", "150", "-singlefile", file, tmp })

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -391,9 +391,10 @@ return {
             },
         },
         init = function()
-            -- PDF: 先頭ページを PNG に変換して image.nvim で表示
-            -- Windows: ImageMagick + Ghostscript、Linux/WSL: pdftoppm (poppler)
-            -- VeryLazy 後に snacks.picker.preview が確実にロードされてからパッチ
+            -- PDF: pdftoppm で先頭ページを PNG に変換して snacks image で表示。
+            -- snacks.picker.util.path() は item._path をキャッシュするため、
+            -- patched item に _path を明示セットしないと元の PDF パスが渡る。
+            -- VeryLazy 後に snacks.picker.preview が確実にロードされてからパッチ。
             vim.api.nvim_create_autocmd("User", {
                 pattern = "VeryLazy",
                 once = true,
@@ -406,14 +407,19 @@ return {
                     preview.file = function(ctx)
                         local file = ctx.item and (ctx.item.file or ctx.item.path or "")
                         if file:match("%.pdf$") then
-                            local tmp = vim.fn.tempname()
-                            if vim.fn.has("win32") == 1 then
-                                vim.fn.system({ "magick", file .. "[0]", "-density", "150", tmp .. ".png" })
-                            else
-                                vim.fn.system({ "pdftoppm", "-png", "-r", "150", "-singlefile", file, tmp })
+                            if vim.fn.executable("pdftoppm") == 0 then
+                                vim.notify(
+                                    "PDF preview requires poppler (pdftoppm). Install via: winget install oschwartz10612.Poppler",
+                                    vim.log.levels.WARN
+                                )
+                                return orig_file(ctx)
                             end
+                            local tmp = vim.fn.tempname()
+                            vim.fn.system({ "pdftoppm", "-png", "-r", "150", "-singlefile", file, tmp })
+                            tmp = tmp .. ".png"
+                            -- _path をリセットしないと元の PDF パスのキャッシュが残る
                             local patched = vim.tbl_deep_extend("force", ctx, {
-                                item = vim.tbl_extend("force", ctx.item, { file = tmp .. ".png" }),
+                                item = vim.tbl_extend("force", ctx.item, { file = tmp, _path = tmp }),
                             })
                             return preview.image and preview.image(patched) or false
                         end

--- a/scripts/powershell/tests/Integration.Tests.ps1
+++ b/scripts/powershell/tests/Integration.Tests.ps1
@@ -55,6 +55,30 @@ Describe 'Integration Verification - Windows Environment' {
         }
     }
 
+    Context 'Neovim PATH Dependencies (options.lua glob patterns)' {
+        It "should find magick.exe via ImageMagick glob" {
+            # options.lua: vim.fn.glob("C:/Program Files/ImageMagick*")
+            $dirs = @(Get-Item "C:/Program Files/ImageMagick*" -ErrorAction SilentlyContinue)
+            $found = $dirs | Where-Object { Test-Path (Join-Path $_.FullName "magick.exe") }
+            if (-not $found) {
+                throw "magick.exe が見つかりません。ImageMagick をインストールしてください: winget install ImageMagick.ImageMagick"
+            }
+            Write-Host "確認完了: magick.exe @ $($found[0].FullName)"
+        }
+
+        It "should find pdftoppm.exe via Poppler glob" {
+            # options.lua: vim.fn.glob("$LOCALAPPDATA/Microsoft/WinGet/Packages/oschwartz10612.Poppler*/*/Library/bin")
+            $localAppData = [Environment]::GetFolderPath('LocalApplicationData')
+            $pattern = Join-Path $localAppData "Microsoft/WinGet/Packages/oschwartz10612.Poppler*/*/Library/bin"
+            $dirs = @(Get-Item $pattern -ErrorAction SilentlyContinue)
+            $found = $dirs | Where-Object { Test-Path (Join-Path $_.FullName "pdftoppm.exe") }
+            if (-not $found) {
+                throw "pdftoppm.exe が見つかりません。Poppler をインストールしてください: winget install oschwartz10612.Poppler"
+            }
+            Write-Host "確認完了: pdftoppm.exe @ $($found[0].FullName)"
+        }
+    }
+
     Context 'Font Installation' {
         It "should have UDEV Gothic NF font installed" {
             # GDI キャッシュ（InstalledFontCollection）はセッション再起動後に更新されるため


### PR DESCRIPTION
## Summary

- **Bug 1**: Windows branch was using `magick` to convert PDF→PNG for picker preview, which requires Ghostscript (not installed). Switched to `pdftoppm` (Poppler, installed via winget) on all platforms.
- **Bug 2**: `Snacks.picker.util.path()` caches the resolved path in `item._path`. When the monkey-patch copies the item with `tbl_extend`, the cached original PDF path carries over to the patched item, so `preview.image` was receiving the PDF path (not our temp PNG) — triggering snacks image's own magick-based PDF convert pipeline (which also needs Ghostscript). Fix: explicitly set `_path = tmp` on the patched item.

## Test plan

- [ ] Open nvim and press `<leader>ff` to open the snacks file picker
- [ ] Navigate to a `.pdf` file
- [ ] Verify the preview shows the first page as an image (no Ghostscript error notification)
- [ ] Verify non-PDF files still preview correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)