### PR TITLE
fix: harden windows install docker startup

### DIFF
--- a/chezmoi/dot_codex/config.toml.tmpl
+++ b/chezmoi/dot_codex/config.toml.tmpl
@@ -93,6 +93,7 @@ TERM = "xterm-256color"
 {{- $home := or (env "HOME") $userProfile }}
 {{- $appData := or (env "APPDATA") (printf "%s\\AppData\\Roaming" $userProfile) }}
 {{- $localAppData := or (env "LOCALAPPDATA") (printf "%s\\AppData\\Local" $userProfile) }}
+{{- $programData := or (env "ProgramData") "C:\\ProgramData" }}
 {{- $temp := or (env "TEMP") (printf "%s\\Temp" $localAppData) }}
 {{- $tmp := or (env "TMP") $temp }}
 # Codex can be launched with a trimmed Windows environment. These variables let
@@ -105,6 +106,7 @@ USERPROFILE = '{{ $userProfile }}'
 HOME = '{{ $home }}'
 APPDATA = '{{ $appData }}'
 LOCALAPPDATA = '{{ $localAppData }}'
+ProgramData = '{{ $programData }}'
 TEMP = '{{ $temp }}'
 TMP = '{{ $tmp }}'
 {{- end }}

--- a/scripts/powershell/handlers/Handler.Docker.ps1
+++ b/scripts/powershell/handlers/Handler.Docker.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Docker Desktop と WSL の連携を管理するハンドラー
 
