### PR TITLE
fix winget path entry warnings

### DIFF
--- a/scripts/powershell/handlers/Handler.Winget.ps1
+++ b/scripts/powershell/handlers/Handler.Winget.ps1
@@ -796,6 +796,7 @@ class WingetHandler : SetupHandlerBase {
         if (-not $pkg.PathEntries) { return }
 
         $resolvedEntries = [System.Collections.Generic.List[string]]::new()
+        $missingEntries = [System.Collections.Generic.List[string]]::new()
         foreach ($rawEntry in @($pkg.PathEntries)) {
             if ([string]::IsNullOrWhiteSpace([string]$rawEntry)) { continue }
 
@@ -806,7 +807,7 @@ class WingetHandler : SetupHandlerBase {
             }
 
             if ($resolvedMatches.Count -eq 0) {
-                $this.LogWarning("pathEntries のディレクトリが見つかりません: $($pkg.Id) ($rawEntry)")
+                $missingEntries.Add([string]$rawEntry)
                 continue
             }
 
@@ -817,7 +818,12 @@ class WingetHandler : SetupHandlerBase {
             }
         }
 
-        if ($resolvedEntries.Count -eq 0) { return }
+        if ($resolvedEntries.Count -eq 0) {
+            if ($missingEntries.Count -gt 0) {
+                $this.LogWarning("pathEntries の候補ディレクトリが見つかりません: $($pkg.Id) ($($missingEntries -join ', '))")
+            }
+            return
+        }
 
         $userPath = Get-UserEnvironmentPath
         $userPathItems = if ($userPath) { @($userPath -split ";" | Where-Object { $_ }) } else { @() }

--- a/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
@@ -1147,6 +1147,66 @@ Describe 'WingetHandler' {
                 $Path -like "*$($script:toolDir)*"
             }
         }
+
+        It 'should not warn when one of multiple path entry candidates exists' {
+            $script:missingToolDir = Join-Path $TestDrive "MissingToolBin"
+            Mock Write-Host { }
+            Mock Get-JsonContent {
+                return [PSCustomObject]@{
+                    Sources = @(
+                        [PSCustomObject]@{
+                            SourceDetails = [PSCustomObject]@{ Name = "winget" }
+                            Packages      = @(
+                                [PSCustomObject]@{
+                                    PackageIdentifier = "Path.Tool"
+                                    pathEntries       = @($script:missingToolDir, $script:toolDir)
+                                    verifyCommand     = [PSCustomObject]@{ command = "path-tool"; args = @("--version") }
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+
+            $ctx.Options["WingetMode"] = "import"
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $env:PATH -split ";" | Should -Contain $script:toolDir
+            Should -Invoke Write-Host -Times 0 -ParameterFilter {
+                [string]$Object -match 'pathEntries の.*見つかりません'
+            }
+        }
+
+        It 'should warn once when no path entry candidate exists' {
+            $script:missingToolDir = Join-Path $TestDrive "MissingToolBin"
+            Mock Write-Host { }
+            Mock Get-JsonContent {
+                return [PSCustomObject]@{
+                    Sources = @(
+                        [PSCustomObject]@{
+                            SourceDetails = [PSCustomObject]@{ Name = "winget" }
+                            Packages      = @(
+                                [PSCustomObject]@{
+                                    PackageIdentifier = "Path.Tool"
+                                    pathEntries       = @($script:missingToolDir)
+                                    verifyCommand     = [PSCustomObject]@{ command = "path-tool"; args = @("--version") }
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+
+            $ctx.Options["WingetMode"] = "import"
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            Should -Invoke Write-Host -Times 1 -ParameterFilter {
+                [string]$Object -match 'pathEntries の候補ディレクトリが見つかりません' -and
+                [string]$Object -match 'Path.Tool'
+            }
+        }
     }
 
     Context 'Apply - import mode: Microsoft.WSL verification' {


### PR DESCRIPTION
## Summary
- Treat winget pathEntries as install-location candidates.
- Warn only when none of the configured candidate directories exist.
- Add regression tests for mixed and missing pathEntries candidates.

## Tests
- pwsh -NoProfile -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
- cmd.exe /d /c install.cmd (confirmed Google.CloudSDK pathEntries warnings no longer appear; later unrelated Chezmoi/NixRebuild failures remain)