### PR TITLE
test(chezmoi): catch unauthenticated-op render regressions in CI

### DIFF
--- a/.github/workflows/ci-chezmoi.yml
+++ b/.github/workflows/ci-chezmoi.yml
@@ -156,3 +156,71 @@ jobs:
           path: scripts/powershell/test-results.xml
           retention-days: 30
           if-no-files-found: warn
+
+  op-guard:
+    # Behavioral guard for the "op present but unauthenticated" environment
+    # (devcontainers, CI, fresh clones). The static Pester lint only checks
+    # that onepasswordRead is wrapped in *a* guard; it cannot tell whether the
+    # guard is strong enough. Here we put a stub `op` on PATH that simulates
+    # the binary being installed with no account signed in, then render every
+    # template that calls onepasswordRead and require each to succeed. A guard
+    # that only checks `lookPath "op"` would call `op read` and fail — which is
+    # exactly the regression this job catches (see the self-check step).
+    name: Render guard (op unauthenticated)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install chezmoi
+        run: |
+          set -euo pipefail
+          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install stub op (present but unauthenticated)
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.local/bin"
+          cat > "$HOME/.local/bin/op" <<'STUB'
+          #!/usr/bin/env bash
+          # Simulate 1Password CLI installed but with no account signed in.
+          [ "${1:-}" = "account" ] && [ "${2:-}" = "list" ] && exit 0   # empty list, success
+          [ "${1:-}" = "--version" ] && { echo "0.0.0-stub"; exit 0; }
+          echo "[stub op] no 1Password account found (unauthenticated)" >&2
+          exit 1
+          STUB
+          chmod +x "$HOME/.local/bin/op"
+
+      - name: Render every onepasswordRead template (must succeed)
+        run: |
+          set -euo pipefail
+          src="$PWD/chezmoi"
+          chezmoi init --source "$src"
+          fail=0
+          while IFS= read -r f; do
+            if ! chezmoi --source "$src" execute-template < "$f" >/dev/null 2>/tmp/te.err; then
+              rel="${f#"$src"/}"
+              echo "::error file=chezmoi/${rel}::onepasswordRead failed while op is unauthenticated — the guard is insufficient (must skip the read when the account is not signed in)"
+              sed 's/^/    /' /tmp/te.err
+              fail=1
+            fi
+          done < <(grep -rl --include='*.tmpl' -E '\{\{[^}]*onepasswordRead' "$src")
+          if [ "$fail" -ne 0 ]; then exit 1; fi
+          echo "OK  all onepasswordRead templates render cleanly with op present but unauthenticated"
+
+      - name: Self-check (a lookPath-only guard must be caught)
+        run: |
+          set -uo pipefail
+          src="$PWD/chezmoi"
+          weak='{{ if lookPath "op" }}{{ onepasswordRead "op://Private/Kaggle/c4patuuzwob2vcwt43qqphoyeu" .op_account_personal }}{{ end }}'
+          if printf '%s' "$weak" | chezmoi --source "$src" execute-template >/dev/null 2>&1; then
+            echo "::error::self-check failed: a lookPath-only guard rendered successfully, so this job would not catch the original bug class"
+            exit 1
+          fi
+          echo "OK  weak lookPath-only guard correctly fails under unauthenticated op"

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -37,51 +37,51 @@ Describe 'chezmoi テンプレート バリデーション' {
             )
         }
 
