### PR TITLE
fix(nvim): suppress line numbers in vsplit terminal via vim.schedule

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/keymaps.lua
+++ b/chezmoi/dot_config/nvim/lua/config/keymaps.lua
@@ -125,6 +125,15 @@ local function add_terminal_session()
     else
         vim.cmd("botright 15split | terminal")
     end
+    local new_win = vim.api.nvim_get_current_win()
+    vim.schedule(function()
+        if vim.api.nvim_win_is_valid(new_win) then
+            vim.wo[new_win].number = false
+            vim.wo[new_win].relativenumber = false
+            vim.wo[new_win].signcolumn = "no"
+            vim.wo[new_win].cursorline = false
+        end
+    end)
     vim.cmd("startinsert")
 end
 map("n", "<M-\\>", add_terminal_session, { desc = "New terminal session" })


### PR DESCRIPTION
## Summary

- `TermOpen` autocmd のタイミングで他の処理が `number` を上書きする問題を修正
- `add_terminal_session` 内で `vim.schedule` を使い、全処理完了後に対象 window へ直接 options を適用

🤖 Generated with [Claude Code](https://claude.com/claude-code)