### PR TITLE
fix(nvim): hide line numbers in vsplit terminal

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/keymaps.lua
+++ b/chezmoi/dot_config/nvim/lua/config/keymaps.lua
@@ -140,10 +140,14 @@ require("config.float_persist").setup()
 vim.cmd([[cabbrev <expr> terminal (getcmdtype() == ':' && getcmdpos() <= 9) ? 'Term' : 'terminal']])
 
 -- Terminal window options: hide line numbers and sign column.
+-- Use win_findbuf to target the correct window regardless of async timing.
 vim.api.nvim_create_autocmd("TermOpen", {
-    callback = function()
-        vim.wo.number = false
-        vim.wo.relativenumber = false
-        vim.wo.signcolumn = "no"
+    callback = function(args)
+        for _, win in ipairs(vim.fn.win_findbuf(args.buf)) do
+            vim.wo[win].number = false
+            vim.wo[win].relativenumber = false
+            vim.wo[win].signcolumn = "no"
+            vim.wo[win].cursorline = false
+        end
     end,
 })


### PR DESCRIPTION
## Summary

- `TermOpen` autocmd で `vim.wo` を直接使うと非同期タイミングで誤 window に適用される問題を修正
- `vim.fn.win_findbuf(args.buf)` で terminal buffer を表示している window を明示的に特定して options を設定

## Why left pane was fine

左 pane（`<leader>tt`）は Snacks.nvim が window options を明示的に管理するため line numbers が出ない。右 pane（`vsplit | terminal`）は TermOpen autocmd に依存していたが、非同期タイミングの問題で適用されていなかった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)