### PR TITLE
repo ごとに GitHub token を自動切替する

### DIFF
--- a/chezmoi/dot_config/shell/gh-token-switch.ps1
+++ b/chezmoi/dot_config/shell/gh-token-switch.ps1
@@ -1,0 +1,98 @@
+# GitHub CLI token switching for personal/work repositories.
+# Sourced by the PowerShell profile after 1Password-managed secrets are loaded.
+
+function Test-DotfilesWorkGitHubRepository {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]$Path = (Get-Location).Path
+    )
+
+    if ($Path) {
+        $normalizedPath = $Path -replace '/', '\'
+        if (
+            $normalizedPath.Equals('D:\my_programing', [System.StringComparison]::OrdinalIgnoreCase) -or
+            $normalizedPath.StartsWith('D:\my_programing\', [System.StringComparison]::OrdinalIgnoreCase)
+        ) {
+            return $true
+        }
+    }
+
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        return $false
+    }
+
+    $insideWorkTree = (& git rev-parse --is-inside-work-tree 2>$null)
+    if ($LASTEXITCODE -ne 0 -or $insideWorkTree -ne 'true') {
+        return $false
+    }
+
+    $remoteUrls = (& git config --get-regexp '^remote\..*\.url$' 2>$null)
+    if ($LASTEXITCODE -ne 0 -or -not $remoteUrls) {
+        return $false
+    }
+
+    return [bool]($remoteUrls -match 'git@github-work:')
+}
+
+function Resolve-DotfilesGitHubCli {
+    [CmdletBinding()]
+    param()
+
+    if ($env:DOTFILES_GH_BIN) {
+        return $env:DOTFILES_GH_BIN
+    }
+
+    $command = Get-Command gh.exe -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $command) {
+        $command = Get-Command gh -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+    }
+
+    if (-not $command) {
+        throw "gh executable not found"
+    }
+
+    return $command.Source
+}
+
+function Invoke-DotfilesGitHubCli {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Arguments
+    )
+
+    $originalGhToken = [Environment]::GetEnvironmentVariable('GH_TOKEN', 'Process')
+
+    try {
+        if (Test-DotfilesWorkGitHubRepository) {
+            if ($env:GITHUB_WORK_TOKEN) {
+                $env:GH_TOKEN = $env:GITHUB_WORK_TOKEN
+            }
+            else {
+                Write-Warning "work repo detected, but GITHUB_WORK_TOKEN is not set; using existing GH_TOKEN"
+            }
+        }
+
+        $ghBin = Resolve-DotfilesGitHubCli
+        & $ghBin @Arguments
+    }
+    finally {
+        if ($null -eq $originalGhToken) {
+            Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:GH_TOKEN = $originalGhToken
+        }
+    }
+}
+
+function gh {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Arguments
+    )
+
+    Invoke-DotfilesGitHubCli @Arguments
+}