@@ -120,6 +120,10 @@ class DockerHandler : SetupHandlerBase {
             # StopLingeringDockerProcesses の後では WSL が一時的に不安定になり
             # wsl -l -q が空を返してディストリビューションを見逃すことがある。
             $nixosRegistered = $this.TestWslDistroExists($distroName)
+            if (-not $nixosRegistered) {
+                $this.Log("$distroName が WSL に登録されていません。Docker Desktop の起動を初回 NixOS セットアップ後まで延期します", "Gray")
+                return $this.CreateSuccessResult("NixOS 未登録のため Docker Desktop 連携を延期しました")
+            }
 
             # 残留プロセスをクリーンアップ（Lingering processes対策）
             $hadLingering = $this.StopLingeringDockerProcesses()
@@ -132,33 +136,28 @@ class DockerHandler : SetupHandlerBase {
                 Start-SleepSafe -Seconds 30
             }
 
-            if ($nixosRegistered) {
-                # NixOS への操作は Docker Desktop 起動より先に行う。
-                # Docker Desktop の初期化が wsl --shutdown を呼ぶ場合があり、
-                # その後に書き込みチェックをすると NixOS 再起動待ちになるため。
-                if (-not $this.WaitForWslWritable($distroName)) {
-                    $this.LogWarning("WSL が書き込み不可のため、NixOS 連携をスキップします")
-                    $this.StartDockerDesktopIfNeeded()
-                    $this.EnsureDockerDesktopDistros()
-                    $this.StartDockerDesktopIfNeeded()
-                    return $this.CreateSuccessResult("WSL が書き込み不可のため NixOS 連携をスキップしました")
-                }
-
-                # 空き容量チェック
-                if (-not $this.TestWslFreeSpace($distroName)) {
-                    $this.LogWarning("WSL の空き容量が不足しているため、NixOS 連携をスキップします")
-                    $this.StartDockerDesktopIfNeeded()
-                    $this.EnsureDockerDesktopDistros()
-                    $this.StartDockerDesktopIfNeeded()
-                    return $this.CreateSuccessResult("WSL の空き容量不足のため NixOS 連携をスキップしました")
-                }
-
-                # docker グループにユーザーを追加（NixOS が起動している今のうちに実施）
-                $this.EnsureDockerGroup($distroName)
+            # NixOS への操作は Docker Desktop 起動より先に行う。
+            # Docker Desktop の初期化が wsl --shutdown を呼ぶ場合があり、
+            # その後に書き込みチェックをすると NixOS 再起動待ちになるため。
+            if (-not $this.WaitForWslWritable($distroName)) {
+                $this.LogWarning("WSL が書き込み不可のため、NixOS 連携をスキップします")
+                $this.StartDockerDesktopIfNeeded()
+                $this.EnsureDockerDesktopDistros()
+                $this.StartDockerDesktopIfNeeded()
+                return $this.CreateSuccessResult("WSL が書き込み不可のため NixOS 連携をスキップしました")
             }
-            else {
-                $this.Log("$distroName が WSL に登録されていません。NixOS 連携をスキップします", "Gray")
+
+            # 空き容量チェック
+            if (-not $this.TestWslFreeSpace($distroName)) {
+                $this.LogWarning("WSL の空き容量が不足しているため、NixOS 連携をスキップします")
+                $this.StartDockerDesktopIfNeeded()
+                $this.EnsureDockerDesktopDistros()
+                $this.StartDockerDesktopIfNeeded()
+                return $this.CreateSuccessResult("WSL の空き容量不足のため NixOS 連携をスキップしました")
             }
+
+            # docker グループにユーザーを追加（NixOS が起動している今のうちに実施）
+            $this.EnsureDockerGroup($distroName)
 
             # NixOS の有無に関わらず Docker Desktop を起動する
             $this.StartDockerDesktopIfNeeded()
@@ -168,10 +167,6 @@ class DockerHandler : SetupHandlerBase {
 
             # Docker Desktop を起動（必要に応じて）
             $this.StartDockerDesktopIfNeeded()
-
-            if (-not $nixosRegistered) {
-                return $this.CreateSuccessResult("Docker Desktop を起動しました（NixOS 連携なし）")
-            }
 
             # Docker Desktop の健全性チェック
             if (-not $this.TestDockerDesktopHealth()) {
@@ -496,6 +491,10 @@ class DockerHandler : SetupHandlerBase {
         Docker Desktop本体も終了させて完全にリセットする。
     #>
     hidden [bool] StopLingeringDockerProcesses() {
+        if ((Get-ProcessSafe -Name "Docker Desktop") -or (Get-ProcessSafe -Name "com.docker.backend")) {
+            return $false
+        }
+
         # 残留プロセス（Docker Desktop本体なしで動いているプロセス）をチェック
         $lingeringProcessNames = @(
             "com.docker.build",

--- a/scripts/powershell/handlers/Handler.NixOSWSL.ps1
+++ b/scripts/powershell/handlers/Handler.NixOSWSL.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     NixOS-WSL のダウンロードとインストールを管理するハンドラー
 
@@ -455,8 +455,9 @@ class NixOSWSLHandler : SetupHandlerBase {
 
         $syncMode = $ctx.GetOption("SyncMode", "link")
         $syncBack = $ctx.GetOption("SyncBack", "lock")
+        $timeoutSeconds = $ctx.GetOption("PostInstallTimeoutSeconds", 1800)
         $cmd = "bash `"$wslPath`" --force --sync-mode $syncMode --sync-back $syncBack"
-        Invoke-Wsl -Arguments @("-d", $ctx.DistroName, "-u", "root", "--", "sh", "-lc", $cmd)
+        Invoke-Wsl -TimeoutSeconds $timeoutSeconds -Arguments @("-d", $ctx.DistroName, "-u", "root", "--", "sh", "-lc", $cmd)
         if ($LASTEXITCODE -ne 0) {
             $this.LogWarning("Post-install スクリプトが非ゼロで終了しました (exit code: $LASTEXITCODE)")
         }

--- a/scripts/powershell/install.admin.ps1
+++ b/scripts/powershell/install.admin.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Admin/non-winget setup phase.
 
@@ -36,6 +36,14 @@ $ErrorActionPreference = "Stop"
 
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
 $OutputEncoding = [System.Text.UTF8Encoding]::new()
+
+$libPath = Join-Path $PSScriptRoot "lib"
+. (Join-Path $libPath "WindowsEnvironment.ps1")
+Repair-WindowsSetupEnvironment
+
+if (-not $PSBoundParameters.ContainsKey("InstallDir")) {
+    $InstallDir = Join-Path $env:USERPROFILE "NixOS"
+}
 
 function Test-IsAdminCurrent {
     [CmdletBinding()]
@@ -76,7 +84,6 @@ function Merge-Options {
 $effectiveOptions = Merge-Options -BaseOptions $Options -JsonOptions $OptionsJson
 
 $repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..\..")).Path
-$libPath = Join-Path $PSScriptRoot "lib"
 . (Join-Path $libPath "SetupHandler.ps1")
 . (Join-Path $libPath "Invoke-ExternalCommand.ps1")
 

--- a/scripts/powershell/install.ps1
+++ b/scripts/powershell/install.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Dotfiles setup orchestrator.
 
@@ -34,6 +34,14 @@ $ErrorActionPreference = "Stop"
 
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
 $OutputEncoding = [System.Text.UTF8Encoding]::new()
+
+$libPath = Join-Path $PSScriptRoot "lib"
+. (Join-Path $libPath "WindowsEnvironment.ps1")
+Repair-WindowsSetupEnvironment
+
+if (-not $PSBoundParameters.ContainsKey("InstallDir")) {
+    $InstallDir = Join-Path $env:USERPROFILE "NixOS"
+}
 
 function Test-IsAdminCurrent {
     [CmdletBinding()]

--- a/scripts/powershell/install.user.ps1
+++ b/scripts/powershell/install.user.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     User-scope setup phase (no elevation).
 
@@ -26,8 +26,15 @@ $ErrorActionPreference = "Stop"
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
 $OutputEncoding = [System.Text.UTF8Encoding]::new()
 
-$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..\..")).Path
 $libPath = Join-Path $PSScriptRoot "lib"
+. (Join-Path $libPath "WindowsEnvironment.ps1")
+Repair-WindowsSetupEnvironment
+
+if (-not $PSBoundParameters.ContainsKey("InstallDir")) {
+    $InstallDir = Join-Path $env:USERPROFILE "NixOS"
+}
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..\..")).Path
 . (Join-Path $libPath "SetupHandler.ps1")
 . (Join-Path $libPath "Invoke-ExternalCommand.ps1")
 

--- a/scripts/powershell/lib/WindowsEnvironment.ps1
+++ b/scripts/powershell/lib/WindowsEnvironment.ps1
@@ -1,0 +1,48 @@
+﻿<#
+.SYNOPSIS
+    Repairs the minimum Windows environment expected by setup tools.
+#>
+
+function Repair-WindowsSetupEnvironment {
+    [CmdletBinding()]
+    param()
+
+    $machineSystemRoot = [Environment]::GetEnvironmentVariable("SystemRoot", "Machine")
+    if (-not $machineSystemRoot -or $machineSystemRoot -like "*%*") {
+        $machineSystemRoot = "C:\WINDOWS"
+    }
+
+    if (-not $env:SystemRoot -or $env:SystemRoot -like "*%*") { $env:SystemRoot = $machineSystemRoot }
+    if (-not $env:WINDIR -or $env:WINDIR -like "*%*") { $env:WINDIR = $machineSystemRoot }
+    if (-not $env:ComSpec -or $env:ComSpec -like "*%*") { $env:ComSpec = Join-Path $machineSystemRoot "System32\cmd.exe" }
+
+    if (-not $env:USERPROFILE) {
+        $env:USERPROFILE = [Environment]::GetFolderPath("UserProfile")
+    }
+    if (-not $env:HOME) { $env:HOME = $env:USERPROFILE }
+    if (-not $env:APPDATA) {
+        $env:APPDATA = [Environment]::GetFolderPath("ApplicationData")
+    }
+    if (-not $env:LOCALAPPDATA) {
+        $env:LOCALAPPDATA = [Environment]::GetFolderPath("LocalApplicationData")
+    }
+    if (-not $env:ProgramData) {
+        $programData = [Environment]::GetFolderPath("CommonApplicationData")
+        if (-not $programData) { $programData = "C:\ProgramData" }
+        $env:ProgramData = $programData
+    }
+    if (-not $env:ProgramFiles) {
+        $programFiles = [Environment]::GetFolderPath("ProgramFiles")
+        if (-not $programFiles) { $programFiles = "C:\Program Files" }
+        $env:ProgramFiles = $programFiles
+    }
+    if (-not ${env:ProgramFiles(x86)}) {
+        $programFilesX86 = [Environment]::GetFolderPath("ProgramFilesX86")
+        if (-not $programFilesX86) { $programFilesX86 = "C:\Program Files (x86)" }
+        ${env:ProgramFiles(x86)} = $programFilesX86
+    }
+    if (-not $env:TEMP -or $env:TEMP -eq $env:USERPROFILE) {
+        $env:TEMP = Join-Path $env:LOCALAPPDATA "Temp"
+    }
+    if (-not $env:TMP) { $env:TMP = $env:TEMP }
+}

--- a/scripts/powershell/tests/Install.Admin.Tests.ps1
+++ b/scripts/powershell/tests/Install.Admin.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Module Pester
+﻿#Requires -Module Pester
 
 BeforeAll {
     $script:target = Join-Path (Split-Path -Parent $PSScriptRoot) "install.admin.ps1"
@@ -39,6 +39,13 @@ Describe 'install.admin.ps1' {
     It 'should filter handlers by Phase 2' {
         $content = Get-Content -LiteralPath $script:target -Raw
         $content | Should -Match '\$_\.Phase -eq 2'
+    }
+
+    It 'should repair Windows environment variables before computing default paths' {
+        $content = Get-Content -LiteralPath $script:target -Raw
+        $content | Should -Match 'WindowsEnvironment\.ps1'
+        $content | Should -Match 'Repair-WindowsSetupEnvironment'
+        $content | Should -Match '\$PSBoundParameters\.ContainsKey\("InstallDir"\)'
     }
 
     It 'should print preflight handler names before Phase 2 apply checks' {

--- a/scripts/powershell/tests/Install.Entrypoint.Tests.ps1
+++ b/scripts/powershell/tests/Install.Entrypoint.Tests.ps1
@@ -94,9 +94,12 @@ exit 0
 
         $workDir = Join-Path $TestDrive "install-cmd-orchestrator"
         $scriptDir = Join-Path $workDir "scripts\powershell"
+        $libDir = Join-Path $scriptDir "lib"
         New-Item -ItemType Directory -Path $scriptDir -Force | Out-Null
+        New-Item -ItemType Directory -Path $libDir -Force | Out-Null
         Copy-Item -LiteralPath (Join-Path $script:repoRoot "install.cmd") -Destination (Join-Path $workDir "install.cmd")
         Copy-Item -LiteralPath (Join-Path $script:repoRoot "scripts\powershell\install.ps1") -Destination (Join-Path $scriptDir "install.ps1")
+        Copy-Item -LiteralPath (Join-Path $script:repoRoot "scripts\powershell\lib\WindowsEnvironment.ps1") -Destination (Join-Path $libDir "WindowsEnvironment.ps1")
 
         $stubUser = @'
 [CmdletBinding()]

--- a/scripts/powershell/tests/Install.Orchestrator.Tests.ps1
+++ b/scripts/powershell/tests/Install.Orchestrator.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Module Pester
+﻿#Requires -Module Pester
 
 BeforeAll {
     $script:target = Join-Path (Split-Path -Parent $PSScriptRoot) "install.ps1"
@@ -52,6 +52,13 @@ Describe 'install.ps1 (orchestrator)' {
         $content | Should -Match '\[switch\]\$UserPhaseOnly'
         $content | Should -Match '\[switch\]\$WingetVerifyCommandOnly'
         $content | Should -Match 'WingetVerifyCommandOnly'
+    }
+
+    It 'should repair Windows environment variables before computing default paths' {
+        $content = Get-Content -LiteralPath $script:target -Raw
+        $content | Should -Match 'WindowsEnvironment\.ps1'
+        $content | Should -Match 'Repair-WindowsSetupEnvironment'
+        $content | Should -Match '\$PSBoundParameters\.ContainsKey\("InstallDir"\)'
     }
 
     It 'install.cmd should prepend the PowerShell 7 MSI directory before resolving pwsh' {

--- a/scripts/powershell/tests/Install.User.Tests.ps1
+++ b/scripts/powershell/tests/Install.User.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Module Pester
+﻿#Requires -Module Pester
 
 BeforeAll {
     $script:target = Join-Path (Split-Path -Parent $PSScriptRoot) "install.user.ps1"
@@ -24,5 +24,12 @@ Describe 'install.user.ps1' {
     It 'should filter handlers by Phase 1' {
         $content = Get-Content -LiteralPath $script:target -Raw
         $content | Should -Match '\$_\.Phase -eq 1'
+    }
+
+    It 'should repair Windows environment variables before computing default paths' {
+        $content = Get-Content -LiteralPath $script:target -Raw
+        $content | Should -Match 'WindowsEnvironment\.ps1'
+        $content | Should -Match 'Repair-WindowsSetupEnvironment'
+        $content | Should -Match '\$PSBoundParameters\.ContainsKey\("InstallDir"\)'
     }
 }

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -256,11 +256,14 @@ Describe 'chezmoi テンプレート バリデーション' {
                     'HOME',
                     'APPDATA',
                     'LOCALAPPDATA',
+                    'ProgramData',
                     'TEMP',
                     'TMP'
                 )) {
                 $content | Should -Match "(?m)^$name\s*=" -Because "$name は op/gh/Windows ツールの設定解決に必要"
             }
+
+            $content | Should -Match 'env "ProgramData"' -Because "Docker Desktop backend は ProgramData が無いと起動に失敗する"
         }
 
         It 'Codex Docker MCP wrapper は stdout に制御ログを書かないこと' {

--- a/scripts/powershell/tests/handlers/Handler.Docker.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Docker.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Module Pester
+﻿#Requires -Module Pester
 
 <#
 .SYNOPSIS
@@ -456,7 +456,7 @@ Describe 'DockerHandler' {
             Mock Copy-FileSafe { }
         }
 
-        It 'should succeed and start Docker Desktop when NixOS is not registered' {
+        It 'should succeed and defer Docker Desktop when NixOS is not registered' {
             $script:startCalled = $false
             Mock Start-ProcessSafe { $script:startCalled = $true }
             Mock Invoke-Wsl {
@@ -472,8 +472,8 @@ Describe 'DockerHandler' {
             $result = $handler.Apply($ctx)
 
             $result.Success | Should -Be $true
-            $result.Message | Should -Match "Docker Desktop"
-            $script:startCalled | Should -Be $true
+            $result.Message | Should -Match "延期"
+            $script:startCalled | Should -Be $false
         }
 
         It 'should not run WSL write check when NixOS is not registered' {
@@ -575,6 +575,25 @@ Describe 'DockerHandler' {
 
             $result.Success | Should -Be $true
             $result.Message | Should -Match "連携を確認しました"
+        }
+
+        It 'should defer Docker Desktop startup when NixOS is not registered yet' {
+            Mock Invoke-Wsl {
+                param($Arguments)
+                $argStr = $Arguments -join " "
+                if ($argStr -match "-l -q") {
+                    return @("docker-desktop", "docker-desktop-data")
+                }
+                return ""
+            }
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $result.Message | Should -Match "延期"
+            Should -Invoke Stop-ProcessSafe -Times 0 -Exactly
+            Should -Invoke Start-ProcessSafe -Times 0 -Exactly
+            Should -Invoke Copy-FileSafe -Times 0 -Exactly
         }
 
         It 'should create Docker Desktop distribution when it does not exist' {
@@ -1362,6 +1381,25 @@ Describe 'DockerHandler' {
 
             $script:sleepCalledWith30 | Should -Be $false
         }
+
+        It 'should not stop build helper while Docker Desktop backend is running' {
+            Mock Get-ProcessSafe {
+                param($Name)
+                if ($Name -eq "com.docker.backend") {
+                    return [PSCustomObject]@{ Name = $Name }
+                }
+                if ($Name -eq "com.docker.build") {
+                    return [PSCustomObject]@{ Name = $Name }
+                }
+                return $null
+            }
+            Mock Stop-Process { }
+
+            $result = $handler.StopLingeringDockerProcesses()
+
+            $result | Should -Be $false
+            Should -Invoke Stop-Process -Times 0 -Exactly
+        }
     }
 
     Context 'TestDockerDesktopProxy - failure path' {
@@ -1486,7 +1524,7 @@ Describe 'DockerHandler' {
                     return ""
                 }
                 if ($argStr -match "-l -q") {
-                    return @("docker-desktop", "docker-desktop-data")
+                    return @("docker-desktop", "docker-desktop-data", "NixOS")
                 }
                 $global:LASTEXITCODE = 0
                 return ""
@@ -1510,7 +1548,7 @@ Describe 'DockerHandler' {
                     $script:copyCalled = $true
                 }
                 if ($argStr -match "-l -q") {
-                    return @("docker-desktop", "docker-desktop-data")
+                    return @("docker-desktop", "docker-desktop-data", "NixOS")
                 }
                 $global:LASTEXITCODE = 0
                 return ""

--- a/scripts/powershell/tests/handlers/Handler.NixOSWSL.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.NixOSWSL.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Module Pester
+﻿#Requires -Module Pester
 
 <#
 .SYNOPSIS
@@ -577,6 +577,28 @@ Describe 'NixOSWSLHandler' {
             $handler.ExecutePostInstall($ctx)
 
             $script:execCmd | Should -Match '/mnt/c/test/postinstall\.sh'
+        }
+
+        It 'should run post-install with timeout to avoid indefinite hangs' {
+            $scriptFile = Join-Path $TestDrive "postinstall.sh"
+            New-Item $scriptFile -ItemType File -Force | Out-Null
+            $ctx.Options["PostInstallScript"] = $scriptFile
+            $ctx.Options["PostInstallTimeoutSeconds"] = 123
+            $script:timeoutSeconds = 0
+            Mock Invoke-Wsl {
+                param($Arguments, $TimeoutSeconds)
+                if ($Arguments -contains "wslpath") {
+                    $global:LASTEXITCODE = 0
+                    return "/mnt/c/test/postinstall.sh"
+                }
+                $script:timeoutSeconds = $TimeoutSeconds
+                $global:LASTEXITCODE = 0
+            }
+            Mock Write-Host { }
+
+            $handler.ExecutePostInstall($ctx)
+
+            $script:timeoutSeconds | Should -Be 123
         }
 
         It 'should fall back to /mnt/ path when wslpath call fails' {


### PR DESCRIPTION
## Summary
- repair minimum Windows environment variables before install phases compute default paths
- defer Docker Desktop startup until NixOS is registered, and avoid killing Docker build helpers while the backend is running
- add a timeout to the NixOS-WSL post-install command
- include ProgramData in the Codex Windows environment template for Docker Desktop backend startup
- update install.cmd entrypoint fixture to include the new environment helper

## Tests
- pwsh -NoProfile -Command "& './scripts/powershell/tests/Invoke-Tests.ps1' -Path @('./scripts/powershell/tests/handlers/Handler.Docker.Tests.ps1','./scripts/powershell/tests/handlers/Handler.NixOSWSL.Tests.ps1','./scripts/powershell/tests/Install.Orchestrator.Tests.ps1','./scripts/powershell/tests/Install.User.Tests.ps1','./scripts/powershell/tests/Install.Admin.Tests.ps1','./scripts/powershell/tests/Install.Entrypoint.Tests.ps1','./scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1')"
- git diff --check