### PR TITLE
fix(pwsh): stabilize Codex input in WezTerm

### DIFF
--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -30,6 +30,57 @@ $env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [En
 # Tell snacks.nvim to use WezTerm's Kitty graphics protocol for image preview.
 $env:SNACKS_WEZTERM = "true"
 
+function Reset-DotfilesTerminalInputMode {
+    $escape = [char]27
+    $host.UI.Write(
+        "$escape[?1000l$escape[?1002l$escape[?1003l$escape[?1004l" +
+        "$escape[?1005l$escape[?1006l$escape[?1015l$escape[?2004l" +
+        "$escape[<u$escape[>4;0m"
+    )
+}
+
+function Invoke-CodexCli {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Arguments
+    )
+
+    $hadTerm = Test-Path Env:\TERM
+    $previousTerm = $env:TERM
+    $hadKeyboardEnhancement = Test-Path Env:\CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT
+    $previousKeyboardEnhancement = $env:CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT
+
+    try {
+        $env:TERM = "xterm-256color"
+        $env:CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT = "1"
+        Reset-DotfilesTerminalInputMode
+        & codex.exe @Arguments
+    }
+    finally {
+        $codexExitCode = $global:LASTEXITCODE
+
+        if ($hadTerm) {
+            $env:TERM = $previousTerm
+        }
+        else {
+            Remove-Item Env:\TERM -ErrorAction SilentlyContinue
+        }
+
+        if ($hadKeyboardEnhancement) {
+            $env:CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT = $previousKeyboardEnhancement
+        }
+        else {
+            Remove-Item Env:\CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT -ErrorAction SilentlyContinue
+        }
+
+        Reset-DotfilesTerminalInputMode
+        $global:LASTEXITCODE = $codexExitCode
+    }
+}
+
+Set-Alias -Name codex -Value Invoke-CodexCli -Scope Global
+
 # Aliases
 if (Get-Command rg -ErrorAction SilentlyContinue) {
     Set-Alias -Name grep -Value rg -Scope Global

--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -40,12 +40,7 @@ function Reset-DotfilesTerminalInputMode {
 }
 
 function Invoke-CodexCli {
-    [CmdletBinding()]
-    param(
-        [Parameter(ValueFromRemainingArguments = $true)]
-        [string[]]$Arguments
-    )
-
+    $codexArgs = [string[]]$args
     $hadTerm = Test-Path Env:\TERM
     $previousTerm = $env:TERM
     $hadKeyboardEnhancement = Test-Path Env:\CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT
@@ -55,7 +50,7 @@ function Invoke-CodexCli {
         $env:TERM = "xterm-256color"
         $env:CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT = "1"
         Reset-DotfilesTerminalInputMode
-        & codex.exe @Arguments
+        & codex.exe @codexArgs
     }
     finally {
         $codexExitCode = $global:LASTEXITCODE

--- a/scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1
@@ -3,6 +3,7 @@
 BeforeAll {
     $script:repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "../../../..")).Path
     $script:profilePath = Join-Path $script:repoRoot "chezmoi/shells/Microsoft.PowerShell_profile.ps1"
+    $script:profileContent = Get-Content -LiteralPath $script:profilePath -Raw
 
     $tokens = $null
     $parseErrors = $null
@@ -16,7 +17,7 @@ BeforeAll {
     }
 
     $script:functionScriptBlockByName = @{}
-    foreach ($name in @("ConvertTo-DcnvimBashSingleQuoted", "dcnvim")) {
+    foreach ($name in @("Reset-DotfilesTerminalInputMode", "Invoke-CodexCli", "ConvertTo-DcnvimBashSingleQuoted", "dcnvim")) {
         $functionAst = $profileAst.Find(
             {
                 param($node)
@@ -33,6 +34,12 @@ BeforeAll {
 
     function Import-DcnvimProfileFunction {
         foreach ($name in @("ConvertTo-DcnvimBashSingleQuoted", "dcnvim")) {
+            Set-Item -Path "Function:\global:$name" -Value $script:functionScriptBlockByName[$name]
+        }
+    }
+
+    function Import-CodexProfileFunction {
+        foreach ($name in @("Reset-DotfilesTerminalInputMode", "Invoke-CodexCli")) {
             Set-Item -Path "Function:\global:$name" -Value $script:functionScriptBlockByName[$name]
         }
     }
@@ -56,6 +63,75 @@ BeforeAll {
 
         New-Item -ItemType Directory -Path (Join-Path $Path ".devcontainer") -Force | Out-Null
         return (Resolve-Path -LiteralPath $Path).Path
+    }
+}
+
+Describe 'PowerShell codex profile wrapper' {
+    BeforeEach {
+        Import-CodexProfileFunction
+
+        $script:codexArgs = $null
+        $script:termDuringCodex = $null
+        $script:keyboardEnhancementDuringCodex = $null
+        $script:resetCalls = 0
+        $script:oldTermExists = Test-Path Env:\TERM
+        $script:oldTerm = $env:TERM
+        $script:oldKeyboardEnhancementExists = Test-Path Env:\CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT
+        $script:oldKeyboardEnhancement = $env:CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT
+
+        function global:codex.exe {
+            $script:codexArgs = [string[]]$args
+            $script:termDuringCodex = $env:TERM
+            $script:keyboardEnhancementDuringCodex = $env:CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT
+            $global:LASTEXITCODE = 7
+        }
+
+        function global:Reset-DotfilesTerminalInputMode {
+            $script:resetCalls++
+        }
+    }
+
+    AfterEach {
+        foreach ($functionName in @(
+                "Invoke-CodexCli",
+                "Reset-DotfilesTerminalInputMode",
+                "codex.exe"
+            )) {
+            Remove-Item "Function:\$functionName" -ErrorAction SilentlyContinue
+        }
+
+        if ($script:oldTermExists) {
+            $env:TERM = $script:oldTerm
+        }
+        else {
+            Remove-Item Env:\TERM -ErrorAction SilentlyContinue
+        }
+
+        if ($script:oldKeyboardEnhancementExists) {
+            $env:CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT = $script:oldKeyboardEnhancement
+        }
+        else {
+            Remove-Item Env:\CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'should alias codex to the compatibility wrapper' {
+        $script:profileContent | Should -Match 'Set-Alias\s+-Name\s+codex\s+-Value\s+Invoke-CodexCli'
+    }
+
+    It 'should run codex.exe with conservative terminal input settings and restore the environment' {
+        $env:TERM = "wezterm"
+        Remove-Item Env:\CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT -ErrorAction SilentlyContinue
+
+        Invoke-CodexCli resume --last
+
+        $script:codexArgs | Should -Be @("resume", "--last")
+        $script:termDuringCodex | Should -Be "xterm-256color"
+        $script:keyboardEnhancementDuringCodex | Should -Be "1"
+        $env:TERM | Should -Be "wezterm"
+        Test-Path Env:\CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT | Should -BeFalse
+        $script:resetCalls | Should -Be 2
+        $global:LASTEXITCODE | Should -Be 7
     }
 }
 

--- a/scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1
@@ -133,6 +133,16 @@ Describe 'PowerShell codex profile wrapper' {
         $script:resetCalls | Should -Be 2
         $global:LASTEXITCODE | Should -Be 7
     }
+
+    It 'should forward short Codex flags without PowerShell common parameter binding' {
+        $env:TERM = "wezterm"
+
+        Invoke-CodexCli -V
+
+        $script:codexArgs | Should -Be @("-V")
+        $script:termDuringCodex | Should -Be "xterm-256color"
+        $env:TERM | Should -Be "wezterm"
+    }
 }
 
 Describe 'PowerShell dcnvim profile function' {


### PR DESCRIPTION
## Summary
- add a PowerShell `codex` wrapper that runs Codex with conservative terminal input settings in WezTerm
- reset focus/mouse/bracketed-paste/kitty keyboard modes before and after Codex exits
- cover the wrapper's TERM and keyboard-enhancement env handling in profile tests

## Tests
- `./Invoke-Tests.ps1 -Path ./chezmoi/DcnvimProfile.Tests.ps1 -MinimumCoverage 0` (11 passed)
- commit hook attempted full checks; `treefmt` failed because `nix` is not installed in this Windows environment, and the full PowerShell hook has an unrelated existing `GhTokenSwitch.Tests.ps1` failure. The changed `DcnvimProfile.Tests.ps1` passed both directly and inside the hook run.