### PR TITLE
feat(ci): add cross-platform devcontainer E2E CI

### DIFF
--- a/.devcontainer/ci/bats.sh
+++ b/.devcontainer/ci/bats.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -d tests/bash ]; then
+  echo "No bats tests found — skipping"
+  exit 0
+fi
+
+apt-get install -y -qq --no-install-recommends bats
+bats tests/bash/

--- a/.devcontainer/ci/devcontainer.json
+++ b/.devcontainer/ci/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "dotfiles CI",
+  "image": "ubuntu:24.04",
+  "postCreateCommand": "bash ${containerWorkspaceFolder}/bootstrap.sh",
+  "remoteUser": "root"
+}

--- a/.devcontainer/ci/e2e.sh
+++ b/.devcontainer/ci/e2e.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export PATH="$HOME/.local/bin:$HOME/.local/npm/bin:$PATH"
+
+echo "=== tmux + nvim headless E2E ==="
+tmux new-session -d -s ci "nvim --headless +qa"
+sleep 2
+tmux kill-session -t ci 2>/dev/null || true
+echo "OK  tmux + nvim headless"

--- a/.devcontainer/ci/smoke.sh
+++ b/.devcontainer/ci/smoke.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export PATH="$HOME/.local/bin:$HOME/.local/npm/bin:$PATH"
+
+check() {
+  local out
+  out=$("$@" 2>&1) || {
+    echo "FAIL $1 (exit $?)"
+    exit 1
+  }
+  echo "OK  $1: ${out%%$'\n'*}"
+}
+
+echo "=== Smoke test ==="
+check nvim --version
+check tmux -V
+check chezmoi --version
+echo "=== Smoke test passed ==="

--- a/.github/workflows/ci-devcontainer.yml
+++ b/.github/workflows/ci-devcontainer.yml
@@ -1,0 +1,170 @@
+name: devcontainer CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "bootstrap.sh"
+      - ".devcontainer/**"
+      - ".github/workflows/ci-devcontainer.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "bootstrap.sh"
+      - ".devcontainer/**"
+      - ".github/workflows/ci-devcontainer.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux-nix:
+    name: E2E (Linux + Nix CLI)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install devcontainer CLI
+        run: |
+          nix profile install 'nixpkgs#devcontainer'
+          echo "$HOME/.nix-profile/bin" >> "$GITHUB_PATH"
+
+      - name: Start devcontainer
+        run: |
+          devcontainer up \
+            --config .devcontainer/ci/devcontainer.json \
+            --workspace-folder .
+
+      - name: Smoke test
+        run: |
+          devcontainer exec \
+            --config .devcontainer/ci/devcontainer.json \
+            --workspace-folder . \
+            -- bash .devcontainer/ci/smoke.sh
+
+      - name: bats unit tests
+        run: |
+          devcontainer exec \
+            --config .devcontainer/ci/devcontainer.json \
+            --workspace-folder . \
+            -- bash .devcontainer/ci/bats.sh
+
+      - name: tmux + nvim headless E2E
+        run: |
+          devcontainer exec \
+            --config .devcontainer/ci/devcontainer.json \
+            --workspace-folder . \
+            -- bash .devcontainer/ci/e2e.sh
+
+  macos:
+    name: E2E (macOS)
+    runs-on: macos-15
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Docker (Colima)
+        run: |
+          brew install colima docker
+          colima start --cpu 2 --memory 4
+
+      - name: Install devcontainer CLI
+        run: npm install -g @devcontainers/cli
+
+      - name: Start devcontainer
+        run: |
+          devcontainer up \
+            --config .devcontainer/ci/devcontainer.json \
+            --workspace-folder .
+
+      - name: Smoke test
+        run: |
+          devcontainer exec \
+            --config .devcontainer/ci/devcontainer.json \
+            --workspace-folder . \
+            -- bash .devcontainer/ci/smoke.sh
+
+      - name: bats unit tests
+        run: |
+          devcontainer exec \
+            --config .devcontainer/ci/devcontainer.json \
+            --workspace-folder . \
+            -- bash .devcontainer/ci/bats.sh
+
+      - name: tmux + nvim headless E2E
+        run: |
+          devcontainer exec \
+            --config .devcontainer/ci/devcontainer.json \
+            --workspace-folder . \
+            -- bash .devcontainer/ci/e2e.sh
+
+  windows:
+    name: E2E (Windows)
+    runs-on: windows-2025
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Switch Docker to Linux containers
+        shell: pwsh
+        run: |
+          & 'C:\Program Files\Docker\Docker\DockerCli.exe' -SwitchLinuxEngine
+          Start-Sleep 15
+
+      - name: Install devcontainer CLI
+        shell: pwsh
+        run: npm install -g @devcontainers/cli
+
+      - name: Start devcontainer
+        shell: bash
+        run: |
+          devcontainer up \
+            --config .devcontainer/ci/devcontainer.json \
+            --workspace-folder .
+
+      - name: Smoke test
+        shell: bash
+        run: |
+          devcontainer exec \
+            --config .devcontainer/ci/devcontainer.json \
+            --workspace-folder . \
+            -- bash .devcontainer/ci/smoke.sh
+
+      - name: bats unit tests
+        shell: bash
+        run: |
+          devcontainer exec \
+            --config .devcontainer/ci/devcontainer.json \
+            --workspace-folder . \
+            -- bash .devcontainer/ci/bats.sh
+
+      - name: tmux + nvim headless E2E
+        shell: bash
+        run: |
+          devcontainer exec \
+            --config .devcontainer/ci/devcontainer.json \
+            --workspace-folder . \
+            -- bash .devcontainer/ci/e2e.sh

