### PR TITLE
feat: deny direct commits on protected branches via shared hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -78,8 +78,9 @@
           {
             "type": "command",
             "shell": "bash",
-            "command": "input=$(cat); case \"$input\" in *'git commit'*) b=$(git branch --show-current); case \"$b\" in main|staging|master) printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Direct commits to %s are prohibited. Create a feature branch first.\"}}' \"$b\";; esac;; esac",
-            "statusMessage": "Checking protected branch..."
+            "command": "if command -v python >/dev/null 2>&1; then py=python; else py=python3; fi; \"$py\" \"$CLAUDE_PROJECT_DIR/.codex/hooks/deny_protected_branch_commit.py\"",
+            "timeout": 30,
+            "statusMessage": "Checking protected branch policy"
           }
         ]
       }

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -121,6 +121,13 @@ command_windows = 'python "D:/ruru/dotfiles/.codex/hooks/claude_permission_polic
 timeout = 30
 statusMessage = "Checking Claude-aligned Bash policy"
 
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = 'python3 "D:/ruru/dotfiles/.codex/hooks/deny_protected_branch_commit.py"'
+command_windows = 'python "D:/ruru/dotfiles/.codex/hooks/deny_protected_branch_commit.py"'
+timeout = 30
+statusMessage = "Checking protected branch policy"
+
 ################################################################################
 # スキル設定
 ################################################################################

--- a/.codex/hooks/deny_protected_branch_commit.py
+++ b/.codex/hooks/deny_protected_branch_commit.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
 import sys
 from typing import Any
@@ -91,9 +92,18 @@ def split_shell_segments(command: str) -> list[str]:
     return segments
 
 
+def tokenize(segment: str) -> list[str]:
+    """Tokenize shell-aware so quoted values (e.g. -c user.name="Jane Doe")
+    stay single tokens. Fall back to naive splitting on unbalanced quotes."""
+    try:
+        return shlex.split(segment, posix=True)
+    except ValueError:
+        return segment.split()
+
+
 def git_subcommand(segment: str) -> str | None:
     """Return the git subcommand if the segment is a git invocation."""
-    tokens = segment.split()
+    tokens = tokenize(segment)
     if not tokens:
         return None
 

