### PR TITLE
fix(ci): devcontainer CI 3件の修正

### DIFF
--- a/.github/workflows/ci-devcontainer.yml
+++ b/.github/workflows/ci-devcontainer.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install Docker (Colima)
         run: |
           brew install colima docker
-          colima start --cpu 2 --memory 4
+          colima start --cpu 2 --memory 4 --vm-type vz
 
       - name: Install devcontainer CLI
         run: npm install -g @devcontainers/cli
@@ -127,12 +127,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
-      - name: Switch Docker to Linux containers
-        shell: pwsh
-        run: |
-          & 'C:\Program Files\Docker\Docker\DockerCli.exe' -SwitchLinuxEngine
-          Start-Sleep 15
 
       - name: Install devcontainer CLI
         shell: pwsh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -45,6 +45,7 @@ if [ "$can_install" -eq 1 ] && have apt-get; then
   have curl || need+=("curl")
   have git || need+=("git")
   have tar || need+=("tar")
+  dpkg -s ca-certificates >/dev/null 2>&1 || need+=("ca-certificates")
   if [ "${#need[@]}" -gt 0 ]; then
     log "apt install: ${need[*]}"
     $SUDO apt-get update -qq


### PR DESCRIPTION
## 修正内容

前回の devcontainer CI (#300) で判明した3件の失敗を修正する。

| job | 原因 | 修正 |
|-----|------|------|
| Linux | ubuntu:24.04 最小イメージに `ca-certificates` 未インストール → curl SSL エラー | `bootstrap.sh` の apt リストに追加 |
| macOS | Apple Silicon runner で QEMU ベースの Colima が起動失敗 | `--vm-type vz` (Apple Virtualization Framework) を使用 |
| Windows | `DockerCli.exe` が windows-2025 に存在しない (Docker CE) | switch ステップを削除 (WSL2 ベースで Linux コンテナ対応済み) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)