### PR TITLE
feat(dcnvim): ghq list | fzf picker when no arg

### DIFF
--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -166,7 +166,23 @@ if (-not $env:CLAUDE_CODE_GIT_BASH_PATH) {
 # container to provide nvim + tmux. See bootstrap.sh at repo root.
 function dcnvim {
     [CmdletBinding()]
-    param([string]$Workspace = (Get-Location).Path)
+    param([string]$Workspace = "")
+
+    # No arg + cwd has .devcontainer  → use cwd
+    # No arg + no .devcontainer       → ghq list | fzf picker
+    # Explicit path                   → use that path
+    if (-not $Workspace) {
+        $cwd = (Get-Location).Path
+        if ((Test-Path (Join-Path $cwd ".devcontainer")) -or (Test-Path (Join-Path $cwd ".devcontainer.json"))) {
+            $Workspace = $cwd
+        } elseif (Get-Command ghq -ErrorAction SilentlyContinue) {
+            $selected = ghq list | fzf --prompt="devcontainer> "
+            if (-not $selected) { return }
+            $Workspace = Join-Path (ghq root) $selected
+        } else {
+            $Workspace = $cwd
+        }
+    }
 
     if (-not (Get-Command devcontainer -ErrorAction SilentlyContinue)) {
         Write-Error "dcnvim: devcontainer CLI not found. Install with: npm i -g @devcontainers/cli"

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -129,13 +129,27 @@ in
       # Windows Terminal, Warp, etc.). Re-running attaches to the existing
       # tmux session so nvim state survives terminal close.
       #
-      # Usage: dcnvim [workspace-folder]   # defaults to $PWD
+      # Usage: dcnvim [workspace-folder]
+      #   No arg + cwd has .devcontainer  → use cwd
+      #   No arg + no .devcontainer       → ghq list | fzf picker
+      #   Explicit path                   → use that path
       #
       # Requires: @devcontainers/cli on host; bootstrap.sh ran inside the
       # container to provide nvim + tmux. See bootstrap.sh at repo root.
       dcnvim() {
         local workspace
-        workspace="$(realpath -e "''${1:-$PWD}" 2>/dev/null || readlink -f "''${1:-$PWD}")"
+        if [ -n "''${1:-}" ]; then
+          workspace="$(realpath -e "$1" 2>/dev/null || readlink -f "$1")"
+        elif [ -d "$PWD/.devcontainer" ] || [ -f "$PWD/.devcontainer.json" ]; then
+          workspace="$PWD"
+        elif command -v ghq >/dev/null 2>&1 && command -v fzf >/dev/null 2>&1; then
+          local ghq_root selected
+          ghq_root="$(ghq root 2>/dev/null)" || ghq_root=""
+          selected="$(ghq list | fzf --prompt='devcontainer> ')" || return 0
+          workspace="$(realpath -e "$ghq_root/$selected" 2>/dev/null || readlink -f "$ghq_root/$selected")"
+        else
+          workspace="$PWD"
+        fi
         if ! command -v devcontainer >/dev/null 2>&1; then
           echo "dcnvim: devcontainer CLI not found. Install with: npm i -g @devcontainers/cli" >&2
           return 127


### PR DESCRIPTION
## 変更内容

`dcnvim` の引数省略時の挙動を改善。

| 状況 | 変更前 | 変更後 |
|------|--------|--------|
| 引数なし + cwd に `.devcontainer` あり | cwd を使用 | cwd を使用（変更なし） |
| 引数なし + cwd に `.devcontainer` なし | cwd を使用 → エラー | `ghq list \| fzf` でリポジトリ選択 |
| 引数あり | そのパスを使用 | そのパスを使用（変更なし） |

bash/zsh (`nix/home/common.nix`) と PowerShell (`Microsoft.PowerShell_profile.ps1`) の両方に適用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)