### PR TITLE
fix(wezterm): enable Acrylic backdrop on Windows for transparency

### DIFF
--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -32,6 +32,9 @@ config.use_ime = true
 
 -- Window appearance
 config.window_background_opacity = 0.85
+if is_windows then
+    config.win32_system_backdrop = "Acrylic"
+end
 config.window_decorations = "TITLE|RESIZE"
 config.window_padding = {
     left = 8,


### PR DESCRIPTION
## Summary

- `window_background_opacity = 0.85` alone does not produce visible transparency on Windows with the WebGpu renderer
- Add `win32_system_backdrop = "Acrylic"` (Windows-only) to activate compositor transparency
- Windows 11: Acrylic blur effect. Windows 10: simple transparency

## Test Plan
- [ ] Relaunch WezTerm on Windows and confirm background is transparent

🤖 Generated with [Claude Code](https://claude.com/claude-code)