--- a/.codex/hooks/deny_protected_branch_commit.py
+++ b/.codex/hooks/deny_protected_branch_commit.py
@@ -1,0 +1,170 @@
+"""Deny direct git commits on protected branches (main, staging, master).
+
+Shared PreToolUse hook for Claude Code (.claude/settings.json) and
+Codex CLI (.codex/config.toml). Both pass the same JSON payload on stdin.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+
+PROTECTED_BRANCHES = {"main", "staging", "master"}
+
+# Global git options that consume the following token as their argument.
+GIT_OPTS_WITH_ARG = {
+    "-c",
+    "-C",
+    "--git-dir",
+    "--work-tree",
+    "--namespace",
+    "--exec-path",
+    "--config-env",
+}
+
+
+def deny(reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            },
+            separators=(",", ":"),
+        )
+    )
+
+
+def split_shell_segments(command: str) -> list[str]:
+    segments: list[str] = []
+    buf: list[str] = []
+    quote: str | None = None
+    i = 0
+
+    while i < len(command):
+        ch = command[i]
+
+        if quote is not None:
+            buf.append(ch)
+            if ch == "\\" and quote == '"' and i + 1 < len(command):
+                i += 1
+                buf.append(command[i])
+            elif ch == quote:
+                quote = None
+            i += 1
+            continue
+
+        if ch in {"'", '"'}:
+            quote = ch
+            buf.append(ch)
+            i += 1
+            continue
+
+        if command.startswith("&&", i) or command.startswith("||", i):
+            segment = "".join(buf).strip()
+            if segment:
+                segments.append(segment)
+            buf = []
+            i += 2
+            continue
+
+        if ch in {";", "|"}:
+            segment = "".join(buf).strip()
+            if segment:
+                segments.append(segment)
+            buf = []
+            i += 1
+            continue
+
+        buf.append(ch)
+        i += 1
+
+    segment = "".join(buf).strip()
+    if segment:
+        segments.append(segment)
+    return segments
+
+
+def git_subcommand(segment: str) -> str | None:
+    """Return the git subcommand if the segment is a git invocation."""
+    tokens = segment.split()
+    if not tokens:
+        return None
+
+    program = os.path.basename(tokens[0]).lower()
+    if program not in {"git", "git.exe"}:
+        return None
+
+    i = 1
+    while i < len(tokens):
+        token = tokens[i]
+        if token in GIT_OPTS_WITH_ARG:
+            i += 2
+            continue
+        if token.startswith("-"):
+            i += 1
+            continue
+        return token
+    return None
+
+
+def current_branch(cwd: str | None) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=cwd or None,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def main() -> int:
+    try:
+        payload: dict[str, Any] = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("hook_event_name") != "PreToolUse":
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return 0
+
+    command = tool_input.get("command")
+    if not isinstance(command, str):
+        return 0
+
+    if not any(
+        git_subcommand(segment) == "commit"
+        for segment in split_shell_segments(command)
+    ):
+        return 0
+
+    branch = current_branch(payload.get("cwd"))
+    if branch in PROTECTED_BRANCHES:
+        deny(
+            f"Direct commits to protected branch '{branch}' are prohibited. "
+            "Create a feature branch and open a PR instead."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/powershell/handlers/Handler.NixRebuild.ps1
+++ b/scripts/powershell/handlers/Handler.NixRebuild.ps1
@@ -31,9 +31,15 @@ class NixRebuildHandler : SetupHandlerBase {
         }
 
         # NixOS ディストリビューションが存在するか確認
-        $distros = Invoke-Wsl -Arguments @("-l", "-q")
-        if ($LASTEXITCODE -ne 0) {
-            $this.LogWarning("WSL が利用できません")
+        try {
+            $distros = Invoke-Wsl -Arguments @("-l", "-q")
+            if ($LASTEXITCODE -ne 0) {
+                $this.LogWarning("WSL が利用できません")
+                return $false
+            }
+        }
+        catch {
+            $this.LogWarning("WSL が利用できません: $($_.Exception.Message)")
             return $false
         }
 

--- a/scripts/powershell/handlers/Handler.Winget.ps1
+++ b/scripts/powershell/handlers/Handler.Winget.ps1
@@ -205,6 +205,8 @@ class WingetHandler : SetupHandlerBase {
                     continue
                 }
 
+                Update-ProcessEnvironmentPath
+
                 if ($pkg.VerifyCommand -and $this.TestPackageVerification($pkg.VerifyCommand)) {
                     $succeeded++
                     $this.Log("✓ $($pkg.Id)", "Green")

--- a/scripts/powershell/install.ps1
+++ b/scripts/powershell/install.ps1
@@ -160,7 +160,14 @@ if ($adminRequired) {
         $argList += "-LogFile"
         $argList += $logFile
 
-        $proc = Start-Process -FilePath $shell -ArgumentList $argList -Verb RunAs -Wait -PassThru
+        try {
+            $proc = Start-Process -FilePath $shell -ArgumentList $argList -Verb RunAs -Wait -PassThru
+        }
+        catch [System.InvalidOperationException] {
+            Write-Warning "Admin phase was canceled or could not be started: $($_.Exception.Message)"
+            Write-Warning "Re-run install.cmd and approve the UAC prompt to apply admin-required tasks."
+            $proc = $null
+        }
 
         # ログファイルの内容を元のコンソールに表示
         if (Test-Path $logFile) {
@@ -168,6 +175,9 @@ if ($adminRequired) {
             Get-Content $logFile | ForEach-Object { Write-Host $_ }
         }
 
+        if ($null -eq $proc) {
+            Write-Host "Admin phase skipped." -ForegroundColor Yellow
+        }
         if ($null -ne $proc -and $proc.ExitCode -ne 0) {
             throw "Admin phase failed with exit code $($proc.ExitCode)."
         }

--- a/scripts/powershell/lib/Invoke-ExternalCommand.ps1
+++ b/scripts/powershell/lib/Invoke-ExternalCommand.ps1
@@ -755,6 +755,40 @@ function Set-UserEnvironmentPath {
 
 <#
 .SYNOPSIS
+    現在の PowerShell プロセスの PATH を環境変数ストアから再構築する
+.DESCRIPTION
+    winget install 後は Machine/User PATH が更新されても、実行中の
+    PowerShell プロセスには自動反映されない。検証コマンドを同じ
+    install.cmd 実行内で見つけられるようにする。
+#>
+function Update-ProcessEnvironmentPath {
+    [CmdletBinding()]
+    param()
+
+    $machinePath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
+    $userPath = Get-UserEnvironmentPath
+    $processPath = [System.Environment]::GetEnvironmentVariable("PATH", "Process")
+
+    $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $items = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($pathValue in @($machinePath, $userPath, $processPath)) {
+        if ([string]::IsNullOrWhiteSpace($pathValue)) { continue }
+
+        foreach ($item in ($pathValue -split ";")) {
+            $trimmed = $item.Trim()
+            if ([string]::IsNullOrWhiteSpace($trimmed)) { continue }
+            if ($seen.Add($trimmed)) {
+                $items.Add($trimmed)
+            }
+        }
+    }
+
+    $env:PATH = $items -join ";"
+}
+
+<#
+.SYNOPSIS
     対話環境かどうかを判定する
 .DESCRIPTION
     Pester でモック可能にするため [Environment]::UserInteractive / [Console]::IsInputRedirected を

--- a/scripts/powershell/tests/Install.Orchestrator.Tests.ps1
+++ b/scripts/powershell/tests/Install.Orchestrator.Tests.ps1
@@ -27,6 +27,13 @@ Describe 'install.ps1 (orchestrator)' {
         $content | Should -Match '-Verb RunAs'
     }
 
+    It 'should handle canceled admin elevation without throwing' {
+        $content = Get-Content -LiteralPath $script:target -Raw
+        $content | Should -Match 'catch \[System\.InvalidOperationException\]'
+        $content | Should -Match 'Admin phase was canceled'
+        $content | Should -Match 'Admin phase skipped'
+    }
+
     It 'should support NoPause switch for non-interactive runs' {
         $content = Get-Content -LiteralPath $script:target -Raw
         $content | Should -Match '\[switch\]\$NoPause'

--- a/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
@@ -61,6 +61,17 @@ Describe 'NixRebuildHandler' {
             $result | Should -Be $false
         }
 
+        It 'should return false when WSL command throws' {
+            Mock Invoke-Wsl {
+                throw "Wsl/CallMsi/Install/REGDB_E_CLASSNOTREG"
+            }
+            Mock Write-Host { }
+
+            $result = $handler.CanApply($ctx)
+
+            $result | Should -Be $false
+        }
+
         It 'should return false when distro does not exist' {
             Mock Invoke-Wsl {
                 $global:LASTEXITCODE = 0

--- a/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
@@ -9,6 +9,7 @@ Describe 'WingetHandler' {
     BeforeEach {
         $script:handler = [WingetHandler]::new()
         $script:ctx = [SetupContext]::new("D:\dotfiles")
+        Mock Update-ProcessEnvironmentPath { }
     }
 
     Context 'Constructor' {
@@ -134,6 +135,15 @@ Describe 'WingetHandler' {
             $handler.Apply($ctx)
             $script:installIds | Should -Contain "Git.Git"
             $script:installIds | Should -Contain "twpayne.chezmoi"
+        }
+
+        It 'should refresh process PATH after successful installs before verification' {
+            $ctx.Options["WingetMode"] = "import"
+
+            $handler.Apply($ctx)
+
+            Should -Invoke Update-ProcessEnvironmentPath -Times 2
+            Should -Invoke Invoke-VerifyCommand -Times 2
         }
     }
 

--- a/scripts/powershell/tests/lib/Invoke-ExternalCommand.Tests.ps1
+++ b/scripts/powershell/tests/lib/Invoke-ExternalCommand.Tests.ps1
@@ -440,6 +440,39 @@ Describe 'Test-DockerDaemon' {
     }
 }
 
+Describe 'Update-ProcessEnvironmentPath' {
+    BeforeEach {
+        $script:originalPath = $env:PATH
+    }
+
+    AfterEach {
+        $env:PATH = $script:originalPath
+    }
+
+    It 'should include User PATH entries in the current process PATH' {
+        $uniqueUserPath = "C:\TestUserPath-$([guid]::NewGuid())"
+        Mock Get-UserEnvironmentPath { return $uniqueUserPath }
+
+        $env:PATH = "C:\ExistingPath"
+
+        Update-ProcessEnvironmentPath
+
+        ($env:PATH -split ";") | Should -Contain $uniqueUserPath
+        ($env:PATH -split ";") | Should -Contain "C:\ExistingPath"
+    }
+
+    It 'should remove duplicate entries case-insensitively' {
+        $uniquePath = "C:\DuplicatePath-$([guid]::NewGuid())"
+        Mock Get-UserEnvironmentPath { return $uniquePath }
+
+        $env:PATH = "$uniquePath;$($uniquePath.ToUpperInvariant())"
+
+        Update-ProcessEnvironmentPath
+
+        @($env:PATH -split ";" | Where-Object { $_ -eq $uniquePath -or $_ -eq $uniquePath.ToUpperInvariant() }).Count | Should -Be 1
+    }
+}
+
 Describe 'Test-WslAvailable' {
     It 'should return true when wsl --status succeeds' {
         Mock Invoke-Wsl { $global:LASTEXITCODE = 0 }


### PR DESCRIPTION
## Summary
- `.claude/settings.json` のインライン bash フックを、共用 Python フック `.codex/hooks/deny_protected_branch_commit.py` に置き換え
- 同スクリプトを `.codex/config.toml` の `[[hooks.PreToolUse.hooks]]` にも登録（Claude / Codex で保護ロジックを一本化）
- main / staging / master 上での `git commit` を deny（`git -c x commit` などのグローバルオプション付きや `&&` 連結も検知、`echo "git commit"` のような誤検知は排除）

## Test
- main 上で `git commit --dry-run` → deny を確認
- feature ブランチ上 → allow を確認
- `git status` / `echo git commit` → allow を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)