### PR TITLE
fix(taskfile): apply chezmoi to Windows from WSL via cmd.exe

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -135,6 +135,8 @@ tasks:
       - cmd: wsl -d {{.DISTRO}} -- chezmoi apply --force
         platforms: [windows]
       - chezmoi apply --force
+      - cmd: cmd.exe /c "chezmoi apply --force"
+        platforms: [linux, darwin]
 
   # ===========================================
   # Docker


### PR DESCRIPTION
## Summary

- WSL から `task chezmoi` を実行したとき Windows 側にも反映されなかった問題を修正
- `linux/darwin` プラットフォーム向けに `cmd.exe /c "chezmoi apply --force"` ステップを追加
- Windows から実行した場合の動作は変わらず（`wsl -d NixOS -- chezmoi apply` → `chezmoi apply`）

## Test plan

- [x] WSL から `task chezmoi` を実行して `C:\Users\...\Microsoft.PowerShell_profile.ps1` が更新されることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)