### PR TITLE
[codex] fix Codex newline keymap

### DIFF
--- a/chezmoi/dot_codex/config.toml.tmpl
+++ b/chezmoi/dot_codex/config.toml.tmpl
@@ -146,7 +146,8 @@ apps = false
 
 [tui.keymap.editor]
 # Claude Code と同じ Shift+Enter でプロンプト内改行する。
-insert_newline = [ "shift-enter" ]
+# Windows Terminal の sendInput "\n" は Ctrl+J として届くため併用する。
+insert_newline = [ "shift-enter", "ctrl-j" ]
 
 ################################################################################
 # ツール


### PR DESCRIPTION
## Summary
- Add `ctrl-j` as a Codex TUI newline binding alongside `shift-enter`.
- Document why Windows Terminal needs this fallback when `Shift+Enter` is configured via `sendInput "\n"`.

## Why
Windows Terminal sends its configured `Shift+Enter` input as a newline sequence, which Codex receives as `ctrl-j` rather than the literal `shift-enter` key event. With only `shift-enter` configured, new Codex sessions could not insert a prompt newline from Windows Terminal.

## Impact
- `Shift+Enter` continues to work where Codex receives a real `shift-enter` event.
- Windows Terminal's newline sendInput path is also accepted via `ctrl-j`.
- `alt-enter` is intentionally not added because it conflicts with WezTerm fullscreen behavior.

## Validation
- Ran `task chezmoi` successfully after 1Password login.
- Verified Windows `~/.codex/config.toml` with `taplo check`.
- Verified Windows and WSL deployed configs contain `insert_newline = [ "shift-enter", "ctrl-j" ]`.
- Ran `git diff --cached --check` before commit.

## Notes
The working tree has unrelated local changes that are not included in this PR.
