### PR TITLE
fix: seed Windows env for Codex shells

### DIFF
--- a/chezmoi/dot_codex/config.toml.tmpl
+++ b/chezmoi/dot_codex/config.toml.tmpl
@@ -81,8 +81,33 @@ show_raw_agent_reasoning = false
 # Windows の DNS/chezmoi/winget は SystemRoot, USERPROFILE, LOCALAPPDATA 等に依存する。
 # core 継承では不足するため、標準の secret 除外を維持しつつ全体を継承する。
 inherit = "all"
-set = { TERM = "xterm-256color" }
 exclude = [ "*KEY*", "*TOKEN*", "*SECRET*", "*PASSWORD*", "*CREDENTIAL*" ]
+
+[shell_environment_policy.set]
+TERM = "xterm-256color"
+{{- if eq .chezmoi.os "windows" }}
+{{- $systemRoot := or (env "SystemRoot") (env "WINDIR") "C:\\WINDOWS" }}
+{{- $windir := or (env "WINDIR") $systemRoot }}
+{{- $comSpec := or (env "ComSpec") (printf "%s\\System32\\cmd.exe" $systemRoot) }}
+{{- $userProfile := or (env "USERPROFILE") .chezmoi.homeDir }}
+{{- $home := or (env "HOME") $userProfile }}
+{{- $appData := or (env "APPDATA") (printf "%s\\AppData\\Roaming" $userProfile) }}
+{{- $localAppData := or (env "LOCALAPPDATA") (printf "%s\\AppData\\Local" $userProfile) }}
+{{- $temp := or (env "TEMP") (printf "%s\\Temp" $localAppData) }}
+{{- $tmp := or (env "TMP") $temp }}
+# Codex can be launched with a trimmed Windows environment. These variables let
+# child shells find Windows config directories, 1Password CLI config, DNS, and
+# core system tools even when the parent process did not pass them through.
+SystemRoot = '{{ $systemRoot }}'
+WINDIR = '{{ $windir }}'
+ComSpec = '{{ $comSpec }}'
+USERPROFILE = '{{ $userProfile }}'
+HOME = '{{ $home }}'
+APPDATA = '{{ $appData }}'
+LOCALAPPDATA = '{{ $localAppData }}'
+TEMP = '{{ $temp }}'
+TMP = '{{ $tmp }}'
+{{- end }}
 
 ################################################################################
 # 機能フラグ

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -240,6 +240,29 @@ Describe 'chezmoi テンプレート バリデーション' {
             $content | Should -Match 'codex-docker-mcp\.ps1' -Because "Docker Desktop の自動起動待ち wrapper を使う"
         }
 
+        It 'Codex Windows テンプレートでは最小 Windows 環境を明示していること' {
+            $templatePath = Join-Path $script:chezmoiRoot "dot_codex/config.toml.tmpl"
+            $content = Get-Content -Path $templatePath -Raw
+
+            $content | Should -Match '\[shell_environment_policy\.set\]' -Because "profile を読まない Codex 子プロセスにも env を渡す"
+            $content | Should -Match 'if eq \.chezmoi\.os "windows"' -Because "Windows 固有のパスは Windows だけに出力する"
+            $content | Should -Match 'env "APPDATA"' -Because "リダイレクトされた AppData パスを尊重する"
+            $content | Should -Match 'env "LOCALAPPDATA"' -Because "リダイレクトされた LocalAppData パスを尊重する"
+            foreach ($name in @(
+                    'SystemRoot',
+                    'WINDIR',
+                    'ComSpec',
+                    'USERPROFILE',
+                    'HOME',
+                    'APPDATA',
+                    'LOCALAPPDATA',
+                    'TEMP',
+                    'TMP'
+                )) {
+                $content | Should -Match "(?m)^$name\s*=" -Because "$name は op/gh/Windows ツールの設定解決に必要"
+            }
+        }
+
         It 'Codex Docker MCP wrapper は stdout に制御ログを書かないこと' {
             $wrapperPath = Join-Path $script:chezmoiRoot "dot_local/bin/executable_codex-docker-mcp.ps1"
             $content = Get-Content -Path $wrapperPath -Raw


### PR DESCRIPTION
## Summary
- Add explicit Windows baseline environment variables to Codex `shell_environment_policy.set`
- Keep the variables Windows-only in the chezmoi template
- Add a Pester regression test so the Codex template keeps the env needed by `op`, `gh`, DNS, and Windows tools

## Background
Codex-launched PowerShell sessions can start with a trimmed environment where `USERPROFILE`, `APPDATA`, `LOCALAPPDATA`, `SystemRoot`, and related variables are empty. In that state, 1Password CLI cannot find its config directory and reports that no account is available even when the desktop app is signed in.

## Tests
- `pwsh -NoProfile -Command "& ./scripts/powershell/tests/Invoke-Tests.ps1 -Path ./scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1"`
- `Get-Content -Raw chezmoi/dot_codex/config.toml.tmpl | chezmoi execute-template | Select-String -Pattern "\\[shell_environment_policy\\.set\\]|SystemRoot|APPDATA|LOCALAPPDATA|USERPROFILE|ComSpec"`
- `git diff --check`

## Notes
- `task commit -- "fix: seed codex windows environment"` was attempted first, but the local WSL `NixOS` distro is unavailable (`WSL_E_DISTRO_NOT_FOUND`), so the commit was created with `git commit` after the focused checks passed.