### PR TITLE
Fix winget install error handling

### DIFF
--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -12,6 +12,7 @@
 #   - msstoreVerifyById  → Microsoft Store Product ID → { command, args } for post-install verification
 #   - wingetInstallArgs  → catalog attr name → extra winget install arguments
 #   - wingetInstallTimeoutSeconds → catalog attr name or winget ID → winget install timeout
+#   - wingetSkipInstall → catalog attr name or winget/msstore ID → skip normal automated install
 #   - wingetCiSkipInstall → catalog attr name or winget/msstore ID → skip CI winget install smoke test
 #   - wingetPathEntries  → catalog attr name or winget ID → extra Windows PATH directories
 #   - windowsOnly        → packages with no nix equivalent (winget/msstore/pnpm)
@@ -626,19 +627,21 @@ lib.mapAttrs (_: names: resolve names) grouped
       "--installer-type"
       "wix"
     ];
-    wezterm = [
-      "--ignore-security-hash"
-    ];
   };
 
   wingetInstallTimeoutSeconds = {
     google-cloud-sdk = 900;
-    warp-terminal = 900;
+  };
+
+  # Packages kept in the catalog but skipped by the non-interactive Windows
+  # installer because upstream live installers are not reliable in that mode.
+  wingetSkipInstall = {
+    wezterm = "WezTerm nightly can require InstallerHashOverride when the live hash drifts";
+    warp-terminal = "Warp installer can hang under non-interactive winget";
   };
 
   # Upstream nightly winget manifests and Microsoft Store installs can drift or
-  # hang in CI. Keep them in normal installs, but avoid making CI depend on
-  # their live installer behavior.
+  # hang in CI. Avoid making CI depend on their live installer behavior.
   wingetCiSkipInstall = {
     wezterm = true;
     "9PLM9XGG6VKS" = true;

--- a/nix/packages/winget.nix
+++ b/nix/packages/winget.nix
@@ -48,6 +48,20 @@ let
     in
     if installTimeoutSeconds == null then pkg else pkg // { inherit installTimeoutSeconds; };
 
+  attachSkipInstall =
+    skipInstallMap: key: pkg:
+    let
+      skipReason = skipInstallMap.${key} or null;
+    in
+    if skipReason == null then
+      pkg
+    else
+      pkg
+      // {
+        skipInstall = true;
+        inherit skipReason;
+      };
+
   attachCiSkipInstall =
     ciSkipInstallMap: key: pkg:
     let
@@ -78,11 +92,13 @@ let
 
   attachWingetMetadata =
     key: pkg:
-    attachCiSkipInstall sets.wingetCiSkipInstall key (
-      attachPathEntries sets.wingetPathEntries key (
-        attachPortableLink sets.wingetPortableLinksById key (
-          attachInstallTimeout sets.wingetInstallTimeoutSeconds key (
-            attachInstallArgs sets.wingetInstallArgs key (attachVerify sets.wingetVerify key pkg)
+    attachSkipInstall sets.wingetSkipInstall key (
+      attachCiSkipInstall sets.wingetCiSkipInstall key (
+        attachPathEntries sets.wingetPathEntries key (
+          attachPortableLink sets.wingetPortableLinksById key (
+            attachInstallTimeout sets.wingetInstallTimeoutSeconds key (
+              attachInstallArgs sets.wingetInstallArgs key (attachVerify sets.wingetVerify key pkg)
+            )
           )
         )
       )
@@ -95,10 +111,12 @@ let
 
   wingetFromWindowsOnly = map (
     id:
-    attachCiSkipInstall sets.wingetCiSkipInstall id (
-      attachPathEntries sets.wingetPathEntries id (
-        attachPortableLink sets.wingetPortableLinksById id (
-          attachVerify sets.wingetVerifyById id { PackageIdentifier = id; }
+    attachSkipInstall sets.wingetSkipInstall id (
+      attachCiSkipInstall sets.wingetCiSkipInstall id (
+        attachPathEntries sets.wingetPathEntries id (
+          attachPortableLink sets.wingetPortableLinksById id (
+            attachVerify sets.wingetVerifyById id { PackageIdentifier = id; }
+          )
         )
       )
     )
@@ -108,8 +126,10 @@ let
 
   msstorePackages = map (
     id:
-    attachCiSkipInstall sets.wingetCiSkipInstall id (
-      attachVerify sets.msstoreVerifyById id { PackageIdentifier = id; }
+    attachSkipInstall sets.wingetSkipInstall id (
+      attachCiSkipInstall sets.wingetCiSkipInstall id (
+        attachVerify sets.msstoreVerifyById id { PackageIdentifier = id; }
+      )
     )
   ) sets.windowsOnly.msstore;
 

--- a/scripts/powershell/handlers/Handler.Winget.ps1
+++ b/scripts/powershell/handlers/Handler.Winget.ps1
@@ -454,6 +454,9 @@ class WingetHandler : SetupHandlerBase {
         if ($ctx.GetOption("WingetVerifyCommandOnly", $false)) {
             return $false
         }
+        if ($ctx.GetOption("UserPhaseOnly", $false)) {
+            return $false
+        }
         if ($ctx.GetOption("SkipWslInstall", $false)) {
             return $false
         }

--- a/scripts/powershell/handlers/Handler.Winget.ps1
+++ b/scripts/powershell/handlers/Handler.Winget.ps1
@@ -154,6 +154,14 @@ class WingetHandler : SetupHandlerBase {
                                 if ($pkg.PSObject.Properties.Name -contains "pathEntries") {
                                     $pathEntries = @($pkg.pathEntries)
                                 }
+                                $skipInstall = $false
+                                if ($pkg.PSObject.Properties.Name -contains "skipInstall") {
+                                    $skipInstall = [bool]$pkg.skipInstall
+                                }
+                                $skipReason = $null
+                                if ($pkg.PSObject.Properties.Name -contains "skipReason") {
+                                    $skipReason = [string]$pkg.skipReason
+                                }
                                 $packages += [PSCustomObject]@{
                                     Id                    = $pkg.PackageIdentifier
                                     Version               = $version
@@ -164,6 +172,8 @@ class WingetHandler : SetupHandlerBase {
                                     CiSkipInstall         = $ciSkipInstall
                                     PortableLink          = $portableLink
                                     PathEntries           = $pathEntries
+                                    SkipInstall           = $skipInstall
+                                    SkipReason            = $skipReason
                                 }
                             }
                         }
@@ -201,7 +211,7 @@ class WingetHandler : SetupHandlerBase {
                     Update-ProcessEnvironmentPath
                     $this.EnsurePortableLink($pkg)
                     $this.EnsurePathEntries($pkg)
-                    if ($this.ShouldDeferWslVerificationToAdminInstall($pkg, $ctx) -and -not (Test-WslAvailable)) {
+                    if ($this.ShouldDeferWslVerificationToAdminInstall($pkg, $ctx)) {
                         $this.LogWarning("Microsoft.WSL の検証は Phase 2b の管理者 WSL インストールに委譲します")
                         $deferred++
                         continue
@@ -214,6 +224,17 @@ class WingetHandler : SetupHandlerBase {
                             continue
                         }
                     }
+                }
+
+                if ($pkg.SkipInstall) {
+                    if ($verificationPassed) {
+                        $this.Log("スキップ (検証済み/手動対象): $($pkg.Id)", "Gray")
+                        continue
+                    }
+
+                    $this.LogSkippedInstall($pkg)
+                    $skipped++
+                    continue
                 }
 
                 if ($pkg.Id -in $installedIds -or $this.IsPackageInstalled($pkg.Id)) {
@@ -408,8 +429,22 @@ class WingetHandler : SetupHandlerBase {
         $text = ($installOutput | ForEach-Object { [string]$_ }) -join "`n"
         return $text -match '0x80073cfb' -or
         $text -match 'No applicable update found' -or
+        $text -match 'No available upgrade found' -or
+        $text -match 'No newer package versions are available' -or
         $text -match 'already installed' -or
+        $text -match '既にインストールされています' -or
+        $text -match '利用可能なアップグレードが見つかりませんでした' -or
+        $text -match '新しいパッケージ バージョンはありません' -or
+        $text -match 'バージョン番号を特定できません' -or
         $text -match '別のバージョンが既にインストールされています'
+    }
+
+    hidden [void] LogSkippedInstall([object]$pkg) {
+        $reason = ""
+        if ($pkg.PSObject.Properties.Name -contains "SkipReason" -and -not [string]::IsNullOrWhiteSpace($pkg.SkipReason)) {
+            $reason = " - $($pkg.SkipReason)"
+        }
+        $this.Log("スキップ (手動対象): $($pkg.Id)$reason", "Yellow")
     }
 
     hidden [bool] ShouldDeferWslVerificationToAdminInstall([object]$pkg, [SetupContext]$ctx) {
@@ -417,9 +452,6 @@ class WingetHandler : SetupHandlerBase {
             return $false
         }
         if ($ctx.GetOption("WingetVerifyCommandOnly", $false)) {
-            return $false
-        }
-        if ($ctx.GetOption("UserPhaseOnly", $false)) {
             return $false
         }
         if ($ctx.GetOption("SkipWslInstall", $false)) {

--- a/scripts/powershell/tests/Integration.Tests.ps1
+++ b/scripts/powershell/tests/Integration.Tests.ps1
@@ -27,7 +27,6 @@ Describe 'Integration Verification - Windows Environment' {
             'fzf'
             'zoxide'
             'winget'
-            'wezterm'
         ) {
             $c = Get-Command -Name $_ -ErrorAction SilentlyContinue
             if ($null -eq $c) { throw "コマンド '$_' が見つかりません" }

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -19,28 +19,40 @@ Describe 'Package catalog consistency' {
             $versionedPackages.Count | Should -Be 0
         }
 
-        It 'should allow WezTerm nightly to use the latest installer even when the live hash drifts' {
+        It 'should not require InstallerHashOverride for WezTerm nightly' {
             $sets = Get-Content -LiteralPath $script:setsPath -Raw
 
-            $sets | Should -Match '(?s)wingetInstallArgs\s*=\s*\{.*?wezterm\s*=\s*\[.*?"--ignore-security-hash"'
+            $sets | Should -Not -Match '(?s)wingetInstallArgs\s*=\s*\{.*?wezterm\s*=\s*\[.*?"--ignore-security-hash"'
         }
 
-        It 'should generate WezTerm nightly with ignore-security-hash install args' {
+        It 'should generate WezTerm nightly without ignore-security-hash install args' {
             $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
             $wingetSource = @($json.Sources | Where-Object { $_.SourceDetails.Name -eq 'winget' }) | Select-Object -First 1
             $package = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'wez.wezterm.nightly' }) | Select-Object -First 1
 
             $package | Should -Not -BeNullOrEmpty
-            @($package.installArgs) | Should -Contain '--ignore-security-hash'
+            @($package.installArgs) | Should -Not -Contain '--ignore-security-hash'
         }
 
-        It 'should give Warp a longer install timeout because the live installer can be slow' {
+        It 'should define volatile terminal packages as manual winget installs in the SSOT' {
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+
+            $sets | Should -Match '(?s)wingetSkipInstall\s*=\s*\{.*?wezterm\s*='
+            $sets | Should -Match '(?s)wingetSkipInstall\s*=\s*\{.*?warp-terminal\s*='
+        }
+
+        It 'should generate skipInstall metadata for volatile terminal packages' {
             $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
             $wingetSource = @($json.Sources | Where-Object { $_.SourceDetails.Name -eq 'winget' }) | Select-Object -First 1
-            $package = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'Warp.Warp' }) | Select-Object -First 1
+            $warp = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'Warp.Warp' }) | Select-Object -First 1
+            $wezterm = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'wez.wezterm.nightly' }) | Select-Object -First 1
 
-            $package | Should -Not -BeNullOrEmpty
-            $package.installTimeoutSeconds | Should -Be 900
+            $warp | Should -Not -BeNullOrEmpty
+            $warp.skipInstall | Should -BeTrue
+            $warp.skipReason | Should -Not -BeNullOrEmpty
+            $wezterm | Should -Not -BeNullOrEmpty
+            $wezterm.skipInstall | Should -BeTrue
+            $wezterm.skipReason | Should -Not -BeNullOrEmpty
         }
 
         It 'should update flake inputs in the Nix rebuild aliases before applying the system' {

--- a/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
@@ -1379,6 +1379,51 @@ Describe 'WingetHandler' {
             Should -Invoke Invoke-VerifyCommand -Times 0
         }
 
+        It 'should keep Microsoft.WSL active during user-phase-only installs because no admin phase follows' {
+            $script:wslVerifyAttempts = 0
+            Mock Test-WslAvailable { return $false }
+            Mock Invoke-VerifyCommand {
+                $script:wslVerifyAttempts++
+                if ($script:wslVerifyAttempts -eq 1) {
+                    $global:LASTEXITCODE = 127
+                    throw "wsl not found"
+                }
+
+                $global:LASTEXITCODE = 0
+                return "WSL version: 2.7.8.0"
+            }
+            Mock Invoke-Winget {
+                param($Arguments)
+                if ($Arguments -contains "install") {
+                    $global:LASTEXITCODE = 0
+                    return "インストールが完了しました"
+                }
+                if ($Arguments -contains "list" -and $Arguments -contains "--id") {
+                    $global:LASTEXITCODE = 1
+                    return "入力条件に一致するインストール済みのパッケージが見つかりませんでした。"
+                }
+
+                $global:LASTEXITCODE = 0
+                return "Name Id Version Source"
+            }
+
+            $ctx.Options["WingetMode"] = "import"
+            $ctx.Options["UserPhaseOnly"] = $true
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $result.Message | Should -Match "1 個インストール"
+            $result.Message | Should -Not -Match "管理者フェーズ待ち"
+            Should -Invoke Invoke-Winget -Times 1 -ParameterFilter {
+                $Arguments -contains "install" -and $Arguments -contains "Microsoft.WSL"
+            }
+            Should -Invoke Invoke-VerifyCommand -Times 2 -ParameterFilter {
+                $Command -eq "wsl" -and
+                $Arguments -contains "--version" -and
+                $TimeoutSeconds -eq 30
+            }
+        }
+
         It 'should repair then reinstall installed Microsoft.WSL and fail when wsl --version still does not exit' {
             Mock Invoke-VerifyCommand {
                 $global:LASTEXITCODE = 124

--- a/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
@@ -253,6 +253,35 @@ Describe 'WingetHandler' {
             $result.Success | Should -Be $true
             $result.Message | Should -Match "1 個インストール"
         }
+
+        It 'should treat localized already-latest no-op installs without verifyCommand as success' {
+            Mock Invoke-Winget {
+                param($Arguments)
+                if ($Arguments -contains "install") {
+                    $global:LASTEXITCODE = 1
+                    return @(
+                        "既存のパッケージが既にインストールされています。インストールされているパッケージ...をアップグレードしようとしています",
+                        "利用可能なアップグレードが見つかりませんでした。",
+                        "構成されたソースから入手できる新しいパッケージ バージョンはありません。"
+                    )
+                }
+                if ($Arguments -contains "list" -and $Arguments -notcontains "--id") {
+                    $global:LASTEXITCODE = 0
+                    return @(
+                        "Name          Id         Version  Source",
+                        "-------------------------------------------",
+                        "Git           Git.Git    2.43.0   winget"
+                    )
+                }
+                $global:LASTEXITCODE = 0
+            }
+
+            $ctx.Options["WingetMode"] = "import"
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $result.Message | Should -Match "1 個インストール"
+        }
     }
 
     Context 'Apply - import mode: installed package verification fails' {
@@ -1325,25 +1354,15 @@ Describe 'WingetHandler' {
             Should -Invoke Invoke-VerifyCommand -Times 0
         }
 
-        It 'should repair installed Microsoft.WSL during normal install when WSL is available but wsl --version fails' {
+        It 'should defer Microsoft.WSL even when WSL is available during normal install' {
             Mock Test-WslAvailable { return $true }
             Mock Invoke-VerifyCommand {
-                $global:LASTEXITCODE = 124
-                return "検証コマンドがタイムアウトしました (30s): wsl --version"
+                throw "wsl --version should be skipped in the non-admin winget phase"
             }
             Mock Invoke-Winget {
                 param($Arguments)
-                if ($Arguments -contains "repair") {
-                    $global:LASTEXITCODE = 0
-                    return "修復が完了しました"
-                }
-                if ($Arguments -contains "uninstall") {
-                    $global:LASTEXITCODE = 0
-                    return "アンインストールが完了しました"
-                }
-                if ($Arguments -contains "install") {
-                    $global:LASTEXITCODE = 0
-                    return "インストールが完了しました"
+                if ($Arguments -contains "install" -or $Arguments -contains "repair" -or $Arguments -contains "uninstall") {
+                    throw "winget install, repair, and uninstall should be skipped when WSL is deferred to admin phase"
                 }
                 $global:LASTEXITCODE = 0
                 return "Linux 用 Windows サブシステム Microsoft.WSL 2.7.3.0 winget"
@@ -1352,17 +1371,12 @@ Describe 'WingetHandler' {
             $ctx.Options["WingetMode"] = "import"
             $result = $handler.Apply($ctx)
 
-            $result.Success | Should -Be $false
-            $result.Message | Should -Match "1 個検証失敗"
-            $result.Message | Should -Not -Match "管理者フェーズ待ち"
-            Should -Invoke Invoke-Winget -Times 1 -ParameterFilter { $Arguments -contains "repair" }
-            Should -Invoke Invoke-Winget -Times 1 -ParameterFilter { $Arguments -contains "uninstall" }
-            Should -Invoke Invoke-Winget -Times 1 -ParameterFilter { $Arguments -contains "install" }
-            Should -Invoke Invoke-VerifyCommand -Times 3 -ParameterFilter {
-                $Command -eq "wsl" -and
-                $Arguments -contains "--version" -and
-                $TimeoutSeconds -eq 30
-            }
+            $result.Success | Should -Be $true
+            $result.Message | Should -Match "1 個管理者フェーズ待ち"
+            Should -Invoke Invoke-Winget -Times 0 -ParameterFilter { $Arguments -contains "install" }
+            Should -Invoke Invoke-Winget -Times 0 -ParameterFilter { $Arguments -contains "repair" }
+            Should -Invoke Invoke-Winget -Times 0 -ParameterFilter { $Arguments -contains "uninstall" }
+            Should -Invoke Invoke-VerifyCommand -Times 0
         }
 
         It 'should repair then reinstall installed Microsoft.WSL and fail when wsl --version still does not exit' {
@@ -1683,6 +1697,89 @@ Describe 'WingetHandler' {
             $result.Success | Should -Be $true
             $result.Message | Should -Match "1 個インストール"
             Should -Invoke Invoke-VerifyCommand -Times 0
+        }
+    }
+
+    Context 'Apply - import mode: skipInstall package' {
+        BeforeEach {
+            Mock Get-ExternalCommand { return @{ Source = "C:\winget.exe" } }
+            Mock Test-PathExist { return $true }
+            Mock Test-Path { return $false } -ParameterFilter { $Path -like "*\.cargo\bin" }
+        }
+
+        It 'should skip manual packages instead of invoking winget install' {
+            Mock Get-JsonContent {
+                return [PSCustomObject]@{
+                    Sources = @(
+                        [PSCustomObject]@{
+                            SourceDetails = [PSCustomObject]@{ Name = "winget" }
+                            Packages      = @(
+                                [PSCustomObject]@{
+                                    PackageIdentifier = "Warp.Warp"
+                                    skipInstall       = $true
+                                    skipReason        = "installer hangs in non-interactive winget"
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+            Mock Invoke-Winget {
+                param($Arguments)
+                if ($Arguments -contains "install") {
+                    throw "winget install should be skipped"
+                }
+                $global:LASTEXITCODE = 1
+            }
+            Mock Write-Host { }
+
+            $ctx.Options["WingetMode"] = "import"
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $result.Message | Should -Match "1 個スキップ"
+            Should -Invoke Invoke-Winget -Times 0 -ParameterFilter { $Arguments -contains "install" }
+            Should -Invoke Write-Host -ParameterFilter {
+                [string]$Object -match 'スキップ \(手動対象\): Warp\.Warp'
+            }
+        }
+
+        It 'should skip manual packages when verification is unavailable' {
+            Mock Get-JsonContent {
+                return [PSCustomObject]@{
+                    Sources = @(
+                        [PSCustomObject]@{
+                            SourceDetails = [PSCustomObject]@{ Name = "winget" }
+                            Packages      = @(
+                                [PSCustomObject]@{
+                                    PackageIdentifier = "wez.wezterm.nightly"
+                                    skipInstall       = $true
+                                    skipReason        = "nightly hash drifts"
+                                    verifyCommand     = [PSCustomObject]@{ command = "wezterm"; args = @("--version") }
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+            Mock Invoke-Winget {
+                param($Arguments)
+                if ($Arguments -contains "install") {
+                    throw "winget install should be skipped"
+                }
+                $global:LASTEXITCODE = 1
+            }
+            Mock Invoke-VerifyCommand {
+                $global:LASTEXITCODE = 127
+                throw "wezterm not found"
+            }
+
+            $ctx.Options["WingetMode"] = "import"
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $result.Message | Should -Match "1 個スキップ"
+            Should -Invoke Invoke-Winget -Times 0 -ParameterFilter { $Arguments -contains "install" }
         }
     }
 

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -214,13 +214,15 @@
         },
         {
           "PackageIdentifier": "Warp.Warp",
-          "installTimeoutSeconds": 900
+          "skipInstall": true,
+          "skipReason": "Warp installer can hang under non-interactive winget"
         },
         {
           "PackageIdentifier": "wez.wezterm.nightly",
           "ciSkipInstall": true,
-          "installArgs": ["--ignore-security-hash"],
           "pathEntries": ["%ProgramFiles%\\WezTerm"],
+          "skipInstall": true,
+          "skipReason": "WezTerm nightly can require InstallerHashOverride when the live hash drifts",
           "verifyCommand": {
             "args": ["--version"],
             "command": "wezterm"


### PR DESCRIPTION
## Summary
- Treat localized winget already-installed / already-latest output as a successful no-op for packages without verification commands.
- Mark Warp and WezTerm nightly as manual installs for non-interactive winget runs.
- Defer Microsoft.WSL verification/repair/reinstall to the admin WSL phase during normal user-phase installs.

## Test Plan
- `pwsh -File scripts/powershell/install.ps1 -UserPhaseOnly -NoPause` -> passed
- `./Invoke-Tests.ps1 -Path ./handlers/Handler.Winget.Tests.ps1 -MinimumCoverage 0` -> 56 passed
- `./Invoke-Tests.ps1 -Path ./PackageCatalog.Tests.ps1 -MinimumCoverage 0` -> 18 passed
- `./Invoke-Tests.ps1 -Path ./PSScriptAnalyzer.Tests.ps1 -MinimumCoverage 0` -> 25 passed
- `git diff --check` -> passed
- `task test` -> 774 passed, 1 failed, 5 skipped locally; remaining failure is environment-only: missing `UDEVGothic NF` font
- `task lint` / `task commit` could not run locally because WSL is currently not installed and `Microsoft.WSL` requires admin privileges to reinstall