--- a/docs/superpowers/specs/2026-06-01-devcontainer-ci-design.md
+++ b/docs/superpowers/specs/2026-06-01-devcontainer-ci-design.md
@@ -1,0 +1,85 @@
+---
+title: devcontainer CLI クロスプラットフォーム CI 設計
+date: 2026-06-01
+status: implemented
+---
+
+# devcontainer CLI クロスプラットフォーム CI 設計
+
+## 目的
+
+`bootstrap.sh` と `.devcontainer/ci/devcontainer.json` が Windows・Linux(Nix)・macOS の 3 プラットフォームで実際に動くことを CI で自動検証する。検証レベルは「`devcontainer up` → `bootstrap.sh` 完走 → tmux + nvim headless 起動」まで。
+
+## アーキテクチャ
+
+```
+.devcontainer/ci/
+  devcontainer.json   ← CI 専用設定 (image: ubuntu:24.04)
+  smoke.sh            ← nvim / tmux / chezmoi バージョン確認
+  bats.sh             ← tests/bash/ が存在すれば bats 実行
+  e2e.sh              ← tmux new-session + nvim --headless E2E
+
+.github/workflows/ci-devcontainer.yml
+  ├── job: linux-nix  (ubuntu-24.04 + Nix + devcontainer CLI via Nix)
+  ├── job: macos      (macos-15 + Colima + npm)
+  └── job: windows    (windows-2025 + Docker Linux mode + npm)
+```
+
+## devcontainer.json 設計
+
+| 項目              | 値                                              | 理由                                                                                          |
+| ----------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| image             | `ubuntu:24.04`                                  | 最小構成で bootstrap.sh のフルセットアップをテスト                                            |
+| postCreateCommand | `bash ${containerWorkspaceFolder}/bootstrap.sh` | CI では `~/.config/devcontainer/devcontainer.json` の dotfiles 機能が使えないため直接呼び出し |
+| remoteUser        | `root`                                          | ubuntu:24.04 最小イメージのデフォルトユーザー。sudo なしで apt-get が通る                     |
+
+## E2E 検証フロー
+
+各 job 共通:
+
+1. `devcontainer up` → `postCreateCommand` 経由で `bootstrap.sh` 実行
+   - apt: tmux / git / curl / tar
+   - chezmoi install + apply (best effort; 1Password template 失敗は継続)
+   - nvim install (`~/.local/bin/nvim`)
+   - claude code install (best effort)
+   - lazy.nvim pre-warm (90s cap)
+2. `devcontainer exec -- bash smoke.sh` → nvim / tmux / chezmoi バージョン確認
+3. `devcontainer exec -- bash bats.sh` → `tests/bash/` が存在すれば bats 実行
+4. `devcontainer exec -- bash e2e.sh` → `tmux new-session -d -s ci "nvim --headless +qa"`
+
+## プラットフォーム固有対応
+
+| Platform  | Docker 準備                                           | CLI インストール                           |
+| --------- | ----------------------------------------------------- | ------------------------------------------ |
+| linux-nix | ネイティブ                                            | `nix profile install nixpkgs#devcontainer` |
+| macos     | `brew install colima docker && colima start`          | `npm install -g @devcontainers/cli`        |
+| windows   | `DockerCli.exe -SwitchLinuxEngine` + `Start-Sleep 15` | `npm install -g @devcontainers/cli`        |
+
+## タイムアウト
+
+| job       | timeout | 理由                                  |
+| --------- | ------- | ------------------------------------- |
+| linux-nix | 30 分   | Docker ネイティブ、Nix キャッシュあり |
+| macos     | 45 分   | Colima 起動 + Docker pull             |
+| windows   | 45 分   | Linux コンテナ切り替え + Docker pull  |
+
+## エラーハンドリング
+
+| ステップ                        | 失敗時                                         |
+| ------------------------------- | ---------------------------------------------- |
+| `devcontainer up`               | ジョブ失敗（必須）                             |
+| `bootstrap.sh` 内 chezmoi apply | best-effort（継続）                            |
+| `bootstrap.sh` 内 claude code   | best-effort（継続）                            |
+| smoke test (nvim/tmux/chezmoi)  | ジョブ失敗                                     |
+| bats                            | `tests/bash/` 不在はスキップ、失敗はジョブ失敗 |
+| tmux+nvim E2E                   | ジョブ失敗                                     |
+
+## トリガー
+
+`bootstrap.sh`, `.devcontainer/**`, `.github/workflows/ci-devcontainer.yml` への push/PR。
+
+## スコープ外
+
+- 実際の dotfiles dotfiles 機能 (`~/.config/devcontainer/devcontainer.json`) のテスト
+- claude code の認証・実際の動作確認
+- Windows ネイティブ (WSL 外) での devcontainer 起動


