### PR TITLE
feat: mirror protected-branch hook to chezmoi + fix admin-skip false success

### DIFF
--- a/.codex/hooks/deny_protected_branch_commit.py
+++ b/.codex/hooks/deny_protected_branch_commit.py
@@ -101,33 +101,45 @@ def tokenize(segment: str) -> list[str]:
         return segment.split()
 
 
-def git_subcommand(segment: str) -> str | None:
-    """Return the git subcommand if the segment is a git invocation."""
+def parse_git_segment(segment: str) -> tuple[str | None, list[str]]:
+    """Return (subcommand, global option tokens) for a git invocation.
+
+    Global options such as -C/--git-dir/--work-tree change which repository
+    the subcommand operates on, so they are collected for branch resolution.
+    """
     tokens = tokenize(segment)
     if not tokens:
-        return None
+        return None, []
 
     program = os.path.basename(tokens[0]).lower()
     if program not in {"git", "git.exe"}:
-        return None
+        return None, []
 
+    global_opts: list[str] = []
     i = 1
     while i < len(tokens):
         token = tokens[i]
         if token in GIT_OPTS_WITH_ARG:
+            global_opts.extend(tokens[i : i + 2])
             i += 2
             continue
         if token.startswith("-"):
+            global_opts.append(token)
             i += 1
             continue
