### PR TITLE
fix(codex): support newline in Windows Terminal

### DIFF
--- a/chezmoi/dot_codex/config.toml.tmpl
+++ b/chezmoi/dot_codex/config.toml.tmpl
@@ -145,9 +145,9 @@ apps = false
 ################################################################################
 
 [tui.keymap.editor]
-# Claude Code と同じ Shift+Enter でプロンプト内改行する。
-# Windows Terminal の sendInput "\n" は Ctrl+J として届くため併用する。
-insert_newline = [ "shift-enter", "ctrl-j" ]
+# ユーザー操作は Shift+Enter に統一する。
+# Windows Terminal の Ctrl+Enter fallback と、LF を送る terminal の Ctrl+J 互換も受ける。
+insert_newline = [ "shift-enter", "ctrl-enter", "ctrl-j" ]
 
 ################################################################################
 # ツール

--- a/chezmoi/terminals/windows-terminal/settings.json
+++ b/chezmoi/terminals/windows-terminal/settings.json
@@ -59,8 +59,12 @@
       "id": "User.moveFocus.left"
     },
     {
-      "command": { "action": "sendInput", "input": "\n" },
-      "id": "User.sendInput.DFCDAF06"
+      "command": { "action": "sendInput", "input": "\u001b[13;2u" },
+      "id": "User.sendInput.ShiftEnter"
+    },
+    {
+      "command": { "action": "sendInput", "input": "\u001b[13;5u" },
+      "id": "User.sendInput.CtrlEnter"
     },
     {
       "command": { "action": "newTab" },
@@ -104,7 +108,8 @@
     { "id": "User.prevTab", "keys": "ctrl+shift+tab" },
     { "id": "User.copy", "keys": "ctrl+c" },
     { "id": null, "keys": "alt+z" },
-    { "id": "User.sendInput.DFCDAF06", "keys": "shift+enter" },
+    { "id": "User.sendInput.ShiftEnter", "keys": "shift+enter" },
+    { "id": "User.sendInput.CtrlEnter", "keys": "ctrl+enter" },
     { "id": null, "keys": "ctrl+plus" },
     { "id": null, "keys": "ctrl+minus" },
     { "id": null, "keys": "ctrl+0" },

--- a/docs/chezmoi/keybindings.md
+++ b/docs/chezmoi/keybindings.md
@@ -14,6 +14,7 @@
 | ------------------ | ------------------- | ------------------------------ |
 | `Ctrl+Shift`       | 移動/ナビゲーション | ペイン移動 (`H/J/K/L`)         |
 | `Ctrl+Alt`         | レイアウト変更      | 分割、ペイン close、ズーム     |
+| `Shift+Enter`      | 複数行入力          | AI CLI / terminal prompt 改行  |
 | `Space` (`Leader`) | ツール機能呼び出し  | 検索、エクスプローラ、タブ操作 |
 | `Alt` (Shell)      | CLI 補助操作        | fzf/zoxide ウィジェット        |
 
@@ -22,11 +23,14 @@
 ### Terminals
 
 - WezTerm
+  - `Shift+Enter`: AI CLI / terminal prompt の複数行入力
   - `Ctrl+Shift+H/J/K/L`: ペイン移動
   - `Ctrl+Alt+H/V/X/W`: 分割/close/ズーム
   - `Leader` (`Ctrl+Space`) + `t/x/h/l/1-9`: タブ操作
   - `Leader` (`Ctrl+Space`) + `c/v`: コピー/ペースト
 - Windows Terminal
+  - `Shift+Enter`: AI CLI / terminal prompt の複数行入力 (`CSI u`)
+  - `Ctrl+Enter`: Windows Terminal 用 fallback (`CSI u`)
   - `Ctrl+Shift+H/J/K/L`: ペイン移動
   - `Ctrl+Alt+H/V/X/W`: 分割/close/ズーム
 - Warp
@@ -48,6 +52,7 @@
   - `Space+du/dc/dd/dt`: Devcontainer up/connect/down/toggle
 - VS Code / Cursor
   - `Vim` 拡張は利用しない
+  - terminal focus の `Shift+Enter`: AI CLI / terminal prompt の複数行入力
   - `Ctrl+Shift+H/J/K/L`: editor group 移動
   - `Ctrl+Alt+H/V/X/W`: split/close/toggle widths
   - それ以外は標準キーバインドを優先
@@ -61,8 +66,15 @@
   - `Alt+Z`: zoxide interactive jump (`zoxide query -i`)
   - `Alt+D/T/R`: fzf ウィジェット
 - PowerShell
+  - `Shift+Enter`: PSReadLine `AddLine`
   - `Alt+Z`: zoxide interactive jump (`zoxide query -i`)
   - `Alt+D/T/R`: fzf ウィジェット (PSReadLine)
+
+### AI CLI
+
+- Claude Code / Codex / terminal 内 AI prompt の複数行入力は `Shift+Enter` に統一する。
+- Windows Terminal では `Shift+Enter` を `CSI u` sequence として送る。`Ctrl+Enter` は fallback として同じ用途に割り当てる。
+- `Ctrl+J` は押下キーとして使わない。Codex では LF を送る terminal の受信互換としてのみ許可する。
 
 ### zoxide + fzf integration
 


### PR DESCRIPTION
## Summary
- Send Windows Terminal Shift+Enter as CSI-u instead of LF
- Add Ctrl+Enter as a Windows Terminal fallback sequence
- Let Codex accept shift-enter, ctrl-enter, and ctrl-j for prompt newlines
- Document the Shift+Enter policy for terminal AI CLIs

## Verification
- task chezmoi
- Windows/WSL Codex config contains: insert_newline = [ "shift-enter", "ctrl-enter", "ctrl-j" ]
- Windows Terminal deployed settings contain ShiftEnter/CtrlEnter CSI-u bindings
- Windows Terminal source settings JSON parse OK
- Rendered Codex config taplo check OK
- Pester: scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1 (17 passed)

Note: pre-commit treefmt was run manually but failed because the Windows-created worktree resolves .git paths as D:/... under WSL/libgit2 and touched unrelated files; those side effects were reverted. Targeted template lint passed.