### PR DESCRIPTION
## Summary

- `ubuntu:24.04` ベースの最小コンテナで `bootstrap.sh` をフルセットアップし、`tmux + nvim headless` まで E2E 検証する CI を追加
- 3 プラットフォームで並列実行: Linux (ubuntu-24.04 + Nix CLI)、macOS (macos-15 + Colima)、Windows (windows-2025 + Docker Linux mode)
- `.devcontainer/ci/` に CI 専用設定と検証スクリプトを追加

## 追加ファイル

| ファイル | 役割 |
|---------|------|
| `.devcontainer/ci/devcontainer.json` | CI 専用 devcontainer 設定 (ubuntu:24.04) |
| `.devcontainer/ci/smoke.sh` | nvim / tmux / chezmoi バージョン確認 |
| `.devcontainer/ci/bats.sh` | `tests/bash/` が存在すれば bats 実行 |
| `.devcontainer/ci/e2e.sh` | tmux + nvim --headless E2E |
| `.github/workflows/ci-devcontainer.yml` | 3 platform CI ワークフロー |

## Test plan

- [ ] GitHub Actions で 3 jobs (linux-nix / macos / windows) が起動すること
- [ ] `bootstrap.sh` が ubuntu:24.04 コンテナ内で完走すること
- [ ] smoke test で nvim / tmux / chezmoi が確認されること
- [ ] tmux + nvim headless E2E が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)