### PR TITLE
fix(pwsh): resolve claude command ambiguity by preferring pnpm over npm

### DIFF
--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -279,7 +279,7 @@ function claude {
         }
         return
     }
-    $ps1 = Get-Command claude -CommandType ExternalScript -ErrorAction SilentlyContinue
+    $ps1 = Get-Command claude -CommandType ExternalScript -ErrorAction SilentlyContinue | Where-Object { $_.Source -like '*\pnpm\*' } | Select-Object -First 1
     if ($ps1) { & $ps1.Source @args } else { & claude.exe @args }
 }
 


### PR DESCRIPTION
## Summary

- `Get-Command claude -CommandType ExternalScript` が pnpm と npm の両方から `claude.ps1` を返すため、`$ps1.Source` が両パスを連結した文字列になりコマンド実行に失敗していた
- `Where-Object { $_.Source -like '*\pnpm\*' }` で pnpm インストール分のみにフィルタするよう修正

## Test plan

- [ ] `chezmoi apply` で Windows 側に反映
- [ ] PowerShell で `claude` コマンドが正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)