### PR TITLE
fix WSL pnpm global bin path

### DIFF
--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -187,6 +187,7 @@ in
   #       pnpm global binaries
   home.sessionPath = [
     "$HOME/.bun/bin"
+    "$HOME/.local/share/pnpm/bin"
     "$HOME/.local/share/pnpm"
   ];
 }

--- a/scripts/powershell/handlers/Handler.NixRebuild.ps1
+++ b/scripts/powershell/handlers/Handler.NixRebuild.ps1
@@ -17,6 +17,10 @@ $libPath = Split-Path -Parent $PSScriptRoot
 class NixRebuildHandler : SetupHandlerBase {
     hidden [string] $PnpmHomePath = '$HOME/.local/share/pnpm'
 
+    hidden [string] GetPnpmShellPrefix() {
+        return "export PNPM_HOME=$($this.PnpmHomePath); export PATH=`"`$PNPM_HOME/bin:`$PNPM_HOME:`$HOME/.npm-global/bin:`$PATH`""
+    }
+
     NixRebuildHandler() {
         $this.Name = "NixRebuild"
         $this.Description = "nixos-rebuild switch の実行"
@@ -97,7 +101,7 @@ class NixRebuildHandler : SetupHandlerBase {
         # Linux ネイティブの pnpm のみを有効とみなすため /mnt/ 配下を除外して確認する。
         Invoke-Wsl -Arguments @(
             "-d", $distroName, "-u", "nixos", "--",
-            "bash", "-lc", "export PATH=`"`$HOME/.npm-global/bin:`$PATH`"; command -v pnpm 2>/dev/null | grep -qv '^/mnt/'"
+            "bash", "-lc", "$($this.GetPnpmShellPrefix()); command -v pnpm 2>/dev/null | grep -qv '^/mnt/'"
         ) | Out-Null
         if ($LASTEXITCODE -ne 0) {
             $this.Log("pnpm が見つかりません。npm 経由でインストールします...")
@@ -116,20 +120,20 @@ class NixRebuildHandler : SetupHandlerBase {
         # PNPM_HOME が未設定なら pnpm setup を実行してグローバル bin ディレクトリを作成
         $pnpmHomeCheck = Invoke-Wsl -Arguments @(
             "-d", $distroName, "-u", "nixos", "--",
-            "bash", "-lc", "export PATH=`"`$HOME/.npm-global/bin:`$PATH`"; export PNPM_HOME=$($this.PnpmHomePath); [ -d `"`$PNPM_HOME`" ] && echo exists"
+            "bash", "-lc", "$($this.GetPnpmShellPrefix()); [ -d `"`$PNPM_HOME`" ] && [ -d `"`$PNPM_HOME/bin`" ] && echo exists"
         )
         if (-not $pnpmHomeCheck -or $pnpmHomeCheck -notmatch 'exists') {
             $this.Log("PNPM_HOME を設定しています...")
             Invoke-Wsl -Arguments @(
                 "-d", $distroName, "-u", "nixos", "--",
-                "bash", "-lc", "export PATH=`"`$HOME/.npm-global/bin:`$PATH`"; export PNPM_HOME=$($this.PnpmHomePath); mkdir -p `"`$PNPM_HOME`"; pnpm setup 2>/dev/null || true"
-            )
-            # .bashrc に PNPM_HOME が無ければ追加
-            Invoke-Wsl -Arguments @(
-                "-d", $distroName, "-u", "nixos", "--",
-                "bash", "-lc", "grep -q PNPM_HOME ~/.bashrc || echo 'export PNPM_HOME=$($this.PnpmHomePath); export PATH=`$PNPM_HOME:`$PATH' >> ~/.bashrc"
+                "bash", "-lc", "$($this.GetPnpmShellPrefix()); mkdir -p `"`$PNPM_HOME`" `"`$PNPM_HOME/bin`"; pnpm setup 2>/dev/null || true"
             )
         }
+        # .bashrc に PNPM_HOME/bin が無ければ追加
+        Invoke-Wsl -Arguments @(
+            "-d", $distroName, "-u", "nixos", "--",
+            "bash", "-lc", "grep -q 'PNPM_HOME/bin' ~/.bashrc || echo 'export PNPM_HOME=$($this.PnpmHomePath); export PATH=`$PNPM_HOME/bin:`$PNPM_HOME:`$PATH' >> ~/.bashrc"
+        )
     }
 
     hidden [bool] InstallPnpmGlobalPackages([string]$distroName, [string]$packagesJsonPath) {
@@ -152,7 +156,7 @@ class NixRebuildHandler : SetupHandlerBase {
             # インストール済みパッケージを取得してフィルタリング
             $installedOutput = Invoke-Wsl -Arguments @(
                 "-d", $distroName, "-u", "nixos", "--",
-                "bash", "-lc", "export PNPM_HOME=$($this.PnpmHomePath); export PATH=`"`$PNPM_HOME:`$HOME/.npm-global/bin:`$PATH`"; pnpm ls -g --depth=0 2>/dev/null"
+                "bash", "-lc", "$($this.GetPnpmShellPrefix()); pnpm ls -g --depth=0 2>/dev/null"
             )
             $toInstall = @()
             $skipped = 0
@@ -220,7 +224,7 @@ class NixRebuildHandler : SetupHandlerBase {
             # PNPM_HOME と ~/.npm-global/bin を PATH に追加
             $pnpmExitCode = $this.InvokeWslPnpmInstall(@(
                     "-d", $distroName, "-u", "nixos", "--",
-                    "bash", "-lc", "export PNPM_HOME=$($this.PnpmHomePath); export PATH=`"`$PNPM_HOME:`$HOME/.npm-global/bin:`$PATH`"; pnpm add -g --reporter=append-only --yes $quotedInstallArgs $quotedPkgs"
+                    "bash", "-lc", "$($this.GetPnpmShellPrefix()); pnpm add -g --reporter=append-only --yes $quotedInstallArgs $quotedPkgs"
                 ))
 
             if ($pnpmExitCode -ne 0) {
@@ -290,7 +294,8 @@ class NixRebuildHandler : SetupHandlerBase {
             if ($timeoutSeconds -le 0) { $timeoutSeconds = 30 }
 
             if ($verifyType -eq "commandExists") {
-                $cmdLine = "command -v $($this.QuoteShellArg($command))"
+                $commandExistsLine = "command -v $($this.QuoteShellArg($command))"
+                $cmdLine = "bash -lc $($this.QuoteShellArg($commandExistsLine))"
                 $this.Log("検証中: command -v $command", "Gray")
             }
             else {
@@ -300,7 +305,7 @@ class NixRebuildHandler : SetupHandlerBase {
 
             Invoke-Wsl -Arguments @(
                 "-d", $distroName, "-u", "nixos", "--",
-                "bash", "-lc", "export PNPM_HOME=$($this.PnpmHomePath); export PATH=`"`$PNPM_HOME:`$HOME/.npm-global/bin:`$PATH`"; timeout ${timeoutSeconds}s $cmdLine"
+                "bash", "-lc", "$($this.GetPnpmShellPrefix()); timeout ${timeoutSeconds}s $cmdLine"
             ) | ForEach-Object {
                 if ($_ -notmatch '^\s*$') {
                     $this.Log("  $_", "Gray")

--- a/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
@@ -255,6 +255,7 @@ Describe 'NixRebuildHandler' {
             $script:pnpmArgs | Should -Match "pnpm add -g"
             $script:pnpmArgs | Should -Match "--reporter=append-only"
             $script:pnpmArgs | Should -Match "--yes"
+            $script:pnpmArgs | Should -Match '\$PNPM_HOME/bin:\$PNPM_HOME'
             $script:pnpmArgs | Should -Match "@prisma/language-server"
             $script:pnpmArgs | Should -Match "@agentclientprotocol/claude-agent-acp"
             $script:pnpmArgs | Should -Match "typescript-language-server"
@@ -297,6 +298,7 @@ Describe 'NixRebuildHandler' {
 
             $result.Success | Should -Be $true
             $script:verifyArgs | Should -Match "timeout 30s"
+            $script:verifyArgs | Should -Match '\$PNPM_HOME/bin:\$PNPM_HOME'
             $script:verifyArgs | Should -Match "claude-agent-acp"
             $script:verifyArgs | Should -Match "--version"
             Should -Invoke Write-Host -ParameterFilter {
@@ -322,7 +324,7 @@ Describe 'NixRebuildHandler' {
                 if ($argStr -match "command -v pnpm") { $global:LASTEXITCODE = 0; return "/nix/store/bin/pnpm" }
                 if ($argStr -match "pnpm ls -g") { $global:LASTEXITCODE = 0; return "" }
                 if ($argStr -match "pnpm add") { $global:LASTEXITCODE = 0; return "installed" }
-                if ($argStr -match "timeout 30s command -v") {
+                if ($argStr -match "timeout 30s bash -lc" -and $argStr -match "command -v") {
                     $script:verifyArgs = $argStr
                     $global:LASTEXITCODE = 0
                     return "/home/nixos/.npm-global/bin/claude-agent-acp"
@@ -339,7 +341,8 @@ Describe 'NixRebuildHandler' {
             $result = $handler.Apply($ctx)
 
             $result.Success | Should -Be $true
-            $script:verifyArgs | Should -Match "timeout 30s command -v"
+            $script:verifyArgs | Should -Match "timeout 30s bash -lc"
+            $script:verifyArgs | Should -Match "command -v"
             $script:verifyArgs | Should -Match "claude-agent-acp"
             Should -Invoke Write-Host -ParameterFilter {
                 $ForegroundColor -eq "Gray" -and ([string]$Object) -match "検証中: command -v claude-agent-acp"
@@ -780,14 +783,17 @@ Describe 'NixRebuildHandler' {
         It 'should setup PNPM_HOME when directory does not exist' {
             $script:pnpmSetupCalled = $false
             $script:bashrcUpdated = $false
+            $script:pnpmHomeCheckArgs = ""
+            $script:pnpmSetupArgs = ""
+            $script:bashrcArgs = ""
             Mock Invoke-Wsl {
                 param($Arguments)
                 $argStr = $Arguments -join " "
                 if ($argStr -match "nixos-rebuild") { $global:LASTEXITCODE = 0; return "" }
                 if ($argStr -match "command -v pnpm") { $global:LASTEXITCODE = 0; return "/nix/store/bin/pnpm" }
-                if ($argStr -match "echo exists") { $global:LASTEXITCODE = 0; return "" }
-                if ($argStr -match "pnpm setup") { $script:pnpmSetupCalled = $true; $global:LASTEXITCODE = 0; return "" }
-                if ($argStr -match "grep.*PNPM_HOME") { $script:bashrcUpdated = $true; $global:LASTEXITCODE = 0; return "" }
+                if ($argStr -match "echo exists") { $script:pnpmHomeCheckArgs = $argStr; $global:LASTEXITCODE = 0; return "" }
+                if ($argStr -match "pnpm setup") { $script:pnpmSetupCalled = $true; $script:pnpmSetupArgs = $argStr; $global:LASTEXITCODE = 0; return "" }
+                if ($argStr -match "grep.*PNPM_HOME") { $script:bashrcUpdated = $true; $script:bashrcArgs = $argStr; $global:LASTEXITCODE = 0; return "" }
                 if ($argStr -match "pnpm ls -g") { $global:LASTEXITCODE = 0; return "" }
                 if ($argStr -match "pnpm add") { $global:LASTEXITCODE = 0; return "" }
                 if ($argStr -match "core\.hooksPath") { $global:LASTEXITCODE = 0; return "" }
@@ -800,6 +806,9 @@ Describe 'NixRebuildHandler' {
             $result.Success | Should -Be $true
             $script:pnpmSetupCalled | Should -Be $true
             $script:bashrcUpdated | Should -Be $true
+            $script:pnpmHomeCheckArgs | Should -Match '\$PNPM_HOME/bin'
+            $script:pnpmSetupArgs | Should -Match '\$PNPM_HOME/bin'
+            $script:bashrcArgs | Should -Match '\$PNPM_HOME/bin:\$PNPM_HOME'
         }
 
         It 'should skip PNPM_HOME setup when directory already exists' {


### PR DESCRIPTION
## Summary
- Add $PNPM_HOME/bin to WSL Home Manager sessionPath.
- Use a shared pnpm shell prefix for WSL pnpm commands so $PNPM_HOME/bin is present during non-interactive install and verification.
- Wrap commandExists verification in bash so 	imeout can run command -v correctly.

## Tests
- pwsh -NoProfile -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
- Direct local NixRebuildHandler.InstallPnpmGlobalPackages('NixOS', windows/pnpm/packages.json) returned RESULT=OK.