### PR TITLE
fix: mempalace MCP 起動エントリポイントと Taskfile の WSL OS 変数を修正

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,9 @@ version: "3"
 vars:
   DISTRO: NixOS
   DOTFILES_PATH: ~/.dotfiles
-  WSL: '{{if eq .OS "windows"}}wsl -d {{.DISTRO}} -- {{end}}'
+  # OS は go-task の特殊変数なのでドット無しで参照する（`.OS` は常に空になり、
+  # Windows から実行しても WSL プレフィックスが付かず失敗する）。
+  WSL: '{{if eq OS "windows"}}wsl -d {{.DISTRO}} -- {{end}}'
 
 tasks:
   default:

--- a/chezmoi/.chezmoidata/mcp_servers.yaml
+++ b/chezmoi/.chezmoidata/mcp_servers.yaml
@@ -198,11 +198,12 @@ mcp_servers:
       - gemini
 
   # MemPalace - Local memory system (stdio via uv tool)
+  # `uv tool install mempalace` で隔離 venv に入るため、system python では
+  # `mempalace.mcp_server` を import できない。uv tool が PATH に出す
+  # 専用エントリポイント `mempalace-mcp` を直接起動する。
   - name: mempalace
-    command: python
-    args:
-      - "-m"
-      - "mempalace.mcp_server"
+    command: mempalace-mcp
+    args: []
     supports:
       - claude-code
       - claude-desktop


### PR DESCRIPTION
## 概要

Codex CLI で mempalace MCP が起動失敗するエラーの修正と、その調査中に判明した Taskfile の潜在バグの修正をまとめたもの。

## 変更点

### 1. `fix(mcp): launch mempalace via mempalace-mcp entrypoint`
- `mempalace` は `uv tool install` で隔離 venv に入るため、system python では `mempalace.mcp_server` を import できず、MCP ハンドシェイクが `connection closed: initialize response` で即座に失敗していた。
- uv tool が PATH に出す専用エントリポイント `mempalace-mcp`（`mempalace-mcp --help` で "MemPalace MCP Server" を確認）を直接起動するよう変更。
- Windows / WSL とも `uv tool install mempalace` で同じ shim が PATH に出るためクロスプラットフォームで動作。

### 2. `fix(taskfile): reference go-task OS special var without dot`
- `WSL` 変数が `{{if eq .OS "windows"}}` と**ドット付き**で参照していたため常に空になり、Windows から `task` を実行しても `wsl` プレフィックスが付かず Git Bash で誤ったパスを叩いて失敗していた。
- go-task の特殊変数は `{{OS}}`（ドット無し）が正しい。修正後 `task --dry fmt` が `wsl -d NixOS -- bash -lc "..."` を出力することを確認済み。

## 検証
- `mempalace-mcp` が PATH 上に存在し MCP サーバとして起動することを確認。
- `~/.codex/config.toml` 反映後、codex 再起動で mempalace 起動エラーが解消。
- `task --dry fmt` で WSL プレフィックス付与を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)