### PR TITLE
[codex] enable Codex app connectors

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -110,8 +110,8 @@ enable_request_compression = true
 
 # 開発中機能の警告を抑制する
 suppress_unstable_features_warning = true
-# ChatGPT Apps 連携 (コーディング特化のため無効)
-apps = false
+# Gmail / Google Calendar などの app connector を Codex に露出する
+apps = true
 
 ################################################################################
 # ツール

--- a/chezmoi/dot_codex/config.toml.tmpl
+++ b/chezmoi/dot_codex/config.toml.tmpl
@@ -137,8 +137,8 @@ enable_request_compression = true
 
 # 開発中機能の警告を抑制する
 suppress_unstable_features_warning = true
-# ChatGPT Apps 連携 (コーディング特化のため無効)
-apps = false
+# Gmail / Google Calendar などの app connector を Codex に露出する
+apps = true
 
 ################################################################################
 # TUI キーバインド

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -11,6 +11,7 @@
 #>
 
 BeforeAll {
+    $script:repoRoot = Join-Path $PSScriptRoot "../../../.."
     $script:chezmoiRoot = Join-Path $PSScriptRoot "../../../../chezmoi"
     $script:templateFiles = Get-ChildItem -Path $script:chezmoiRoot -Filter "*.tmpl" -Recurse
 }
@@ -264,6 +265,22 @@ Describe 'chezmoi テンプレート バリデーション' {
             }
 
             $content | Should -Match 'env "ProgramData"' -Because "Docker Desktop backend は ProgramData が無いと起動に失敗する"
+        }
+
+        It 'should enable Codex apps for plugin-bundled connectors' {
+            $templatePath = Join-Path $script:chezmoiRoot "dot_codex/config.toml.tmpl"
+            $content = Get-Content -Path $templatePath -Raw
+
+            $content | Should -Match '(?m)^apps\s*=\s*true\s*$' -Because "Gmail や Google Calendar などの app connector は features.apps が無効だと露出しない"
+            $content | Should -Not -Match '(?m)^apps\s*=\s*false\s*$' -Because "chezmoi 再適用で connector 利用を無効化しない"
+        }
+
+        It 'should keep Codex project config apps enabled' {
+            $projectConfigPath = Join-Path $script:repoRoot ".codex/config.toml"
+            $content = Get-Content -Path $projectConfigPath -Raw
+
+            $content | Should -Match '(?m)^apps\s*=\s*true\s*$' -Because "project-scoped config が global/chezmoi の apps=true を上書きしない"
+            $content | Should -Not -Match '(?m)^apps\s*=\s*false\s*$' -Because "この repo で connector tool が露出しなくなる"
         }
 
         It 'Codex Docker MCP wrapper は stdout に制御ログを書かないこと' {

--- a/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
@@ -425,6 +425,17 @@ Describe 'NixRebuildHandler' {
 
         It 'should skip already installed pnpm packages' {
             $script:pnpmAddCalled = $false
+            Mock Get-JsonContent {
+                return @{ globalPackages = @(
+                        "@example/native-tool",
+                        "@prisma/language-server",
+                        "@agentclientprotocol/claude-agent-acp",
+                        "typescript-language-server",
+                        "typescript",
+                        "@google/gemini-cli"
+                    )
+                }
+            }
             Mock Invoke-Wsl {
                 param($Arguments)
                 $argStr = $Arguments -join " "


### PR DESCRIPTION
## Summary

- Enable `[features].apps` in both project and chezmoi-managed Codex config.
- Update the comment so the config no longer says app connectors are disabled.
- Add PowerShell template tests to keep app connectors enabled in both config layers.

## Root cause

Google Calendar and Gmail plugins can be installed and enabled while their app connector tools remain hidden when `[features].apps` is false. The repo also had a project-scoped `.codex/config.toml` with `apps = false`, so it overrode the global setting inside this checkout.

## Validation

- `codex features list | rg "^apps\s+"`
- `pwsh -NoProfile -Command "& ./scripts/powershell/tests/Invoke-Tests.ps1 -Path ./scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1 -MinimumCoverage 0"`
- `nix fmt`
- `pre-commit run --all-files`