--- a/chezmoi/dot_config/shell/gh-token-switch.sh
+++ b/chezmoi/dot_config/shell/gh-token-switch.sh
@@ -1,0 +1,46 @@
+# GitHub CLI token switching for personal/work repositories.
+# Sourced by ~/.bashrc after 1Password-managed secrets are loaded.
+
+_dotfiles_git_remote_is_work() {
+  command -v git >/dev/null 2>&1 || return 1
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
+
+  git config --get-regexp '^remote\..*\.url$' 2>/dev/null |
+    awk '{print $2}' |
+    grep -Eq '(^|[[:space:]])git@github-work:'
+}
+
+_dotfiles_path_is_work() {
+  case "${PWD:-}" in
+  /mnt/d/my_programing | /mnt/d/my_programing/* | D:/my_programing | D:/my_programing/* | D:\\my_programing | D:\\my_programing\\*)
+    return 0
+    ;;
+  esac
+
+  return 1
+}
+
+_dotfiles_github_repo_is_work() {
+  _dotfiles_git_remote_is_work || _dotfiles_path_is_work
+}
+
+gh() {
+  if _dotfiles_github_repo_is_work; then
+    if [ -n "${GITHUB_WORK_TOKEN:-}" ]; then
+      if [ -n "${DOTFILES_GH_BIN:-}" ]; then
+        GH_TOKEN="$GITHUB_WORK_TOKEN" "$DOTFILES_GH_BIN" "$@"
+      else
+        GH_TOKEN="$GITHUB_WORK_TOKEN" command gh "$@"
+      fi
+      return $?
+    fi
+
+    printf 'gh: work repo detected, but GITHUB_WORK_TOKEN is not set; using existing GH_TOKEN\n' >&2
+  fi
+
+  if [ -n "${DOTFILES_GH_BIN:-}" ]; then
+    "$DOTFILES_GH_BIN" "$@"
+  else
+    command gh "$@"
+  fi
+}

--- a/chezmoi/secret/env.ps1
+++ b/chezmoi/secret/env.ps1
@@ -2,10 +2,10 @@
 # Sourced by PowerShell profile at shell startup.
 #
 # Preferred usage: launch WezTerm via ~/.local/bin/wezterm-launch.cmd
-#   op run --env-file injects GH_TOKEN/TAVILY_API_KEY once at WezTerm startup;
+#   op run --env-file injects GH_TOKEN/TAVILY_API_KEY/GITHUB_WORK_TOKEN once at WezTerm startup;
 #   all tabs inherit them and this guard exits immediately.
 #
 # For standalone pwsh outside WezTerm:
 #   op run --env-file="$env:USERPROFILE\.config\shell\secrets.env" -- pwsh
 
-if ($env:GH_TOKEN -and $env:TAVILY_API_KEY) { return }
+if ($env:GH_TOKEN -and $env:TAVILY_API_KEY -and $env:GITHUB_WORK_TOKEN) { return }

--- a/chezmoi/secret/wezterm-launch.cmd
+++ b/chezmoi/secret/wezterm-launch.cmd
@@ -2,11 +2,11 @@
 rem Launch WezTerm with 1Password-injected secrets (op run official pattern).
 rem
 rem  - One biometric prompt on WezTerm startup; no further prompts per tab.
-rem  - WSLENV bridges GH_TOKEN / TAVILY_API_KEY into WSL child processes
+rem  - WSLENV bridges GH_TOKEN / TAVILY_API_KEY / GITHUB_WORK_TOKEN into WSL child processes
 rem    so env.sh guard triggers and op.exe inject is skipped there too.
 rem
 rem Usage: pin this file to taskbar or create a Start-menu shortcut.
 rem        Replace any existing "WezTerm" shortcut with this launcher.
 
-set WSLENV=GH_TOKEN:TAVILY_API_KEY
+set WSLENV=GH_TOKEN:TAVILY_API_KEY:GITHUB_WORK_TOKEN
 op run --env-file="%USERPROFILE%\.config\shell\secrets.env" -- wezterm

--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -308,4 +308,8 @@ if ($HOME) {
     $_secretPs1 = Join-Path $HOME ".config\shell\secret.ps1"
     if (Test-Path $_secretPs1) { . $_secretPs1 }
     Remove-Variable _secretPs1
+
+    $_ghTokenSwitchPs1 = Join-Path $HOME ".config\shell\gh-token-switch.ps1"
+    if (Test-Path $_ghTokenSwitchPs1) { . $_ghTokenSwitchPs1 }
+    Remove-Variable _ghTokenSwitchPs1
 }

--- a/chezmoi/shells/bashrc
+++ b/chezmoi/shells/bashrc
@@ -179,3 +179,6 @@ dotf() { (cd ~/.dotfiles && task "$@"); }
 
 # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)
 [[ -f "$HOME/.config/shell/secret.sh" ]] && source "$HOME/.config/shell/secret.sh"
+
+# GitHub CLI token switching for personal/work repositories.
+[[ -f "$HOME/.config/shell/gh-token-switch.sh" ]] && source "$HOME/.config/shell/gh-token-switch.sh"

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -220,6 +220,9 @@ in
 
       # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)
       [[ -f "$HOME/.config/shell/secret.sh" ]] && source "$HOME/.config/shell/secret.sh"
+
+      # GitHub CLI token switching for personal/work repositories.
+      [[ -f "$HOME/.config/shell/gh-token-switch.sh" ]] && source "$HOME/.config/shell/gh-token-switch.sh"
     '';
   };
 

--- a/scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1
@@ -1,0 +1,167 @@
+#Requires -Module Pester
+
+BeforeAll {
+    $script:repoRoot = Join-Path $PSScriptRoot "../../../../"
+    $script:chezmoiRoot = Join-Path $script:repoRoot "chezmoi"
+    $script:helperPath = Join-Path $script:chezmoiRoot "dot_config/shell/gh-token-switch.ps1"
+    $script:weztermLaunch = Join-Path $script:chezmoiRoot "secret/wezterm-launch.cmd"
+}
+
+AfterAll {
+    Remove-Item Function:\gh -ErrorAction SilentlyContinue
+    Remove-Item Function:\Invoke-DotfilesGitHubCli -ErrorAction SilentlyContinue
+    Remove-Item Function:\Resolve-DotfilesGitHubCli -ErrorAction SilentlyContinue
+    Remove-Item Function:\Test-DotfilesWorkGitHubRepository -ErrorAction SilentlyContinue
+}
+
+Describe 'GitHub token switching helper (PowerShell)' {
+    BeforeEach {
+        $script:previousGhToken = [Environment]::GetEnvironmentVariable('GH_TOKEN', 'Process')
+        $script:previousWorkToken = [Environment]::GetEnvironmentVariable('GITHUB_WORK_TOKEN', 'Process')
+        $script:previousGhBin = [Environment]::GetEnvironmentVariable('DOTFILES_GH_BIN', 'Process')
+
+        . $script:helperPath
+
+        $script:tempRepo = Join-Path $TestDrive ([Guid]::NewGuid().ToString('N'))
+        $script:fakeGh = Join-Path $TestDrive "fake-gh.ps1"
+        New-Item -ItemType Directory -Path $script:tempRepo -Force | Out-Null
+        Set-Content -LiteralPath $script:fakeGh -Value @'
+param([Parameter(ValueFromRemainingArguments = $true)][string[]]$RemainingArgs)
+"token=$env:GH_TOKEN"
+"args=$($RemainingArgs -join ',')"
+exit 23
+'@
+        $env:DOTFILES_GH_BIN = $script:fakeGh
+    }
+
+    AfterEach {
+        if ($null -eq $script:previousGhToken) {
+            Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:GH_TOKEN = $script:previousGhToken
+        }
+
+        if ($null -eq $script:previousWorkToken) {
+            Remove-Item Env:GITHUB_WORK_TOKEN -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:GITHUB_WORK_TOKEN = $script:previousWorkToken
+        }
+
+        if ($null -eq $script:previousGhBin) {
+            Remove-Item Env:DOTFILES_GH_BIN -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:DOTFILES_GH_BIN = $script:previousGhBin
+        }
+    }
+
+    It 'git@github-work remote の repo では GITHUB_WORK_TOKEN を GH_TOKEN として使うこと' {
+        Push-Location $script:tempRepo
+        try {
+            git init | Out-Null
+            git remote add origin 'git@github-work:org/repo.git'
+            $env:GH_TOKEN = 'personal-token'
+            $env:GITHUB_WORK_TOKEN = 'work-token'
+
+            $output = Invoke-DotfilesGitHubCli pr list 2>$null
+
+            $output | Should -Contain 'token=work-token'
+            $output | Should -Contain 'args=pr,list'
+            $env:GH_TOKEN | Should -Be 'personal-token' -Because 'wrapper 実行後は元の GH_TOKEN に戻す'
+            $LASTEXITCODE | Should -Be 23
+        }
+        finally {
+            Pop-Location
+        }
+    }
+
+    It 'personal remote の repo では既存 GH_TOKEN を維持すること' {
+        Push-Location $script:tempRepo
+        try {
+            git init | Out-Null
+            git remote add origin 'git@github.com:rurusasu/dotfiles.git'
+            $env:GH_TOKEN = 'personal-token'
+            $env:GITHUB_WORK_TOKEN = 'work-token'
+
+            $output = Invoke-DotfilesGitHubCli issue list 2>$null
+
+            $output | Should -Contain 'token=personal-token'
+            $env:GH_TOKEN | Should -Be 'personal-token'
+            $LASTEXITCODE | Should -Be 23
+        }
+        finally {
+            Pop-Location
+        }
+    }
+
+    It 'Windows work root 配下では work repo と判定すること' {
+        Test-DotfilesWorkGitHubRepository -Path 'D:\my_programing\org\repo' | Should -BeTrue
+    }
+
+    It 'personal root 配下では path だけで work repo と判定しないこと' {
+        Test-DotfilesWorkGitHubRepository -Path 'D:\ruru\dotfiles' | Should -BeFalse
+    }
+
+    It 'work repo で GITHUB_WORK_TOKEN が未設定なら GH_TOKEN を壊さないこと' {
+        Push-Location $script:tempRepo
+        try {
+            git init | Out-Null
+            git remote add origin 'git@github-work:org/repo.git'
+            $env:GH_TOKEN = 'personal-token'
+            Remove-Item Env:GITHUB_WORK_TOKEN -ErrorAction SilentlyContinue
+
+            $output = Invoke-DotfilesGitHubCli repo view 3>$null
+
+            $output | Should -Contain 'token=personal-token'
+            $env:GH_TOKEN | Should -Be 'personal-token'
+        }
+        finally {
+            Pop-Location
+        }
+    }
+}
+
+Describe 'GitHub token switching templates' {
+    It 'PowerShell profile が gh token switching helper を読み込むこと' {
+        $profilePath = Join-Path $script:chezmoiRoot "shells/Microsoft.PowerShell_profile.ps1"
+        $content = Get-Content -LiteralPath $profilePath -Raw
+
+        $content | Should -Match 'gh-token-switch\.ps1'
+    }
+
+    It 'bashrc が gh token switching helper を読み込むこと' {
+        $bashrcPath = Join-Path $script:chezmoiRoot "shells/bashrc"
+        $content = Get-Content -LiteralPath $bashrcPath -Raw
+
+        $content | Should -Match 'gh-token-switch\.sh'
+    }
+
+    It 'Home Manager zsh init が gh token switching helper を読み込むこと' {
+        $commonNixPath = Join-Path $script:repoRoot "nix/home/common.nix"
+        $content = Get-Content -LiteralPath $commonNixPath -Raw
+
+        $content | Should -Match 'gh-token-switch\.sh'
+    }
+
+    It 'WezTerm launcher が GITHUB_WORK_TOKEN を WSL に渡すこと' {
+        $content = Get-Content -LiteralPath $script:weztermLaunch -Raw
+
+        $content | Should -Match 'WSLENV=.*GITHUB_WORK_TOKEN'
+    }
+
+    It 'secrets.env が work token の 1Password 参照を含むこと' {
+        $secretsEnvPath = Join-Path $script:chezmoiRoot "secret/secrets.env"
+        $content = Get-Content -LiteralPath $secretsEnvPath -Raw
+
+        $content | Should -Match 'GITHUB_WORK_TOKEN=op://devcontainer/GITHUB_PERSONAL_ACCESS_TOKEN_KOHEI-MIKI-IM8/credential'
+    }
+
+    It 'PowerShell secret loader の guard が GITHUB_WORK_TOKEN を含むこと' {
+        $secretPs1Path = Join-Path $script:chezmoiRoot "secret/env.ps1"
+        $content = Get-Content -LiteralPath $secretPs1Path -Raw
+
+        $content | Should -Match 'GITHUB_WORK_TOKEN'
+    }
+}

--- a/tests/bash/gh_token_switch.bats
+++ b/tests/bash/gh_token_switch.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+	HELPER="$REPO_ROOT/chezmoi/dot_config/shell/gh-token-switch.sh"
+	TEST_REPO="$BATS_TEST_TMPDIR/repo"
+	FAKE_GH="$BATS_TEST_TMPDIR/fake-gh"
+	mkdir -p "$TEST_REPO"
+	cat >"$FAKE_GH" <<'EOF'
+#!/usr/bin/env bash
+printf 'token=%s\n' "${GH_TOKEN:-}"
+printf 'args=%s\n' "$*"
+exit 23
+EOF
+	chmod +x "$FAKE_GH"
+	export DOTFILES_GH_BIN="$FAKE_GH"
+}
+
+teardown() {
+	unset GH_TOKEN GITHUB_WORK_TOKEN DOTFILES_GH_BIN
+}
+
+init_repo() {
+	local remote_url="$1"
+	git -C "$TEST_REPO" init >/dev/null
+	git -C "$TEST_REPO" remote add origin "$remote_url"
+}
+
+@test "work remote uses GITHUB_WORK_TOKEN for gh" {
+	init_repo "git@github-work:org/repo.git"
+	export GH_TOKEN="personal-token"
+	export GITHUB_WORK_TOKEN="work-token"
+	# shellcheck source=/dev/null
+	source "$HELPER"
+
+	cd "$TEST_REPO"
+	run gh pr list
+
+	[ "$status" -eq 23 ]
+	[[ "$output" == *"token=work-token"* ]]
+	[[ "$output" == *"args=pr list"* ]]
+	[ "$GH_TOKEN" = "personal-token" ]
+}
+
+@test "personal remote keeps existing GH_TOKEN" {
+	init_repo "git@github.com:rurusasu/dotfiles.git"
+	export GH_TOKEN="personal-token"
+	export GITHUB_WORK_TOKEN="work-token"
+	# shellcheck source=/dev/null
+	source "$HELPER"
+
+	cd "$TEST_REPO"
+	run gh issue list
+
+	[ "$status" -eq 23 ]
+	[[ "$output" == *"token=personal-token"* ]]
+	[ "$GH_TOKEN" = "personal-token" ]
+}
+
+@test "outside a repo keeps existing GH_TOKEN" {
+	export GH_TOKEN="personal-token"
+	export GITHUB_WORK_TOKEN="work-token"
+	# shellcheck source=/dev/null
+	source "$HELPER"
+
+	cd "$BATS_TEST_TMPDIR"
+	run gh auth status
+
+	[ "$status" -eq 23 ]
+	[[ "$output" == *"token=personal-token"* ]]
+}
+
+@test "work repo without GITHUB_WORK_TOKEN keeps GH_TOKEN" {
+	init_repo "git@github-work:org/repo.git"
+	export GH_TOKEN="personal-token"
+	unset GITHUB_WORK_TOKEN
+	# shellcheck source=/dev/null
+	source "$HELPER"
+
+	cd "$TEST_REPO"
+	run gh repo view
+
+	[ "$status" -eq 23 ]
+	[[ "$output" == *"token=personal-token"* ]]
+}


### PR DESCRIPTION
## Summary

Closes #322.

- Add bash and PowerShell gh wrappers that detect work repositories and use `GITHUB_WORK_TOKEN` only for that command invocation.
- Keep personal repositories and repo-external gh calls on the existing `GH_TOKEN`.
- Wire the wrappers into bashrc / PowerShell profile after 1Password secret loading.
- Bridge `GITHUB_WORK_TOKEN` through the WezTerm WSL launch path.

## TDD / Tests

- Added `GhTokenSwitch.Tests.ps1` for PowerShell token selection, token restoration, work path detection, and template wiring.
- Added `tests/bash/gh_token_switch.bats` for bash token selection behavior.

Verified:

- `pwsh -NoProfile -Command "& ./scripts/powershell/tests/Invoke-Tests.ps1 -Path ./scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1"`
- `pwsh -NoProfile -Command "& ./scripts/powershell/tests/Invoke-Tests.ps1 -Path ./scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1,./scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1,./scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1"`
- `git diff --check`

Also ran full `task test`; it reached 685 passed / 32 failed / 5 skipped. The failures are existing environment-dependent Docker/VHD handler tests in this Codex environment where the expected NixOS WSL distro is unavailable, while the new token switching tests passed.

Note: `task commit` could not be used because this environment has no `NixOS` WSL distro. The commit was created directly and amended to the personal `rurusasu` noreply identity.