### PR TITLE
feat: add project-scoped .codex rendered from chezmoi/dot_codex

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,88 @@
+{
+  "permissions": {
+    "allow": ["Read", "Write", "WebSearch", "Bash"],
+    "deny": [
+      "Bash(sudo:*)",
+      "Bash(curl:*)",
+      "Bash(wget:*)",
+      "Bash(rm:*)",
+      "Bash(pip:*)",
+      "Bash(uv pip:*)",
+      "Bash(git pop:*)",
+      "Bash(git pull:*)",
+      "Bash(git rm:*)",
+      "Bash(git rebase:*)",
+      "Bash(git reset:*)",
+      "Bash(git restore:*)",
+      "Bash(git revert:*)",
+      "Bash(git stash:*)",
+      "Read(.env*)",
+      "Edit(.env*)",
+      "Write(.env*)",
+      "Read(secrets/*)",
+      "Edit(secrets/*)",
+      "Write(secrets/*)",
+      "Read(id_rsa*)",
+      "Read(id_ed25519*)",
+      "Read(*.pem)",
+      "Edit(*.pem)",
+      "Write(*.pem)",
+      "Read(*.key)",
+      "Edit(*.key)",
+      "Write(*.key)",
+      "Edit(pyproject.toml)",
+      "Write(pyproject.toml)",
+      "Edit(requirements.txt)",
+      "Write(requirements.txt)",
+      "Edit(uv.lock)",
+      "Write(uv.lock)",
+      "Bash(python:*pyproject:*)",
+      "Bash(python3:*pyproject:*)",
+      "Bash(python3 -c:*pyproject:*)"
+    ],
+    "ask": ["Bash(git checkout:*)", "Bash(git commit:*)"]
+  },
+  "model": "sonnet",
+  "theme": "light-daltonized",
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "enabledPlugins": {
+    "superpowers@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
+    "github@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "ralph-loop@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": true,
+    "commit-commands@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "pyright-lsp@claude-plugins-official": true,
+    "linear@claude-plugins-official": true,
+    "warp@claude-code-warp": true
+  },
+  "extraKnownMarketplaces": {
+    "claude-code-warp": {
+      "source": {
+        "source": "github",
+        "repo": "warpdotdev/claude-code-warp"
+      }
+    }
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "shell": "bash",
+            "command": "input=$(cat); case \"$input\" in *'git commit'*) b=$(git branch --show-current); case \"$b\" in main|staging|master) printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Direct commits to %s are prohibited. Create a feature branch first.\"}}' \"$b\";; esac;; esac",
+            "statusMessage": "Checking protected branch..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/agents/fast_worker.toml
+++ b/.codex/agents/fast_worker.toml
@@ -1,0 +1,6 @@
+# Fast Worker Agent - 高速スコープ実装エージェント
+# 軽量モデルで素早くコーディング・バグ修正を行う
+
+model = "gpt-5.3-spark"
+model_reasoning_effort = "low"
+model_verbosity = "low"

--- a/.codex/agents/python_coding.toml
+++ b/.codex/agents/python_coding.toml
@@ -1,0 +1,28 @@
+# Python Coding Agent - Python実装専任エージェント
+# 実装・修正・変更・置換・継続作業を担当し、テスト実行は行わない
+
+model = "gpt-5.3-codex"
+model_reasoning_effort = "medium"
+model_verbosity = "medium"
+
+developer_instructions = """
+あなたは Python 実装専用のサブエージェントです。
+
+適用条件:
+- ユーザーから「実装して」「直して」「修正して」「変更して」「置き換えて」「続けて」に相当する依頼があり、対象実装言語が Python の場合に担当する。
+
+責務:
+- Python の実装・修正・変更・置換・継続作業を行う。
+- 既存コード規約に従い、必要最小限の差分で変更する。
+- `python-clean-architecture` と `python-docstring` の 2 skills を優先して適用する。
+- 型安全性、エラーハンドリング、保守性を重視する。
+- docstring は Google スタイルを優先する。
+
+非責務:
+- Python 以外の言語の実装は担当しない。
+- テスト実行は担当しない（テストは別エージェントが担当）。
+
+出力:
+- 変更内容の要点（何を、なぜ）を簡潔に報告する。
+- 必要なテスト観点と確認依頼事項を簡潔に共有する（実行はしない）。
+"""

--- a/.codex/bin/codex-docker-mcp.ps1
+++ b/.codex/bin/codex-docker-mcp.ps1
@@ -1,0 +1,86 @@
+<#
+.SYNOPSIS
+    Starts Docker Desktop if needed, then runs docker for Codex MCP servers.
+
+.DESCRIPTION
+    Codex MCP stdio servers use stdout for JSON-RPC. This wrapper writes its
+    own status messages to stderr only, waits for the Docker daemon, then
+    replaces the current action with the requested docker command.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$DockerArgs
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-McpLog {
+    param([Parameter(Mandatory)][string]$Message)
+    [Console]::Error.WriteLine("[codex-docker-mcp] $Message")
+}
+
+function Test-DockerReady {
+    $null = & docker info 2>$null
+    return $LASTEXITCODE -eq 0
+}
+
+function Get-DockerDesktopPath {
+    $candidates = @()
+
+    if ($env:ProgramFiles) {
+        $candidates += Join-Path $env:ProgramFiles "Docker\Docker\Docker Desktop.exe"
+    }
+    if (${env:ProgramFiles(x86)}) {
+        $candidates += Join-Path ${env:ProgramFiles(x86)} "Docker\Docker\Docker Desktop.exe"
+    }
+    if ($env:LOCALAPPDATA) {
+        $candidates += Join-Path $env:LOCALAPPDATA "Docker\Docker Desktop.exe"
+    }
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate) {
+            return $candidate
+        }
+    }
+
+    return $null
+}
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-McpLog "docker command was not found on PATH."
+    exit 127
+}
+
+if ($DockerArgs.Count -eq 0) {
+    Write-McpLog "No docker arguments were supplied."
+    exit 64
+}
+
+if (-not (Test-DockerReady)) {
+    $dockerDesktop = Get-DockerDesktopPath
+    if ($dockerDesktop) {
+        Write-McpLog "Docker daemon is not ready. Starting Docker Desktop."
+        Start-Process -FilePath $dockerDesktop -WindowStyle Hidden | Out-Null
+    }
+    else {
+        Write-McpLog "Docker daemon is not ready and Docker Desktop was not found."
+    }
+
+    $deadline = (Get-Date).AddSeconds(150)
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Seconds 2
+        if (Test-DockerReady) {
+            break
+        }
+    }
+}
+
+if (-not (Test-DockerReady)) {
+    Write-McpLog "Docker daemon did not become ready before timeout."
+    exit 1
+}
+
+& docker @DockerArgs
+exit $LASTEXITCODE

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,221 @@
+# Codex CLI 設定 (project-scoped)
+# Rendered from chezmoi/dot_codex/config.toml.tmpl — edit the template, not this file.
+# 参照: https://developers.openai.com/codex/config-reference/
+
+# 使用するデフォルトモデル
+model = "gpt-5.5"
+
+# モデルの推論努力を制御する
+model_reasoning_effort = "medium"
+
+# モデルの推論要約を制御する
+model_reasoning_summary = "auto"
+
+# GPT-5 ファミリー (Responses API) のテキストの冗長性:
+# low | medium | high (デフォルト: medium)
+model_verbosity = "medium"
+
+################################################################################
+# Instruction Overrides
+################################################################################
+
+# カスタム指示ファイルの読み込み (Copilot と統一)
+project_doc_fallback_filenames = [ "copilot-instructions.md" ]
+
+################################################################################
+# 通知設定
+################################################################################
+
+# コマンドの実行後に通知を表示する
+# notify = [ "bash", "-lc", "afplay /System/Library/Sounds/Ping.aiff" ]
+
+################################################################################
+# 承認とサンドボックス設定
+################################################################################
+
+# 承認ポリシー: "untrusted" (信頼できないコマンドのみ確認), "on-failure" (失敗時のみ確認), "on-request" (モデルが判断), "never" (常に確認しない - 危険)
+approval_policy = "on-request"
+
+# ツール呼び出しのファイルシステム/ネットワークサンドボックスポリシー:
+# "read-only" (デフォルト), "workspace-write", "danger-full-access" (サンドボックスなし - 極めて危険)
+sandbox_mode = "danger-full-access"
+
+################################################################################
+# ウェブ検索
+################################################################################
+
+# ウェブ検索モード: disabled | cached | live。デフォルト: "cached"
+# cached はウェブ検索キャッシュ（OpenAI が管理するインデックス）から結果を返す。
+# live は最新のデータを取得する。--yolo やフルアクセスサンドボックス使用時は live がデフォルト。
+web_search = "live"
+
+################################################################################
+# 認証設定
+################################################################################
+
+# MCP OAuth 認証情報の優先保存先: auto (デフォルト) | file | keyring
+mcp_oauth_credentials_store = "auto"
+
+################################################################################
+# mcp 周りの設定
+################################################################################
+
+##########################################################
+# agent 周りの設定
+##########################################################
+
+# 出力から内部的な推論イベントを隠す (デフォルト: false)
+hide_agent_reasoning = false
+
+# 利用可能な場合、生の推論コンテンツを表示する (デフォルト: false)
+show_raw_agent_reasoning = false
+
+################################################################################
+# サンドボックス設定 (詳細)
+################################################################################
+
+[sandbox_workspace_write]
+# /tmp を除外する
+exclude_slash_tmp = true
+# $TMPDIR 環境変数を除外する
+exclude_tmpdir_env_var = true
+
+################################################################################
+# シェル環境ポリシー
+################################################################################
+
+[shell_environment_policy]
+# 含める環境変数
+include_only = [ "PATH", "HOME", "USER", "SHELL", "TERM" ]
+
+################################################################################
+# 特殊な機能
+################################################################################
+
+[features]
+# Windows サンドボックスを有効にする
+elevated_windows_sandbox = true
+# 繰り返しコマンドを高速化する
+shell_snapshot = true
+# サブエージェント (Multi-agent mode)
+multi_agent = true
+# ライフサイクルフック
+hooks = true
+
+# 開発中機能の警告を抑制する
+suppress_unstable_features_warning = true
+# ChatGPT Apps 連携
+apps = false
+
+################################################################################
+# フック設定
+################################################################################
+
+[[hooks.PreToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = 'python3 "D:/ruru/dotfiles/.codex/hooks/claude_permission_policy.py"'
+command_windows = 'python "D:/ruru/dotfiles/.codex/hooks/claude_permission_policy.py"'
+timeout = 30
+statusMessage = "Checking Claude-aligned Bash policy"
+
+################################################################################
+# スキル設定
+################################################################################
+
+# スキルは `~/.codex/skills/<skill-name>/SKILL.md` を基準に解決される。
+# この repo では chezmoi 管理で配布する前提で、config 側に明示登録する。
+[[skills.config]]
+name = "python-clean-architecture"
+path = "~/.codex/skills/python-clean-architecture"
+enabled = true
+
+[[skills.config]]
+name = "python-docstring"
+path = "~/.codex/skills/python-docstring"
+enabled = true
+
+################################################################################
+# エージェント設定
+################################################################################
+
+# この repo では chezmoi を source of truth としてエージェントを共有する。
+# 追加手順:
+# 1) `chezmoi/dot_codex/agents/<role>.toml` を作成
+# 2) 下記に `[agents.<role>]` を追加し、`description` と `config_file` を必ず設定
+# 3) `config_file` は chezmoi テンプレートで絶対パスに展開すること
+#    ※ Windows で Codex CLI が `~` を展開しないため絶対パスが必要
+# 4) スキル依存がある場合は `[[skills.config]]` もこのファイルで管理する
+# 詳細: `chezmoi/dot_codex/agents/AGENTS.md`
+[agents]
+# セッションあたりの最大エージェントスレッド数 (デフォルト: 6)
+max_threads = 12
+
+# カスタムエージェント: 高速実装用
+[agents.fast_worker]
+description = "Fast scoped implementation agent."
+config_file = "D:/ruru/dotfiles/.codex/agents/fast_worker.toml"
+
+# カスタムエージェント: Python 実装専任
+[agents.python_coding]
+description = "Python implementation-only agent (no test execution)."
+config_file = "D:/ruru/dotfiles/.codex/agents/python_coding.toml"
+
+################################################################################
+# MCP サーバー設定 (Generated from .chezmoidata/mcp_servers.yaml)
+################################################################################
+[mcp_servers]
+
+[mcp_servers.context7]
+command = "pnpm"
+args = ["dlx", "@upstash/context7-mcp@2.2.3"]
+startup_timeout_sec = 30
+
+[mcp_servers.linear]
+url = "https://mcp.linear.app/mcp"
+
+[mcp_servers.deepwiki]
+url = "https://mcp.deepwiki.com/mcp"
+
+[mcp_servers.tavily]
+command = "pwsh"
+args = ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "D:/ruru/dotfiles/.codex/bin/codex-docker-mcp.ps1", "run", "-i", "--rm", "-e", "TAVILY_API_KEY", "mcp/tavily"]
+startup_timeout_sec = 300
+[mcp_servers.tavily.env]
+TAVILY_API_KEY = "${TAVILY_API_KEY}"
+
+[mcp_servers.exa]
+command = "pwsh"
+args = ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "D:/ruru/dotfiles/.codex/bin/codex-docker-mcp.ps1", "run", "-i", "--rm", "-e", "EXA_API_KEY", "mcp/exa"]
+startup_timeout_sec = 300
+[mcp_servers.exa.env]
+EXA_API_KEY = "${EXA_API_KEY}"
+
+[mcp_servers.firecrawl]
+command = "pwsh"
+args = ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "D:/ruru/dotfiles/.codex/bin/codex-docker-mcp.ps1", "run", "-i", "--rm", "-e", "FIRECRAWL_API_KEY", "mcp/firecrawl"]
+startup_timeout_sec = 300
+[mcp_servers.firecrawl.env]
+FIRECRAWL_API_KEY = "${FIRECRAWL_API_KEY}"
+
+[mcp_servers.drawio]
+command = "pnpm"
+args = ["dlx", "@drawio/mcp@1.2.6"]
+startup_timeout_sec = 30
+
+[mcp_servers.sentry]
+url = "https://mcp.sentry.dev/mcp"
+
+[mcp_servers.cloud-run]
+command = "pnpm"
+args = ["dlx", "@google-cloud/cloud-run-mcp@1.10.0"]
+startup_timeout_sec = 120
+
+[mcp_servers.mempalace]
+command = "mempalace-mcp"
+args = []
+
+[mcp_servers.kaggle]
+url = "https://www.kaggle.com/mcp"

