### PR TITLE
fix(nvim): clear statuscolumn in terminal windows

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/keymaps.lua
+++ b/chezmoi/dot_config/nvim/lua/config/keymaps.lua
@@ -132,6 +132,7 @@ local function add_terminal_session()
             vim.wo[new_win].relativenumber = false
             vim.wo[new_win].signcolumn = "no"
             vim.wo[new_win].cursorline = false
+            vim.wo[new_win].statuscolumn = ""
         end
     end)
     vim.cmd("startinsert")
@@ -157,6 +158,7 @@ vim.api.nvim_create_autocmd("TermOpen", {
             vim.wo[win].relativenumber = false
             vim.wo[win].signcolumn = "no"
             vim.wo[win].cursorline = false
+            vim.wo[win].statuscolumn = ""
         end
     end,
 })


### PR DESCRIPTION
## Summary

- `options.lua` の `opt.statuscolumn` カスタム式が `number=false` を上書きして行番号を表示し続ける問題を修正
- terminal window で `statuscolumn = ""` を設定して行番号列を非表示にする

## Root cause

```lua
-- options.lua line 8
opt.statuscolumn = "%{v:lnum}  %=%{v:relnum?printf('%3d', v:relnum):'   '} "
```

`number`/`relativenumber` を false にしても `statuscolumn` が独立して行番号を描画するため、両方クリアが必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)