### PR TITLE
ci(chezmoi): run on all PRs so its checks can be required

### DIFF
--- a/.github/workflows/ci-chezmoi.yml
+++ b/.github/workflows/ci-chezmoi.yml
@@ -8,10 +8,11 @@ on:
       - "chezmoi/**"
       - ".github/workflows/ci-chezmoi.yml"
   pull_request:
+    # No paths filter: this workflow's checks are required by the main ruleset,
+    # so they must report on every PR (a path-filtered required check stays
+    # "expected" forever and blocks unrelated PRs). Jobs are fast; running them
+    # on every PR is the cost of having them be reliable required checks.
     branches: [main]
-    paths:
-      - "chezmoi/**"
-      - ".github/workflows/ci-chezmoi.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Required status checks must report on every PR. A `paths`-filtered workflow leaves its checks "expected" forever on PRs that don't touch those paths, blocking merge. Drop the `pull_request` paths filter so Chezmoi CI runs on every PR (push stays path-filtered). Prereq for making Lint (Pester chezmoi) / Render guard / Format required in the main ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)