### PR TITLE
fix: update codex defaults and run chezmoi scripts with pwsh

### DIFF
--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -44,5 +44,5 @@ sourceDir = {{ .chezmoi.sourceDir | quote }}
     OP_ACCOUNT = "EJLA3HRAVZBCXIQ7SRSFGQBTNU"
 
 [interpreters.ps1]
-    command = "powershell"
+    command = "pwsh"
     args = ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File"]

--- a/chezmoi/.chezmoidata/mcp_servers.yaml
+++ b/chezmoi/.chezmoidata/mcp_servers.yaml
@@ -80,7 +80,7 @@ mcp_servers:
       - "-e"
       - "TAVILY_API_KEY"
       - "mcp/tavily"
-    startup_timeout_sec: 60
+    startup_timeout_sec: 300
     env:
       TAVILY_API_KEY: "${TAVILY_API_KEY}"
     op_env:
@@ -105,7 +105,7 @@ mcp_servers:
       - "-e"
       - "EXA_API_KEY"
       - "mcp/exa"
-    startup_timeout_sec: 60
+    startup_timeout_sec: 300
     env:
       EXA_API_KEY: "${EXA_API_KEY}"
     op_env:
@@ -130,7 +130,7 @@ mcp_servers:
       - "-e"
       - "FIRECRAWL_API_KEY"
       - "mcp/firecrawl"
-    startup_timeout_sec: 60
+    startup_timeout_sec: 300
     env:
       FIRECRAWL_API_KEY: "${FIRECRAWL_API_KEY}"
     op_env:

