### PR TITLE
chore(packages): remove Cursor and Zed from winget/nix package sets

### DIFF
--- a/chezmoi/terminals/windows-terminal/settings.json
+++ b/chezmoi/terminals/windows-terminal/settings.json
@@ -130,9 +130,7 @@
     { "id": "User.decreaseFontSize", "keys": "ctrl+shift+minus" }
   ],
   "language": "ja",
-  "newTabMenu": [
-    { "type": "remainingProfiles" }
-  ],
+  "newTabMenu": [{ "type": "remainingProfiles" }],
   "profiles": {
     "defaults": {
       "colorScheme": "Catppuccin Mocha",

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -564,7 +564,6 @@ lib.mapAttrs (_: names: resolve names) grouped
     winget = [
       "AgileBits.1Password"
       "Anthropic.Claude"
-      "Anysphere.Cursor"
       "TheBrowserCompany.Arc"
       "Docker.DockerDesktop"
       "GitHub.Copilot"
@@ -579,7 +578,6 @@ lib.mapAttrs (_: names: resolve names) grouped
       "OpenAI.Codex"
       "TablePlus.TablePlus"
       "Oven-sh.Bun"
-      "ZedIndustries.Zed"
       "zig.zig"
     ];
     msstore = [

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -173,9 +173,6 @@
           "PackageIdentifier": "Anthropic.Claude"
         },
         {
-          "PackageIdentifier": "Anysphere.Cursor"
-        },
-        {
           "PackageIdentifier": "TheBrowserCompany.Arc"
         },
         {
@@ -219,9 +216,6 @@
         },
         {
           "PackageIdentifier": "Oven-sh.Bun"
-        },
-        {
-          "PackageIdentifier": "ZedIndustries.Zed"
         },
         {
           "PackageIdentifier": "zig.zig"


### PR DESCRIPTION
## 概要

管理対象から **Cursor**（`Anysphere.Cursor`）と **Zed**（`ZedIndustries.Zed`）エディタを削除します。あわせて、未整形のままコミットされていた Windows Terminal 設定を treefmt で整形します。

## 変更

1. **エディタ削除**
   - `nix/packages/sets.nix`（SSOT）: `windowsOnly.winget` から両 ID を削除
   - `windows/winget/packages.json`（生成物）: 対応エントリを削除
2. **整形**
   - `chezmoi/terminals/windows-terminal/settings.json`: treefmt 適用（`newTabMenu` を1行化）。Windows Terminal から同期されたまま treefmt 未適用で、nix を触る PR が repo 全体の `nix fmt --fail-on-change` チェックで落ちていたため。

エディタ設定（`chezmoi/editors/zed/` 等）はパッケージではないため対象外。

## 検証

- `ci-consistency.yml` 相当: SSOT から再生成した winget ID 集合と `packages.json` が **`IN SYNC`**
- `nix fmt`（treefmt）: **0 changed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
