### PR TITLE
fix(powershell): refresh stale WinGet Links shim after winget upgrade

### DIFF
--- a/scripts/powershell/handlers/Handler.Bun.ps1
+++ b/scripts/powershell/handlers/Handler.Bun.ps1
@@ -34,9 +34,9 @@ class BunHandler : SetupHandlerBase {
         $linksPath = $this.GetLinksPath()
         $linkPath = Join-Path $linksPath "bun.exe"
 
-        # リンクが既にあっても Links パスが USER PATH に無い場合は適用する。
-        # (手動 shim, 過去の部分実行, copy フォールバック後を想定。)
-        if ((Test-Path $linkPath) -and $this.IsLinksInUserPath($linksPath)) {
+        # リンクが最新でも Links パスが USER PATH に無い場合は適用する。
+        # (winget upgrade 後の陳腐化, 手動 shim, 過去の部分実行, copy フォールバック後を想定。)
+        if ($this.IsPortableLinkCurrent($linkPath, $bunExe) -and $this.IsLinksInUserPath($linksPath)) {
             $this.Log("bun.exe リンクと PATH 設定は既に完了しています", "Gray")
             return $false
         }
@@ -58,41 +58,13 @@ class BunHandler : SetupHandlerBase {
 
             $linkPath = Join-Path $linksPath "bun.exe"
 
-            # リンクが無いときだけ作成。既存リンクは尊重して再作成しない。
-            if (-not (Test-Path $linkPath)) {
-                $this.Log("シンボリックリンクを作成しています: $linkPath -> $bunExe")
-
-                # Windows ではシンボリックリンク作成に管理者権限または開発者モードが必要。
-                # 失敗時はハードリンク、それも失敗ならコピーへフォールバック。
-                $linkCreated = $false
-
-                try {
-                    New-Item -ItemType SymbolicLink -Path $linkPath -Target $bunExe -ErrorAction Stop | Out-Null
-                    $this.Log("シンボリックリンクを作成しました", "Green")
-                    $linkCreated = $true
-                }
-                catch {
-                    $this.LogWarning("シンボリックリンク作成失敗: $($_.Exception.Message)")
-                }
-
-                if (-not $linkCreated) {
-                    try {
-                        New-Item -ItemType HardLink -Path $linkPath -Target $bunExe -ErrorAction Stop | Out-Null
-                        $this.Log("ハードリンクを作成しました", "Green")
-                        $linkCreated = $true
-                    }
-                    catch {
-                        $this.LogWarning("ハードリンク作成失敗: $($_.Exception.Message)")
-                    }
-                }
-
-                if (-not $linkCreated) {
-                    Copy-Item -Path $bunExe -Destination $linkPath -Force
-                    $this.Log("ファイルをコピーしました", "Green")
-                }
+            # リンクが陳腐化している（旧バージョンを指すコピー等）場合のみ貼り直す。
+            # winget upgrade 後に Links\bun.exe が旧バージョンを指す問題への対処。
+            if (-not $this.IsPortableLinkCurrent($linkPath, $bunExe)) {
+                $this.CreatePortableLink($linkPath, $bunExe)
             }
             else {
-                $this.Log("bun.exe リンクは既に存在します", "Gray")
+                $this.Log("bun.exe リンクは最新です", "Gray")
             }
 
             # PATH は常に冪等チェック。リンクが既存でも PATH 未設定なら追加する。

--- a/scripts/powershell/handlers/Handler.Codex.ps1
+++ b/scripts/powershell/handlers/Handler.Codex.ps1
@@ -27,7 +27,9 @@ class CodexHandler : SetupHandlerBase {
     .SYNOPSIS
         実行可否を判定する
     .DESCRIPTION
-        Codex パッケージがインストールされていて、Links に codex.exe がない場合に適用
+        Codex パッケージがインストールされていて、Links\codex.exe が
+        現行 exe を指していない（未作成 / winget upgrade 後の陳腐化）か、
+        Links が USER PATH に未登録の場合に適用する。
     #>
     [bool] CanApply([SetupContext]$ctx) {
         $codexExe = $this.GetCodexExecutablePath()
@@ -39,8 +41,10 @@ class CodexHandler : SetupHandlerBase {
         $linksPath = $this.GetLinksPath()
         $linkPath = Join-Path $linksPath "codex.exe"
 
-        if (Test-Path $linkPath) {
-            $this.Log("codex.exe リンクは既に存在します", "Gray")
+        # リンクが最新でも Links が PATH に無ければ適用する。
+        # (winget upgrade 後の陳腐化, copy フォールバック後, 過去の部分実行を想定。)
+        if ($this.IsPortableLinkCurrent($linkPath, $codexExe) -and $this.IsLinksInUserPath($linksPath)) {
+            $this.Log("codex.exe リンクと PATH 設定は既に完了しています", "Gray")
             return $false
         }
 
@@ -64,51 +68,27 @@ class CodexHandler : SetupHandlerBase {
             }
 
             $linkPath = Join-Path $linksPath "codex.exe"
-            $this.Log("シンボリックリンクを作成しています: $linkPath -> $codexExe")
 
-            # Windows ではシンボリックリンク作成に管理者権限または開発者モードが必要
-            # 失敗した場合はハードリンクまたはコピーにフォールバック
-            $linkCreated = $false
-
-            # まずシンボリックリンクを試す
-            try {
-                New-Item -ItemType SymbolicLink -Path $linkPath -Target $codexExe -Force -ErrorAction Stop | Out-Null
-                $this.Log("シンボリックリンクを作成しました", "Green")
-                $linkCreated = $true
+            # リンクが陳腐化している（旧バージョンを指すコピー等）場合のみ貼り直す。
+            # winget upgrade 後に Links\codex.exe が旧バージョンを指す問題への対処。
+            if (-not $this.IsPortableLinkCurrent($linkPath, $codexExe)) {
+                $this.CreatePortableLink($linkPath, $codexExe)
             }
-            catch {
-                $this.LogWarning("シンボリックリンク作成失敗: $($_.Exception.Message)")
+            else {
+                $this.Log("codex.exe リンクは最新です", "Gray")
             }
 
-            # シンボリックリンクが失敗した場合、ハードリンクを試す
-            if (-not $linkCreated) {
-                try {
-                    New-Item -ItemType HardLink -Path $linkPath -Target $codexExe -Force -ErrorAction Stop | Out-Null
-                    $this.Log("ハードリンクを作成しました", "Green")
-                    $linkCreated = $true
-                }
-                catch {
-                    $this.LogWarning("ハードリンク作成失敗: $($_.Exception.Message)")
-                }
-            }
-
-            # すべて失敗した場合はファイルをコピー
-            if (-not $linkCreated) {
-                Copy-Item -Path $codexExe -Destination $linkPath -Force
-                $this.Log("ファイルをコピーしました", "Green")
-            }
-
-            # Links パスが PATH に登録されているか確認
-            $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-            if ($userPath -notlike "*$linksPath*") {
+            # PATH は常に冪等チェック。リンクが既存でも PATH 未設定なら追加する。
+            if (-not $this.IsLinksInUserPath($linksPath)) {
                 $this.Log("PATH に Links フォルダを追加しています...")
-                $newPath = "$userPath;$linksPath"
-                [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+                $userPath = Get-UserEnvironmentPath
+                $newPath = if ($userPath) { "$userPath;$linksPath" } else { $linksPath }
+                Set-UserEnvironmentPath -Path $newPath
                 $env:Path = "$env:Path;$linksPath"
                 $this.Log("PATH を更新しました", "Green")
             }
 
-            return $this.CreateSuccessResult("codex.exe リンクを作成しました")
+            return $this.CreateSuccessResult("codex.exe リンクと PATH を設定しました")
         }
         catch {
             return $this.CreateFailureResult("Codex 設定に失敗しました", $_)
@@ -146,5 +126,15 @@ class CodexHandler : SetupHandlerBase {
     #>
     hidden [string] GetLinksPath() {
         return Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
+    }
+
+    <#
+    .SYNOPSIS
+        Links フォルダが USER PATH に登録済みか判定する
+    #>
+    hidden [bool] IsLinksInUserPath([string]$linksPath) {
+        $userPath = Get-UserEnvironmentPath
+        if (-not $userPath) { return $false }
+        return $userPath -like "*$linksPath*"
     }
 }

--- a/scripts/powershell/lib/SetupHandler.ps1
+++ b/scripts/powershell/lib/SetupHandler.ps1
@@ -269,6 +269,79 @@ class SetupHandlerBase {
 
     <#
     .SYNOPSIS
+        WinGet\Links 配下の shim が現行 exe を指しているか判定する
+    .DESCRIPTION
+        winget portable パッケージは安定したパッケージディレクトリ内で in-place 更新される。
+        Links\<name>.exe がシンボリックリンクなら更新を自動追従するが、
+        シンボリックリンク作成に失敗してハードリンク/コピーへフォールバックしていると、
+        winget upgrade 後も旧バージョンの実体を指したまま陳腐化する。
+        - シンボリックリンク: ターゲットが現行 exe と一致すれば最新
+        - ハードリンク/コピー: サイズと更新日時を現行 exe と比較して同一性を判定
+        ダングリング（ターゲット消失）や未作成は最新ではないとみなす。
+    .PARAMETER linkPath
+        Links 配下の shim パス
+    .PARAMETER targetExe
+        現在インストールされている実行ファイルのパス
+    .OUTPUTS
+        shim が現行 exe と一致していれば $true
+    #>
+    [bool] IsPortableLinkCurrent([string]$linkPath, [string]$targetExe) {
+        if (-not (Test-Path -LiteralPath $linkPath)) { return $false }
+
+        $link = Get-Item -LiteralPath $linkPath -Force
+        if ($link.LinkType -eq "SymbolicLink") {
+            return (@($link.Target)[0]) -eq $targetExe
+        }
+
+        # ハードリンク/コピーは内容で比較する。
+        # winget の更新でサイズと更新日時の双方が変わるため陳腐化を検出できる。
+        $src = Get-Item -LiteralPath $targetExe -Force
+        return ($link.Length -eq $src.Length) -and ($link.LastWriteTimeUtc -eq $src.LastWriteTimeUtc)
+    }
+
+    <#
+    .SYNOPSIS
+        WinGet\Links 配下に shim を作成する（symlink→hardlink→copy フォールバック）
+    .DESCRIPTION
+        Windows ではシンボリックリンク作成に管理者権限または開発者モードが必要なため、
+        失敗時はハードリンク、それも失敗ならコピーへフォールバックする。
+        既存 shim は事前に削除し、確実に現行 exe へ貼り直す。
+    .PARAMETER linkPath
+        作成する shim パス
+    .PARAMETER targetExe
+        リンク先の実行ファイル
+    #>
+    [void] CreatePortableLink([string]$linkPath, [string]$targetExe) {
+        if (Test-Path -LiteralPath $linkPath) {
+            Remove-Item -LiteralPath $linkPath -Force
+        }
+
+        $this.Log("シンボリックリンクを作成しています: $linkPath -> $targetExe")
+
+        try {
+            New-Item -ItemType SymbolicLink -Path $linkPath -Target $targetExe -Force -ErrorAction Stop | Out-Null
+            $this.Log("シンボリックリンクを作成しました", "Green")
+            return
+        }
+        catch {
+            $this.LogWarning("シンボリックリンク作成失敗: $($_.Exception.Message)")
+        }
+
+        try {
+            New-Item -ItemType HardLink -Path $linkPath -Target $targetExe -Force -ErrorAction Stop | Out-Null
+            $this.Log("ハードリンクを作成しました", "Green")
+            return
+        }
+        catch {
+            $this.LogWarning("ハードリンク作成失敗: $($_.Exception.Message)")
+        }
+
+        Copy-Item -Path $targetExe -Destination $linkPath -Force
+        $this.Log("ファイルをコピーしました", "Green")
+    }
+
+    <#
+    .SYNOPSIS
         ログメッセージを出力するヘルパーメソッド
     .PARAMETER message
         出力するメッセージ

--- a/scripts/powershell/tests/handlers/Handler.Bun.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Bun.Tests.ps1
@@ -13,6 +13,18 @@ BeforeAll {
     . $PSScriptRoot/../../lib/Invoke-ExternalCommand.ps1
     . $PSScriptRoot/../../handlers/Handler.Bun.ps1
     $script:projectRoot = (Resolve-Path -LiteralPath "$PSScriptRoot/../../../..").Path
+
+    # GetBunExecutablePath() が返すパス（パッケージ dir + サブディレクトリ + 実行ファイル）
+    $script:bunPkgDir = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\Oven-sh.Bun_Microsoft.Winget.Source_8wekyb3d8bbwe"
+    $script:bunExe = Join-Path $script:bunPkgDir "bun-windows-x64\bun.exe"
+
+    function script:Set-BunPackageInstalled {
+        Mock Get-ChildItem {
+            return [PSCustomObject]@{ FullName = $script:bunPkgDir }
+        } -ParameterFilter {
+            $Path -like "*WinGet\Packages" -and $Filter -like "Oven-sh.Bun_*"
+        }
+    }
 }
 
 Describe 'BunHandler' {
@@ -51,18 +63,17 @@ Describe 'BunHandler' {
         }
     }
 
-    Context 'CanApply - link exists AND PATH already configured' {
+    Context 'CanApply - link is current AND PATH already configured' {
         BeforeEach {
-            Mock Get-ChildItem {
-                return [PSCustomObject]@{
-                    FullName = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\Oven-sh.Bun_Microsoft.Winget.Source_8wekyb3d8bbwe"
-                }
-            } -ParameterFilter {
-                $Path -like "*WinGet\Packages" -and $Filter -like "Oven-sh.Bun_*"
+            Set-BunPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*bun-windows-x64\bun.exe") { return $true }
+                if ($LiteralPath -like "*Links\bun.exe") { return $true }
+                return $false
             }
-
-            Mock Test-Path { return $true }
-            # 実行環境ごとに変わる Links パスを含めて USER PATH を返す
+            Mock Get-Item {
+                return [PSCustomObject]@{ LinkType = "SymbolicLink"; Target = $script:bunExe }
+            } -ParameterFilter { $LiteralPath -like "*Links\bun.exe" }
             $script:expectedLinks = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
             Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedLinks" }
             Mock Write-Host { }
@@ -74,18 +85,42 @@ Describe 'BunHandler' {
         }
     }
 
-    Context 'CanApply - link exists but PATH not configured' {
+    Context 'CanApply - link is stale copy from old version (winget upgrade)' {
         BeforeEach {
-            Mock Get-ChildItem {
-                return [PSCustomObject]@{
-                    FullName = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\Oven-sh.Bun_Microsoft.Winget.Source_8wekyb3d8bbwe"
-                }
-            } -ParameterFilter {
-                $Path -like "*WinGet\Packages" -and $Filter -like "Oven-sh.Bun_*"
+            Set-BunPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*bun-windows-x64\bun.exe") { return $true }
+                if ($LiteralPath -like "*Links\bun.exe") { return $true }
+                return $false
             }
+            Mock Get-Item {
+                if ($LiteralPath -like "*Links\bun.exe") {
+                    return [PSCustomObject]@{ LinkType = ""; Length = 100; LastWriteTimeUtc = [datetime]'2024-01-01' }
+                }
+                return [PSCustomObject]@{ LinkType = ""; Length = 200; LastWriteTimeUtc = [datetime]'2024-06-01' }
+            }
+            $script:expectedLinks = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedLinks" }
+            Mock Write-Host { }
+        }
 
-            Mock Test-Path { return $true }
-            # USER PATH に Links が含まれていない状態
+        It 'should return true so the stale link is refreshed' {
+            $result = $handler.CanApply($ctx)
+            $result | Should -Be $true
+        }
+    }
+
+    Context 'CanApply - link is current but PATH not configured' {
+        BeforeEach {
+            Set-BunPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*bun-windows-x64\bun.exe") { return $true }
+                if ($LiteralPath -like "*Links\bun.exe") { return $true }
+                return $false
+            }
+            Mock Get-Item {
+                return [PSCustomObject]@{ LinkType = "SymbolicLink"; Target = $script:bunExe }
+            } -ParameterFilter { $LiteralPath -like "*Links\bun.exe" }
             Mock Get-UserEnvironmentPath { return "C:\Windows;C:\Windows\System32" }
             Mock Write-Host { }
         }
@@ -98,19 +133,10 @@ Describe 'BunHandler' {
 
     Context 'CanApply - Bun installed but no link' {
         BeforeEach {
-            Mock Get-ChildItem {
-                return [PSCustomObject]@{
-                    FullName = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\Oven-sh.Bun_Microsoft.Winget.Source_8wekyb3d8bbwe"
-                }
-            } -ParameterFilter {
-                $Path -like "*WinGet\Packages" -and $Filter -like "Oven-sh.Bun_*"
-            }
-
+            Set-BunPackageInstalled
             Mock Test-Path {
-                param($Path)
                 if ($Path -like "*bun-windows-x64\bun.exe") { return $true }
-                if ($Path -like "*Links\bun.exe") { return $false }
-                if ($Path -like "*Links") { return $true }
+                if ($LiteralPath -like "*Links\bun.exe") { return $false }
                 return $false
             }
             Mock Get-UserEnvironmentPath { return "" }
@@ -139,65 +165,49 @@ Describe 'BunHandler' {
         }
     }
 
-    Context 'Apply - creates link successfully' {
+    Context 'Apply - creates link when missing' {
         BeforeEach {
-            Mock Get-ChildItem {
-                return [PSCustomObject]@{
-                    FullName = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\Oven-sh.Bun_Microsoft.Winget.Source_8wekyb3d8bbwe"
-                }
-            } -ParameterFilter {
-                $Path -like "*WinGet\Packages" -and $Filter -like "Oven-sh.Bun_*"
-            }
-
+            Set-BunPackageInstalled
             Mock Test-Path {
-                param($Path)
                 if ($Path -like "*bun-windows-x64\bun.exe") { return $true }
                 if ($Path -like "*Links") { return $true }
+                if ($LiteralPath -like "*Links\bun.exe") { return $false }
                 return $false
             }
-
             Mock New-Item { } -ParameterFilter { $ItemType -eq "SymbolicLink" }
             Mock New-Item { } -ParameterFilter { $ItemType -eq "HardLink" }
             Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
+            Mock Remove-Item { }
             Mock Copy-Item { }
             Mock Get-UserEnvironmentPath { return "C:\Windows" }
             Mock Set-UserEnvironmentPath { }
-
             Mock Write-Host { }
         }
 
-        It 'should return success result' {
+        It 'should create symlink and return success' {
             $result = $handler.Apply($ctx)
             $result.Success | Should -Be $true
+            Should -Invoke New-Item -Times 1 -ParameterFilter { $ItemType -eq "SymbolicLink" }
         }
     }
 
     Context 'Apply - fallback to copy when symlink fails' {
         BeforeEach {
-            Mock Get-ChildItem {
-                return [PSCustomObject]@{
-                    FullName = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\Oven-sh.Bun_Microsoft.Winget.Source_8wekyb3d8bbwe"
-                }
-            } -ParameterFilter {
-                $Path -like "*WinGet\Packages" -and $Filter -like "Oven-sh.Bun_*"
-            }
-
+            Set-BunPackageInstalled
             Mock Test-Path {
-                param($Path)
                 if ($Path -like "*bun-windows-x64\bun.exe") { return $true }
                 if ($Path -like "*Links") { return $true }
+                if ($LiteralPath -like "*Links\bun.exe") { return $false }
                 return $false
             }
-
             Mock New-Item { throw "Administrator privilege required" } -ParameterFilter {
                 $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
             }
             Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
-
+            Mock Remove-Item { }
             Mock Copy-Item { }
             Mock Get-UserEnvironmentPath { return "C:\Windows" }
             Mock Set-UserEnvironmentPath { }
-
             Mock Write-Host { }
         }
 
@@ -208,26 +218,60 @@ Describe 'BunHandler' {
         }
     }
 
-    Context 'Apply - link exists but PATH missing (recovers from previous partial run)' {
+    Context 'Apply - refreshes stale link after winget upgrade' {
         BeforeEach {
-            Mock Get-ChildItem {
-                return [PSCustomObject]@{
-                    FullName = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\Oven-sh.Bun_Microsoft.Winget.Source_8wekyb3d8bbwe"
-                }
-            } -ParameterFilter {
-                $Path -like "*WinGet\Packages" -and $Filter -like "Oven-sh.Bun_*"
+            Set-BunPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*bun-windows-x64\bun.exe") { return $true }
+                if ($Path -like "*Links") { return $true }
+                if ($LiteralPath -like "*Links\bun.exe") { return $true }
+                return $false
             }
-
-            # link はすでに存在するが PATH に含まれていない状態を再現
-            Mock Test-Path { return $true }
+            Mock Get-Item {
+                if ($LiteralPath -like "*Links\bun.exe") {
+                    return [PSCustomObject]@{ LinkType = ""; Length = 100; LastWriteTimeUtc = [datetime]'2024-01-01' }
+                }
+                return [PSCustomObject]@{ LinkType = ""; Length = 200; LastWriteTimeUtc = [datetime]'2024-06-01' }
+            }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "SymbolicLink" }
             Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
-            Mock New-Item { throw "should not be called when link exists" } -ParameterFilter {
+            Mock Remove-Item { }
+            Mock Copy-Item { }
+            $script:expectedLinks = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedLinks" }
+            Mock Set-UserEnvironmentPath { }
+            Mock Write-Host { }
+        }
+
+        It 'should remove the stale link and recreate it' {
+            $result = $handler.Apply($ctx)
+            $result.Success | Should -Be $true
+            Should -Invoke Remove-Item -Times 1 -ParameterFilter { $LiteralPath -like "*Links\bun.exe" }
+            Should -Invoke New-Item -Times 1 -ParameterFilter { $ItemType -eq "SymbolicLink" }
+        }
+    }
+
+    Context 'Apply - link current but PATH missing (recovers from previous partial run)' {
+        BeforeEach {
+            Set-BunPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*bun-windows-x64\bun.exe") { return $true }
+                if ($Path -like "*Links") { return $true }
+                if ($LiteralPath -like "*Links\bun.exe") { return $true }
+                return $false
+            }
+            # 現行 exe を指すシンボリックリンク（最新）
+            Mock Get-Item {
+                return [PSCustomObject]@{ LinkType = "SymbolicLink"; Target = $script:bunExe }
+            } -ParameterFilter { $LiteralPath -like "*Links\bun.exe" }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
+            Mock New-Item { throw "should not recreate a current link" } -ParameterFilter {
                 $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
             }
+            Mock Remove-Item { }
             Mock Copy-Item { }
             Mock Get-UserEnvironmentPath { return "C:\Windows;C:\Windows\System32" }
             Mock Set-UserEnvironmentPath { }
-
             Mock Write-Host { }
         }
 

--- a/scripts/powershell/tests/handlers/Handler.Codex.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Codex.Tests.ps1
@@ -13,6 +13,19 @@ BeforeAll {
     . $PSScriptRoot/../../lib/Invoke-ExternalCommand.ps1
     . $PSScriptRoot/../../handlers/Handler.Codex.ps1
     $script:projectRoot = (Resolve-Path -LiteralPath "$PSScriptRoot/../../../..").Path
+
+    # GetCodexExecutablePath() が返すパス（パッケージ dir + 実行ファイル名）
+    $script:codexPkgDir = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\OpenAI.Codex_Microsoft.Winget.Source_8wekyb3d8bbwe"
+    $script:codexExe = Join-Path $script:codexPkgDir "codex-x86_64-pc-windows-msvc.exe"
+
+    # Codex パッケージが存在することにする共通モック
+    function script:Set-CodexPackageInstalled {
+        Mock Get-ChildItem {
+            return [PSCustomObject]@{ FullName = $script:codexPkgDir }
+        } -ParameterFilter {
+            $Path -like "*WinGet\Packages" -and $Filter -like "OpenAI.Codex_*"
+        }
+    }
 }
 
 Describe 'CodexHandler' {
@@ -51,48 +64,86 @@ Describe 'CodexHandler' {
         }
     }
 
-    Context 'CanApply - codex.exe link already exists' {
+    Context 'CanApply - link is current AND PATH configured' {
         BeforeEach {
-            # Mock: Codex パッケージが存在
-            Mock Get-ChildItem {
-                return [PSCustomObject]@{
-                    FullName = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\OpenAI.Codex_Microsoft.Winget.Source_8wekyb3d8bbwe"
-                }
-            } -ParameterFilter {
-                $Path -like "*WinGet\Packages" -and $Filter -like "OpenAI.Codex_*"
+            Set-CodexPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*codex-x86_64-pc-windows-msvc.exe") { return $true }
+                if ($LiteralPath -like "*Links\codex.exe") { return $true }
+                return $false
             }
-
-            # Mock: codex-x86_64-pc-windows-msvc.exe が存在
-            Mock Test-Path { return $true }
+            # 現行 exe を指すシンボリックリンク
+            Mock Get-Item {
+                return [PSCustomObject]@{ LinkType = "SymbolicLink"; Target = $script:codexExe }
+            } -ParameterFilter { $LiteralPath -like "*Links\codex.exe" }
+            $script:expectedLinks = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedLinks" }
             Mock Write-Host { }
         }
 
-        It 'should return false when link exists' {
+        It 'should return false when link and PATH are both set' {
             $result = $handler.CanApply($ctx)
-            # codex.exe も存在するので false
             $result | Should -Be $false
+        }
+    }
+
+    Context 'CanApply - link is stale copy from old version (winget upgrade)' {
+        BeforeEach {
+            Set-CodexPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*codex-x86_64-pc-windows-msvc.exe") { return $true }
+                if ($LiteralPath -like "*Links\codex.exe") { return $true }
+                return $false
+            }
+            # Links\codex.exe は旧バージョンのコピー（symlink ではない）。
+            # 現行 exe とサイズ/更新日時が異なる。
+            Mock Get-Item {
+                if ($LiteralPath -like "*Links\codex.exe") {
+                    return [PSCustomObject]@{ LinkType = ""; Length = 174106600; LastWriteTimeUtc = [datetime]'2024-01-01' }
+                }
+                return [PSCustomObject]@{ LinkType = ""; Length = 246156592; LastWriteTimeUtc = [datetime]'2024-06-01' }
+            }
+            $script:expectedLinks = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedLinks" }
+            Mock Write-Host { }
+        }
+
+        It 'should return true so the stale link is refreshed' {
+            $result = $handler.CanApply($ctx)
+            $result | Should -Be $true
+        }
+    }
+
+    Context 'CanApply - link is current but PATH not configured' {
+        BeforeEach {
+            Set-CodexPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*codex-x86_64-pc-windows-msvc.exe") { return $true }
+                if ($LiteralPath -like "*Links\codex.exe") { return $true }
+                return $false
+            }
+            Mock Get-Item {
+                return [PSCustomObject]@{ LinkType = "SymbolicLink"; Target = $script:codexExe }
+            } -ParameterFilter { $LiteralPath -like "*Links\codex.exe" }
+            Mock Get-UserEnvironmentPath { return "C:\Windows;C:\Windows\System32" }
+            Mock Write-Host { }
+        }
+
+        It 'should return true so Apply can add PATH' {
+            $result = $handler.CanApply($ctx)
+            $result | Should -Be $true
         }
     }
 
     Context 'CanApply - Codex installed but no link' {
         BeforeEach {
-            # Mock: Codex パッケージが存在
-            Mock Get-ChildItem {
-                return [PSCustomObject]@{
-                    FullName = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\OpenAI.Codex_Microsoft.Winget.Source_8wekyb3d8bbwe"
-                }
-            } -ParameterFilter {
-                $Path -like "*WinGet\Packages" -and $Filter -like "OpenAI.Codex_*"
-            }
-
-            # Mock: codex-x86_64-pc-windows-msvc.exe は存在するが codex.exe は存在しない
+            Set-CodexPackageInstalled
             Mock Test-Path {
-                param($Path)
                 if ($Path -like "*codex-x86_64-pc-windows-msvc.exe") { return $true }
-                if ($Path -like "*Links\codex.exe") { return $false }
-                if ($Path -like "*Links") { return $true }
+                if ($LiteralPath -like "*Links\codex.exe") { return $false }
                 return $false
             }
+            Mock Get-UserEnvironmentPath { return "" }
             Mock Write-Host { }
         }
 
@@ -104,7 +155,6 @@ Describe 'CodexHandler' {
 
     Context 'Apply - executable not found' {
         BeforeEach {
-            # Mock: Codex パッケージが存在しない → GetCodexExecutablePath が null を返す
             Mock Get-ChildItem { return $null } -ParameterFilter {
                 $Path -like "*WinGet\Packages" -and $Filter -like "OpenAI.Codex_*"
             }
@@ -119,67 +169,49 @@ Describe 'CodexHandler' {
         }
     }
 
-    Context 'Apply - creates link successfully' {
+    Context 'Apply - creates link when missing' {
         BeforeEach {
-            # Mock: Codex パッケージが存在
-            Mock Get-ChildItem {
-                return [PSCustomObject]@{
-                    FullName = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\OpenAI.Codex_Microsoft.Winget.Source_8wekyb3d8bbwe"
-                }
-            } -ParameterFilter {
-                $Path -like "*WinGet\Packages" -and $Filter -like "OpenAI.Codex_*"
-            }
-
-            # Mock: ファイルパス
+            Set-CodexPackageInstalled
             Mock Test-Path {
-                param($Path)
                 if ($Path -like "*codex-x86_64-pc-windows-msvc.exe") { return $true }
                 if ($Path -like "*Links") { return $true }
+                if ($LiteralPath -like "*Links\codex.exe") { return $false }
                 return $false
             }
-
-            # Mock: リンク/コピー作成
             Mock New-Item { } -ParameterFilter { $ItemType -eq "SymbolicLink" }
             Mock New-Item { } -ParameterFilter { $ItemType -eq "HardLink" }
             Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
+            Mock Remove-Item { }
             Mock Copy-Item { }
-
+            Mock Get-UserEnvironmentPath { return "C:\Windows" }
+            Mock Set-UserEnvironmentPath { }
             Mock Write-Host { }
         }
 
-        It 'should return success result' {
+        It 'should create symlink and return success' {
             $result = $handler.Apply($ctx)
             $result.Success | Should -Be $true
+            Should -Invoke New-Item -Times 1 -ParameterFilter { $ItemType -eq "SymbolicLink" }
         }
     }
 
     Context 'Apply - fallback to copy when symlink fails' {
         BeforeEach {
-            # Mock: Codex パッケージが存在
-            Mock Get-ChildItem {
-                return [PSCustomObject]@{
-                    FullName = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\OpenAI.Codex_Microsoft.Winget.Source_8wekyb3d8bbwe"
-                }
-            } -ParameterFilter {
-                $Path -like "*WinGet\Packages" -and $Filter -like "OpenAI.Codex_*"
-            }
-
+            Set-CodexPackageInstalled
             Mock Test-Path {
-                param($Path)
                 if ($Path -like "*codex-x86_64-pc-windows-msvc.exe") { return $true }
                 if ($Path -like "*Links") { return $true }
+                if ($LiteralPath -like "*Links\codex.exe") { return $false }
                 return $false
             }
-
-            # Mock: シンボリックリンクとハードリンクは失敗
             Mock New-Item { throw "Administrator privilege required" } -ParameterFilter {
                 $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
             }
             Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
-
-            # Mock: コピーは成功
+            Mock Remove-Item { }
             Mock Copy-Item { }
-
+            Mock Get-UserEnvironmentPath { return "C:\Windows" }
+            Mock Set-UserEnvironmentPath { }
             Mock Write-Host { }
         }
 
@@ -187,6 +219,73 @@ Describe 'CodexHandler' {
             $result = $handler.Apply($ctx)
             $result.Success | Should -Be $true
             Should -Invoke Copy-Item -Times 1
+        }
+    }
+
+    Context 'Apply - refreshes stale link after winget upgrade' {
+        BeforeEach {
+            Set-CodexPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*codex-x86_64-pc-windows-msvc.exe") { return $true }
+                if ($Path -like "*Links") { return $true }
+                if ($LiteralPath -like "*Links\codex.exe") { return $true }
+                return $false
+            }
+            # 既存リンクは旧バージョンのコピーで陳腐化している
+            Mock Get-Item {
+                if ($LiteralPath -like "*Links\codex.exe") {
+                    return [PSCustomObject]@{ LinkType = ""; Length = 174106600; LastWriteTimeUtc = [datetime]'2024-01-01' }
+                }
+                return [PSCustomObject]@{ LinkType = ""; Length = 246156592; LastWriteTimeUtc = [datetime]'2024-06-01' }
+            }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
+            Mock Remove-Item { }
+            Mock Copy-Item { }
+            $script:expectedLinks = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedLinks" }
+            Mock Set-UserEnvironmentPath { }
+            Mock Write-Host { }
+        }
+
+        It 'should remove the stale link and recreate it' {
+            $result = $handler.Apply($ctx)
+            $result.Success | Should -Be $true
+            Should -Invoke Remove-Item -Times 1 -ParameterFilter { $LiteralPath -like "*Links\codex.exe" }
+            Should -Invoke New-Item -Times 1 -ParameterFilter { $ItemType -eq "SymbolicLink" }
+        }
+    }
+
+    Context 'Apply - link current, only PATH missing' {
+        BeforeEach {
+            Set-CodexPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*codex-x86_64-pc-windows-msvc.exe") { return $true }
+                if ($Path -like "*Links") { return $true }
+                if ($LiteralPath -like "*Links\codex.exe") { return $true }
+                return $false
+            }
+            # 既存リンクは現行 exe を指すシンボリックリンク（最新）
+            Mock Get-Item {
+                return [PSCustomObject]@{ LinkType = "SymbolicLink"; Target = $script:codexExe }
+            } -ParameterFilter { $LiteralPath -like "*Links\codex.exe" }
+            Mock New-Item { throw "should not recreate a current link" } -ParameterFilter {
+                $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
+            }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
+            Mock Remove-Item { }
+            Mock Copy-Item { }
+            Mock Get-UserEnvironmentPath { return "C:\Windows;C:\Windows\System32" }
+            Mock Set-UserEnvironmentPath { }
+            Mock Write-Host { }
+        }
+
+        It 'should add PATH without recreating the link' {
+            $result = $handler.Apply($ctx)
+            $result.Success | Should -Be $true
+            Should -Invoke Set-UserEnvironmentPath -Times 1
+            Should -Invoke Copy-Item -Times 0
+            Should -Invoke New-Item -Times 0 -ParameterFilter { $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink" }
         }
     }
 }


### PR DESCRIPTION
## 背景 / 症状

`codex` を winget で `0.118.0` → `0.136.0` に更新したのに `codex --version` が旧バージョンのままだった。原因は `Handler.Codex.ps1` / `Handler.Bun.ps1` が `WinGet\Links\<name>.exe` の shim を **「存在するか」だけ** で判定し、**現行 exe を指しているかを見ていなかった** こと。

開発者モード/管理者権限の無い環境では symlink 作成に失敗して **実体コピー** にフォールバックするため、winget の in-place 更新後も shim が旧バイナリを指したまま陳腐化する。

## 変更

- **lib(SetupHandler)**: 共通ヘルパーを追加（DRY化）
  - `IsPortableLinkCurrent`: symlink はターゲット一致、copy/hardlink はサイズ＋更新日時で鮮度判定
  - `CreatePortableLink`: 既存 shim を消して symlink→hardlink→copy で確実に貼り直す
- **Codex / Bun ハンドラー**: `CanApply` を「最新を指す && PATH 登録済み」に変更し、陳腐化時は `Apply` で貼り直す（冪等）。Codex も `Get/Set-UserEnvironmentPath` ラッパー経由に統一
- **tests**: バグ挙動を正解として固定していた `exists => skip` のアサーションを撤去し、winget upgrade 後の貼り直し回帰テストを Codex/Bun 双方に追加

## なぜ CI で取れなかったか

1. 旧テストが「リンクが在れば false」というバグ契約を正解として固定していた
2. ユニットテストが FS を全モックし、アップグレード経路を一度も実行していなかった
3. 統合テスト（`Integration.Tests.ps1`）は CI で除外

→ 鮮度判定の契約テスト＋アップグレード回帰テストで (1)(2) を是正。

## 影響範囲

`WinGet\Links` shim を自作するのは Codex / Bun の2ハンドラーのみ（全16ハンドラー調査済み）。両方修正。`Chezmoi` は shim を読むだけで対象外。

## 検証

`task test:powershell` 相当: **611 passed / 0 failed**。PSScriptAnalyzer は Error/ParseError なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