--- a/.codex/hooks/claude_permission_policy.py
+++ b/.codex/hooks/claude_permission_policy.py
@@ -1,0 +1,109 @@
+"""Claude-aligned command policy hook for Codex."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from typing import Any
+
+
+PYTHON_PREFIX_RE = re.compile(r"(?is)^\s*(?:python|python3)(?:\s|$)")
+
+
+def deny(reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            },
+            separators=(",", ":"),
+        )
+    )
+
+
+def split_shell_segments(command: str) -> list[str]:
+    segments: list[str] = []
+    buf: list[str] = []
+    quote: str | None = None
+    i = 0
+
+    while i < len(command):
+        ch = command[i]
+
+        if quote is not None:
+            buf.append(ch)
+            if ch == "\\" and quote == '"' and i + 1 < len(command):
+                i += 1
+                buf.append(command[i])
+            elif ch == quote:
+                quote = None
+            i += 1
+            continue
+
+        if ch in {"'", '"'}:
+            quote = ch
+            buf.append(ch)
+            i += 1
+            continue
+
+        if command.startswith("&&", i) or command.startswith("||", i):
+            segment = "".join(buf).strip()
+            if segment:
+                segments.append(segment)
+            buf = []
+            i += 2
+            continue
+
+        if ch in {";", "|"}:
+            segment = "".join(buf).strip()
+            if segment:
+                segments.append(segment)
+            buf = []
+            i += 1
+            continue
+
+        buf.append(ch)
+        i += 1
+
+    segment = "".join(buf).strip()
+    if segment:
+        segments.append(segment)
+    return segments
+
+
+def main() -> int:
+    try:
+        payload: dict[str, Any] = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("hook_event_name") != "PreToolUse":
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return 0
+
+    command = tool_input.get("command")
+    if not isinstance(command, str):
+        return 0
+
+    for segment in split_shell_segments(command):
+        if PYTHON_PREFIX_RE.search(segment) and "pyproject" in segment.lower():
+            deny(
+                "Blocked to match Claude permissions: Python commands that reference pyproject are denied."
+            )
+            break
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/rules/commands.rules
+++ b/.codex/rules/commands.rules
@@ -1,0 +1,134 @@
+# Codex execpolicy rules (Starlark)
+# Keep Bash deny/ask decisions aligned with chezmoi/dot_claude/settings.json.
+
+# --- Forbidden: destructive or sensitive ---
+prefix_rule(
+    pattern = ["sudo"],
+    decision = "forbidden",
+    justification = "Avoid sudo in automated runs.",
+)
+
+prefix_rule(
+    pattern = ["rm"],
+    decision = "forbidden",
+    justification = "Avoid destructive deletes; prefer safer alternatives or manual review.",
+    match = ["rm -rf .", "rm -rf /", "rm -r *"],
+)
+
+prefix_rule(
+    pattern = ["curl"],
+    decision = "forbidden",
+    justification = "Network fetch requires explicit approval.",
+)
+
+prefix_rule(
+    pattern = ["wget"],
+    decision = "forbidden",
+    justification = "Network fetch requires explicit approval.",
+)
+
+prefix_rule(
+    pattern = ["git", "pop"],
+    decision = "forbidden",
+    justification = "History rewrite/unsafe operation.",
+)
+
+prefix_rule(
+    pattern = ["git", "pull"],
+    decision = "forbidden",
+    justification = "Pull can change working tree unexpectedly.",
+)
+
+prefix_rule(
+    pattern = ["git", "rm"],
+    decision = "forbidden",
+    justification = "Destructive change; require manual review.",
+)
+
+prefix_rule(
+    pattern = ["git", "rebase"],
+    decision = "forbidden",
+    justification = "Rewrites history.",
+)
+
+prefix_rule(
+    pattern = ["git", "reset"],
+    decision = "forbidden",
+    justification = "Resets can discard work.",
+)
+
+prefix_rule(
+    pattern = ["git", "restore"],
+    decision = "forbidden",
+    justification = "Restore can discard work.",
+)
+
+prefix_rule(
+    pattern = ["git", "revert"],
+    decision = "forbidden",
+    justification = "Requires manual review.",
+)
+
+prefix_rule(
+    pattern = ["git", "stash"],
+    decision = "forbidden",
+    justification = "Stash requires manual review.",
+)
+
+# --- Prompt: ask before risky actions ---
+prefix_rule(
+    pattern = ["git", "checkout"],
+    decision = "prompt",
+    justification = "Confirm before switching branches.",
+    match = ["git checkout main", "git checkout -b feature/test"],
+)
+
+prefix_rule(
+    pattern = ["git", "commit"],
+    decision = "prompt",
+    justification = "Confirm before creating commits.",
+    match = ["git commit -m \"msg\""],
+)
+
+# --- Allow: safe read-only commands ---
+prefix_rule(
+    pattern = ["git", "status"],
+    decision = "allow",
+    justification = "Read-only status check.",
+)
+
+prefix_rule(
+    pattern = ["git", "diff"],
+    decision = "allow",
+    justification = "Read-only diff.",
+)
+
+prefix_rule(
+    pattern = ["ls"],
+    decision = "allow",
+    justification = "Read-only listing.",
+)
+
+prefix_rule(
+    pattern = ["rg"],
+    decision = "allow",
+    justification = "Read-only search.",
+)
+
+prefix_rule(
+    pattern = ["cat"],
+    decision = "allow",
+    justification = "Read-only view.",
+)
+
+prefix_rule(
+    pattern = ["pwd"],
+    decision = "allow",
+    justification = "Read-only path display.",
+)
+
+prefix_rule(
+    pattern = ["whoami"],
+    decision = "allow",
+    justification = "Read-only identity check.",
+)

--- a/.codex/rules/nix.rules
+++ b/.codex/rules/nix.rules
@@ -1,0 +1,47 @@
+# nix.rules
+# Rules for Dotfiles, Nix, and WSL management (Repo specific)
+
+# Allow Taskfile execution (central to this repo)
+prefix_rule(
+    pattern = ["task"],
+    decision = "allow",
+    justification = "Taskfile is the main entry point for operations in this repository.",
+    match = ["task", "task build", "task test"],
+    not_match = [],
+)
+
+# Allow Nix commands
+prefix_rule(
+    pattern = ["nix"],
+    decision = "allow",
+    justification = "Nix commands are required for environment management.",
+    match = ["nix fmt", "nix flake check", "nix develop", "nix build"],
+    not_match = [],
+)
+
+# Allow WSL interaction (frequently used in Taskfile)
+prefix_rule(
+    pattern = ["wsl"],
+    decision = "allow",
+    justification = "WSL commands are used to interface with the NixOS distro.",
+    match = ["wsl -d NixOS", "wsl --list"],
+    not_match = [],
+)
+
+# Allow Chezmoi
+prefix_rule(
+    pattern = ["chezmoi"],
+    decision = "allow",
+    justification = "Chezmoi is used for dotfiles management.",
+    match = ["chezmoi apply", "chezmoi diff"],
+    not_match = [],
+)
+
+# Allow Git typical operations (that are not covered by commands.rules)
+prefix_rule(
+    pattern = ["git", ["status", "diff", "add", "fetch", "log"]],
+    decision = "allow",
+    justification = "Standard safe git operations that do not conflict with Claude-aligned ask/deny rules.",
+    match = ["git status", "git add .", "git fetch", "git log"],
+    not_match = [],
+)

--- a/.codex/rules/python.rules
+++ b/.codex/rules/python.rules
@@ -1,0 +1,83 @@
+# python.rules
+# Rules for Python development workflows
+
+# Allow python execution
+prefix_rule(
+    pattern = ["python"],
+    decision = "allow",
+    justification = "Allow executing Python scripts.",
+    match = ["python script.py", "python -m http.server"],
+    not_match = [],
+)
+
+# Allow python3 execution
+prefix_rule(
+    pattern = ["python3"],
+    decision = "allow",
+    justification = "Allow executing Python3 scripts.",
+    match = ["python3 script.py", "python3 -m http.server"],
+    not_match = [],
+)
+
+# Deny pip - use uv instead
+prefix_rule(
+    pattern = ["pip"],
+    decision = "forbidden",
+    justification = "pip is deprecated in this project. Use 'uv add <package>' to add dependencies, 'uv sync' to install from pyproject.toml.",
+    match = ["pip install requests", "pip uninstall numpy", "pip freeze"],
+    not_match = [],
+)
+
+# Deny uv pip - use uv add/sync instead
+prefix_rule(
+    pattern = ["uv", "pip"],
+    decision = "forbidden",
+    justification = "Do not use 'uv pip'. Use 'uv add <package>' to add dependencies and 'uv sync' to install them.",
+    match = ["uv pip install requests", "uv pip freeze"],
+    not_match = [],
+)
+
+# Allow uv commands (except uv pip which is denied above)
+prefix_rule(
+    pattern = ["uv", ["add", "remove", "sync", "lock", "run", "venv", "init", "build", "publish", "tree", "tool"]],
+    decision = "allow",
+    justification = "uv is the preferred package manager. Use 'uv add' for dependencies, 'uv sync' to install.",
+    match = ["uv add flask", "uv sync", "uv run python app.py", "uv venv"],
+    not_match = [],
+)
+
+# Allow Poetry commands (legacy support)
+prefix_rule(
+    pattern = ["poetry"],
+    decision = "allow",
+    justification = "Poetry is allowed for legacy projects. For new projects, prefer uv.",
+    match = ["poetry add flask", "poetry run python app.py"],
+    not_match = [],
+)
+
+# Allow common testing and linting tools
+prefix_rule(
+    pattern = [["pytest", "mypy", "black", "flake8", "ruff", "isort"]],
+    decision = "allow",
+    justification = "Standard code quality and testing tools are safe to run.",
+    match = ["pytest tests/", "black .", "ruff check ."],
+    not_match = [],
+)
+
+# Allow venv creation
+prefix_rule(
+    pattern = ["python", "-m", "venv"],
+    decision = "allow",
+    justification = "Creating virtual environments is safe.",
+    match = ["python -m venv .venv"],
+    not_match = [],
+)
+
+# Allow python3 venv creation
+prefix_rule(
+    pattern = ["python3", "-m", "venv"],
+    decision = "allow",
+    justification = "Creating virtual environments is safe.",
+    match = ["python3 -m venv .venv"],
+    not_match = [],
+)

--- a/.codex/rules/safety.rules
+++ b/.codex/rules/safety.rules
@@ -1,0 +1,11 @@
+# safety.rules
+# Global safety nets for OpenAI Codex CLI
+
+# Prevent "rm -rf /" - exact root deletion
+prefix_rule(
+    pattern = ["rm", "-rf", "/"],
+    decision = "forbidden",
+    justification = "Recursively deleting the root directory is catastrophic.",
+    match = ["rm -rf /"],
+    not_match = ["rm -rf ./temp", "rm -rf /tmp/test"],
+)

--- a/.codex/rules/starlark.rules
+++ b/.codex/rules/starlark.rules
@@ -1,0 +1,38 @@
+# starlark.rules
+# Rules for Starlark/Bazel development workflows
+
+# Allow buildifier (Starlark formatter)
+prefix_rule(
+    pattern = ["buildifier"],
+    decision = "allow",
+    justification = "buildifier is the standard formatter for Starlark/Bazel files.",
+    match = ["buildifier BUILD", "buildifier -r .", "buildifier --lint=fix BUILD.bazel"],
+    not_match = [],
+)
+
+# Allow buildozer (Bazel BUILD file editor)
+prefix_rule(
+    pattern = ["buildozer"],
+    decision = "allow",
+    justification = "buildozer is a tool for editing BUILD files programmatically.",
+    match = ["buildozer 'add deps //foo:bar' //my:target", "buildozer 'print srcs' //..."],
+    not_match = [],
+)
+
+# Allow bazel commands
+prefix_rule(
+    pattern = ["bazel", ["build", "test", "run", "query", "clean", "info", "fetch", "sync"]],
+    decision = "allow",
+    justification = "Standard Bazel build commands.",
+    match = ["bazel build //...", "bazel test //...", "bazel run //:app"],
+    not_match = [],
+)
+
+# Allow bazelisk (Bazel version manager)
+prefix_rule(
+    pattern = ["bazelisk"],
+    decision = "allow",
+    justification = "bazelisk is a Bazel launcher that manages versions.",
+    match = ["bazelisk build //...", "bazelisk test //..."],
+    not_match = [],
+)

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,9 @@ Thumbs.db
 .idea/
 *.iml
 .vscode/
-.claude/
+# `.claude/` 配下はローカル専用だが、プロジェクト共有設定の settings.json のみ追跡する
+.claude/*
+!.claude/settings.json
 
 # Personal/sensitive files
 *_local

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,57 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "pnpm",
+      "args": ["dlx", "@upstash/context7-mcp@2.2.3"]
+    },
+    "linear": {
+      "command": "pnpm",
+      "args": ["dlx", "mcp-remote@0.1.38", "https://mcp.linear.app/mcp"]
+    },
+    "deepwiki": {
+      "command": "pnpm",
+      "args": ["dlx", "mcp-remote@0.1.38", "https://mcp.deepwiki.com/mcp"]
+    },
+    "tavily": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "TAVILY_API_KEY", "mcp/tavily"],
+      "env": {
+        "TAVILY_API_KEY": "${TAVILY_API_KEY}"
+      }
+    },
+    "exa": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "EXA_API_KEY", "mcp/exa"],
+      "env": {
+        "EXA_API_KEY": "${EXA_API_KEY}"
+      }
+    },
+    "firecrawl": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "FIRECRAWL_API_KEY", "mcp/firecrawl"],
+      "env": {
+        "FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}"
+      }
+    },
+    "drawio": {
+      "command": "pnpm",
+      "args": ["dlx", "@drawio/mcp@1.2.6"]
+    },
+    "sentry": {
+      "command": "pnpm",
+      "args": ["dlx", "mcp-remote@0.1.38", "https://mcp.sentry.dev/mcp"]
+    },
+    "cloud-run": {
+      "command": "pnpm",
+      "args": ["dlx", "@google-cloud/cloud-run-mcp@1.10.0"]
+    },
+    "mempalace": {
+      "command": "mempalace-mcp",
+      "args": []
+    },
+    "kaggle": {
+      "command": "pnpm",
+      "args": ["dlx", "mcp-remote@0.1.38", "https://www.kaggle.com/mcp"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- chezmoi/dot_codex を基にプロジェクト直下に自己完結の `.codex/` を作成
- `config.toml` はテンプレートからレンダリング（hooks/agents のパスは `D:/ruru/dotfiles/.codex` を指す）
- `agents/`, `hooks/`, `rules/` はそのままコピー、docker MCP 用に `bin/codex-docker-mcp.ps1` を dot_local から同梱
- git 管理するため MCP のシークレットは `${ENV}` プレースホルダのまま（1Password 実値は埋め込まない）

## Usage
`CODEX_HOME=D:/ruru/dotfiles/.codex` を設定して Codex CLI を起動

🤖 Generated with [Claude Code](https://claude.com/claude-code)