### PR TITLE
Fix NixRebuild dotfiles symlink target

### DIFF
--- a/scripts/powershell/handlers/Handler.NixRebuild.ps1
+++ b/scripts/powershell/handlers/Handler.NixRebuild.ps1
@@ -331,9 +331,16 @@ class NixRebuildHandler : SetupHandlerBase {
         $driveLetter = $dotfilesPath.Substring(0, 1).ToLower()
         $wslMountPath = '/mnt/' + $driveLetter + ($dotfilesPath.Substring(2) -replace '\\', '/')
 
-        # /home/nixos/.dotfiles が存在するか確認
-        Invoke-Wsl -Arguments @("-d", $distroName, "-u", "nixos", "--", "bash", "-lc", "test -e /home/nixos/.dotfiles") | Out-Null
-        if ($LASTEXITCODE -eq 0) {
+        $dotfilesLinkPath = "/home/nixos/.dotfiles"
+        $existingTarget = Invoke-Wsl -Arguments @(
+            "-d", $distroName, "-u", "nixos", "--",
+            "bash", "-lc", "if [ -L $dotfilesLinkPath ]; then readlink -f $dotfilesLinkPath 2>/dev/null; elif [ -e $dotfilesLinkPath ]; then printf '__non_symlink__'; fi"
+        )
+        $existingTargetText = if ($existingTarget) { ([string]($existingTarget | Select-Object -First 1)).Trim() } else { "" }
+        if ($existingTargetText -eq $wslMountPath) {
+            return
+        }
+        if ($existingTargetText -eq "__non_symlink__") {
             return
         }
 
@@ -341,11 +348,11 @@ class NixRebuildHandler : SetupHandlerBase {
         Invoke-Wsl -Arguments @("-d", $distroName, "-u", "nixos", "--", "bash", "-lc", "test -d `"$wslMountPath`"") | Out-Null
         if ($LASTEXITCODE -eq 0) {
             $this.Log("dotfiles を WSL マウント経由でリンクします: $wslMountPath")
-            Invoke-Wsl -Arguments @("-d", $distroName, "-u", "nixos", "--", "bash", "-lc", "ln -sf `"$wslMountPath`" /home/nixos/.dotfiles")
+            Invoke-Wsl -Arguments @("-d", $distroName, "-u", "nixos", "--", "bash", "-lc", "ln -sfn `"$wslMountPath`" $dotfilesLinkPath")
             if ($LASTEXITCODE -ne 0) {
                 throw "dotfiles のシンボリックリンク作成に失敗しました"
             }
-            $this.Log("dotfiles リンク完了: /home/nixos/.dotfiles -> $wslMountPath", "Green")
+            $this.Log("dotfiles リンク完了: $dotfilesLinkPath -> $wslMountPath", "Green")
         }
         else {
             throw "dotfiles が見つかりません。Windows パス '$dotfilesPath' が WSL から '$wslMountPath' としてアクセスできません"

--- a/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
@@ -893,13 +893,13 @@ Describe 'NixRebuildHandler' {
             Mock Write-Host { }
         }
 
-        It 'should return early when dotfiles already exist' {
+        It 'should return early when dotfiles exists as a non-symlink' {
             $script:linkCalled = $false
             Mock Invoke-Wsl {
                 param($Arguments)
                 $argStr = $Arguments -join " "
-                if ($argStr -match "test -e") { $global:LASTEXITCODE = 0; return "" }
-                if ($argStr -match "ln -sf") { $script:linkCalled = $true; $global:LASTEXITCODE = 0; return "" }
+                if ($argStr -match "if \[ -L /home/nixos/\.dotfiles \]") { $global:LASTEXITCODE = 0; return "__non_symlink__" }
+                if ($argStr -match "ln -sfn") { $script:linkCalled = $true; $global:LASTEXITCODE = 0; return "" }
                 $global:LASTEXITCODE = 0; return ""
             }
 
@@ -908,14 +908,47 @@ Describe 'NixRebuildHandler' {
             $script:linkCalled | Should -Be $false
         }
 
+        It 'should return early when dotfiles symlink already targets the requested path' {
+            $script:linkCalled = $false
+            Mock Invoke-Wsl {
+                param($Arguments)
+                $argStr = $Arguments -join " "
+                if ($argStr -match "if \[ -L /home/nixos/\.dotfiles \]") { $global:LASTEXITCODE = 0; return "/mnt/d/ruru/dotfiles" }
+                if ($argStr -match "ln -sfn") { $script:linkCalled = $true; $global:LASTEXITCODE = 0; return "" }
+                $global:LASTEXITCODE = 0; return ""
+            }
+
+            $handler.EnsureDotfilesAvailable("NixOS", "D:\ruru\dotfiles")
+
+            $script:linkCalled | Should -Be $false
+        }
+
+        It 'should update dotfiles symlink when it targets a different path' {
+            $script:linkArgs = ""
+            Mock Invoke-Wsl {
+                param($Arguments)
+                $argStr = $Arguments -join " "
+                if ($argStr -match "if \[ -L /home/nixos/\.dotfiles \]") { $global:LASTEXITCODE = 0; return "/mnt/d/ruru/dotfiles" }
+                if ($argStr -match "test -d") { $global:LASTEXITCODE = 0; return "" }
+                if ($argStr -match "ln -sfn") { $script:linkArgs = $argStr; $global:LASTEXITCODE = 0; return "" }
+                $global:LASTEXITCODE = 0; return ""
+            }
+
+            $handler.EnsureDotfilesAvailable("NixOS", "D:\ruru\dotfiles-nixrebuild-link-clone")
+
+            $script:linkArgs | Should -Match "ln -sfn"
+            $script:linkArgs | Should -Match "/mnt/d/ruru/dotfiles-nixrebuild-link-clone"
+            $script:linkArgs | Should -Match "/home/nixos/.dotfiles"
+        }
+
         It 'should create symlink when dotfiles missing but WSL mount accessible' {
             $script:linkArgs = ""
             Mock Invoke-Wsl {
                 param($Arguments)
                 $argStr = $Arguments -join " "
-                if ($argStr -match "test -e") { $global:LASTEXITCODE = 1; return "" }
+                if ($argStr -match "if \[ -L /home/nixos/\.dotfiles \]") { $global:LASTEXITCODE = 0; return "" }
                 if ($argStr -match "test -d") { $global:LASTEXITCODE = 0; return "" }
-                if ($argStr -match "ln -sf") { $script:linkArgs = $argStr; $global:LASTEXITCODE = 0; return "" }
+                if ($argStr -match "ln -sfn") { $script:linkArgs = $argStr; $global:LASTEXITCODE = 0; return "" }
                 $global:LASTEXITCODE = 0; return ""
             }
 
@@ -930,7 +963,7 @@ Describe 'NixRebuildHandler' {
             Mock Invoke-Wsl {
                 param($Arguments)
                 $argStr = $Arguments -join " "
-                if ($argStr -match "test -e") { $global:LASTEXITCODE = 1; return "" }
+                if ($argStr -match "if \[ -L /home/nixos/\.dotfiles \]") { $global:LASTEXITCODE = 0; return "" }
                 if ($argStr -match "test -d") { $global:LASTEXITCODE = 1; return "" }
                 $global:LASTEXITCODE = 0; return ""
             }
@@ -943,7 +976,7 @@ Describe 'NixRebuildHandler' {
             Mock Invoke-Wsl {
                 param($Arguments)
                 $argStr = $Arguments -join " "
-                if ($argStr -match "test -e") { $global:LASTEXITCODE = 1; return "" }
+                if ($argStr -match "if \[ -L /home/nixos/\.dotfiles \]") { $global:LASTEXITCODE = 0; return "" }
                 if ($argStr -match "test -d") {
                     # argStr から /mnt/... パスを抽出
                     if ($argStr -match '(/mnt/[^\s"]+)') { $script:mountPath = $Matches[1] }


### PR DESCRIPTION
## Summary
- Update `EnsureDotfilesAvailable` to verify the existing `/home/nixos/.dotfiles` symlink target instead of returning as soon as the path exists.
- Relink stale symlinks with `ln -sfn` so running `install.cmd` from a PR clone actually rebuilds that clone.
- Preserve existing non-symlink `/home/nixos/.dotfiles` directories to avoid destructive replacement.

## Why
During the local full `install.cmd` rerun from a clean PR clone, `nixos-rebuild` still reported the old `/mnt/d/ruru/dotfiles` tree. The existing symlink was never checked, so branch-local Nix changes could be missed in live verification.

## Tests
- `pwsh -NoProfile -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1`
- `pwsh -NoProfile -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/PSScriptAnalyzer.Tests.ps1`