### PR TITLE
fix(docker): verify engine readiness

### DIFF
--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -12,7 +12,7 @@
 #   - msstoreVerifyById  → Microsoft Store Product ID → { command, args } for post-install verification
 #   - wingetInstallArgs  → catalog attr name → extra winget install arguments
 #   - wingetInstallTimeoutSeconds → catalog attr name or winget ID → winget install timeout
-#   - wingetCiSkipInstall → catalog attr name → skip CI winget install smoke test
+#   - wingetCiSkipInstall → catalog attr name or winget/msstore ID → skip CI winget install smoke test
 #   - wingetPathEntries  → catalog attr name or winget ID → extra Windows PATH directories
 #   - windowsOnly        → packages with no nix equivalent (winget/msstore/pnpm)
 #
@@ -621,10 +621,12 @@ lib.mapAttrs (_: names: resolve names) grouped
     google-cloud-sdk = 900;
   };
 
-  # Upstream nightly winget manifests can drift before winget cache catches up.
-  # Keep them in normal installs, but avoid making CI depend on their live installer hash.
+  # Upstream nightly winget manifests and Microsoft Store installs can drift or
+  # hang in CI. Keep them in normal installs, but avoid making CI depend on
+  # their live installer behavior.
   wingetCiSkipInstall = {
     wezterm = true;
+    "9PLM9XGG6VKS" = true;
   };
 
   # Extra PATH directories for installers that do not register CLI commands on PATH.

