### PR TITLE
fix(pwsh): wrap claude update to handle pnpm postinstall

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -36,6 +36,7 @@ return {
                 ["t"] = { "actions.select", opts = { tab = true }, desc = "Open in new tab" },
                 ["<C-h>"] = false,
                 ["<C-l>"] = false,
+                ["<Esc>"] = "actions.close",
             },
         },
         config = function(_, opts)

--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -266,6 +266,23 @@ function dotf {
     try { task @args } finally { Pop-Location }
 }
 
+# claude: intercept `claude update` to run pnpm install + postinstall.
+# pnpm v10 blocks build scripts by default, so the native binary postinstall
+# never runs when using `claude update` directly, leaving a stub exe.
+function claude {
+    if ($args[0] -eq 'update') {
+        pnpm install -g "@anthropic-ai/claude-code@latest"
+        if ($LASTEXITCODE -eq 0) {
+            $pkgDir = Join-Path (pnpm root -g).Trim() "@anthropic-ai\claude-code"
+            Push-Location $pkgDir
+            try { node install.cjs } finally { Pop-Location }
+        }
+        return
+    }
+    $ps1 = Get-Command claude -CommandType ExternalScript -ErrorAction SilentlyContinue
+    if ($ps1) { & $ps1.Source @args } else { & claude.exe @args }
+}
+
 # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)
 # Codex 等の最小環境では $HOME が空文字列のため Join-Path がエラーになる。
 if ($HOME) {


### PR DESCRIPTION
## Summary

- `claude update` on Windows with pnpm v10 fails because pnpm blocks build scripts by default, leaving a stub `claude.exe` that errors with "not a valid application for this OS platform"
- Add a `claude` function to PowerShell profile that intercepts the `update` subcommand: runs `pnpm install -g @anthropic-ai/claude-code@latest` then `node install.cjs` (postinstall) automatically
- Add `<Esc>` keymap to close oil.nvim

## Test Plan
- [ ] Run `claude update` in PowerShell → confirm it completes without error and `claude --version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)