### PR TITLE
Make package installs track latest

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -77,7 +77,7 @@ tasks:
   rebuild:
     desc: Run nixos-rebuild switch
     cmds:
-      - '{{.WSL}}bash -lc "cd {{.DOTFILES_PATH}} && sudo nixos-rebuild switch --flake . --impure"'
+      - '{{.WSL}}bash -lc "cd {{.DOTFILES_PATH}} && nix flake update && sudo nixos-rebuild switch --flake . --impure"'
 
   build:
     desc: Dry build NixOS configuration

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,10 @@
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    gwq-src = {
+      url = "github:d-kuro/gwq";
+      flake = false;
+    };
     workmux.url = "github:raine/workmux";
   };
 

--- a/nix/flakes/home.nix
+++ b/nix/flakes/home.nix
@@ -19,6 +19,7 @@ let
         config.allowUnfree = true;
         overlays = [ workmuxOverlay ];
       };
+      extraSpecialArgs = { inherit inputs; };
       modules = [ ../home/common.nix ];
     };
 in

--- a/nix/flakes/lib/hosts.nix
+++ b/nix/flakes/lib/hosts.nix
@@ -24,6 +24,7 @@
             {
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
+              home-manager.extraSpecialArgs = { inherit inputs; };
               home-manager.users = import homeModulePath;
             }
           ]

--- a/nix/flakes/packages.nix
+++ b/nix/flakes/packages.nix
@@ -5,7 +5,7 @@
 #   nix profile install .#full      (everything, unfree allowed)
 #   nix profile install .#core      (individual set)
 #   nix build .#winget-export       (generate Windows package JSON)
-{ ... }:
+{ inputs, ... }:
 {
   perSystem =
     {
@@ -29,10 +29,12 @@
       sets = import ../packages/sets.nix {
         pkgs = pkgs.extend workmuxOverlay;
         inherit lib;
+        gwqSrc = inputs.gwq-src;
       };
       unfreeSets = import ../packages/sets.nix {
         pkgs = unfreePkgs;
         inherit lib;
+        gwqSrc = inputs.gwq-src;
       };
     in
     {
@@ -78,7 +80,10 @@
         };
 
         # Windows package export
-        winget-export = import ../packages/winget.nix { inherit pkgs lib; };
+        winget-export = import ../packages/winget.nix {
+          inherit pkgs lib;
+          gwqSrc = inputs.gwq-src;
+        };
       };
     };
 }

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -7,10 +7,14 @@
 {
   pkgs,
   lib,
+  inputs ? null,
   ...
 }:
 let
-  sets = import ../packages/sets.nix { inherit pkgs lib; };
+  sets = import ../packages/sets.nix {
+    inherit pkgs lib;
+    gwqSrc = if inputs == null then null else inputs.gwq-src;
+  };
   user = builtins.getEnv "USER";
   home = builtins.getEnv "HOME";
   fdOpts = "--hidden --follow --no-ignore-vcs --max-depth 10";

--- a/nix/home/linux/users.nix
+++ b/nix/home/linux/users.nix
@@ -8,7 +8,7 @@
 
       # NixOS rebuild shortcuts (also defined in wsl/users.nix for WSL context)
       programs.zsh.shellAliases = {
-        nrs = "sudo nixos-rebuild switch --flake ~/.dotfiles --impure && nix profile upgrade '.*' || nix profile install ~/.dotfiles#default";
+        nrs = "nix flake update ~/.dotfiles && sudo nixos-rebuild switch --flake ~/.dotfiles --impure && nix profile upgrade '.*' || nix profile install ~/.dotfiles#default";
         nrt = "sudo nixos-rebuild test --flake ~/.dotfiles --impure";
         nrb = "sudo nixos-rebuild boot --flake ~/.dotfiles --impure";
       };

--- a/nix/home/wsl/users.nix
+++ b/nix/home/wsl/users.nix
@@ -58,7 +58,7 @@
         # at runtime and the binary bypasses nix-ld (it links directly against NixOS glibc).
         warp = "LD_LIBRARY_PATH=${pkgs.wayland}/lib:\${LD_LIBRARY_PATH:-} MESA_D3D12_DEFAULT_ADAPTER_NAME=Microsoft warp-terminal";
         # NixOS rebuild shortcuts
-        nrs = "sudo nixos-rebuild switch --flake ~/.dotfiles --impure && nix profile upgrade '.*' || nix profile install ~/.dotfiles#default";
+        nrs = "nix flake update ~/.dotfiles && sudo nixos-rebuild switch --flake ~/.dotfiles --impure && nix profile upgrade '.*' || nix profile install ~/.dotfiles#default";
         nrt = "sudo nixos-rebuild test --flake ~/.dotfiles --impure";
         nrb = "sudo nixos-rebuild boot --flake ~/.dotfiles --impure";
       };

