### PR TITLE
fix(chezmoi): guard onepasswordRead by signed-in 1Password account

### DIFF
--- a/chezmoi/.chezmoiscripts/deploy/kaggle/run_onchange_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/kaggle/run_onchange_deploy.ps1.tmpl
@@ -1,6 +1,9 @@
 {{ if eq .chezmoi.os "windows" -}}
 # Deploy Kaggle API credentials for Windows
-{{- if lookPath "op" }}
+{{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
+{{- $opPersonal := false }}
+{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
+{{- if $opPersonal }}
 # token-hash: {{ onepasswordRead "op://Private/Kaggle/c4patuuzwob2vcwt43qqphoyeu" .op_account_personal | sha256sum }}
 {{- end }}
 
@@ -8,7 +11,7 @@ $ErrorActionPreference = "Stop"
 
 $KaggleDir = "$env:USERPROFILE\.kaggle"
 
-{{- if lookPath "op" }}
+{{- if $opPersonal }}
 Write-Host "Deploying Kaggle API credentials..."
 
 if (-not (Test-Path -LiteralPath $KaggleDir)) {
@@ -21,6 +24,6 @@ $token = '{{ onepasswordRead "op://Private/Kaggle/c4patuuzwob2vcwt43qqphoyeu" .o
 Set-Content -Path "$KaggleDir\access_token" -Value $token -NoNewline -Force
 Write-Host "Deployed: $KaggleDir\access_token"
 {{- else }}
-Write-Host "WARNING: op CLI not available, skipping Kaggle API credentials deployment"
+Write-Host "WARNING: 1Password personal account not signed in, skipping Kaggle API credentials deployment"
 {{- end }}
 {{ end -}}

--- a/chezmoi/.chezmoiscripts/deploy/kaggle/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/kaggle/run_onchange_deploy.sh.tmpl
@@ -1,7 +1,10 @@
 {{ if ne .chezmoi.os "windows" -}}
 #!/bin/bash
 # Deploy Kaggle API credentials for Linux/macOS
-{{- if lookPath "op" }}
+{{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
+{{- $opPersonal := false }}
+{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
+{{- if $opPersonal }}
 # token-hash: {{ onepasswordRead "op://Private/Kaggle/c4patuuzwob2vcwt43qqphoyeu" .op_account_personal | sha256sum }}
 {{- end }}
 
@@ -10,7 +13,7 @@ set -euo pipefail
 HOME_DIR="${HOME:-/home/$(whoami)}"
 KAGGLE_DIR="$HOME_DIR/.kaggle"
 
-{{- if lookPath "op" }}
+{{- if $opPersonal }}
 echo "Deploying Kaggle API credentials..."
 
 mkdir -p "$KAGGLE_DIR"
@@ -23,6 +26,6 @@ chmod 600 "$KAGGLE_DIR/access_token"
 
 echo "Deployed: $KAGGLE_DIR/access_token"
 {{- else }}
-echo "WARNING: op CLI not available, skipping Kaggle API credentials deployment"
+echo "WARNING: 1Password personal account not signed in, skipping Kaggle API credentials deployment"
 {{- end }}
 {{ end -}}

--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.ps1.tmpl
@@ -4,10 +4,14 @@
 {{/* Accept either op or op.exe (symmetric with the Unix variant). */}}
 {{- $hasOp := or (lookPath "op") (lookPath "op.exe") }}
 {{- $hasWorkAccount := false }}
+{{- $hasPersonalAccount := false }}
 {{- if $hasOp }}
 {{- $accounts := output $hasOp "account" "list" }}
 {{- $hasWorkAccount = contains .op_account_work $accounts }}
+{{- $hasPersonalAccount = contains .op_account_personal $accounts }}
+{{- if $hasPersonalAccount }}
 # personal-pubkey-hash: {{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" .op_account_personal | sha256sum }}
+{{- end }}
 {{- if $hasWorkAccount }}
 # work-pubkey-hash:     {{ onepasswordRead "op://Employee/GitHub Work/public key" .op_account_work | sha256sum }}
 {{- end }}
@@ -39,10 +43,11 @@ $sshConfig = @'
 '@
 Deploy-Content $sshConfig "$HomeDir\.ssh\config"
 
-{{- if $hasOp }}
+{{- if $hasPersonalAccount }}
 # Personal SSH public key (from rurusasu's Private vault).
 $personalPubkey = '{{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" .op_account_personal }}'
 Deploy-Content $personalPubkey "$HomeDir\.ssh\signing_key.pub"
+{{- end }}
 
 {{- if $hasWorkAccount }}
 # Work SSH public key (from kohei-miki-im8's Employee vault on the work
@@ -50,8 +55,8 @@ Deploy-Content $personalPubkey "$HomeDir\.ssh\signing_key.pub"
 $workPubkey = '{{ onepasswordRead "op://Employee/GitHub Work/public key" .op_account_work }}'
 Deploy-Content $workPubkey "$HomeDir\.ssh\github_work.pub"
 {{- end }}
-{{- else }}
-Write-Host "WARNING: op/op.exe CLI not available, skipping public key deployment"
+{{- if not (or $hasPersonalAccount $hasWorkAccount) }}
+Write-Host "WARNING: no 1Password account signed in, skipping public key deployment"
 {{- end }}
 
 Write-Host "SSH configuration deployed."

--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.sh.tmpl
@@ -6,10 +6,14 @@
      accept either binary as evidence that 1Password CLI is reachable. */}}
 {{- $hasOp := or (lookPath "op") (lookPath "op.exe") }}
 {{- $hasWorkAccount := false }}
+{{- $hasPersonalAccount := false }}
 {{- if $hasOp }}
 {{- $accounts := output $hasOp "account" "list" }}
 {{- $hasWorkAccount = contains .op_account_work $accounts }}
+{{- $hasPersonalAccount = contains .op_account_personal $accounts }}
+{{- if $hasPersonalAccount }}
 # personal-pubkey-hash: {{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" .op_account_personal | sha256sum }}
+{{- end }}
 {{- if $hasWorkAccount }}
 # work-pubkey-hash:     {{ onepasswordRead "op://Employee/GitHub Work/public key" .op_account_work | sha256sum }}
 {{- end }}
@@ -35,11 +39,12 @@ SSH_CONFIG='{{ include "ssh/config.tmpl" }}'
 deploy_content "$SSH_CONFIG" "$HOME_DIR/.ssh/config"
 chmod 600 "$HOME_DIR/.ssh/config"
 
-{{- if $hasOp }}
+{{- if $hasPersonalAccount }}
 # Personal SSH public key (from rurusasu's Private vault).
 PERSONAL_PUBKEY='{{ onepasswordRead "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key" .op_account_personal }}'
 deploy_content "$PERSONAL_PUBKEY" "$HOME_DIR/.ssh/signing_key.pub"
 chmod 644 "$HOME_DIR/.ssh/signing_key.pub"
+{{- end }}
 
 {{- if $hasWorkAccount }}
 # Work SSH public key (from kohei-miki-im8's Employee vault on the work
@@ -48,8 +53,8 @@ WORK_PUBKEY='{{ onepasswordRead "op://Employee/GitHub Work/public key" .op_accou
 deploy_content "$WORK_PUBKEY" "$HOME_DIR/.ssh/github_work.pub"
 chmod 644 "$HOME_DIR/.ssh/github_work.pub"
 {{- end }}
-{{- else }}
-echo "WARNING: op/op.exe CLI not available, skipping public key deployment"
+{{- if not (or $hasPersonalAccount $hasWorkAccount) }}
+echo "WARNING: no 1Password account signed in, skipping public key deployment"
 {{- end }}
 
 echo "SSH configuration deployed."

--- a/chezmoi/AppData/Roaming/Claude/claude_desktop_config.json.tmpl
+++ b/chezmoi/AppData/Roaming/Claude/claude_desktop_config.json.tmpl
@@ -1,6 +1,9 @@
 {
   "mcpServers": {
 {{- $first := true }}
+{{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
+{{- $opPersonal := false }}
+{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}
 {{- if has "claude-desktop" .supports }}
@@ -17,7 +20,7 @@
 {{- if hasKey . "env" }},
       "env": {
 {{- $envFirst := true }}
-{{- $hasOp := and (hasKey . "op_env") (lookPath "op") }}
+{{- $hasOp := and (hasKey . "op_env") $opPersonal }}
 {{- $opEnv := dict }}
 {{- if hasKey . "op_env" }}{{ $opEnv = .op_env }}{{ end }}
 {{- range $key, $value := .env }}

--- a/chezmoi/dot_claude/dot_claude.json.tmpl
+++ b/chezmoi/dot_claude/dot_claude.json.tmpl
@@ -1,6 +1,9 @@
 {
   "mcpServers": {
 {{- $first := true }}
+{{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
+{{- $opPersonal := false }}
+{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}
 {{- if has "claude-code" .supports }}
@@ -17,7 +20,7 @@
 {{- if hasKey . "env" }},
       "env": {
 {{- $envFirst := true }}
-{{- $hasOp := and (hasKey . "op_env") (lookPath "op") }}
+{{- $hasOp := and (hasKey . "op_env") $opPersonal }}
 {{- $opEnv := dict }}
 {{- if hasKey . "op_env" }}{{ $opEnv = .op_env }}{{ end }}
 {{- range $key, $value := .env }}

--- a/chezmoi/dot_codeium/windsurf/mcp_config.json.tmpl
+++ b/chezmoi/dot_codeium/windsurf/mcp_config.json.tmpl
@@ -1,6 +1,9 @@
 {
   "mcpServers": {
 {{- $first := true }}
+{{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
+{{- $opPersonal := false }}
+{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}
 {{- if has "windsurf" .supports }}
@@ -16,7 +19,7 @@
 {{- if hasKey . "env" }},
       "env": {
 {{- $envFirst := true }}
-{{- $hasOp := and (hasKey . "op_env") (lookPath "op") }}
+{{- $hasOp := and (hasKey . "op_env") $opPersonal }}
 {{- $opEnv := dict }}
 {{- if hasKey . "op_env" }}{{ $opEnv = .op_env }}{{ end }}
 {{- range $key, $value := .env }}

--- a/chezmoi/dot_codex/config.toml.tmpl
+++ b/chezmoi/dot_codex/config.toml.tmpl
@@ -150,6 +150,9 @@ config_file = "{{ .chezmoi.homeDir | replace "\\" "/" }}/.codex/agents/python_co
 # MCP サーバー設定 (Generated from .chezmoidata/mcp_servers.yaml)
 ################################################################################
 
+{{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
+{{- $opPersonal := false }}
+{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
 [mcp_servers]
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}
@@ -167,7 +170,7 @@ startup_timeout_sec = {{ .startup_timeout_sec }}
 {{- end }}
 {{- if hasKey . "env" }}
 [mcp_servers.{{ .name }}.env]
-{{- $hasOp := and (hasKey . "op_env") (lookPath "op") }}
+{{- $hasOp := and (hasKey . "op_env") $opPersonal }}
 {{- $opEnv := dict }}
 {{- if hasKey . "op_env" }}{{ $opEnv = .op_env }}{{ end }}
 {{- range $key, $value := .env }}

--- a/chezmoi/dot_cursor/cli-config.json.tmpl
+++ b/chezmoi/dot_cursor/cli-config.json.tmpl
@@ -35,6 +35,9 @@
   },
   "mcpServers": {
 {{- $first := true }}
+{{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
+{{- $opPersonal := false }}
+{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}
 {{- if has "cursor" .supports }}
@@ -50,7 +53,7 @@
 {{- if hasKey . "env" }},
       "env": {
 {{- $envFirst := true }}
-{{- $hasOp := and (hasKey . "op_env") (lookPath "op") }}
+{{- $hasOp := and (hasKey . "op_env") $opPersonal }}
 {{- $opEnv := dict }}
 {{- if hasKey . "op_env" }}{{ $opEnv = .op_env }}{{ end }}
 {{- range $key, $value := .env }}

--- a/chezmoi/dot_gemini/settings.json.tmpl
+++ b/chezmoi/dot_gemini/settings.json.tmpl
@@ -20,6 +20,9 @@
   },
   "mcpServers": {
 {{- $first := true }}
+{{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
+{{- $opPersonal := false }}
+{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}
 {{- if has "gemini" .supports }}
@@ -35,7 +38,7 @@
 {{- if hasKey . "env" }},
       "env": {
 {{- $envFirst := true }}
-{{- $hasOp := and (hasKey . "op_env") (lookPath "op") }}
+{{- $hasOp := and (hasKey . "op_env") $opPersonal }}
 {{- $opEnv := dict }}
 {{- if hasKey . "op_env" }}{{ $opEnv = .op_env }}{{ end }}
 {{- range $key, $value := .env }}


### PR DESCRIPTION
## 背景

devcontainer など **op が未認証**の環境で `onepasswordRead` が失敗し、`chezmoi apply` が途中で中断していた。その結果、中断地点（kaggle）以降のデプロイ（nvim / shells / tmux 等）が走らず、コンテナが部分構成のままになる。`dcnvim` が最後の nvim 起動まで到達できない一因。

## 原因

`onepasswordRead` を呼ぶテンプレートのガードが不十分だった:

- kaggle / 各 MCP 設定テンプレ: `lookPath "op"` のみ判定 → コンテナは「op バイナリは在るが account 未サインイン」なので true になり、`onepasswordRead` を実行して失敗。
- ssh テンプレ: work account は `contains .op_account_work $accounts` で出し分けていたが、**personal の読み取りは `$hasOp` だけで無条件**だった。

## 変更

既存 ssh テンプレの「サインイン済み account 一覧（`op account list`）に含まれる時だけ読む」パターンを全テンプレに統一:

```gotmpl
{{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
{{- $opPersonal := false }}
{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
```

- kaggle deploy (sh / ps1): ガードを `$opPersonal` に変更
- ssh deploy (sh / ps1): personal 読み取りも `$hasPersonalAccount` でガード（personal/work を独立判定）
- MCP 設定テンプレ 6 種（claude / codex / cursor / gemini / windsurf / claude-desktop）: `$hasOp` に personal 認証チェックを合成

未認証時は既存のフォールバック（`$value` / WARNING ログ）で skip するため apply は中断しない。**host（認証済）の挙動は不変**。

## 検証

`chezmoi source-path` = ローカルソースで実テンプレを直接レンダリング:

- host（両 account 認証済）: `$opPersonal` が true と評価され `onepasswordRead` まで到達（ロジック正常・退行なし）。
- コンテナ相当（op を PATH から除外 = skip パス）: JSON 5 種すべて valid、codex TOML rc=0、kaggle/ssh の ps1 が想定どおり skip ログを出力。

> Docker Desktop が一時的に 500 を返していたため、実コンテナでの `dcnvim` e2e は未実施。復帰後に再実行で最終確認予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