-        return token
-    return None
+        return token, global_opts
+    return None, global_opts
 
 
-def current_branch(cwd: str | None) -> str | None:
+def current_branch(cwd: str | None, global_opts: list[str]) -> str | None:
+    """Resolve the branch of the repository the git invocation targets.
+
+    Re-passing the global options (e.g. -C <path>) makes git itself resolve
+    the effective working tree, matching the commit invocation exactly.
+    """
     try:
         result = subprocess.run(
-            ["git", "branch", "--show-current"],
+            ["git", *global_opts, "branch", "--show-current"],
             cwd=cwd or None,
             capture_output=True,
             text=True,
@@ -160,18 +172,17 @@ def main() -> int:
     if not isinstance(command, str):
         return 0
 
-    if not any(
-        git_subcommand(segment) == "commit"
-        for segment in split_shell_segments(command)
-    ):
-        return 0
-
-    branch = current_branch(payload.get("cwd"))
-    if branch in PROTECTED_BRANCHES:
-        deny(
-            f"Direct commits to protected branch '{branch}' are prohibited. "
-            "Create a feature branch and open a PR instead."
-        )
+    for segment in split_shell_segments(command):
+        subcommand, global_opts = parse_git_segment(segment)
+        if subcommand != "commit":
+            continue
+        branch = current_branch(payload.get("cwd"), global_opts)
+        if branch in PROTECTED_BRANCHES:
+            deny(
+                f"Direct commits to protected branch '{branch}' are prohibited. "
+                "Create a feature branch and open a PR instead."
+            )
+            break
 
     return 0
 

--- a/chezmoi/dot_codex/config.toml.tmpl
+++ b/chezmoi/dot_codex/config.toml.tmpl
@@ -120,6 +120,13 @@ command_windows = 'python "{{ .chezmoi.homeDir | replace "\\" "/" }}/.codex/hook
 timeout = 30
 statusMessage = "Checking Claude-aligned Bash policy"
 
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = 'python3 "{{ .chezmoi.homeDir | replace "\\" "/" }}/.codex/hooks/deny_protected_branch_commit.py"'
+command_windows = 'python "{{ .chezmoi.homeDir | replace "\\" "/" }}/.codex/hooks/deny_protected_branch_commit.py"'
+timeout = 30
+statusMessage = "Checking protected branch policy"
+
 ################################################################################
 # スキル設定
 ################################################################################

--- a/chezmoi/dot_codex/hooks/deny_protected_branch_commit.py
+++ b/chezmoi/dot_codex/hooks/deny_protected_branch_commit.py
@@ -1,0 +1,180 @@
+"""Deny direct git commits on protected branches (main, staging, master).
+
+Shared PreToolUse hook for Claude Code (.claude/settings.json) and
+Codex CLI (.codex/config.toml). Both pass the same JSON payload on stdin.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+from typing import Any
+
+PROTECTED_BRANCHES = {"main", "staging", "master"}
+
+# Global git options that consume the following token as their argument.
+GIT_OPTS_WITH_ARG = {
+    "-c",
+    "-C",
+    "--git-dir",
+    "--work-tree",
+    "--namespace",
+    "--exec-path",
+    "--config-env",
+}
+
+
+def deny(reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            },
+            separators=(",", ":"),
+        )
+    )
+
+
+def split_shell_segments(command: str) -> list[str]:
+    segments: list[str] = []
+    buf: list[str] = []
+    quote: str | None = None
+    i = 0
+
+    while i < len(command):
+        ch = command[i]
+
+        if quote is not None:
+            buf.append(ch)
+            if ch == "\\" and quote == '"' and i + 1 < len(command):
+                i += 1
+                buf.append(command[i])
+            elif ch == quote:
+                quote = None
+            i += 1
+            continue
+
+        if ch in {"'", '"'}:
+            quote = ch
+            buf.append(ch)
+            i += 1
+            continue
+
+        if command.startswith("&&", i) or command.startswith("||", i):
+            segment = "".join(buf).strip()
+            if segment:
+                segments.append(segment)
+            buf = []
+            i += 2
+            continue
+
+        if ch in {";", "|"}:
+            segment = "".join(buf).strip()
+            if segment:
+                segments.append(segment)
+            buf = []
+            i += 1
+            continue
+
+        buf.append(ch)
+        i += 1
+
+    segment = "".join(buf).strip()
+    if segment:
+        segments.append(segment)
+    return segments
+
+
+def tokenize(segment: str) -> list[str]:
+    """Tokenize shell-aware so quoted values (e.g. -c user.name="Jane Doe")
+    stay single tokens. Fall back to naive splitting on unbalanced quotes."""
+    try:
+        return shlex.split(segment, posix=True)
+    except ValueError:
+        return segment.split()
+
+
+def git_subcommand(segment: str) -> str | None:
+    """Return the git subcommand if the segment is a git invocation."""
+    tokens = tokenize(segment)
+    if not tokens:
+        return None
+
+    program = os.path.basename(tokens[0]).lower()
+    if program not in {"git", "git.exe"}:
+        return None
+
+    i = 1
+    while i < len(tokens):
+        token = tokens[i]
+        if token in GIT_OPTS_WITH_ARG:
+            i += 2
+            continue
+        if token.startswith("-"):
+            i += 1
+            continue
+        return token
+    return None
+
+
+def current_branch(cwd: str | None) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=cwd or None,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def main() -> int:
+    try:
+        payload: dict[str, Any] = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("hook_event_name") != "PreToolUse":
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return 0
+
+    command = tool_input.get("command")
+    if not isinstance(command, str):
+        return 0
+
+    if not any(
+        git_subcommand(segment) == "commit"
+        for segment in split_shell_segments(command)
+    ):
+        return 0
+
+    branch = current_branch(payload.get("cwd"))
+    if branch in PROTECTED_BRANCHES:
+        deny(
+            f"Direct commits to protected branch '{branch}' are prohibited. "
+            "Create a feature branch and open a PR instead."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/chezmoi/dot_codex/hooks/deny_protected_branch_commit.py
+++ b/chezmoi/dot_codex/hooks/deny_protected_branch_commit.py
@@ -101,33 +101,45 @@ def tokenize(segment: str) -> list[str]:
         return segment.split()
 
 
-def git_subcommand(segment: str) -> str | None:
-    """Return the git subcommand if the segment is a git invocation."""
+def parse_git_segment(segment: str) -> tuple[str | None, list[str]]:
+    """Return (subcommand, global option tokens) for a git invocation.
+
+    Global options such as -C/--git-dir/--work-tree change which repository
+    the subcommand operates on, so they are collected for branch resolution.
+    """
     tokens = tokenize(segment)
     if not tokens:
-        return None
+        return None, []
 
     program = os.path.basename(tokens[0]).lower()
     if program not in {"git", "git.exe"}:
-        return None
+        return None, []
 
+    global_opts: list[str] = []
     i = 1
     while i < len(tokens):
         token = tokens[i]
         if token in GIT_OPTS_WITH_ARG:
+            global_opts.extend(tokens[i : i + 2])
             i += 2
             continue
         if token.startswith("-"):
+            global_opts.append(token)
             i += 1
             continue
-        return token
-    return None
+        return token, global_opts
+    return None, global_opts
 
 
-def current_branch(cwd: str | None) -> str | None:
+def current_branch(cwd: str | None, global_opts: list[str]) -> str | None:
+    """Resolve the branch of the repository the git invocation targets.
+
+    Re-passing the global options (e.g. -C <path>) makes git itself resolve
+    the effective working tree, matching the commit invocation exactly.
+    """
     try:
         result = subprocess.run(
-            ["git", "branch", "--show-current"],
+            ["git", *global_opts, "branch", "--show-current"],
             cwd=cwd or None,
             capture_output=True,
             text=True,
@@ -160,18 +172,17 @@ def main() -> int:
     if not isinstance(command, str):
         return 0
 
-    if not any(
-        git_subcommand(segment) == "commit"
-        for segment in split_shell_segments(command)
-    ):
-        return 0
-
-    branch = current_branch(payload.get("cwd"))
-    if branch in PROTECTED_BRANCHES:
-        deny(
-            f"Direct commits to protected branch '{branch}' are prohibited. "
-            "Create a feature branch and open a PR instead."
-        )
+    for segment in split_shell_segments(command):
+        subcommand, global_opts = parse_git_segment(segment)
+        if subcommand != "commit":
+            continue
+        branch = current_branch(payload.get("cwd"), global_opts)
+        if branch in PROTECTED_BRANCHES:
+            deny(
+                f"Direct commits to protected branch '{branch}' are prohibited. "
+                "Create a feature branch and open a PR instead."
+            )
+            break
 
     return 0
 

--- a/scripts/powershell/install.ps1
+++ b/scripts/powershell/install.ps1
@@ -177,8 +177,18 @@ if ($adminRequired) {
 
         if ($null -eq $proc) {
             Write-Host "Admin phase skipped." -ForegroundColor Yellow
+            Write-Host ""
+            Write-Host "========================================" -ForegroundColor Yellow
+            Write-Host "Setup Incomplete" -ForegroundColor Yellow
+            Write-Host "========================================" -ForegroundColor Yellow
+            Write-Warning "Admin-required tasks did not run. Re-run install.cmd and approve the UAC prompt to finish setup."
+            if (-not $NoPause) {
+                Write-Host "Press Enter to close..." -ForegroundColor Gray
+                Read-Host | Out-Null
+            }
+            exit 1
         }
-        if ($null -ne $proc -and $proc.ExitCode -ne 0) {
+        if ($proc.ExitCode -ne 0) {
             throw "Admin phase failed with exit code $($proc.ExitCode)."
         }
     }

--- a/scripts/powershell/tests/Install.Orchestrator.Tests.ps1
+++ b/scripts/powershell/tests/Install.Orchestrator.Tests.ps1
@@ -34,6 +34,12 @@ Describe 'install.ps1 (orchestrator)' {
         $content | Should -Match 'Admin phase skipped'
     }
 
+    It 'should exit with failure when admin phase is skipped' {
+        $content = Get-Content -LiteralPath $script:target -Raw
+        $content | Should -Match 'Setup Incomplete'
+        $content | Should -Match '(?s)Admin phase skipped.*exit 1'
+    }
+
     It 'should support NoPause switch for non-interactive runs' {
         $content = Get-Content -LiteralPath $script:target -Raw
         $content | Should -Match '\[switch\]\$NoPause'


### PR DESCRIPTION
## Summary
- `chezmoi/dot_codex` に `deny_protected_branch_commit.py` を追加し `config.toml.tmpl` に登録（ホーム側 `~/.codex` にも PR #317 と同じブランチ保護を展開）
- `install.ps1`: 管理者タスク検出時に UAC キャンセルでスキップされた場合、"Setup Complete!" の偽成功表示と exit 0 をやめ、"Setup Incomplete" 表示 + exit 1 に修正（PR #317 での Codex レビュー P2 対応）
- `Install.Orchestrator.Tests.ps1` に新挙動のテストを追加

## Test
- `Invoke-Tests.ps1 -Path .\Install.Orchestrator.Tests.ps1` → 7/7 pass
- `Invoke-Tests.ps1 -Path .\chezmoi\ChezmoiTemplate.Tests.ps1` → 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)