### PR TITLE
fix(ci): use docker/setup-docker-action for macOS and Windows

### DIFF
--- a/.github/workflows/ci-devcontainer.yml
+++ b/.github/workflows/ci-devcontainer.yml
@@ -81,10 +81,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Docker (Colima)
-        run: |
-          brew install colima docker
-          colima start --cpu 2 --memory 4 --vm-type vz
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
 
       - name: Install devcontainer CLI
         run: npm install -g @devcontainers/cli
@@ -127,6 +125,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
 
       - name: Install devcontainer CLI
         shell: pwsh


### PR DESCRIPTION
## 修正内容

macOS と Windows の Docker セットアップを Docker 公式 Action に切り替える。

| job | 旧 | 新 |
|-----|----|----|
| macOS | `colima start --vm-type vz`（M-series で VM 起動失敗） | `docker/setup-docker-action@v4` |
| Windows | `DockerCli.exe -SwitchLinuxEngine`（ファイル不在） | `docker/setup-docker-action@v4` |

`docker/setup-docker-action` は macOS Apple Silicon と Windows の Linux コンテナ設定を自動で処理する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)