### PR TITLE
feat(terminals): increase transparency for WezTerm and Windows Terminal

### DIFF
--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -31,7 +31,7 @@ config.front_end = "WebGpu"
 config.use_ime = true
 
 -- Window appearance
-config.window_background_opacity = 0.85
+config.window_background_opacity = 0.75
 if is_windows then
     config.win32_system_backdrop = "Acrylic"
 end

--- a/chezmoi/terminals/windows-terminal/settings.json
+++ b/chezmoi/terminals/windows-terminal/settings.json
@@ -247,7 +247,7 @@
         "size": 10
       },
       "useAcrylic": true,
-      "opacity": 85,
+      "opacity": 75,
       "colorScheme": "Catppuccin Mocha",
       "cursorShape": "bar",
       "padding": "8, 8, 8, 8"


### PR DESCRIPTION
## Summary

- WezTerm / Windows Terminal の背景透過度を 85 → 75 に変更
- 両ターミナルで統一した値を使用

## Test plan

- [ ] `task chezmoi` で反映後、WezTerm と Windows Terminal で透過が強くなっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)