-        It 'onepasswordRead の各呼び出しが個別に lookPath ブロック内にあること' {
+        It 'onepasswordRead の各呼び出しが個別に op ガードブロック内にあること' {
             foreach ($file in $script:templateFiles) {
                 $lines = Get-Content -Path $file.FullName -ErrorAction SilentlyContinue
                 if (-not $lines) { continue }
 
-                $inOpGuard = $false
-                # $hasOp 変数経由の間接ガードも検出する
-                # 受理パターン:
-                #   $hasOp := and (hasKey . "op_env") (lookPath "op")
-                #   $hasOp := or  (lookPath "op")    (lookPath "op.exe")
-                #   {{- if and $hasOp ... }}
-                #   {{- if $hasOp }}
-                $hasOpVarGuard = $false
-                $inHasOpBlock = $false
-                $lineNum = 0
+                # op に由来するガード変数を収集する。lookPath / op アカウント /
+                # 既存の op 変数から派生したものだけを「ガード」として認める。
+                #   $opCmd      := or (lookPath "op") (lookPath "op.exe")        ← lookPath 由来
+                #   $opPersonal  = contains .op_account_personal (output $opCmd ...) ← account 由来
+                #   $hasOp      := and (hasKey . "op_env") $opPersonal           ← op 変数派生
+                #   $hasPersonalAccount = contains .op_account_personal $accounts
+                $opVars = [System.Collections.Generic.HashSet[string]]::new()
+                foreach ($line in $lines) {
+                    if ($line -match '\$(\w+)\s*:?=\s*.*lookPath\s+"op') {
+                        [void]$opVars.Add($Matches[1])
+                    }
+                    elseif ($line -match '\$(\w+)\s*:?=\s*.*op_account') {
+                        [void]$opVars.Add($Matches[1])
+                    }
+                    elseif ($line -match '\$(\w+)\s*:?=\s*.*\$(\w+)' -and $opVars.Contains($Matches[2])) {
+                        [void]$opVars.Add($Matches[1])
+                    }
+                }
 
+                $inOpGuard = $false
+                $lineNum = 0
                 foreach ($line in $lines) {
                     $lineNum++
 
-                    # 直接ガード: {{- if lookPath "op" }} または {{- if (lookPath "op" ) ... }}
+                    # ガードブロック開始: {{ if ... }} が lookPath "op" か op 由来変数を参照
                     if ($line -match '\{\{-?\s*if\s+[^}]*lookPath\s+"op"') {
                         $inOpGuard = $true
                     }
-
-                    # 間接ガード: $hasOp := (and|or) ... (lookPath "op")
-                    if ($line -match '\$hasOp\s*:=\s*(?:and|or)\s.*lookPath\s+"op"') {
-                        $hasOpVarGuard = $true
-                    }
-
-                    # 間接ガードブロック開始: {{- if $hasOp }} / {{- if and $hasOp ... }}
-                    if ($line -match '\{\{-?\s*if\s+(?:and\s+)?\$hasOp' -and $hasOpVarGuard) {
-                        $inHasOpBlock = $true
+                    elseif ($line -match '\{\{-?\s*if\b[^}]*?\$(\w+)' -and $opVars.Contains($Matches[1])) {
+                        $inOpGuard = $true
                     }
 
                     # テンプレート展開 ({{...}}) 内の呼び出しのみを対象とする。
                     # コメント (`# For onepasswordRead, ...`) やドキュメント記述は除外。
-                    if ($line -match '\{\{[^}]*onepasswordRead' -and -not $inOpGuard -and -not $inHasOpBlock) {
-                        "$($file.Name):$lineNum should be inside a lookPath `"op`" block" |
+                    if ($line -match '\{\{[^}]*onepasswordRead' -and -not $inOpGuard) {
+                        "$($file.Name):$lineNum should be inside an op guard block (lookPath `"op`" / `$opPersonal / etc.)" |
                             Should -BeNullOrEmpty
                     }
 
-                    if ($line -match '\{\{-?\s*end\s*\}\}') {
-                        if ($inHasOpBlock) { $inHasOpBlock = $false }
-                        elseif ($inOpGuard) { $inOpGuard = $false }
-                    }
+                    if ($line -match '\{\{-?\s*end\s*\}\}' -and $inOpGuard) { $inOpGuard = $false }
                 }
             }
         }

--- a/scripts/powershell/tests/chezmoi/FontConsistency.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/FontConsistency.Tests.ps1
@@ -15,6 +15,14 @@
     - nix package と Windows font installer の zip 名が同じバージョンを参照している
 #>
 
+# It -ForEach は Discovery フェーズで評価されるため、そこで参照する定数は
+# BeforeDiscovery で設定する必要がある（BeforeAll は Run フェーズで遅すぎ、
+# StrictMode 下では「変数未設定」で Discovery が失敗する）。
+BeforeDiscovery {
+    $script:expectedFont = "UDEV Gothic NF"
+    $script:expectedNixPkg = "udev-gothic-nf"
+}
+
 BeforeAll {
     $script:repoRoot = Resolve-Path (Join-Path $PSScriptRoot "../../../..")
     $script:expectedFont = "UDEV Gothic NF"

--- a/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
@@ -171,7 +171,7 @@ Describe 'SSH deploy スクリプト' {
 
             foreach ($line in $lines) {
                 $lineNum++
-                if ($line -match '\{\{-?\s*if\s+(lookPath\s+"op[^"]*"|\$hasOp)\b') { $inOpGuard = $true }
+                if ($line -match '\{\{-?\s*if\s+[^}]*(lookPath\s+"op[^"]*"|\$hasOp|\$hasPersonalAccount|\$hasWorkAccount|\$opPersonal)\b') { $inOpGuard = $true }
                 if ($line -match 'onepasswordRead' -and -not $inOpGuard -and $line -notmatch '^\s*#') {
                     $violations += "line $lineNum"
                 }
@@ -202,7 +202,7 @@ Describe 'SSH deploy スクリプト' {
 
             foreach ($line in $lines) {
                 $lineNum++
-                if ($line -match '\{\{-?\s*if\s+(lookPath\s+"op[^"]*"|\$hasOp)\b') { $inOpGuard = $true }
+                if ($line -match '\{\{-?\s*if\s+[^}]*(lookPath\s+"op[^"]*"|\$hasOp|\$hasPersonalAccount|\$hasWorkAccount|\$opPersonal)\b') { $inOpGuard = $true }
                 if ($line -match 'onepasswordRead' -and -not $inOpGuard -and $line -notmatch '^\s*#') {
                     $violations += "line $lineNum"
                 }


### PR DESCRIPTION
## 背景

PR #311（op 未認証で onepasswordRead が落ちて apply 中断する問題の修正）をマージしたが、**Chezmoi CI の Lint が失敗したまま main に入っていた**（ブランチ保護が「PR 必須」のみで status check 必須でないため auto-merge が通った）。原因は静的 Pester lint が新しいガード方式を認識できなかったこと。あわせて CI がこのバグ種別を**実検出できていなかった**点を補強する。

## 変更

**静的 lint の更新（main を緑化）**
- `ChezmoiTemplate.Tests.ps1`: op 由来のガード変数を**導出追跡**で認識（lookPath / op_account / それらから派生した変数）。`$opPersonal` / `$hasOp` / `$hasPersonalAccount` 方式のガードを正しく受理。
- `SshGitconfig.Tests.ps1`: アカウント別ガード変数（`$hasPersonalAccount` / `$hasWorkAccount`）を受理。

**FontConsistency の Discovery エラー修正**
- `It -ForEach` と `It` タイトルが Discovery 時に `$script:expectedFont` / `$script:expectedNixPkg` を参照していたが、これらは `BeforeAll`（Run 時）設定で、StrictMode 下の Discovery で未設定例外になっていた。`BeforeDiscovery` に移動。

**実ガードテストの追加（バグ種別を実検出）**
- `ci-chezmoi.yml` に `op-guard` ジョブを追加。**スタブ op**（存在するが未サインイン）を PATH に置き、`onepasswordRead` を含む全テンプレを `chezmoi execute-template` して**成功を要求**。さらに「`lookPath "op"` だけの弱いガードは失敗する」ことを確認する self-check 付き。静的 lint では担保できない振る舞いを CI で常時検証する。

## 検証

- ローカル Pester（StrictMode）: **58 passed / 0 failed**（Discovery エラーなし）。
- クリーン Linux コンテナでの runtime ロジック実証: 全 op テンプレ render = ALL-EXIT-0、弱いガードの negative control = exit 1（`no 1Password account found`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