--- a/nix/modules/host/default.nix
+++ b/nix/modules/host/default.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   config,
+  inputs ? null,
   ...
 }:
 let
@@ -11,7 +12,10 @@ let
     mkMerge
     types
     ;
-  sets = import ../../packages/sets.nix { inherit pkgs lib; };
+  sets = import ../../packages/sets.nix {
+    inherit pkgs lib;
+    gwqSrc = if inputs == null then null else inputs.gwq-src;
+  };
 in
 {
   options.mySettings.wsl.dockerDesktopIntegration = mkOption {

--- a/nix/packages/gwq/default.nix
+++ b/nix/packages/gwq/default.nix
@@ -1,14 +1,21 @@
-{ pkgs, ... }:
-pkgs.buildGoModule {
-  pname = "gwq";
-  version = "0.1.1";
-
-  src = pkgs.fetchFromGitHub {
+{
+  pkgs,
+  src ? null,
+  ...
+}:
+let
+  upstreamSrc = pkgs.fetchFromGitHub {
     owner = "d-kuro";
     repo = "gwq";
     rev = "v0.1.1";
     sha256 = "044cjn57373zsz0v283012masgiibjwv1fhzqz7pfnl3ncariw1i";
   };
+in
+pkgs.buildGoModule {
+  pname = "gwq";
+  version = if src == null then "0.1.1" else "unstable";
+
+  src = if src == null then upstreamSrc else src;
 
   vendorHash = "sha256-4K01Xf1EXl/NVX1loQ76l1bW8QglBAQdvlZSo7J4NPI=";
 

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -20,7 +20,11 @@
 #   - nix/flakes/packages.nix → perSystem buildEnv outputs
 #   - nix/home/packages.nix   → home.packages
 #   - nix/packages/winget.nix → winget/pnpm JSON generation
-{ pkgs, lib }:
+{
+  pkgs,
+  lib,
+  gwqSrc ? null,
+}:
 let
   catalog = {
     # ── core ──────────────────────────────────────────────
@@ -122,7 +126,9 @@ let
       category = "dev";
     };
     gwq = {
-      pkg = import ./gwq/default.nix { inherit pkgs; };
+      pkg = import ./gwq/default.nix (
+        { inherit pkgs; } // lib.optionalAttrs (gwqSrc != null) { src = gwqSrc; }
+      );
       winget = null;
       category = "dev";
     };
@@ -620,10 +626,14 @@ lib.mapAttrs (_: names: resolve names) grouped
       "--installer-type"
       "wix"
     ];
+    wezterm = [
+      "--ignore-security-hash"
+    ];
   };
 
   wingetInstallTimeoutSeconds = {
     google-cloud-sdk = 900;
+    warp-terminal = 900;
   };
 
   # Upstream nightly winget manifests and Microsoft Store installs can drift or

--- a/nix/packages/winget.nix
+++ b/nix/packages/winget.nix
@@ -5,9 +5,13 @@
 #   nix build .#winget-export
 #   cp result/winget/packages.json windows/winget/packages.json
 #   cp result/pnpm/packages.json windows/pnpm/packages.json
-{ pkgs, lib }:
+{
+  pkgs,
+  lib,
+  gwqSrc ? null,
+}:
 let
-  sets = import ./sets.nix { inherit pkgs lib; };
+  sets = import ./sets.nix { inherit pkgs lib gwqSrc; };
 
   # Attach verifyCommand to a package object if defined in verifyMap
   attachVerify =

--- a/scripts/powershell/handlers/Handler.NixRebuild.ps1
+++ b/scripts/powershell/handlers/Handler.NixRebuild.ps1
@@ -185,17 +185,15 @@ class NixRebuildHandler : SetupHandlerBase {
                 if ($installedOutput -and ($installedOutput | Where-Object { $_ -match [regex]::Escape($pkgName) })) {
                     if ($verifyCmd) {
                         if ($this.TestPnpmPackageVerificationInWsl($distroName, $verifyCmd)) {
-                            $this.Log("スキップ (検証済み): $pkgName", "Gray")
+                            $this.Log("検証済み。latest を確認します: $pkgName", "Gray")
                             $verified++
-                            continue
                         }
-
-                        $this.LogWarning("インストール済みですが検証に失敗しました。再インストールします: $pkgName")
+                        else {
+                            $this.LogWarning("インストール済みですが検証に失敗しました。再インストールします: $pkgName")
+                        }
                     }
                     else {
-                        $this.Log("スキップ (インストール済み): $pkgName", "Gray")
-                        $skipped++
-                        continue
+                        $this.Log("インストール済み。latest を確認します: $pkgName", "Gray")
                     }
                 }
 
@@ -365,6 +363,26 @@ class NixRebuildHandler : SetupHandlerBase {
 
             # dotfiles が NixOS 内に存在しなければ Windows マウント経由でリンク
             $this.EnsureDotfilesAvailable($distroName, $ctx.DotfilesPath)
+
+            $this.Log("nix flake update を実行しています...")
+            $flakeUpdateOutput = Invoke-Wsl -Arguments @("-d", $distroName, "-u", "nixos", "--", "bash", "-lc", "cd /home/nixos/.dotfiles && nix flake update 2>&1")
+            $flakeUpdateExitCode = $LASTEXITCODE
+            $flakeUpdateErrors = [System.Collections.Generic.List[string]]::new()
+            $flakeUpdateOutput | ForEach-Object {
+                if ($_ -notmatch '^\s*$') {
+                    if ($_ -match '^error:') {
+                        $this.LogError("  $_")
+                        $flakeUpdateErrors.Add([string]$_)
+                    }
+                    else {
+                        $this.Log("  $_", "Gray")
+                    }
+                }
+            }
+            if ($flakeUpdateExitCode -ne 0) {
+                $errorDetail = if ($flakeUpdateErrors.Count -gt 0) { ": $($flakeUpdateErrors[0])" } else { "" }
+                throw "nix flake update が失敗しました (exit code: $flakeUpdateExitCode)$errorDetail"
+            }
 
             $this.Log("nixos-rebuild switch を実行しています...")
 

--- a/scripts/powershell/handlers/Handler.Npm.ps1
+++ b/scripts/powershell/handlers/Handler.Npm.ps1
@@ -127,17 +127,15 @@ class NpmHandler : SetupHandlerBase {
                 if ($installed -contains $pkgName) {
                     if ($verifyCmd) {
                         if ($this.TestPackageVerification($verifyCmd)) {
-                            $this.Log("スキップ (検証済み): $pkgName", "Gray")
+                            $this.Log("検証済み。latest を確認します: $pkgName", "Gray")
                             $verified++
-                            continue
                         }
-
-                        $this.LogWarning("インストール済みですが検証に失敗しました。再インストールします: $pkgName")
+                        else {
+                            $this.LogWarning("インストール済みですが検証に失敗しました。再インストールします: $pkgName")
+                        }
                     }
                     else {
-                        $this.Log("スキップ (インストール済み): $pkgName", "Gray")
-                        $skipped++
-                        continue
+                        $this.Log("インストール済み。latest を確認します: $pkgName", "Gray")
                     }
                 }
 
@@ -160,7 +158,7 @@ class NpmHandler : SetupHandlerBase {
             $verifyFailed = @()
 
             foreach ($pkg in $toInstall) {
-                $this.Log("インストール中: $($pkg.Spec)")
+                $this.Log("インストール/更新中: $($pkg.Spec)")
                 Invoke-Npm -Arguments @("install", "-g", $pkg.Spec) | Out-Null
 
                 if ($LASTEXITCODE -ne 0) {

--- a/scripts/powershell/handlers/Handler.Pnpm.ps1
+++ b/scripts/powershell/handlers/Handler.Pnpm.ps1
@@ -159,21 +159,19 @@ class PnpmHandler : SetupHandlerBase {
                 if ($this.IsPackageInstalled($pkgName, $globalRootForCheck)) {
                     if ($verifyCmd) {
                         if ($this.TestPackageVerification($verifyCmd)) {
-                            $this.Log("スキップ (検証済み): $pkgName", "Gray")
+                            $this.Log("検証済み。latest を確認します: $pkgName", "Gray")
                             $verified++
-                            continue
                         }
-
-                        $this.LogWarning("インストール済みですが検証に失敗しました。再インストールします: $pkgName")
+                        else {
+                            $this.LogWarning("インストール済みですが検証に失敗しました。再インストールします: $pkgName")
+                        }
                     }
                     else {
-                        $this.Log("スキップ (インストール済み): $pkgName", "Gray")
-                        $skipped++
-                        continue
+                        $this.Log("インストール済み。latest を確認します: $pkgName", "Gray")
                     }
                 }
 
-                $this.Log("インストール中: $pkgSpec")
+                $this.Log("インストール/更新中: $pkgSpec")
                 $pnpmExitCode = $this.InvokePnpmInstall(@("add", "-g", "--reporter=append-only", "--yes") + $installArgs + @($pkgSpec))
 
                 if ($pnpmExitCode -ne 0) {

--- a/scripts/powershell/handlers/Handler.Winget.ps1
+++ b/scripts/powershell/handlers/Handler.Winget.ps1
@@ -187,13 +187,16 @@ class WingetHandler : SetupHandlerBase {
             # 正規表現で検出できないパッケージ（ARP エントリ等）は個別チェックにフォールバック
             $installedIds = $this.GetInstalledPackageIds()
 
-            # 未インストール、または検証に失敗したパッケージをフィルタリング
+            # 通常実行ではインストール済みも含めて winget install を流し、
+            # winget 側の install-or-upgrade 動作で latest を選ばせる。
+            $verifyCommandOnly = $ctx.GetOption("WingetVerifyCommandOnly", $false)
             $toInstall = @()
             $skipped = 0
             $verified = 0
             $verifyFailed = 0
             $deferred = 0
             foreach ($pkg in $packages) {
+                $verificationPassed = $false
                 if ($pkg.VerifyCommand) {
                     Update-ProcessEnvironmentPath
                     $this.EnsurePortableLink($pkg)
@@ -204,14 +207,31 @@ class WingetHandler : SetupHandlerBase {
                         continue
                     }
                     if ($this.TestPackageVerification($pkg.VerifyCommand)) {
-                        $this.Log("スキップ (検証済み): $($pkg.Id)", "Gray")
+                        $verificationPassed = $true
                         $verified++
-                        continue
+                        if ($verifyCommandOnly) {
+                            $this.Log("スキップ (検証済み): $($pkg.Id)", "Gray")
+                            continue
+                        }
                     }
                 }
 
                 if ($pkg.Id -in $installedIds -or $this.IsPackageInstalled($pkg.Id)) {
-                    if ($pkg.VerifyCommand) {
+                    if ($pkg.VerifyCommand -and $verificationPassed) {
+                        $toInstall += [PSCustomObject]@{
+                            Id                    = $pkg.Id
+                            Version               = $pkg.Version
+                            SourceName            = $pkg.SourceName
+                            VerifyCommand         = $pkg.VerifyCommand
+                            InstallArgs           = $pkg.InstallArgs
+                            InstallTimeoutSeconds = $pkg.InstallTimeoutSeconds
+                            CiSkipInstall         = $pkg.CiSkipInstall
+                            PortableLink          = $pkg.PortableLink
+                            PathEntries           = $pkg.PathEntries
+                            Force                 = $false
+                        }
+                    }
+                    elseif ($pkg.VerifyCommand) {
                         if (-not [string]::IsNullOrWhiteSpace($this.GetRecoveryStrategy($pkg.VerifyCommand))) {
                             if ($this.RecoverPackageVerification($pkg)) {
                                 $verified++
@@ -244,8 +264,18 @@ class WingetHandler : SetupHandlerBase {
                         }
                     }
                     else {
-                        $this.Log("スキップ (インストール済み): $($pkg.Id)", "Gray")
-                        $skipped++
+                        $toInstall += [PSCustomObject]@{
+                            Id                    = $pkg.Id
+                            Version               = $pkg.Version
+                            SourceName            = $pkg.SourceName
+                            VerifyCommand         = $pkg.VerifyCommand
+                            InstallArgs           = $pkg.InstallArgs
+                            InstallTimeoutSeconds = $pkg.InstallTimeoutSeconds
+                            CiSkipInstall         = $pkg.CiSkipInstall
+                            PortableLink          = $pkg.PortableLink
+                            PathEntries           = $pkg.PathEntries
+                            Force                 = $false
+                        }
                     }
                 }
                 else {
@@ -279,13 +309,12 @@ class WingetHandler : SetupHandlerBase {
                 return $this.CreateSuccessResult($parts -join ", ")
             }
 
-            # 未インストール分をインストール
+            # 対象パッケージをインストール/更新
             $succeeded = 0
             $failed = 0
 
             foreach ($pkg in $toInstall) {
-                $logSuffix = if ($pkg.Version) { " (v$($pkg.Version))" } else { "" }
-                $this.Log("インストール中: $($pkg.Id)$logSuffix")
+                $this.Log("インストール/更新中: $($pkg.Id)")
                 $installArgs = $this.NewWingetInstallArguments($pkg, [bool]$pkg.Force)
 
                 $installOutput = $this.InvokeWingetInstall($pkg, $installArgs)
@@ -304,6 +333,12 @@ class WingetHandler : SetupHandlerBase {
                     if ($pkg.VerifyCommand -and $this.TestPackageVerification($pkg.VerifyCommand)) {
                         $verified++
                         $this.Log("✓ $($pkg.Id) (winget install は失敗扱いでしたが検証済み)", "Green")
+                        continue
+                    }
+
+                    if ($alreadyInstalledInstallFailure -and -not $pkg.VerifyCommand) {
+                        $succeeded++
+                        $this.Log("✓ $($pkg.Id) (winget install は no-op でした)", "Green")
                         continue
                     }
 
@@ -372,6 +407,7 @@ class WingetHandler : SetupHandlerBase {
     hidden [bool] IsAlreadyInstalledInstallFailure([object[]]$installOutput) {
         $text = ($installOutput | ForEach-Object { [string]$_ }) -join "`n"
         return $text -match '0x80073cfb' -or
+        $text -match 'No applicable update found' -or
         $text -match 'already installed' -or
         $text -match '別のバージョンが既にインストールされています'
     }
@@ -400,12 +436,6 @@ class WingetHandler : SetupHandlerBase {
             "--accept-source-agreements",
             "--disable-interactivity"
         )
-        # Version が packages.json に書かれていれば --version で固定する。
-        # msstore source は固定 version 指定をサポートしないため除外。
-        if ($pkg.Version -and $pkg.SourceName -ne "msstore") {
-            $installArgs += "--version"
-            $installArgs += $pkg.Version
-        }
         if ($pkg.SourceName -eq "msstore") {
             $installArgs += "--source"
             $installArgs += "msstore"

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -7,6 +7,73 @@ BeforeAll {
 }
 
 Describe 'Package catalog consistency' {
+    Context 'Latest package policy' {
+        It 'should not pin winget package versions in generated packages.json' {
+            $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
+            $versionedPackages = @(
+                $json.Sources |
+                    ForEach-Object { $_.Packages } |
+                    Where-Object { $_.PSObject.Properties.Name -contains 'Version' }
+            )
+
+            $versionedPackages.Count | Should -Be 0
+        }
+
+        It 'should allow WezTerm nightly to use the latest installer even when the live hash drifts' {
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+
+            $sets | Should -Match '(?s)wingetInstallArgs\s*=\s*\{.*?wezterm\s*=\s*\[.*?"--ignore-security-hash"'
+        }
+
+        It 'should generate WezTerm nightly with ignore-security-hash install args' {
+            $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
+            $wingetSource = @($json.Sources | Where-Object { $_.SourceDetails.Name -eq 'winget' }) | Select-Object -First 1
+            $package = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'wez.wezterm.nightly' }) | Select-Object -First 1
+
+            $package | Should -Not -BeNullOrEmpty
+            @($package.installArgs) | Should -Contain '--ignore-security-hash'
+        }
+
+        It 'should give Warp a longer install timeout because the live installer can be slow' {
+            $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
+            $wingetSource = @($json.Sources | Where-Object { $_.SourceDetails.Name -eq 'winget' }) | Select-Object -First 1
+            $package = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'Warp.Warp' }) | Select-Object -First 1
+
+            $package | Should -Not -BeNullOrEmpty
+            $package.installTimeoutSeconds | Should -Be 900
+        }
+
+        It 'should update flake inputs in the Nix rebuild aliases before applying the system' {
+            $wslUsers = Get-Content -LiteralPath (Join-Path $script:repoRoot "nix/home/wsl/users.nix") -Raw
+            $linuxUsers = Get-Content -LiteralPath (Join-Path $script:repoRoot "nix/home/linux/users.nix") -Raw
+
+            $wslUsers | Should -Match 'nrs\s*=\s*"nix flake update ~/.dotfiles && sudo nixos-rebuild switch --flake ~/.dotfiles --impure'
+            $linuxUsers | Should -Match 'nrs\s*=\s*"nix flake update ~/.dotfiles && sudo nixos-rebuild switch --flake ~/.dotfiles --impure'
+        }
+
+        It 'should update flake inputs before every scripted NixOS rebuild entry point' {
+            $taskfile = Get-Content -LiteralPath (Join-Path $script:repoRoot "Taskfile.yml") -Raw
+            $updateScript = Get-Content -LiteralPath (Join-Path $script:repoRoot "scripts/sh/update.sh") -Raw
+            $postInstallScript = Get-Content -LiteralPath (Join-Path $script:repoRoot "scripts/sh/nixos-wsl-postinstall.sh") -Raw
+
+            $taskfile | Should -Match 'nix flake update && sudo nixos-rebuild switch --flake \. --impure'
+            $updateScript | Should -Match 'nix flake update ~/.dotfiles'
+            $postInstallScript | Should -Match 'nix flake update "\$TARGET_DIR"'
+        }
+
+        It 'should source gwq from a flake input so nix flake update can move it forward' {
+            $flake = Get-Content -LiteralPath (Join-Path $script:repoRoot "flake.nix") -Raw
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+            $gwqPackage = Get-Content -LiteralPath (Join-Path $script:repoRoot "nix/packages/gwq/default.nix") -Raw
+
+            $flake | Should -Match 'gwq-src\s*=\s*\{'
+            $flake | Should -Match 'url\s*=\s*"github:d-kuro/gwq"'
+            $sets | Should -Match 'gwqSrc \? null'
+            $sets | Should -Match 'src = gwqSrc'
+            $gwqPackage | Should -Match 'version = if src == null then "0\.1\.1" else "unstable"'
+        }
+    }
+
     Context 'Windows-only WSL package' {
         It 'should include Microsoft.WSL as a Windows-only winget package in the SSOT' {
             $sets = Get-Content -LiteralPath $script:setsPath -Raw

--- a/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
@@ -423,7 +423,7 @@ Describe 'NixRebuildHandler' {
             $script:pnpmArgs | Should -Not -Match "@\{name="
         }
 
-        It 'should skip already installed pnpm packages' {
+        It 'should install already installed pnpm packages so they can update to latest' {
             $script:pnpmAddCalled = $false
             Mock Get-JsonContent {
                 return @{ globalPackages = @(
@@ -460,7 +460,7 @@ Describe 'NixRebuildHandler' {
             }
             $handler.Apply($ctx)
 
-            $script:pnpmAddCalled | Should -Be $false
+            $script:pnpmAddCalled | Should -Be $true
         }
 
         It 'should reinstall installed pnpm package when verifyCommand fails in WSL' {
@@ -556,6 +556,39 @@ Describe 'NixRebuildHandler' {
             $script:wslArgs | Should -Match "-u root"
             $script:wslArgs | Should -Match "cd /home/nixos/.dotfiles"
             $script:wslArgs | Should -Match "nixos-rebuild switch --flake"
+        }
+
+        It 'should update the flake lock before nixos-rebuild so Nix packages use latest inputs' {
+            $script:flakeUpdateCalled = $false
+            $script:rebuildCalled = $false
+            $script:flakeUpdateCalledFirst = $false
+            $script:flakeUpdateArgs = ""
+            Mock Invoke-Wsl {
+                param($Arguments)
+                $argStr = $Arguments -join " "
+                if ($argStr -match "nix flake update") {
+                    $script:flakeUpdateArgs = $argStr
+                    $script:flakeUpdateCalled = $true
+                    if (-not $script:rebuildCalled) { $script:flakeUpdateCalledFirst = $true }
+                    $global:LASTEXITCODE = 0; return @("updated lock file")
+                }
+                if ($argStr -match "nixos-rebuild") { $script:rebuildCalled = $true; $global:LASTEXITCODE = 0; return "" }
+                if ($argStr -match "command -v pnpm") { $global:LASTEXITCODE = 0; return "/nix/store/bin/pnpm" }
+                if ($argStr -match "pnpm ls -g") { $global:LASTEXITCODE = 0; return "" }
+                if ($argStr -match "pnpm add") { $global:LASTEXITCODE = 0; return "" }
+                if ($argStr -match "core\.hooksPath") { $global:LASTEXITCODE = 0; return "" }
+                if ($argStr -match "pre-commit install") { $global:LASTEXITCODE = 0; return "" }
+                if ($argStr -match "echo exists") { $global:LASTEXITCODE = 0; return "exists" }
+                if ($argStr -match "pnpm setup") { $global:LASTEXITCODE = 0; return "" }
+                if ($argStr -match "grep.*PNPM_HOME") { $global:LASTEXITCODE = 0; return "" }
+                if ($argStr -match "test -e") { $global:LASTEXITCODE = 0; return "" }
+                $global:LASTEXITCODE = 0; return ""
+            }
+            $handler.Apply($ctx)
+
+            $script:flakeUpdateCalled | Should -Be $true
+            $script:flakeUpdateCalledFirst | Should -Be $true
+            $script:flakeUpdateArgs | Should -Match "-u nixos"
         }
 
         It 'should set git safe.directory before nixos-rebuild as root' {

--- a/scripts/powershell/tests/handlers/Handler.Npm.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Npm.Tests.ps1
@@ -153,12 +153,11 @@ Describe 'NpmHandler' {
             }
         }
 
-        It 'should skip already installed packages' {
+        It 'should install already installed packages so they can update to latest' {
             $ctx.Options["NpmMode"] = "import"
             $result = $handler.Apply($ctx)
             $result.Success | Should -Be $true
-            $result.Message | Should -Match "1 個インストール"
-            $result.Message | Should -Match "1 個スキップ"
+            $result.Message | Should -Match "2 個インストール"
         }
     }
 
@@ -182,11 +181,11 @@ Describe 'NpmHandler' {
             }
         }
 
-        It 'should return success with all installed message' {
+        It 'should reinstall all installed packages so npm selects latest' {
             $ctx.Options["NpmMode"] = "import"
             $result = $handler.Apply($ctx)
             $result.Success | Should -Be $true
-            $result.Message | Should -Match "2 個スキップ"
+            $result.Message | Should -Match "2 個インストール"
         }
     }
 

--- a/scripts/powershell/tests/handlers/Handler.Pnpm.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Pnpm.Tests.ps1
@@ -493,16 +493,16 @@ Describe 'PnpmHandler' {
         }
         AfterEach { $env:PATH = $script:origPath }
 
-        It 'should skip all already-installed packages' {
+        It 'should install all already-installed packages so pnpm selects latest' {
             $result = $handler.Apply($ctx)
             $result.Success | Should -Be $true
             $result.Message | Should -Match "1 個検証済み"
-            $result.Message | Should -Match "1 個スキップ"
+            $result.Message | Should -Match "2 個インストール"
         }
 
-        It 'should not call pnpm add for installed packages' {
+        It 'should call pnpm add for installed packages' {
             $handler.Apply($ctx)
-            Should -Invoke Invoke-Pnpm -ParameterFilter { $Arguments -contains "add" } -Times 0
+            Should -Invoke Invoke-Pnpm -ParameterFilter { $Arguments -contains "add" } -Times 2
         }
     }
 

--- a/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
@@ -200,14 +200,14 @@ Describe 'WingetHandler' {
             Mock Test-Path { return $false } -ParameterFilter { $Path -like "*\.cargo\bin" }
         }
 
-        It 'should skip and return success' {
+        It 'should run winget install for installed packages to pick up the latest installer' {
             $ctx.Options["WingetMode"] = "import"
             $result = $handler.Apply($ctx)
             $result.Success | Should -Be $true
-            $result.Message | Should -Match "1 個スキップ"
+            $result.Message | Should -Match "1 個インストール"
         }
 
-        It 'should not call winget install' {
+        It 'should call winget install even when winget list reports the package is installed' {
             $script:installCalled = $false
             Mock Invoke-Winget {
                 param($Arguments)
@@ -226,7 +226,32 @@ Describe 'WingetHandler' {
             }
             $ctx.Options["WingetMode"] = "import"
             $handler.Apply($ctx)
-            $script:installCalled | Should -Be $false
+            $script:installCalled | Should -Be $true
+        }
+
+        It 'should treat already-latest no-op installs without verifyCommand as success' {
+            Mock Invoke-Winget {
+                param($Arguments)
+                if ($Arguments -contains "install") {
+                    $global:LASTEXITCODE = 1
+                    return @("No applicable update found")
+                }
+                if ($Arguments -contains "list" -and $Arguments -notcontains "--id") {
+                    $global:LASTEXITCODE = 0
+                    return @(
+                        "Name          Id         Version  Source",
+                        "-------------------------------------------",
+                        "Git           Git.Git    2.43.0   winget"
+                    )
+                }
+                $global:LASTEXITCODE = 0
+            }
+
+            $ctx.Options["WingetMode"] = "import"
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $result.Message | Should -Match "1 個インストール"
         }
     }
 
@@ -528,7 +553,7 @@ Describe 'WingetHandler' {
             Mock Test-Path { return $false } -ParameterFilter { $Path -like "*\.cargo\bin" }
         }
 
-        It 'should skip without calling install' {
+        It 'should call winget install so Microsoft Store packages can upgrade to latest' {
             $script:installCalled = $false
             Mock Invoke-Winget {
                 param($Arguments)
@@ -547,7 +572,7 @@ Describe 'WingetHandler' {
             }
             $ctx.Options["WingetMode"] = "import"
             $handler.Apply($ctx)
-            $script:installCalled | Should -Be $false
+            $script:installCalled | Should -Be $true
         }
     }
 
@@ -995,6 +1020,39 @@ Describe 'WingetHandler' {
             $result.Success | Should -Be $true
             $script:capturedArgs | Should -Contain "--installer-type"
             $script:capturedArgs | Should -Contain "wix"
+        }
+
+        It 'should ignore package Version metadata so winget selects the latest installer' {
+            $script:capturedArgs = $null
+            Mock Get-JsonContent {
+                return [PSCustomObject]@{
+                    Sources = @(
+                        [PSCustomObject]@{
+                            SourceDetails = [PSCustomObject]@{ Name = "winget" }
+                            Packages      = @(
+                                [PSCustomObject]@{
+                                    PackageIdentifier = "Versioned.Tool"
+                                    Version           = "1.2.3"
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+            Mock Invoke-Winget {
+                param($Arguments)
+                if ($Arguments -contains "install") {
+                    $script:capturedArgs = $Arguments
+                }
+                if ($Arguments -contains "list") { $global:LASTEXITCODE = 1 } else { $global:LASTEXITCODE = 0 }
+            }
+
+            $ctx.Options["WingetMode"] = "import"
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $script:capturedArgs | Should -Not -Contain "--version"
+            $script:capturedArgs | Should -Not -Contain "1.2.3"
         }
     }
 
@@ -1653,11 +1711,11 @@ Describe 'WingetHandler' {
             Mock Test-Path { return $false } -ParameterFilter { $Path -like "*\.cargo\bin" }
         }
 
-        It 'should install packages without verifyCommand and skip verified CLI packages' {
+        It 'should install packages with and without verifyCommand so both can upgrade to latest' {
             $ctx.Options["WingetMode"] = "import"
             $result = $handler.Apply($ctx)
             $result.Success | Should -Be $true
-            $result.Message | Should -Match "1 個インストール"
+            $result.Message | Should -Match "2 個インストール"
             $result.Message | Should -Match "1 個検証済み"
         }
 

--- a/scripts/sh/nixos-wsl-postinstall.sh
+++ b/scripts/sh/nixos-wsl-postinstall.sh
@@ -299,6 +299,10 @@ else
   echo "Skipping (exists): $HOST_HW_PATH"
 fi
 
+# Update flake inputs so first install uses the latest Nix sources.
+NIX_CONFIG="experimental-features = nix-command flakes" \
+  nix flake update "$TARGET_DIR"
+
 # Run nixos-rebuild
 NIX_CONFIG="experimental-features = nix-command flakes" \
   nixos-rebuild switch --flake "path:$TARGET_DIR#$FLAKE_NAME"

--- a/scripts/sh/update.sh
+++ b/scripts/sh/update.sh
@@ -45,6 +45,9 @@ if [ ! -d ~/.dotfiles ]; then
 fi
 
 # NixOS rebuild
+info "Nix flake inputs を更新しています..."
+nix flake update ~/.dotfiles
+
 info "NixOS 設定をビルドしています..."
 echo ""
 
@@ -106,5 +109,5 @@ echo ""
 success "Dotfiles が正常にインストールされました"
 echo ""
 echo "次回以降の更新は:"
-echo "  nrs  # または: sudo nixos-rebuild switch --flake ~/.dotfiles#nixos --impure"
+echo "  nrs  # または: nix flake update ~/.dotfiles && sudo nixos-rebuild switch --flake ~/.dotfiles#nixos --impure"
 echo ""

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -213,11 +213,13 @@
           }
         },
         {
-          "PackageIdentifier": "Warp.Warp"
+          "PackageIdentifier": "Warp.Warp",
+          "installTimeoutSeconds": 900
         },
         {
           "PackageIdentifier": "wez.wezterm.nightly",
           "ciSkipInstall": true,
+          "installArgs": ["--ignore-security-hash"],
           "pathEntries": ["%ProgramFiles%\\WezTerm"],
           "verifyCommand": {
             "args": ["--version"],


### PR DESCRIPTION
## Summary
- Make winget/npm/pnpm installs run for existing packages so package managers can select latest versions.
- Stop pinning winget install versions and add WezTerm nightly/Warp installer safeguards.
- Update Nix rebuild entry points to refresh flake inputs and add regression coverage for latest-package policy.

## Test Plan
- [x] `scripts/powershell/tests/Invoke-Tests.ps1 -Path ./PackageCatalog.Tests.ps1 -MinimumCoverage 0`
- [x] `scripts/powershell/tests/Invoke-Tests.ps1 -Path ./handlers/Handler.Winget.Tests.ps1 -MinimumCoverage 0`
- [x] `scripts/powershell/tests/Invoke-Tests.ps1 -Path ./handlers/Handler.Npm.Tests.ps1 -MinimumCoverage 0`
- [x] `scripts/powershell/tests/Invoke-Tests.ps1 -Path ./handlers/Handler.Pnpm.Tests.ps1 -MinimumCoverage 0`
- [x] `scripts/powershell/tests/Invoke-Tests.ps1 -Path ./handlers/Handler.NixRebuild.Tests.ps1 -MinimumCoverage 0`
- [x] `git diff --check`

## Local environment notes
- `task commit` could not run because Windows chezmoi sourceDir is not initialized and WSL is failing with `Wsl/CallMsi/Install/REGDB_E_CLASSNOTREG`.
- `task fmt:check` / `task lint` require WSL and could not be run locally.
- `Microsoft.WSL` upgrade to 2.7.3 requires administrator privileges on this machine.