### PR TITLE
Install Codex Desktop via winget

### DIFF
--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -9,6 +9,7 @@
 #   - pnpmVerify         → package name → { command, args } for post-install verification
 #   - pnpmInstallArgs    → package name → extra pnpm add -g arguments
 #   - wingetVerify       → catalog attr name → { command, args } for post-install verification
+#   - msstoreVerifyById  → Microsoft Store Product ID → { command, args } for post-install verification
 #   - wingetInstallArgs  → catalog attr name → extra winget install arguments
 #   - wingetInstallTimeoutSeconds → catalog attr name or winget ID → winget install timeout
 #   - wingetPathEntries  → catalog attr name or winget ID → extra Windows PATH directories
@@ -676,6 +677,16 @@ lib.mapAttrs (_: names: resolve names) grouped
     };
   };
 
+  # Post-install verification commands for Windows-only Microsoft Store packages.
+  # Keys match Microsoft Store Product ID values because these packages have no catalog attr.
+  msstoreVerifyById = {
+    "9PLM9XGG6VKS" = {
+      type = "appxLaunchTarget";
+      command = "OpenAI.Codex";
+      args = [ "OpenAI.Codex_2p2nqsd0c76g0!App" ];
+    };
+  };
+
   # Windows-only packages (no nix equivalent)
   windowsOnly = {
     winget = [
@@ -699,6 +710,7 @@ lib.mapAttrs (_: names: resolve names) grouped
     ];
     msstore = [
       "9NT1R1C2HH7J"
+      "9PLM9XGG6VKS"
     ];
     pnpm = [
       "@google/gemini-cli"

--- a/nix/packages/winget.nix
+++ b/nix/packages/winget.nix
@@ -91,7 +91,9 @@ let
 
   wingetPackages = wingetFromMap ++ wingetFromWindowsOnly;
 
-  msstorePackages = map (id: { PackageIdentifier = id; }) sets.windowsOnly.msstore;
+  msstorePackages = map (
+    id: attachVerify sets.msstoreVerifyById id { PackageIdentifier = id; }
+  ) sets.windowsOnly.msstore;
 
   # --- pnpm ---
   pnpmFromGlobal = map (

--- a/scripts/powershell/handlers/Handler.Winget.ps1
+++ b/scripts/powershell/handlers/Handler.Winget.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     winget パッケージ管理ハンドラー
 
@@ -622,6 +622,10 @@ class WingetHandler : SetupHandlerBase {
                 return $null -ne $appxPackage
             }
 
+            if ($type -eq "appxLaunchTarget") {
+                return $this.TestAppxLaunchTarget($command, $arguments)
+            }
+
             $timeoutSeconds = $this.GetVerifyTimeoutSeconds($verifyCmd)
             $output = @(Invoke-VerifyCommand -Command $command -Arguments $arguments -TimeoutSeconds $timeoutSeconds)
             if ($LASTEXITCODE -eq 0) {
@@ -639,6 +643,65 @@ class WingetHandler : SetupHandlerBase {
         }
         catch {
             $this.Log("検証コマンド実行エラー: $($_.Exception.Message)", "Yellow")
+            return $false
+        }
+    }
+
+    hidden [bool] TestAppxLaunchTarget([string]$packageName, [object[]]$arguments) {
+        if (-not (Get-Command Get-AppxPackage -ErrorAction SilentlyContinue)) {
+            $this.Log("検証コマンド実行エラー: Get-AppxPackage が利用できません", "Yellow")
+            return $false
+        }
+
+        if ($arguments.Count -lt 1 -or [string]::IsNullOrWhiteSpace([string]$arguments[0])) {
+            $this.LogWarning("appxLaunchTarget 検証には AppUserModelID を args[0] に指定してください")
+            return $false
+        }
+
+        $appUserModelId = [string]$arguments[0]
+        $appxPackage = Get-AppxPackage -Name $packageName -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($null -eq $appxPackage) {
+            return $false
+        }
+
+        $packageFamilyName = [string]$appxPackage.PackageFamilyName
+        if ([string]::IsNullOrWhiteSpace($packageFamilyName)) {
+            $this.LogWarning("AppX PackageFamilyName が取得できません: $packageName")
+            return $false
+        }
+
+        $expectedPrefix = "$packageFamilyName!"
+        if (-not $appUserModelId.StartsWith($expectedPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+            $this.LogWarning("AppUserModelID が PackageFamilyName と一致しません: $appUserModelId")
+            return $false
+        }
+
+        $applicationId = $appUserModelId.Substring($expectedPrefix.Length)
+        if ([string]::IsNullOrWhiteSpace($applicationId)) {
+            $this.LogWarning("AppUserModelID に Application ID が含まれていません: $appUserModelId")
+            return $false
+        }
+
+        $installLocation = [string]$appxPackage.InstallLocation
+        if ([string]::IsNullOrWhiteSpace($installLocation)) {
+            $this.LogWarning("AppX InstallLocation が取得できません: $packageName")
+            return $false
+        }
+
+        $manifestPath = Join-Path $installLocation "AppxManifest.xml"
+        if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+            $this.LogWarning("AppX manifest が見つかりません: $manifestPath")
+            return $false
+        }
+
+        try {
+            [xml]$manifest = Get-Content -LiteralPath $manifestPath -Raw
+            $match = Select-Xml -Xml $manifest -XPath "//*[local-name()='Application' and @Id='$applicationId']" |
+                Select-Object -First 1
+            return $null -ne $match
+        }
+        catch {
+            $this.LogWarning("AppX manifest の読み込みに失敗しました: $($_.Exception.Message)")
             return $false
         }
     }

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Module Pester
+﻿#Requires -Module Pester
 
 BeforeAll {
     $script:repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
@@ -62,6 +62,31 @@ Describe 'Package catalog consistency' {
             @($package.pathEntries) | Should -Contain '%LOCALAPPDATA%\Google\Cloud SDK\google-cloud-sdk\bin'
             $package.verifyCommand.command | Should -Be 'gcloud'
             @($package.verifyCommand.args) | Should -Contain 'version'
+        }
+    }
+
+    Context 'Codex Desktop Microsoft Store package' {
+        It 'should include Codex Desktop as a Windows-only Microsoft Store package in the SSOT' {
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+
+            $sets | Should -Match '(?s)windowsOnly\s*=\s*\{.*?msstore\s*=\s*\[.*?"9PLM9XGG6VKS".*?\]'
+        }
+
+        It 'should define Codex Desktop AppX launch target verification in the SSOT' {
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+
+            $sets | Should -Match '(?s)msstoreVerifyById\s*=\s*\{.*?"9PLM9XGG6VKS"\s*=\s*\{.*?type\s*=\s*"appxLaunchTarget".*?command\s*=\s*"OpenAI\.Codex".*?args\s*=\s*\[\s*"OpenAI\.Codex_2p2nqsd0c76g0!App"\s*\]'
+        }
+
+        It 'should generate Codex Desktop under the msstore source with launch target verification' {
+            $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
+            $msstoreSource = @($json.Sources | Where-Object { $_.SourceDetails.Name -eq 'msstore' }) | Select-Object -First 1
+            $package = @($msstoreSource.Packages | Where-Object { $_.PackageIdentifier -eq '9PLM9XGG6VKS' }) | Select-Object -First 1
+
+            $package | Should -Not -BeNullOrEmpty
+            $package.verifyCommand.type | Should -Be 'appxLaunchTarget'
+            $package.verifyCommand.command | Should -Be 'OpenAI.Codex'
+            @($package.verifyCommand.args) | Should -Contain 'OpenAI.Codex_2p2nqsd0c76g0!App'
         }
     }
 }

--- a/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
@@ -7,6 +7,7 @@
     if (-not (Get-Command Get-AppxPackage -ErrorAction SilentlyContinue)) {
         function global:Get-AppxPackage {
             param([string]$Name)
+            $null = $Name
             return $null
         }
     }
@@ -452,6 +453,9 @@ Describe 'WingetHandler' {
             $script:getAppxPackageCalls = 0
             Mock Get-AppxPackage {
                 param($Name)
+                if ($Name -ne "OpenAI.Codex") {
+                    return $null
+                }
                 $script:getAppxPackageCalls++
                 if ($script:getAppxPackageCalls -eq 1) {
                     return $null

--- a/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
@@ -1,8 +1,15 @@
-BeforeAll {
+﻿BeforeAll {
     Set-StrictMode -Version Latest
     . $PSScriptRoot/../../lib/SetupHandler.ps1
     . $PSScriptRoot/../../lib/Invoke-ExternalCommand.ps1
     . $PSScriptRoot/../../handlers/Handler.Winget.ps1
+
+    if (-not (Get-Command Get-AppxPackage -ErrorAction SilentlyContinue)) {
+        function global:Get-AppxPackage {
+            param([string]$Name)
+            return $null
+        }
+    }
 }
 
 Describe 'WingetHandler' {
@@ -402,6 +409,87 @@ Describe 'WingetHandler' {
             $handler.Apply($ctx)
             $script:capturedArgs | Should -Contain "--source"
             $script:capturedArgs | Should -Contain "msstore"
+        }
+    }
+
+    Context 'Apply - import mode: Codex Desktop msstore package' {
+        BeforeEach {
+            $script:codexInstallLocation = Join-Path $TestDrive "CodexDesktop"
+            New-Item -ItemType Directory -Path $script:codexInstallLocation -Force | Out-Null
+            @'
+<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Applications>
+    <Application Id="App" Executable="app\Codex.exe" EntryPoint="Windows.FullTrustApplication" />
+  </Applications>
+</Package>
+'@ | Set-Content -LiteralPath (Join-Path $script:codexInstallLocation "AppxManifest.xml") -Encoding utf8
+
+            Mock Get-ExternalCommand { return @{ Source = "C:\winget.exe" } }
+            Mock Test-PathExist { return $true }
+            Mock Get-JsonContent {
+                return [PSCustomObject]@{
+                    Sources = @(
+                        [PSCustomObject]@{
+                            SourceDetails = [PSCustomObject]@{ Name = "msstore" }
+                            Packages      = @(
+                                [PSCustomObject]@{
+                                    PackageIdentifier = "9PLM9XGG6VKS"
+                                    verifyCommand     = [PSCustomObject]@{
+                                        type    = "appxLaunchTarget"
+                                        command = "OpenAI.Codex"
+                                        args    = @("OpenAI.Codex_2p2nqsd0c76g0!App")
+                                    }
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+            Mock Get-Command { return [PSCustomObject]@{ Name = "Get-AppxPackage" } } -ParameterFilter {
+                $Name -eq "Get-AppxPackage"
+            }
+            $script:getAppxPackageCalls = 0
+            Mock Get-AppxPackage {
+                param($Name)
+                $script:getAppxPackageCalls++
+                if ($script:getAppxPackageCalls -eq 1) {
+                    return $null
+                }
+
+                return [PSCustomObject]@{
+                    Name              = "OpenAI.Codex"
+                    PackageFamilyName = "OpenAI.Codex_2p2nqsd0c76g0"
+                    InstallLocation   = $script:codexInstallLocation
+                }
+            }
+            Mock Invoke-Winget {
+                param($Arguments)
+                if ($Arguments -contains "install") {
+                    $script:capturedArgs = $Arguments
+                    $global:LASTEXITCODE = 0
+                    return "Installed Codex Desktop"
+                }
+                $global:LASTEXITCODE = 1
+                return @()
+            }
+            Mock Test-Path { return $false } -ParameterFilter { $Path -like "*\.cargo\bin" }
+        }
+
+        It 'should install Codex Desktop from msstore and verify its AppX launch target' {
+            $ctx.Options["WingetMode"] = "import"
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $result.Message | Should -Match "1 個インストール"
+            $script:capturedArgs | Should -Contain "--id"
+            $script:capturedArgs | Should -Contain "9PLM9XGG6VKS"
+            $script:capturedArgs | Should -Contain "--source"
+            $script:capturedArgs | Should -Contain "msstore"
+            $script:getAppxPackageCalls | Should -Be 2
+            Should -Invoke Get-AppxPackage -Times 2 -ParameterFilter {
+                $Name -eq "OpenAI.Codex"
+            }
         }
     }
 

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -319,6 +319,14 @@
       "Packages": [
         {
           "PackageIdentifier": "9NT1R1C2HH7J"
+        },
+        {
+          "PackageIdentifier": "9PLM9XGG6VKS",
+          "verifyCommand": {
+            "args": ["OpenAI.Codex_2p2nqsd0c76g0!App"],
+            "command": "OpenAI.Codex",
+            "type": "appxLaunchTarget"
+          }
         }
       ],
       "SourceDetails": {


### PR DESCRIPTION
## Summary
- add Codex Desktop Microsoft Store package to generated winget package definitions
- attach AppX launch target verification for msstore packages
- add catalog and Winget handler tests for Codex Desktop install verification

## Tests
- pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/PackageCatalog.Tests.ps1
- pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1