### PR TITLE
fix: normalize admin phase AdminOnly arguments

### DIFF
--- a/scripts/powershell/install.admin.ps1
+++ b/scripts/powershell/install.admin.ps1
@@ -23,7 +23,7 @@ param(
     [string]$SyncBack = "lock",
     [switch]$CheckOnly,
     [string]$LogFile = "",
-    [Nullable[bool]]$AdminOnly = $null
+    [object]$AdminOnly = $null
 )
 
 Set-StrictMode -Version Latest
@@ -54,6 +54,40 @@ function Test-IsAdminCurrent {
     return $principal.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
 }
 
+function ConvertTo-AdminOnlyFilter {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object]$Value
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    if ($Value -is [bool]) {
+        return [bool]$Value
+    }
+
+    if ($Value -is [System.Management.Automation.SwitchParameter]) {
+        return [bool]$Value
+    }
+
+    $text = ([string]$Value).Trim()
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+
+    switch -Regex ($text) {
+        '^\$?true$' { return $true }
+        '^\$?false$' { return $false }
+        '^1$' { return $true }
+        '^0$' { return $false }
+    }
+
+    throw "AdminOnly must be true, false, 1, 0, or omitted. Received: $Value"
+}
+
 function Merge-Options {
     [CmdletBinding()]
     [OutputType([hashtable])]
@@ -82,6 +116,7 @@ function Merge-Options {
 }
 
 $effectiveOptions = Merge-Options -BaseOptions $Options -JsonOptions $OptionsJson
+$adminOnlyFilter = ConvertTo-AdminOnlyFilter -Value $AdminOnly
 
 $repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..\..")).Path
 . (Join-Path $libPath "SetupHandler.ps1")
@@ -114,8 +149,8 @@ $handlers = @($handlers | Where-Object { $_.Phase -eq 2 })
 # $true = 管理者必須のみ（UAC 昇格プロセス用）
 # $false = 管理者不要のみ（非昇格プロセス用、1Password 連携などが動作する）
 # $null = 全て（後方互換）
-if ($null -ne $AdminOnly) {
-    $handlers = @($handlers | Where-Object { $_.RequiresAdmin -eq $AdminOnly })
+if ($null -ne $adminOnlyFilter) {
+    $handlers = @($handlers | Where-Object { $_.RequiresAdmin -eq $adminOnlyFilter })
 }
 
 # standalone 実行時にも同意プロンプトが走るようにする
@@ -125,7 +160,7 @@ Invoke-ConsentPrompt -Handlers $handlers
 $applicableCount = 0
 foreach ($handler in $handlers) {
     # AdminOnly フィルタ未使用時（後方互換）: 管理者必須のみカウント
-    if ($null -eq $AdminOnly -and -not $handler.RequiresAdmin) {
+    if ($null -eq $adminOnlyFilter -and -not $handler.RequiresAdmin) {
         continue
     }
 

--- a/scripts/powershell/tests/Install.Admin.Tests.ps1
+++ b/scripts/powershell/tests/Install.Admin.Tests.ps1
@@ -2,6 +2,13 @@
 
 BeforeAll {
     $script:target = Join-Path (Split-Path -Parent $PSScriptRoot) "install.admin.ps1"
+    $script:runsOnWindows = [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+    $script:windowsPowerShell = if ($script:runsOnWindows) {
+        (Get-Command powershell.exe -ErrorAction SilentlyContinue).Source
+    }
+    else {
+        $null
+    }
 }
 
 Describe 'install.admin.ps1' {
@@ -34,6 +41,27 @@ Describe 'install.admin.ps1' {
         finally {
             $env:DOTFILES_WSL_CHECK_TIMEOUT_SECONDS = $oldTimeout
         }
+    }
+
+    It 'should accept AdminOnly when invoked through powershell.exe -File like the elevated admin phase' {
+        if (-not $script:windowsPowerShell) {
+            Set-ItResult -Skipped -Because "Windows PowerShell is required to verify the elevated -File argument boundary"
+            return
+        }
+
+        $output = & $script:windowsPowerShell `
+            -NoLogo `
+            -NoProfile `
+            -ExecutionPolicy Bypass `
+            -File $script:target `
+            -CheckOnly `
+            "-AdminOnly:$true" `
+            -OptionsJson '{"SkipWslInstall":true,"SkipVhdExpand":true}' 2>&1
+        $exitCode = $LASTEXITCODE
+        $outputText = ($output | Out-String).Trim()
+
+        $exitCode | Should -Be 0 -Because $outputText
+        $outputText | Should -Be "False"
     }
 
     It 'should filter handlers by Phase 2' {

--- a/scripts/powershell/tests/Install.Admin.Tests.ps1
+++ b/scripts/powershell/tests/Install.Admin.Tests.ps1
@@ -59,9 +59,15 @@ Describe 'install.admin.ps1' {
             -OptionsJson '{"SkipWslInstall":true,"SkipVhdExpand":true}' 2>&1
         $exitCode = $LASTEXITCODE
         $outputText = ($output | Out-String).Trim()
+        $outputLines = @(
+            $output |
+            ForEach-Object { [string]$_ } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        )
 
         $exitCode | Should -Be 0 -Because $outputText
-        $outputText | Should -Be "False"
+        $outputText | Should -Not -Match "Cannot process argument transformation on parameter 'AdminOnly'"
+        $outputLines[-1] | Should -Be "False" -Because $outputText
     }
 
     It 'should filter handlers by Phase 2' {

--- a/scripts/powershell/tests/Install.Admin.Tests.ps1
+++ b/scripts/powershell/tests/Install.Admin.Tests.ps1
@@ -2,9 +2,13 @@
 
 BeforeAll {
     $script:target = Join-Path (Split-Path -Parent $PSScriptRoot) "install.admin.ps1"
-    $script:runsOnWindows = [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
-    $script:windowsPowerShell = if ($script:runsOnWindows) {
-        (Get-Command powershell.exe -ErrorAction SilentlyContinue).Source
+    $pwsh = Get-Command pwsh -ErrorAction SilentlyContinue
+    $windowsPowerShell = Get-Command powershell.exe -ErrorAction SilentlyContinue
+    $script:fileBoundaryShell = if ($pwsh) {
+        $pwsh.Source
+    }
+    elseif ($windowsPowerShell) {
+        $windowsPowerShell.Source
     }
     else {
         $null
@@ -43,13 +47,13 @@ Describe 'install.admin.ps1' {
         }
     }
 
-    It 'should accept AdminOnly when invoked through powershell.exe -File like the elevated admin phase' {
-        if (-not $script:windowsPowerShell) {
-            Set-ItResult -Skipped -Because "Windows PowerShell is required to verify the elevated -File argument boundary"
+    It 'should accept AdminOnly when invoked through a PowerShell -File boundary like the elevated admin phase' {
+        if (-not $script:fileBoundaryShell) {
+            Set-ItResult -Skipped -Because "PowerShell is required to verify the elevated -File argument boundary"
             return
         }
 
-        $output = & $script:windowsPowerShell `
+        $output = & $script:fileBoundaryShell `
             -NoLogo `
             -NoProfile `
             -ExecutionPolicy Bypass `


### PR DESCRIPTION
## Summary
- Normalize `install.admin.ps1` `AdminOnly` input after the PowerShell process boundary so `-File -AdminOnly:$true` no longer fails parameter binding.
- Use the normalized filter for handler selection and applicable-count logic.
- Add a regression test that invokes `install.admin.ps1` through a PowerShell `-File` process boundary, preferring `pwsh` in CI and falling back to `powershell.exe` where needed.

## Test Plan
- `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "cd scripts/powershell/tests; .\Invoke-Tests.ps1 -Path .\Install.Admin.Tests.ps1 -MinimumCoverage 0"`
- `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\scripts\powershell\install.admin.ps1 -CheckOnly -AdminOnly:$true`
- `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "cd scripts/powershell/tests; .\Invoke-Tests.ps1 -Path .\PSScriptAnalyzer.Tests.ps1 -MinimumCoverage 0"`
- GitHub Actions: PowerShell CI #116, Chezmoi CI #364

Note: full local `Invoke-Tests.ps1 -MinimumCoverage 0` still has 5 pre-existing failures unrelated to this PR in `Install.Entrypoint.Tests.ps1` and `Invoke-ExternalCommand.Tests.ps1` on this machine.