--- a/chezmoi/.chezmoiscripts/deploy/kaggle/run_onchange_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/kaggle/run_onchange_deploy.ps1.tmpl
@@ -2,7 +2,9 @@
 # Deploy Kaggle API credentials for Windows
 {{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
 {{- $opPersonal := false }}
-{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
+{{- $opAccounts := "" }}
+{{- if $opCmd }}{{ $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}{{ end }}
+{{- $opPersonal = contains .op_account_personal $opAccounts }}
 {{- if $opPersonal }}
 # token-hash: {{ onepasswordRead "op://Private/Kaggle/c4patuuzwob2vcwt43qqphoyeu" .op_account_personal | sha256sum }}
 {{- end }}

--- a/chezmoi/.chezmoiscripts/deploy/kaggle/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/kaggle/run_onchange_deploy.sh.tmpl
@@ -3,7 +3,9 @@
 # Deploy Kaggle API credentials for Linux/macOS
 {{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
 {{- $opPersonal := false }}
-{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
+{{- $opAccounts := "" }}
+{{- if $opCmd }}{{ $opAccounts = output "sh" "-c" (printf "'%s' account list 2>/dev/null || true" $opCmd) }}{{ end }}
+{{- $opPersonal = contains .op_account_personal $opAccounts }}
 {{- if $opPersonal }}
 # token-hash: {{ onepasswordRead "op://Private/Kaggle/c4patuuzwob2vcwt43qqphoyeu" .op_account_personal | sha256sum }}
 {{- end }}

--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.ps1.tmpl
@@ -6,7 +6,7 @@
 {{- $hasWorkAccount := false }}
 {{- $hasPersonalAccount := false }}
 {{- if $hasOp }}
-{{- $accounts := output $hasOp "account" "list" }}
+{{- $accounts := output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $hasOp) }}
 {{- $hasWorkAccount = contains .op_account_work $accounts }}
 {{- $hasPersonalAccount = contains .op_account_personal $accounts }}
 {{- if $hasPersonalAccount }}

--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_onchange_deploy.sh.tmpl
@@ -8,7 +8,7 @@
 {{- $hasWorkAccount := false }}
 {{- $hasPersonalAccount := false }}
 {{- if $hasOp }}
-{{- $accounts := output $hasOp "account" "list" }}
+{{- $accounts := output "sh" "-c" (printf "'%s' account list 2>/dev/null || true" $hasOp) }}
 {{- $hasWorkAccount = contains .op_account_work $accounts }}
 {{- $hasPersonalAccount = contains .op_account_personal $accounts }}
 {{- if $hasPersonalAccount }}

--- a/chezmoi/.chezmoiscripts/run_onchange_nixos-rebuild.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_nixos-rebuild.ps1.tmpl
@@ -3,7 +3,7 @@
 # This script runs when nix/ directory changes
 #
 # Hash of nix directory (triggers rebuild on change):
-# {{ output "powershell.exe" "-NoProfile" "-NonInteractive" "-Command" "$d=$null; try{$d=wsl --list --quiet 2>&1}catch{$d=''}; if($d -match 'NixOS'){wsl -d NixOS -- bash -c 'find ~/.dotfiles/nix -name ''*.nix'' -exec sha256sum {} + 2>/dev/null|sort|sha256sum|cut -d\" \" -f1' 2>$null}else{'no-nixos'}" | trim }}
+# {{ output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" "$d=$null; try{$d=wsl --list --quiet 2>&1}catch{$d=''}; if($d -match 'NixOS'){wsl -d NixOS -- bash -c 'find ~/.dotfiles/nix -name ''*.nix'' -exec sha256sum {} + 2>/dev/null|sort|sha256sum|cut -d\" \" -f1' 2>$null}else{'no-nixos'}" | trim }}
 
 $ErrorActionPreference = "Continue"
 

--- a/chezmoi/AppData/Roaming/Claude/claude_desktop_config.json.tmpl
+++ b/chezmoi/AppData/Roaming/Claude/claude_desktop_config.json.tmpl
@@ -4,7 +4,13 @@
 {{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
 {{- $opPersonal := false }}
 {{- $opAccounts := "" }}
-{{- if $opCmd }}{{ $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}{{ end }}
+{{- if $opCmd }}
+{{- if eq .chezmoi.os "windows" }}
+{{- $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}
+{{- else }}
+{{- $opAccounts = output "sh" "-c" (printf "'%s' account list 2>/dev/null || true" $opCmd) }}
+{{- end }}
+{{- end }}
 {{- $opPersonal = contains .op_account_personal $opAccounts }}
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}

--- a/chezmoi/AppData/Roaming/Claude/claude_desktop_config.json.tmpl
+++ b/chezmoi/AppData/Roaming/Claude/claude_desktop_config.json.tmpl
@@ -3,7 +3,9 @@
 {{- $first := true }}
 {{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
 {{- $opPersonal := false }}
-{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
+{{- $opAccounts := "" }}
+{{- if $opCmd }}{{ $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}{{ end }}
+{{- $opPersonal = contains .op_account_personal $opAccounts }}
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}
 {{- if has "claude-desktop" .supports }}

--- a/chezmoi/dot_claude/dot_claude.json.tmpl
+++ b/chezmoi/dot_claude/dot_claude.json.tmpl
@@ -4,7 +4,13 @@
 {{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
 {{- $opPersonal := false }}
 {{- $opAccounts := "" }}
-{{- if $opCmd }}{{ $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}{{ end }}
+{{- if $opCmd }}
+{{- if eq .chezmoi.os "windows" }}
+{{- $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}
+{{- else }}
+{{- $opAccounts = output "sh" "-c" (printf "'%s' account list 2>/dev/null || true" $opCmd) }}
+{{- end }}
+{{- end }}
 {{- $opPersonal = contains .op_account_personal $opAccounts }}
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}

--- a/chezmoi/dot_claude/dot_claude.json.tmpl
+++ b/chezmoi/dot_claude/dot_claude.json.tmpl
@@ -3,7 +3,9 @@
 {{- $first := true }}
 {{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
 {{- $opPersonal := false }}
-{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
+{{- $opAccounts := "" }}
+{{- if $opCmd }}{{ $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}{{ end }}
+{{- $opPersonal = contains .op_account_personal $opAccounts }}
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}
 {{- if has "claude-code" .supports }}

--- a/chezmoi/dot_claude/settings.json.tmpl
+++ b/chezmoi/dot_claude/settings.json.tmpl
@@ -6,6 +6,8 @@
       "Bash(curl:*)",
       "Bash(wget:*)",
       "Bash(rm:*)",
+      "Bash(pip:*)",
+      "Bash(uv pip:*)",
       "Bash(git pop:*)",
       "Bash(git pull:*)",
       "Bash(git rm:*)",

--- a/chezmoi/dot_codeium/windsurf/mcp_config.json.tmpl
+++ b/chezmoi/dot_codeium/windsurf/mcp_config.json.tmpl
@@ -4,7 +4,13 @@
 {{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
 {{- $opPersonal := false }}
 {{- $opAccounts := "" }}
-{{- if $opCmd }}{{ $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}{{ end }}
+{{- if $opCmd }}
+{{- if eq .chezmoi.os "windows" }}
+{{- $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}
+{{- else }}
+{{- $opAccounts = output "sh" "-c" (printf "'%s' account list 2>/dev/null || true" $opCmd) }}
+{{- end }}
+{{- end }}
 {{- $opPersonal = contains .op_account_personal $opAccounts }}
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}

--- a/chezmoi/dot_codeium/windsurf/mcp_config.json.tmpl
+++ b/chezmoi/dot_codeium/windsurf/mcp_config.json.tmpl
@@ -3,7 +3,9 @@
 {{- $first := true }}
 {{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
 {{- $opPersonal := false }}
-{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
+{{- $opAccounts := "" }}
+{{- if $opCmd }}{{ $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}{{ end }}
+{{- $opPersonal = contains .op_account_personal $opAccounts }}
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}
 {{- if has "windsurf" .supports }}

--- a/chezmoi/dot_codex/AGENTS.md
+++ b/chezmoi/dot_codex/AGENTS.md
@@ -5,6 +5,7 @@
 - `config.toml`
 - `agents/*.toml`
 - `rules/*.rules`
+- `hooks/*.py`
 - `AGENTS.override.md`
 
 ## ルール

--- a/chezmoi/dot_codex/config.toml.tmpl
+++ b/chezmoi/dot_codex/config.toml.tmpl
@@ -2,7 +2,7 @@
 # 参照: https://developers.openai.com/codex/config-reference/
 
 # 使用するデフォルトモデル
-model = "gpt-5.3-codex"
+model = "gpt-5.5"
 
 # モデルの推論努力を制御する
 model_reasoning_effort = "medium"
@@ -37,7 +37,7 @@ approval_policy = "on-request"
 
 # ツール呼び出しのファイルシステム/ネットワークサンドボックスポリシー:
 # "read-only" (デフォルト), "workspace-write", "danger-full-access" (サンドボックスなし - 極めて危険)
-sandbox_mode = "read-only"
+sandbox_mode = "danger-full-access"
 
 ################################################################################
 # ウェブ検索
@@ -98,11 +98,27 @@ elevated_windows_sandbox = true
 shell_snapshot = true
 # サブエージェント (Multi-agent mode)
 multi_agent = true
+# ライフサイクルフック
+hooks = true
 
 # 開発中機能の警告を抑制する
 suppress_unstable_features_warning = true
 # ChatGPT Apps 連携
 apps = false
+
+################################################################################
+# フック設定
+################################################################################
+
+[[hooks.PreToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = 'python3 "{{ .chezmoi.homeDir | replace "\\" "/" }}/.codex/hooks/claude_permission_policy.py"'
+command_windows = 'python "{{ .chezmoi.homeDir | replace "\\" "/" }}/.codex/hooks/claude_permission_policy.py"'
+timeout = 30
+statusMessage = "Checking Claude-aligned Bash policy"
 
 ################################################################################
 # スキル設定
@@ -163,8 +179,13 @@ config_file = "{{ .chezmoi.homeDir | replace "\\" "/" }}/.codex/agents/python_co
 url = "{{ .url }}"
 {{- else }}
 [mcp_servers.{{ .name }}]
+{{- if and (eq .command "docker") (eq $.chezmoi.os "windows") }}
+command = "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+args = ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "{{ $.chezmoi.homeDir | replace "\\" "/" }}/.local/bin/codex-docker-mcp.ps1"{{ range $i, $arg := .args }}, "{{ $arg }}"{{ end }}]
+{{- else }}
 command = "{{ .command }}"
 args = [{{ range $i, $arg := .args }}{{ if $i }}, {{ end }}"{{ $arg }}"{{ end }}]
+{{- end }}
 {{- if hasKey . "startup_timeout_sec" }}
 startup_timeout_sec = {{ .startup_timeout_sec }}
 {{- end }}

--- a/chezmoi/dot_codex/config.toml.tmpl
+++ b/chezmoi/dot_codex/config.toml.tmpl
@@ -168,7 +168,15 @@ config_file = "{{ .chezmoi.homeDir | replace "\\" "/" }}/.codex/agents/python_co
 
 {{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
 {{- $opPersonal := false }}
-{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
+{{- $opAccounts := "" }}
+{{- if $opCmd }}
+{{- if eq .chezmoi.os "windows" }}
+{{- $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}
+{{- else }}
+{{- $opAccounts = output "sh" "-c" (printf "'%s' account list 2>/dev/null || true" $opCmd) }}
+{{- end }}
+{{- end }}
+{{- $opPersonal = contains .op_account_personal $opAccounts }}
 [mcp_servers]
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}
@@ -180,7 +188,7 @@ url = "{{ .url }}"
 {{- else }}
 [mcp_servers.{{ .name }}]
 {{- if and (eq .command "docker") (eq $.chezmoi.os "windows") }}
-command = "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+command = "pwsh"
 args = ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "{{ $.chezmoi.homeDir | replace "\\" "/" }}/.local/bin/codex-docker-mcp.ps1"{{ range $i, $arg := .args }}, "{{ $arg }}"{{ end }}]
 {{- else }}
 command = "{{ .command }}"

--- a/chezmoi/dot_codex/hooks/claude_permission_policy.py
+++ b/chezmoi/dot_codex/hooks/claude_permission_policy.py
@@ -1,0 +1,109 @@
+"""Claude-aligned command policy hook for Codex."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from typing import Any
+
+
+PYTHON_PREFIX_RE = re.compile(r"(?is)^\s*(?:python|python3)(?:\s|$)")
+
+
+def deny(reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            },
+            separators=(",", ":"),
+        )
+    )
+
+
+def split_shell_segments(command: str) -> list[str]:
+    segments: list[str] = []
+    buf: list[str] = []
+    quote: str | None = None
+    i = 0
+
+    while i < len(command):
+        ch = command[i]
+
+        if quote is not None:
+            buf.append(ch)
+            if ch == "\\" and quote == '"' and i + 1 < len(command):
+                i += 1
+                buf.append(command[i])
+            elif ch == quote:
+                quote = None
+            i += 1
+            continue
+
+        if ch in {"'", '"'}:
+            quote = ch
+            buf.append(ch)
+            i += 1
+            continue
+
+        if command.startswith("&&", i) or command.startswith("||", i):
+            segment = "".join(buf).strip()
+            if segment:
+                segments.append(segment)
+            buf = []
+            i += 2
+            continue
+
+        if ch in {";", "|"}:
+            segment = "".join(buf).strip()
+            if segment:
+                segments.append(segment)
+            buf = []
+            i += 1
+            continue
+
+        buf.append(ch)
+        i += 1
+
+    segment = "".join(buf).strip()
+    if segment:
+        segments.append(segment)
+    return segments
+
+
+def main() -> int:
+    try:
+        payload: dict[str, Any] = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("hook_event_name") != "PreToolUse":
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return 0
+
+    command = tool_input.get("command")
+    if not isinstance(command, str):
+        return 0
+
+    for segment in split_shell_segments(command):
+        if PYTHON_PREFIX_RE.search(segment) and "pyproject" in segment.lower():
+            deny(
+                "Blocked to match Claude permissions: Python commands that reference pyproject are denied."
+            )
+            break
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/chezmoi/dot_codex/rules/commands.rules
+++ b/chezmoi/dot_codex/rules/commands.rules
@@ -1,5 +1,5 @@
 # Codex execpolicy rules (Starlark)
-# Based on chezmoi/dot_claude/settings.json (deny/ask mapped to forbidden/prompt).
+# Keep Bash deny/ask decisions aligned with chezmoi/dot_claude/settings.json.
 
 # --- Forbidden: destructive or sensitive ---
 prefix_rule(
@@ -37,12 +37,6 @@ prefix_rule(
     pattern = ["git", "pull"],
     decision = "forbidden",
     justification = "Pull can change working tree unexpectedly.",
-)
-
-prefix_rule(
-    pattern = ["git", "push"],
-    decision = "forbidden",
-    justification = "Pushing requires manual review.",
 )
 
 prefix_rule(

--- a/chezmoi/dot_codex/rules/nix.rules
+++ b/chezmoi/dot_codex/rules/nix.rules
@@ -37,11 +37,11 @@ prefix_rule(
     not_match = [],
 )
 
-# Allow Git typical operations (that are not covered by safety.rules)
+# Allow Git typical operations (that are not covered by commands.rules)
 prefix_rule(
-    pattern = ["git", ["status", "diff", "add", "commit", "pull", "fetch", "log"]],
+    pattern = ["git", ["status", "diff", "add", "fetch", "log"]],
     decision = "allow",
-    justification = "Standard safe git operations.",
-    match = ["git status", "git add .", "git commit -m 'fix'", "git pull"],
-    not_match = ["git push -f"],  # Blocked by safety.rules
+    justification = "Standard safe git operations that do not conflict with Claude-aligned ask/deny rules.",
+    match = ["git status", "git add .", "git fetch", "git log"],
+    not_match = [],
 )

--- a/chezmoi/dot_codex/rules/safety.rules
+++ b/chezmoi/dot_codex/rules/safety.rules
@@ -9,18 +9,3 @@ prefix_rule(
     match = ["rm -rf /"],
     not_match = ["rm -rf ./temp", "rm -rf /tmp/test"],
 )
-
-# Prevent force pushing without lease
-prefix_rule(
-    pattern = ["git", "push", ["-f", "--force"]],
-    decision = "forbidden",
-    justification = "Force pushing can overwrite remote history. Use --force-with-lease instead for safety.",
-    match = [
-        "git push -f origin main",
-        "git push --force origin feature",
-    ],
-    not_match = [
-        "git push --force-with-lease origin main",
-        "git push origin main",
-    ],
-)

--- a/chezmoi/dot_cursor/cli-config.json.tmpl
+++ b/chezmoi/dot_cursor/cli-config.json.tmpl
@@ -38,7 +38,13 @@
 {{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
 {{- $opPersonal := false }}
 {{- $opAccounts := "" }}
-{{- if $opCmd }}{{ $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}{{ end }}
+{{- if $opCmd }}
+{{- if eq .chezmoi.os "windows" }}
+{{- $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}
+{{- else }}
+{{- $opAccounts = output "sh" "-c" (printf "'%s' account list 2>/dev/null || true" $opCmd) }}
+{{- end }}
+{{- end }}
 {{- $opPersonal = contains .op_account_personal $opAccounts }}
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}

--- a/chezmoi/dot_cursor/cli-config.json.tmpl
+++ b/chezmoi/dot_cursor/cli-config.json.tmpl
@@ -37,7 +37,9 @@
 {{- $first := true }}
 {{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
 {{- $opPersonal := false }}
-{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
+{{- $opAccounts := "" }}
+{{- if $opCmd }}{{ $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}{{ end }}
+{{- $opPersonal = contains .op_account_personal $opAccounts }}
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}
 {{- if has "cursor" .supports }}

--- a/chezmoi/dot_gemini/settings.json.tmpl
+++ b/chezmoi/dot_gemini/settings.json.tmpl
@@ -23,7 +23,13 @@
 {{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
 {{- $opPersonal := false }}
 {{- $opAccounts := "" }}
-{{- if $opCmd }}{{ $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}{{ end }}
+{{- if $opCmd }}
+{{- if eq .chezmoi.os "windows" }}
+{{- $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}
+{{- else }}
+{{- $opAccounts = output "sh" "-c" (printf "'%s' account list 2>/dev/null || true" $opCmd) }}
+{{- end }}
+{{- end }}
 {{- $opPersonal = contains .op_account_personal $opAccounts }}
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}

--- a/chezmoi/dot_gemini/settings.json.tmpl
+++ b/chezmoi/dot_gemini/settings.json.tmpl
@@ -22,7 +22,9 @@
 {{- $first := true }}
 {{- $opCmd := or (lookPath "op") (lookPath "op.exe") }}
 {{- $opPersonal := false }}
-{{- if $opCmd }}{{ $opPersonal = contains .op_account_personal (output $opCmd "account" "list") }}{{ end }}
+{{- $opAccounts := "" }}
+{{- if $opCmd }}{{ $opAccounts = output "pwsh" "-NoLogo" "-NoProfile" "-NonInteractive" "-Command" (printf "& '%s' account list 2>$null; exit 0" $opCmd) }}{{ end }}
+{{- $opPersonal = contains .op_account_personal $opAccounts }}
 {{- if hasKey . "mcp_servers" }}
 {{- range .mcp_servers }}
 {{- if has "gemini" .supports }}

--- a/chezmoi/dot_local/bin/executable_codex-docker-mcp.ps1
+++ b/chezmoi/dot_local/bin/executable_codex-docker-mcp.ps1
@@ -1,0 +1,86 @@
+<#
+.SYNOPSIS
+    Starts Docker Desktop if needed, then runs docker for Codex MCP servers.
+
+.DESCRIPTION
+    Codex MCP stdio servers use stdout for JSON-RPC. This wrapper writes its
+    own status messages to stderr only, waits for the Docker daemon, then
+    replaces the current action with the requested docker command.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$DockerArgs
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-McpLog {
+    param([Parameter(Mandatory)][string]$Message)
+    [Console]::Error.WriteLine("[codex-docker-mcp] $Message")
+}
+
+function Test-DockerReady {
+    $null = & docker info 2>$null
+    return $LASTEXITCODE -eq 0
+}
+
+function Get-DockerDesktopPath {
+    $candidates = @()
+
+    if ($env:ProgramFiles) {
+        $candidates += Join-Path $env:ProgramFiles "Docker\Docker\Docker Desktop.exe"
+    }
+    if (${env:ProgramFiles(x86)}) {
+        $candidates += Join-Path ${env:ProgramFiles(x86)} "Docker\Docker\Docker Desktop.exe"
+    }
+    if ($env:LOCALAPPDATA) {
+        $candidates += Join-Path $env:LOCALAPPDATA "Docker\Docker Desktop.exe"
+    }
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate) {
+            return $candidate
+        }
+    }
+
+    return $null
+}
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-McpLog "docker command was not found on PATH."
+    exit 127
+}
+
+if ($DockerArgs.Count -eq 0) {
+    Write-McpLog "No docker arguments were supplied."
+    exit 64
+}
+
+if (-not (Test-DockerReady)) {
+    $dockerDesktop = Get-DockerDesktopPath
+    if ($dockerDesktop) {
+        Write-McpLog "Docker daemon is not ready. Starting Docker Desktop."
+        Start-Process -FilePath $dockerDesktop -WindowStyle Hidden | Out-Null
+    }
+    else {
+        Write-McpLog "Docker daemon is not ready and Docker Desktop was not found."
+    }
+
+    $deadline = (Get-Date).AddSeconds(150)
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Seconds 2
+        if (Test-DockerReady) {
+            break
+        }
+    }
+}
+
+if (-not (Test-DockerReady)) {
+    Write-McpLog "Docker daemon did not become ready before timeout."
+    exit 1
+}
+
+& docker @DockerArgs
+exit $LASTEXITCODE

--- a/scripts/powershell/handlers/Handler.Codex.ps1
+++ b/scripts/powershell/handlers/Handler.Codex.ps1
@@ -6,6 +6,8 @@
     winget の OpenAI.Codex パッケージは portable インストーラーで
     実行ファイル名が codex-x86_64-pc-windows-msvc.exe となっている。
     このハンドラーは WinGet\Links に codex.exe シンボリックリンクを作成する。
+    また、Codex MCP から uv tool のエントリポイント（mempalace-mcp 等）を
+    起動できるよう ~/.local/bin を USER PATH に追加する。
 
 .NOTES
     Order = 6 (Winget の後、Bun の前)
@@ -17,7 +19,7 @@ $libPath = Split-Path -Parent $PSScriptRoot
 class CodexHandler : SetupHandlerBase {
     CodexHandler() {
         $this.Name = "Codex"
-        $this.Description = "Codex CLI シンボリックリンク作成"
+        $this.Description = "Codex CLI シンボリックリンクと MCP PATH 設定"
         $this.Order = 6
         $this.RequiresAdmin = $false
         $this.Phase = 1
@@ -29,7 +31,7 @@ class CodexHandler : SetupHandlerBase {
     .DESCRIPTION
         Codex パッケージがインストールされていて、Links\codex.exe が
         現行 exe を指していない（未作成 / winget upgrade 後の陳腐化）か、
-        Links が USER PATH に未登録の場合に適用する。
+        Links または ~/.local/bin が USER PATH に未登録の場合に適用する。
     #>
     [bool] CanApply([SetupContext]$ctx) {
         $codexExe = $this.GetCodexExecutablePath()
@@ -40,10 +42,15 @@ class CodexHandler : SetupHandlerBase {
 
         $linksPath = $this.GetLinksPath()
         $linkPath = Join-Path $linksPath "codex.exe"
+        $localBin = $this.GetLocalBinPath()
 
-        # リンクが最新でも Links が PATH に無ければ適用する。
+        # リンクが最新でも PATH 設定が欠けていれば適用する。
         # (winget upgrade 後の陳腐化, copy フォールバック後, 過去の部分実行を想定。)
-        if ($this.IsPortableLinkCurrent($linkPath, $codexExe) -and $this.IsLinksInUserPath($linksPath)) {
+        if (
+            $this.IsPortableLinkCurrent($linkPath, $codexExe) -and
+            $this.IsPathInUserPath($linksPath) -and
+            $this.IsPathInUserPath($localBin)
+        ) {
             $this.Log("codex.exe リンクと PATH 設定は既に完了しています", "Gray")
             return $false
         }
@@ -79,16 +86,13 @@ class CodexHandler : SetupHandlerBase {
             }
 
             # PATH は常に冪等チェック。リンクが既存でも PATH 未設定なら追加する。
-            if (-not $this.IsLinksInUserPath($linksPath)) {
-                $this.Log("PATH に Links フォルダを追加しています...")
-                $userPath = Get-UserEnvironmentPath
-                $newPath = if ($userPath) { "$userPath;$linksPath" } else { $linksPath }
-                Set-UserEnvironmentPath -Path $newPath
-                $env:Path = "$env:Path;$linksPath"
-                $this.Log("PATH を更新しました", "Green")
-            }
+            $this.EnsureUserPathEntry($linksPath, $false, "WinGet Links")
 
-            return $this.CreateSuccessResult("codex.exe リンクと PATH を設定しました")
+            # Codex MCP の stdio サーバーは Codex プロセスの PATH を継承する。
+            # uv tool が作成する mempalace-mcp.exe 等を解決できるようにする。
+            $this.EnsureUserPathEntry($this.GetLocalBinPath(), $true, "~/.local/bin")
+
+            return $this.CreateSuccessResult("codex.exe リンクと MCP PATH を設定しました")
         }
         catch {
             return $this.CreateFailureResult("Codex 設定に失敗しました", $_)
@@ -100,7 +104,7 @@ class CodexHandler : SetupHandlerBase {
         Codex パッケージの実行ファイルパスを取得する
     #>
     hidden [string] GetCodexExecutablePath() {
-        $packagesBase = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Packages"
+        $packagesBase = Join-Path $this.GetLocalAppDataPath() "Microsoft\WinGet\Packages"
         $codexPattern = "OpenAI.Codex_*"
 
         $codexDir = Get-ChildItem -Path $packagesBase -Directory -Filter $codexPattern -ErrorAction SilentlyContinue | Select-Object -First 1
@@ -125,16 +129,110 @@ class CodexHandler : SetupHandlerBase {
         WinGet Links フォルダパスを取得する
     #>
     hidden [string] GetLinksPath() {
-        return Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
+        return Join-Path $this.GetLocalAppDataPath() "Microsoft\WinGet\Links"
     }
 
     <#
     .SYNOPSIS
-        Links フォルダが USER PATH に登録済みか判定する
+        LOCALAPPDATA パスを取得する
     #>
-    hidden [bool] IsLinksInUserPath([string]$linksPath) {
+    hidden [string] GetLocalAppDataPath() {
+        if ($env:LOCALAPPDATA) {
+            return $env:LOCALAPPDATA
+        }
+
+        $homeDir = $this.GetHomeDir()
+        return Join-Path $homeDir "AppData\Local"
+    }
+
+    <#
+    .SYNOPSIS
+        ~/.local/bin パスを取得する
+    #>
+    hidden [string] GetLocalBinPath() {
+        return Join-Path $this.GetHomeDir() ".local\bin"
+    }
+
+    <#
+    .SYNOPSIS
+        ユーザーホームパスを取得する
+    #>
+    hidden [string] GetHomeDir() {
+        $homeDir = if ($env:USERPROFILE) {
+            $env:USERPROFILE
+        }
+        elseif ($env:HOME) {
+            $env:HOME
+        }
+        else {
+            [Environment]::GetFolderPath("UserProfile")
+        }
+        return $homeDir
+    }
+
+    <#
+    .SYNOPSIS
+        指定パスが USER PATH に登録済みか判定する
+    #>
+    hidden [bool] IsPathInUserPath([string]$targetPath) {
         $userPath = Get-UserEnvironmentPath
         if (-not $userPath) { return $false }
-        return $userPath -like "*$linksPath*"
+        $normalizedTarget = $this.NormalizePathForComparison($targetPath)
+        foreach ($item in @($userPath -split ";" | Where-Object { $_ })) {
+            if ($this.NormalizePathForComparison($item) -eq $normalizedTarget) {
+                return $true
+            }
+        }
+        return $false
+    }
+
+    <#
+    .SYNOPSIS
+        USER PATH と現在のプロセス PATH に指定パスを追加する
+    #>
+    hidden [void] EnsureUserPathEntry([string]$targetPath, [bool]$prepend, [string]$label) {
+        $normalizedTarget = $this.NormalizePathForComparison($targetPath)
+        $userPath = Get-UserEnvironmentPath
+        $userItems = if ($userPath) { @($userPath -split ";" | Where-Object { $_ }) } else { @() }
+
+        $hasUserEntry = $false
+        foreach ($item in $userItems) {
+            if ($this.NormalizePathForComparison($item) -eq $normalizedTarget) {
+                $hasUserEntry = $true
+                break
+            }
+        }
+
+        if (-not $hasUserEntry) {
+            $newItems = if ($prepend) { @($targetPath) + $userItems } else { $userItems + @($targetPath) }
+            Set-UserEnvironmentPath -Path ($newItems -join ";")
+            $this.Log("USER PATH に $label を追加しました: $targetPath", "Green")
+        }
+        else {
+            $this.Log("$label は既に USER PATH に含まれています", "Gray")
+        }
+
+        $processItems = if ($env:PATH) { @($env:PATH -split ";" | Where-Object { $_ }) } else { @() }
+        $hasProcessEntry = $false
+        foreach ($item in $processItems) {
+            if ($this.NormalizePathForComparison($item) -eq $normalizedTarget) {
+                $hasProcessEntry = $true
+                break
+            }
+        }
+
+        if (-not $hasProcessEntry) {
+            $env:PATH = if ($prepend) { "$targetPath;$env:PATH" } else { "$env:PATH;$targetPath" }
+        }
+    }
+
+    <#
+    .SYNOPSIS
+        PATH 比較用に大小文字と末尾区切り文字を正規化する
+    #>
+    hidden [string] NormalizePathForComparison([string]$path) {
+        if (-not $path) { return "" }
+        $trimChars = [char[]]@([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+        return $path.Trim('"').TrimEnd($trimChars).ToLowerInvariant()
     }
 }

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -236,7 +236,7 @@ Describe 'chezmoi テンプレート バリデーション' {
             $content = Get-Content -Path $templatePath -Raw
 
             $content | Should -Match 'eq \.command "docker"' -Because "Docker MCP だけを wrapper 経由にする"
-            $content | Should -Match 'C:/Windows/System32/WindowsPowerShell/v1\.0/powershell\.exe' -Because "PATH が絞られていても PowerShell wrapper を起動できる"
+            $content | Should -Match 'command = "pwsh"' -Because "PowerShell 7 で wrapper を起動できる"
             $content | Should -Match 'codex-docker-mcp\.ps1' -Because "Docker Desktop の自動起動待ち wrapper を使う"
         }
 

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -230,6 +230,24 @@ Describe 'chezmoi テンプレート バリデーション' {
 
             $violations | Should -BeNullOrEmpty -Because "Docker MCP サーバーの env 変数は args の -e で Docker に渡す必要がある"
         }
+
+        It 'Codex Windows テンプレートでは Docker MCP が起動 wrapper 経由で実行されること' {
+            $templatePath = Join-Path $script:chezmoiRoot "dot_codex/config.toml.tmpl"
+            $content = Get-Content -Path $templatePath -Raw
+
+            $content | Should -Match 'eq \.command "docker"' -Because "Docker MCP だけを wrapper 経由にする"
+            $content | Should -Match 'C:/Windows/System32/WindowsPowerShell/v1\.0/powershell\.exe' -Because "PATH が絞られていても PowerShell wrapper を起動できる"
+            $content | Should -Match 'codex-docker-mcp\.ps1' -Because "Docker Desktop の自動起動待ち wrapper を使う"
+        }
+
+        It 'Codex Docker MCP wrapper は stdout に制御ログを書かないこと' {
+            $wrapperPath = Join-Path $script:chezmoiRoot "dot_local/bin/executable_codex-docker-mcp.ps1"
+            $content = Get-Content -Path $wrapperPath -Raw
+
+            $content | Should -Match '\[Console\]::Error\.WriteLine' -Because "MCP stdio の stdout を壊さないためログは stderr に出す"
+            $content | Should -Not -Match 'Write-Host' -Because "Write-Host は MCP stdio と相性が悪い"
+            $content | Should -Match 'Docker Desktop\.exe' -Because "Docker daemon 未起動時に Docker Desktop を起動する"
+        }
     }
 
     Context 'supports ID の整合性' {

--- a/scripts/powershell/tests/handlers/Handler.Codex.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Codex.Tests.ps1
@@ -17,6 +17,10 @@ BeforeAll {
     # GetCodexExecutablePath() が返すパス（パッケージ dir + 実行ファイル名）
     $script:codexPkgDir = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\OpenAI.Codex_Microsoft.Winget.Source_8wekyb3d8bbwe"
     $script:codexExe = Join-Path $script:codexPkgDir "codex-x86_64-pc-windows-msvc.exe"
+    $script:homeDir = if ($env:USERPROFILE) { $env:USERPROFILE } elseif ($env:HOME) { $env:HOME } else { [Environment]::GetFolderPath("UserProfile") }
+    $script:localAppData = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { Join-Path $script:homeDir "AppData\Local" }
+    $script:expectedLinks = Join-Path $script:localAppData "Microsoft\WinGet\Links"
+    $script:expectedLocalBin = Join-Path $script:homeDir ".local\bin"
 
     # Codex パッケージが存在することにする共通モック
     function script:Set-CodexPackageInstalled {
@@ -76,8 +80,7 @@ Describe 'CodexHandler' {
             Mock Get-Item {
                 return [PSCustomObject]@{ LinkType = "SymbolicLink"; Target = $script:codexExe }
             } -ParameterFilter { $LiteralPath -like "*Links\codex.exe" }
-            $script:expectedLinks = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
-            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedLinks" }
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedLinks;$script:expectedLocalBin" }
             Mock Write-Host { }
         }
 
@@ -103,7 +106,6 @@ Describe 'CodexHandler' {
                 }
                 return [PSCustomObject]@{ LinkType = ""; Length = 246156592; LastWriteTimeUtc = [datetime]'2024-06-01' }
             }
-            $script:expectedLinks = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
             Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedLinks" }
             Mock Write-Host { }
         }
@@ -130,6 +132,27 @@ Describe 'CodexHandler' {
         }
 
         It 'should return true so Apply can add PATH' {
+            $result = $handler.CanApply($ctx)
+            $result | Should -Be $true
+        }
+    }
+
+    Context 'CanApply - link and WinGet PATH configured but local bin missing' {
+        BeforeEach {
+            Set-CodexPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*codex-x86_64-pc-windows-msvc.exe") { return $true }
+                if ($LiteralPath -like "*Links\codex.exe") { return $true }
+                return $false
+            }
+            Mock Get-Item {
+                return [PSCustomObject]@{ LinkType = "SymbolicLink"; Target = $script:codexExe }
+            } -ParameterFilter { $LiteralPath -like "*Links\codex.exe" }
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedLinks" }
+            Mock Write-Host { }
+        }
+
+        It 'should return true so Apply can add local bin for MCP tools' {
             $result = $handler.CanApply($ctx)
             $result | Should -Be $true
         }
@@ -242,7 +265,6 @@ Describe 'CodexHandler' {
             Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
             Mock Remove-Item { }
             Mock Copy-Item { }
-            $script:expectedLinks = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
             Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedLinks" }
             Mock Set-UserEnvironmentPath { }
             Mock Write-Host { }
@@ -275,15 +297,47 @@ Describe 'CodexHandler' {
             Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
             Mock Remove-Item { }
             Mock Copy-Item { }
-            Mock Get-UserEnvironmentPath { return "C:\Windows;C:\Windows\System32" }
+            Mock Get-UserEnvironmentPath { return "C:\Windows;C:\Windows\System32;$script:expectedLocalBin" }
             Mock Set-UserEnvironmentPath { }
             Mock Write-Host { }
         }
 
-        It 'should add PATH without recreating the link' {
+        It 'should add WinGet Links PATH without recreating the link' {
             $result = $handler.Apply($ctx)
             $result.Success | Should -Be $true
             Should -Invoke Set-UserEnvironmentPath -Times 1
+            Should -Invoke Copy-Item -Times 0
+            Should -Invoke New-Item -Times 0 -ParameterFilter { $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink" }
+        }
+    }
+
+    Context 'Apply - link current, only local bin missing' {
+        BeforeEach {
+            Set-CodexPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*codex-x86_64-pc-windows-msvc.exe") { return $true }
+                if ($Path -like "*Links") { return $true }
+                if ($LiteralPath -like "*Links\codex.exe") { return $true }
+                return $false
+            }
+            Mock Get-Item {
+                return [PSCustomObject]@{ LinkType = "SymbolicLink"; Target = $script:codexExe }
+            } -ParameterFilter { $LiteralPath -like "*Links\codex.exe" }
+            Mock New-Item { throw "should not recreate a current link" } -ParameterFilter {
+                $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
+            }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
+            Mock Remove-Item { }
+            Mock Copy-Item { }
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedLinks" }
+            Mock Set-UserEnvironmentPath { }
+            Mock Write-Host { }
+        }
+
+        It 'should add local bin for MCP tools without recreating the link' {
+            $result = $handler.Apply($ctx)
+            $result.Success | Should -Be $true
+            Should -Invoke Set-UserEnvironmentPath -Times 1 -ParameterFilter { $Path -like "$script:expectedLocalBin*" }
             Should -Invoke Copy-Item -Times 0
             Should -Invoke New-Item -Times 0 -ParameterFilter { $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink" }
         }


### PR DESCRIPTION
## Summary
- Update codex defaults and permissions (add claude_permission_policy.py hook, codex-docker-mcp.ps1)
- Run chezmoi scripts with pwsh instead of powershell

main への直接 push が禁止のため、ローカル main 上の未 push コミット (a849e66, 7907798) を本ブランチに cherry-pick したものです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)