--- a/nix/packages/winget.nix
+++ b/nix/packages/winget.nix
@@ -91,9 +91,11 @@ let
 
   wingetFromWindowsOnly = map (
     id:
-    attachPathEntries sets.wingetPathEntries id (
-      attachPortableLink sets.wingetPortableLinksById id (
-        attachVerify sets.wingetVerifyById id { PackageIdentifier = id; }
+    attachCiSkipInstall sets.wingetCiSkipInstall id (
+      attachPathEntries sets.wingetPathEntries id (
+        attachPortableLink sets.wingetPortableLinksById id (
+          attachVerify sets.wingetVerifyById id { PackageIdentifier = id; }
+        )
       )
     )
   ) sets.windowsOnly.winget;
@@ -101,7 +103,10 @@ let
   wingetPackages = wingetFromMap ++ wingetFromWindowsOnly;
 
   msstorePackages = map (
-    id: attachVerify sets.msstoreVerifyById id { PackageIdentifier = id; }
+    id:
+    attachCiSkipInstall sets.wingetCiSkipInstall id (
+      attachVerify sets.msstoreVerifyById id { PackageIdentifier = id; }
+    )
   ) sets.windowsOnly.msstore;
 
   # --- pnpm ---

--- a/scripts/powershell/handlers/Handler.Docker.ps1
+++ b/scripts/powershell/handlers/Handler.Docker.ps1
@@ -28,6 +28,7 @@ class DockerHandler : SetupHandlerBase {
     # NixOS-WSL (systemd) は wsl --terminate 後の再起動に 20-120 秒かかるため
     # デフォルト 15 回 (最大待機: 3+6+9+...+42 = 315 秒)
     [int]$WslWritableMaxAttempts = 15
+    [int]$DockerEngineCheckTimeoutSeconds = 15
 
     DockerHandler() {
         $this.Name = "Docker"
@@ -49,6 +50,7 @@ class DockerHandler : SetupHandlerBase {
         $this.Retries = $ctx.GetOption("DockerIntegrationRetries", 5)
         $this.RetryDelaySeconds = $ctx.GetOption("DockerIntegrationRetryDelaySeconds", 5)
         $this.WslWritableMaxAttempts = $ctx.GetOption("WslWritableMaxAttempts", 15)
+        $this.DockerEngineCheckTimeoutSeconds = $ctx.GetOption("DockerEngineCheckTimeoutSeconds", 15)
 
         if ($this.Retries -le 0) {
             $this.Log("リトライ回数が 0 のためスキップします", "Gray")
@@ -355,6 +357,9 @@ class DockerHandler : SetupHandlerBase {
         }
 
         if ($running) {
+            # 起動済みでも Docker Desktop が共有 proxy を 0 バイトで残すことがある。
+            # その状態では install.cmd が再実行されても起動処理に入らないため、ここでも修復する。
+            $this.RepairWslProxyBinary()
             return
         }
 
@@ -680,6 +685,14 @@ class DockerHandler : SetupHandlerBase {
 
     <#
     .SYNOPSIS
+        Docker Engine が実際に応答しているか確認する
+    #>
+    hidden [bool] TestDockerEngineReady() {
+        return Test-DockerDaemon -TimeoutSeconds $this.DockerEngineCheckTimeoutSeconds
+    }
+
+    <#
+    .SYNOPSIS
         Docker Desktop 連携をリトライする
     #>
     hidden [bool] RetryDockerIntegration([string]$distroName) {
@@ -696,9 +709,13 @@ class DockerHandler : SetupHandlerBase {
             Start-SleepSafe -Seconds $this.RetryDelaySeconds
             $this.SetupDockerBindMounts()
 
-            if ($this.TestDockerDesktopProxy($distroName)) {
+            $engineReady = $this.TestDockerEngineReady()
+            if ($engineReady -and $this.TestDockerDesktopProxy($distroName)) {
                 $this.Log("Docker Desktop 連携の確認に成功しました", "Green")
                 return $true
+            }
+            if (-not $engineReady) {
+                $this.LogWarning("Docker Engine が応答しません")
             }
 
             if (-not $restarted) {

--- a/scripts/powershell/lib/Invoke-ExternalCommand.ps1
+++ b/scripts/powershell/lib/Invoke-ExternalCommand.ps1
@@ -691,8 +691,12 @@ function Invoke-Docker {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments)]
-        [string[]]$Arguments
+        [string[]]$Arguments,
+        [int]$TimeoutSeconds = 0
     )
+    if ($TimeoutSeconds -gt 0) {
+        return Invoke-ExternalCommandWithTimeout -Command "docker" -Arguments $Arguments -TimeoutSeconds $TimeoutSeconds
+    }
     & docker @Arguments
 }
 
@@ -700,16 +704,41 @@ function Invoke-Docker {
 .SYNOPSIS
     Docker デーモンへの接続性を確認する
 .DESCRIPTION
-    docker info を実行してデーモンが応答するかチェックする。
+    Docker Desktop の Linux engine が応答するかチェックする。
     Pester でモック可能にするためラッパーとして提供。
 .OUTPUTS
     [bool] デーモン接続可能なら $true
 #>
 function Test-DockerDaemon {
     [CmdletBinding()]
-    param()
-    Invoke-Docker -Arguments @("info") | Out-Null
-    return $LASTEXITCODE -eq 0
+    param(
+        [int]$TimeoutSeconds = 15
+    )
+
+    $originalDockerHost = $env:DOCKER_HOST
+    $originalDockerContext = $env:DOCKER_CONTEXT
+    try {
+        Remove-Item Env:\DOCKER_HOST -ErrorAction SilentlyContinue
+        Remove-Item Env:\DOCKER_CONTEXT -ErrorAction SilentlyContinue
+
+        Invoke-Docker -Arguments @("--context", "desktop-linux", "version", "--format", "{{.Server.Version}}") -TimeoutSeconds $TimeoutSeconds | Out-Null
+        return $LASTEXITCODE -eq 0
+    }
+    finally {
+        if ($null -eq $originalDockerHost) {
+            Remove-Item Env:\DOCKER_HOST -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:DOCKER_HOST = $originalDockerHost
+        }
+
+        if ($null -eq $originalDockerContext) {
+            Remove-Item Env:\DOCKER_CONTEXT -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:DOCKER_CONTEXT = $originalDockerContext
+        }
+    }
 }
 
 <#

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -78,12 +78,19 @@ Describe 'Package catalog consistency' {
             $sets | Should -Match '(?s)msstoreVerifyById\s*=\s*\{.*?"9PLM9XGG6VKS"\s*=\s*\{.*?type\s*=\s*"appxLaunchTarget".*?command\s*=\s*"OpenAI\.Codex".*?args\s*=\s*\[\s*"OpenAI\.Codex_2p2nqsd0c76g0!App"\s*\]'
         }
 
+        It 'should skip Codex Desktop live Store install in the CI smoke test' {
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+
+            $sets | Should -Match '(?s)wingetCiSkipInstall\s*=\s*\{.*?"9PLM9XGG6VKS"\s*=\s*true;'
+        }
+
         It 'should generate Codex Desktop under the msstore source with launch target verification' {
             $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
             $msstoreSource = @($json.Sources | Where-Object { $_.SourceDetails.Name -eq 'msstore' }) | Select-Object -First 1
             $package = @($msstoreSource.Packages | Where-Object { $_.PackageIdentifier -eq '9PLM9XGG6VKS' }) | Select-Object -First 1
 
             $package | Should -Not -BeNullOrEmpty
+            $package.ciSkipInstall | Should -BeTrue
             $package.verifyCommand.type | Should -Be 'appxLaunchTarget'
             $package.verifyCommand.command | Should -Be 'OpenAI.Codex'
             @($package.verifyCommand.args) | Should -Contain 'OpenAI.Codex_2p2nqsd0c76g0!App'

--- a/scripts/powershell/tests/handlers/Handler.Docker.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Docker.Tests.ps1
@@ -19,6 +19,7 @@ Describe 'DockerHandler' {
     BeforeEach {
         $script:handler = [DockerHandler]::new()
         $script:ctx = [SetupContext]::new("D:\dotfiles")
+        Mock Test-DockerDaemon { return $true }
     }
 
     Context 'Constructor' {
@@ -30,6 +31,7 @@ Describe 'DockerHandler' {
             @{ property = "Retries"; expected = 5 }
             @{ property = "RetryDelaySeconds"; expected = 5 }
             @{ property = "WslWritableMaxAttempts"; expected = 15 }
+            @{ property = "DockerEngineCheckTimeoutSeconds"; expected = 15 }
         ) {
             $handler.$property | Should -Be $expected
         }
@@ -117,6 +119,14 @@ Describe 'DockerHandler' {
             $handler.CanApply($ctx)
 
             $handler.WslWritableMaxAttempts | Should -Be 12
+        }
+
+        It 'should read DockerEngineCheckTimeoutSeconds from Options' {
+            $ctx.Options["DockerEngineCheckTimeoutSeconds"] = 7
+
+            $handler.CanApply($ctx)
+
+            $handler.DockerEngineCheckTimeoutSeconds | Should -Be 7
         }
 
         It 'should default WslWritableMaxAttempts to 15' {
@@ -1494,6 +1504,29 @@ Describe 'DockerHandler' {
             # タイムアウトは成功扱い
             $result.Success | Should -Be $true
         }
+
+        It 'should fail when Docker Engine does not respond even if proxy times out' {
+            Mock Test-DockerDaemon { return $false }
+            Mock Invoke-Wsl {
+                param($Arguments)
+                $argStr = $Arguments -join " "
+                if ($argStr -match "wsl-write-test") { $global:LASTEXITCODE = 0; return "" }
+                if ($argStr -match "df -Pk") { return "50000" }
+                if ($argStr -match "-l -q") { return @("docker-desktop", "docker-desktop-data", "NixOS") }
+                if ($argStr -match "componentsVersion") { $global:LASTEXITCODE = 0 }
+                if ($argStr -match "\[ -x.*docker-desktop-user-distro") { $global:LASTEXITCODE = 0 }
+                if ($argStr -match "proxy --distro-name") { $global:LASTEXITCODE = 124 }
+                $global:LASTEXITCODE = 0
+                return ""
+            }
+            $handler.Retries = 1
+            $handler.RetryDelaySeconds = 0
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $false
+            Should -Invoke Test-DockerDaemon -Times 1
+        }
     }
 
     Context 'RepairWslProxyBinary' {
@@ -1557,6 +1590,39 @@ Describe 'DockerHandler' {
             $handler.Apply($ctx)
 
             $script:copyCalled | Should -Be $false
+        }
+
+        It 'should repair 0-byte proxy binary when Docker Desktop is already running' {
+            $script:copyCalled = $false
+            Mock Get-ProcessSafe {
+                param($Name)
+                if ($Name -eq "Docker Desktop") { return [PSCustomObject]@{ Name = $Name } }
+                return $null
+            }
+            Mock Invoke-Wsl {
+                param($Arguments)
+                $argStr = $Arguments -join " "
+                if ($argStr -match "stat -c") {
+                    $global:LASTEXITCODE = 0
+                    return "0"
+                }
+                if ($argStr -match "cp /docker-desktop-user-distro") {
+                    $script:copyCalled = $true
+                    $global:LASTEXITCODE = 0
+                    return ""
+                }
+                if ($argStr -match "chmod") {
+                    $global:LASTEXITCODE = 0
+                    return ""
+                }
+                $global:LASTEXITCODE = 0
+                return ""
+            }
+
+            $handler.StartDockerDesktopIfNeeded()
+
+            $script:copyCalled | Should -Be $true
+            Should -Invoke Start-ProcessSafe -Times 0
         }
 
         It 'should skip repair when docker-desktop distro is not available' {

--- a/scripts/powershell/tests/lib/Invoke-ExternalCommand.Tests.ps1
+++ b/scripts/powershell/tests/lib/Invoke-ExternalCommand.Tests.ps1
@@ -646,23 +646,74 @@ Describe 'Start-SleepSafe' {
 }
 
 Describe 'Test-DockerDaemon' {
-    It 'should return true when docker info succeeds' {
+    It 'should return true when docker version succeeds' {
         Mock Invoke-Docker { $global:LASTEXITCODE = 0 }
 
         $result = Test-DockerDaemon
 
         $result | Should -Be $true
         Should -Invoke Invoke-Docker -Times 1 -ParameterFilter {
-            "$Arguments" -match 'info'
+            $Arguments -contains "--context" -and
+            $Arguments -contains "desktop-linux" -and
+            "$Arguments" -match 'version' -and
+            $TimeoutSeconds -eq 15
         }
     }
 
-    It 'should return false when docker info fails' {
+    It 'should return false when docker version fails' {
         Mock Invoke-Docker { $global:LASTEXITCODE = 1 }
 
         $result = Test-DockerDaemon
 
         $result | Should -Be $false
+    }
+
+    It 'should pass custom timeout to docker version' {
+        Mock Invoke-Docker { $global:LASTEXITCODE = 0 }
+
+        Test-DockerDaemon -TimeoutSeconds 3
+
+        Should -Invoke Invoke-Docker -Times 1 -ParameterFilter {
+            $TimeoutSeconds -eq 3
+        }
+    }
+
+    It 'should ignore ambient Docker context environment variables during the Desktop check' {
+        $originalDockerHost = $env:DOCKER_HOST
+        $originalDockerContext = $env:DOCKER_CONTEXT
+        try {
+            $env:DOCKER_HOST = "tcp://example.invalid:2375"
+            $env:DOCKER_CONTEXT = "remote"
+            $script:dockerHostDuringCheck = $null
+            $script:dockerContextDuringCheck = $null
+            Mock Invoke-Docker {
+                $script:dockerHostDuringCheck = $env:DOCKER_HOST
+                $script:dockerContextDuringCheck = $env:DOCKER_CONTEXT
+                $global:LASTEXITCODE = 0
+            }
+
+            Test-DockerDaemon | Should -Be $true
+
+            $script:dockerHostDuringCheck | Should -BeNullOrEmpty
+            $script:dockerContextDuringCheck | Should -BeNullOrEmpty
+            $env:DOCKER_HOST | Should -Be "tcp://example.invalid:2375"
+            $env:DOCKER_CONTEXT | Should -Be "remote"
+        }
+        finally {
+            if ($null -eq $originalDockerHost) {
+                Remove-Item Env:\DOCKER_HOST -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:DOCKER_HOST = $originalDockerHost
+            }
+
+            if ($null -eq $originalDockerContext) {
+                Remove-Item Env:\DOCKER_CONTEXT -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:DOCKER_CONTEXT = $originalDockerContext
+            }
+        }
     }
 }
 

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -322,6 +322,7 @@
           "PackageIdentifier": "9NT1R1C2HH7J"
         },
         {
+          "ciSkipInstall": true,
           "PackageIdentifier": "9PLM9XGG6VKS",
           "verifyCommand": {
             "args": ["OpenAI.Codex_2p2nqsd0c76g0!App"],


### PR DESCRIPTION
## Summary
- Add a timeout-aware Docker Engine readiness check to the shared Docker wrapper.
- Require Engine readiness before accepting Docker Desktop proxy success.
- Repair a 0-byte `docker-desktop-user-distro` proxy even when Docker Desktop is already running.

## Tests
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/handlers/Handler.Docker.Tests.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/lib/Invoke-ExternalCommand.Tests.ps1`
- `task test` (`751 passed, 5 skipped`)
- `pre-commit run fix-byte-order-marker --files ...`
- `pre-commit run powershell-tests --files ...`
- `docker version`