### PR TITLE
fix: guard codex remote mcp config

### DIFF
--- a/chezmoi/.chezmoidata/mcp_servers.yaml
+++ b/chezmoi/.chezmoidata/mcp_servers.yaml
@@ -200,7 +200,8 @@ mcp_servers:
   # Kaggle - Official remote MCP (competitions, datasets, notebooks, models, benchmarks)
   # Docs: https://www.kaggle.com/docs/mcp
   - name: kaggle
-    # URL-based MCP (remote, auth handled by mcp-remote on first connect)
+    # URL-based MCP (remote). Codex uses native Streamable HTTP; stdio-only
+    # clients use the mcp-remote bridge below.
     url: "https://www.kaggle.com/mcp"
     # stdio bridge for tools that don't speak HTTP MCP natively
     command: pnpm

--- a/chezmoi/dot_codex/config.toml.tmpl
+++ b/chezmoi/dot_codex/config.toml.tmpl
@@ -237,6 +237,8 @@ config_file = "{{ .chezmoi.homeDir | replace "\\" "/" }}/.codex/agents/python_co
 {{- if has "codex" .supports }}
 
 {{- if hasKey . "url" }}
+# Codex supports Streamable HTTP natively. Do not emit command/args for
+# URL-based servers, because mixing url with stdio config is invalid.
 [mcp_servers.{{ .name }}]
 url = "{{ .url }}"
 {{- else }}

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -302,7 +302,7 @@ Describe 'chezmoi テンプレート バリデーション' {
     }
 
     Context 'Codex remote MCP テンプレート' {
-        It 'URL-based MCP は native Streamable HTTP として出力し stdio 設定を混ぜないこと' {
+        It 'should emit URL-based MCP as native Streamable HTTP without stdio settings' {
             $templatePath = Join-Path $script:chezmoiRoot "dot_codex/config.toml.tmpl"
             $content = Get-Content -Path $templatePath -Raw
 

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -301,6 +301,26 @@ Describe 'chezmoi テンプレート バリデーション' {
         }
     }
 
+    Context 'Codex remote MCP テンプレート' {
+        It 'URL-based MCP は native Streamable HTTP として出力し stdio 設定を混ぜないこと' {
+            $templatePath = Join-Path $script:chezmoiRoot "dot_codex/config.toml.tmpl"
+            $content = Get-Content -Path $templatePath -Raw
+
+            $marker = '{{- if hasKey . "url" }}'
+            $elseMarker = '{{- else }}'
+            $start = $content.IndexOf($marker, [System.StringComparison]::Ordinal)
+            $start | Should -Not -Be -1 -Because "URL-based MCP の分岐が必要"
+
+            $end = $content.IndexOf($elseMarker, $start, [System.StringComparison]::Ordinal)
+            $end | Should -BeGreaterThan $start -Because "URL 分岐と stdio 分岐を分離する必要がある"
+
+            $urlBranch = $content.Substring($start, $end - $start)
+            $urlBranch | Should -Match 'url = "\{\{ \.url \}\}"' -Because "Codex は Streamable HTTP を native URL で扱える"
+            $urlBranch | Should -Not -Match '(?m)^\s*command\s*=' -Because "url と stdio command を混ぜると Codex config load が失敗する"
+            $urlBranch | Should -Not -Match '(?m)^\s*args\s*=' -Because "url と stdio args を混ぜると Codex config load が失敗する"
+        }
+    }
+
     Context 'stdio-only テンプレートで HTTP サーバーに mcp-remote が使われていること' {
         It 'Claude Desktop テンプレートで mcp-remote が含まれていること' {
             $templatePath = Join-Path $script:chezmoiRoot "AppData/Roaming/Claude/claude_desktop_config.json.tmpl"


### PR DESCRIPTION
## Summary
- document that Codex uses native Streamable HTTP for URL-based MCP servers
- clarify Kaggle remote MCP comments for Codex vs stdio-only clients
- add a Pester guard so Codex URL-based MCP output does not mix `url` with stdio `command`/`args`

## Tests
- `Invoke-Pester -Path scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1 -Output Detailed`
- `codex mcp list`
- `codex doctor --json`