### PR TITLE
Configure OpenClaw workspace from lifelog root

### DIFF
--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -42,8 +42,13 @@ sourceDir = {{ .chezmoi.sourceDir | quote }}
 
 [scriptEnv]
     OP_ACCOUNT = "EJLA3HRAVZBCXIQ7SRSFGQBTNU"
-{{- $lifelogRoot := promptString "LIFELOG_ROOT" (env "LIFELOG_ROOT") }}
-{{- if $lifelogRoot }}
+{{- $setupLifelogRoot := env "OPENCLAW_LIFELOG_ROOT_FOR_INIT" }}
+{{- $lifelogRoot := env "LIFELOG_ROOT" }}
+{{- if $setupLifelogRoot }}
+    # Explicit lifelog root for OpenClaw. No default path is baked in; set
+    # LIFELOG_ROOT via scripts/powershell/configure-lifelog-root.ps1.
+    LIFELOG_ROOT = {{ $setupLifelogRoot | quote }}
+{{- else if $lifelogRoot }}
     # Explicit lifelog root for OpenClaw. No default path is baked in; set
     # LIFELOG_ROOT via scripts/powershell/configure-lifelog-root.ps1.
     LIFELOG_ROOT = {{ $lifelogRoot | quote }}

--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -42,6 +42,12 @@ sourceDir = {{ .chezmoi.sourceDir | quote }}
 
 [scriptEnv]
     OP_ACCOUNT = "EJLA3HRAVZBCXIQ7SRSFGQBTNU"
+{{- $lifelogRoot := promptString "LIFELOG_ROOT" (env "LIFELOG_ROOT") }}
+{{- if $lifelogRoot }}
+    # Explicit lifelog root for OpenClaw. No default path is baked in; set
+    # LIFELOG_ROOT via scripts/powershell/configure-lifelog-root.ps1.
+    LIFELOG_ROOT = {{ $lifelogRoot | quote }}
+{{- end }}
 
 [interpreters.ps1]
     command = "pwsh"

--- a/chezmoi/.chezmoiscripts/run_after_configure-openclaw-workspace_windows.ps1
+++ b/chezmoi/.chezmoiscripts/run_after_configure-openclaw-workspace_windows.ps1
@@ -1,0 +1,123 @@
+#!/usr/bin/env pwsh
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-NormalizedPath {
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return $null
+    }
+
+    return [System.IO.Path]::GetFullPath($Path.Trim()).TrimEnd("\")
+}
+
+function Get-OpenClawConfigPath {
+    if (-not [string]::IsNullOrWhiteSpace($env:OPENCLAW_CONFIG)) {
+        return $env:OPENCLAW_CONFIG
+    }
+
+    if ([string]::IsNullOrWhiteSpace($env:USERPROFILE)) {
+        throw "USERPROFILE is required to resolve OpenClaw config path."
+    }
+
+    return Join-Path (Join-Path $env:USERPROFILE ".openclaw") "openclaw.json"
+}
+
+function Set-JsonProperty {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Object,
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [AllowNull()]
+        [object]$Value
+    )
+
+    $property = $Object.PSObject.Properties[$Name]
+    if ($property) {
+        $property.Value = $Value
+        return
+    }
+
+    Add-Member -InputObject $Object -MemberType NoteProperty -Name $Name -Value $Value
+}
+
+function Get-JsonObjectProperty {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Object,
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    $property = $Object.PSObject.Properties[$Name]
+    if ($property -and $property.Value -and $property.Value -is [pscustomobject]) {
+        return $property.Value
+    }
+
+    $value = [pscustomobject]@{}
+    Set-JsonProperty -Object $Object -Name $Name -Value $value
+    return $value
+}
+
+function Read-OpenClawConfig {
+    param([string]$ConfigPath)
+
+    if (-not (Test-Path -LiteralPath $ConfigPath -PathType Leaf)) {
+        return [pscustomobject]@{}
+    }
+
+    $content = Get-Content -LiteralPath $ConfigPath -Raw
+    if ([string]::IsNullOrWhiteSpace($content)) {
+        return [pscustomobject]@{}
+    }
+
+    $config = $content | ConvertFrom-Json
+    if (-not $config) {
+        return [pscustomobject]@{}
+    }
+    if ($config -is [array] -or $config -isnot [pscustomobject]) {
+        throw "OpenClaw config root must be a JSON object: $ConfigPath"
+    }
+
+    return $config
+}
+
+function Write-OpenClawConfig {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Config,
+        [Parameter(Mandatory = $true)]
+        [string]$ConfigPath
+    )
+
+    $directory = Split-Path -Parent $ConfigPath
+    if ($directory -and -not (Test-Path -LiteralPath $directory -PathType Container)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+
+    $json = $Config | ConvertTo-Json -Depth 20
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::WriteAllText($ConfigPath, "$json`r`n", $utf8NoBom)
+}
+
+$lifelogRoot = Get-NormalizedPath $env:LIFELOG_ROOT
+if (-not $lifelogRoot) {
+    throw "LIFELOG_ROOT is required. Set it to the explicit lifelog repository root before running chezmoi apply."
+}
+
+$agentsPath = Join-Path $lifelogRoot "AGENTS.md"
+if (-not (Test-Path -LiteralPath $agentsPath -PathType Leaf)) {
+    throw "LIFELOG_ROOT does not look like lifelog root; AGENTS.md was not found: $agentsPath"
+}
+
+$configPath = Get-OpenClawConfigPath
+$config = Read-OpenClawConfig -ConfigPath $configPath
+$agents = Get-JsonObjectProperty -Object $config -Name "agents"
+$defaults = Get-JsonObjectProperty -Object $agents -Name "defaults"
+Set-JsonProperty -Object $defaults -Name "workspace" -Value $lifelogRoot
+Write-OpenClawConfig -Config $config -ConfigPath $configPath
+
+Write-Host "OpenClaw agents.defaults.workspace: $lifelogRoot"

--- a/scripts/powershell/configure-lifelog-root.ps1
+++ b/scripts/powershell/configure-lifelog-root.ps1
@@ -1,0 +1,142 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [string]$ExpectedRemoteRegex = 'github\.com[:/]rurusasu/lifelog(?:\.git)?$',
+
+    [string]$GitCommand = "git",
+
+    [string]$ChezmoiCommand = "chezmoi",
+
+    [string]$ChezmoiSource = (Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) "chezmoi"),
+
+    [ValidateSet("User", "Process")]
+    [string]$EnvironmentTarget = "User",
+
+    [switch]$SkipChezmoiApply
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-NormalizedPath {
+    param([string]$InputPath)
+
+    if ([string]::IsNullOrWhiteSpace($InputPath)) {
+        throw "Path is required."
+    }
+
+    return [System.IO.Path]::GetFullPath($InputPath.Trim()).TrimEnd("\")
+}
+
+function Invoke-CheckedCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Command,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Description
+    )
+
+    $output = & $Command @Arguments 2>&1
+    $exitCode = if ($null -eq $global:LASTEXITCODE) { 0 } else { $global:LASTEXITCODE }
+    if ($exitCode -ne 0) {
+        $joinedOutput = ($output | Out-String).Trim()
+        if ($joinedOutput) {
+            throw "$Description failed (exit=$exitCode): $joinedOutput"
+        }
+        throw "$Description failed (exit=$exitCode)."
+    }
+
+    return @($output)
+}
+
+function Assert-LifelogRoot {
+    param([string]$Root)
+
+    if (-not (Test-Path -LiteralPath $Root -PathType Container)) {
+        throw "Lifelog root does not exist: $Root"
+    }
+
+    $agentsPath = Join-Path $Root "AGENTS.md"
+    if (-not (Test-Path -LiteralPath $agentsPath -PathType Leaf)) {
+        throw "AGENTS.md was not found under the explicit lifelog root: $agentsPath"
+    }
+
+    $gitTopLevel = @(
+        Invoke-CheckedCommand `
+            -Command $GitCommand `
+            -Arguments @("-C", $Root, "rev-parse", "--show-toplevel") `
+            -Description "git rev-parse --show-toplevel"
+    )[0]
+    $normalizedTopLevel = Get-NormalizedPath ([string]$gitTopLevel)
+    if (-not [string]::Equals($normalizedTopLevel, $Root, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Explicit path is not the git top-level. Expected $Root but git returned $normalizedTopLevel."
+    }
+
+    $gitDir = @(
+        Invoke-CheckedCommand `
+            -Command $GitCommand `
+            -Arguments @("-C", $Root, "rev-parse", "--git-dir") `
+            -Description "git rev-parse --git-dir"
+    )[0]
+    if ([string]::IsNullOrWhiteSpace([string]$gitDir)) {
+        throw "Git directory could not be resolved for explicit lifelog root: $Root"
+    }
+
+    $origin = @(
+        Invoke-CheckedCommand `
+            -Command $GitCommand `
+            -Arguments @("-C", $Root, "remote", "get-url", "origin") `
+            -Description "git remote get-url origin"
+    )[0]
+    if ([string]::IsNullOrWhiteSpace([string]$origin) -or ([string]$origin) -notmatch $ExpectedRemoteRegex) {
+        throw "Explicit path is not the expected lifelog repository. Origin was: $origin"
+    }
+}
+
+function Set-LifelogRootEnvironment {
+    param(
+        [string]$Root,
+        [string]$Target
+    )
+
+    [System.Environment]::SetEnvironmentVariable("LIFELOG_ROOT", $Root, $Target)
+    $env:LIFELOG_ROOT = $Root
+}
+
+function Invoke-ChezmoiRefresh {
+    param([string]$Root)
+
+    if ($SkipChezmoiApply) {
+        Write-Host "Skipping chezmoi init/apply. LIFELOG_ROOT is set for $EnvironmentTarget."
+        return
+    }
+
+    if (-not (Test-Path -LiteralPath $ChezmoiSource -PathType Container)) {
+        throw "Chezmoi source directory does not exist: $ChezmoiSource"
+    }
+
+    Invoke-CheckedCommand `
+        -Command $ChezmoiCommand `
+        -Arguments @("init", "--source", $ChezmoiSource, "--promptString", "LIFELOG_ROOT=$Root") `
+        -Description "chezmoi init" | Out-Null
+
+    Invoke-CheckedCommand `
+        -Command $ChezmoiCommand `
+        -Arguments @("apply", "--source", $ChezmoiSource, "--force") `
+        -Description "chezmoi apply" | Out-Null
+
+    Write-Host "chezmoi init/apply completed with LIFELOG_ROOT: $Root"
+}
+
+$lifelogRoot = Get-NormalizedPath $Path
+Assert-LifelogRoot -Root $lifelogRoot
+Set-LifelogRootEnvironment -Root $lifelogRoot -Target $EnvironmentTarget
+Invoke-ChezmoiRefresh -Root $lifelogRoot
+Write-Host "LIFELOG_ROOT: $lifelogRoot"

--- a/scripts/powershell/configure-lifelog-root.ps1
+++ b/scripts/powershell/configure-lifelog-root.ps1
@@ -122,15 +122,28 @@ function Invoke-ChezmoiRefresh {
         throw "Chezmoi source directory does not exist: $ChezmoiSource"
     }
 
-    Invoke-CheckedCommand `
-        -Command $ChezmoiCommand `
-        -Arguments @("init", "--source", $ChezmoiSource, "--promptString", "LIFELOG_ROOT=$Root") `
-        -Description "chezmoi init" | Out-Null
+    $oldSetupRoot = $env:OPENCLAW_LIFELOG_ROOT_FOR_INIT
+    try {
+        $env:OPENCLAW_LIFELOG_ROOT_FOR_INIT = $Root
 
-    Invoke-CheckedCommand `
-        -Command $ChezmoiCommand `
-        -Arguments @("apply", "--source", $ChezmoiSource, "--force") `
-        -Description "chezmoi apply" | Out-Null
+        Invoke-CheckedCommand `
+            -Command $ChezmoiCommand `
+            -Arguments @("init", "--source", $ChezmoiSource) `
+            -Description "chezmoi init" | Out-Null
+
+        Invoke-CheckedCommand `
+            -Command $ChezmoiCommand `
+            -Arguments @("apply", "--source", $ChezmoiSource, "--force") `
+            -Description "chezmoi apply" | Out-Null
+    }
+    finally {
+        if ($null -eq $oldSetupRoot) {
+            Remove-Item Env:\OPENCLAW_LIFELOG_ROOT_FOR_INIT -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:OPENCLAW_LIFELOG_ROOT_FOR_INIT = $oldSetupRoot
+        }
+    }
 
     Write-Host "chezmoi init/apply completed with LIFELOG_ROOT: $Root"
 }

--- a/scripts/powershell/tests/ConfigureLifelogRoot.Tests.ps1
+++ b/scripts/powershell/tests/ConfigureLifelogRoot.Tests.ps1
@@ -61,7 +61,7 @@ exit /b 1
 
         Set-Content -LiteralPath $chezmoiStub -Encoding UTF8 -Value @'
 @echo off
->> "%CONFIGURE_LIFELOG_TEST_LOG%" echo chezmoi %* LIFELOG_ROOT=%LIFELOG_ROOT%
+>> "%CONFIGURE_LIFELOG_TEST_LOG%" echo chezmoi %* LIFELOG_ROOT=%LIFELOG_ROOT% OPENCLAW_LIFELOG_ROOT_FOR_INIT=%OPENCLAW_LIFELOG_ROOT_FOR_INIT%
 exit /b 0
 '@
 
@@ -81,9 +81,10 @@ exit /b 0
             ($calls -join "`n") | Should -Match 'git .*rev-parse --git-dir'
             ($calls -join "`n") | Should -Match 'git .*remote get-url origin'
             ($calls -join "`n") | Should -Match 'chezmoi .*init .*--source'
-            ($calls -join "`n") | Should -Match ('--promptString LIFELOG_ROOT=' + [regex]::Escape($env:CONFIGURE_LIFELOG_TEST_ROOT))
+            ($calls -join "`n") | Should -Not -Match '--promptString' -Because 'chezmoi init must not prompt in CI or bootstrap contexts'
             ($calls -join "`n") | Should -Match 'chezmoi .*apply .*--source'
             ($calls -join "`n") | Should -Match ('LIFELOG_ROOT=' + [regex]::Escape($env:CONFIGURE_LIFELOG_TEST_ROOT))
+            ($calls -join "`n") | Should -Match ('OPENCLAW_LIFELOG_ROOT_FOR_INIT=' + [regex]::Escape($env:CONFIGURE_LIFELOG_TEST_ROOT))
         }
         finally {
             Remove-Item Env:\CONFIGURE_LIFELOG_TEST_LOG -ErrorAction SilentlyContinue

--- a/scripts/powershell/tests/ConfigureLifelogRoot.Tests.ps1
+++ b/scripts/powershell/tests/ConfigureLifelogRoot.Tests.ps1
@@ -1,0 +1,93 @@
+#Requires -Module Pester
+
+BeforeAll {
+    $script:repoRoot = Resolve-Path (Join-Path $PSScriptRoot "../../..")
+    $script:scriptPath = Join-Path $script:repoRoot "scripts/powershell/configure-lifelog-root.ps1"
+}
+
+Describe 'configure-lifelog-root.ps1' {
+    It 'exists as an explicit setup entrypoint' {
+        Test-Path -LiteralPath $script:scriptPath -PathType Leaf | Should -BeTrue
+    }
+
+    It 'requires -Path and does not contain a default lifelog path' {
+        $content = Get-Content -LiteralPath $script:scriptPath -Raw
+
+        $content | Should -Match '\[Parameter\(Mandatory\s*=\s*\$true\)\]\s*\[string\]\$Path' -Because 'the caller must choose the lifelog root'
+        $content | Should -Not -Match 'D:\\\\lifelog|D:/lifelog|\.openclaw\\workspace' -Because 'the script must not bake in a candidate root'
+        $content | Should -Not -Match 'Get-ChildItem.*lifelog|Resolve-Path.*lifelog' -Because 'the script must not discover lifelog by scanning the filesystem'
+    }
+
+    It 'fails when the explicit path is not a lifelog root' {
+        $root = Join-Path $TestDrive "not-lifelog"
+        New-Item -ItemType Directory -Path $root -Force | Out-Null
+
+        $result = & pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File $script:scriptPath `
+            -Path $root `
+            -EnvironmentTarget Process `
+            -SkipChezmoiApply 2>&1
+
+        $LASTEXITCODE | Should -Not -Be 0
+        ($result | Out-String) | Should -Match 'AGENTS\.md'
+    }
+
+    It 'validates the explicit path with git and runs chezmoi init/apply with LIFELOG_ROOT set' {
+        $root = Join-Path $TestDrive "explicit-root"
+        New-Item -ItemType Directory -Path $root -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $root ".git") -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $root "AGENTS.md") -Value "# lifelog" -Encoding UTF8
+
+        $log = Join-Path $TestDrive "calls.log"
+        $gitStub = Join-Path $TestDrive "git-stub.cmd"
+        $chezmoiStub = Join-Path $TestDrive "chezmoi-stub.cmd"
+
+        Set-Content -LiteralPath $gitStub -Encoding UTF8 -Value @'
+@echo off
+>> "%CONFIGURE_LIFELOG_TEST_LOG%" echo git %*
+if "%~3"=="rev-parse" if "%~4"=="--show-toplevel" (
+  echo %CONFIGURE_LIFELOG_TEST_ROOT%
+  exit /b 0
+)
+if "%~3"=="rev-parse" if "%~4"=="--git-dir" (
+  echo %CONFIGURE_LIFELOG_TEST_ROOT%\.git
+  exit /b 0
+)
+if "%~3"=="remote" if "%~4"=="get-url" if "%~5"=="origin" (
+  echo https://github.com/rurusasu/lifelog.git
+  exit /b 0
+)
+exit /b 1
+'@
+
+        Set-Content -LiteralPath $chezmoiStub -Encoding UTF8 -Value @'
+@echo off
+>> "%CONFIGURE_LIFELOG_TEST_LOG%" echo chezmoi %* LIFELOG_ROOT=%LIFELOG_ROOT%
+exit /b 0
+'@
+
+        $env:CONFIGURE_LIFELOG_TEST_LOG = $log
+        $env:CONFIGURE_LIFELOG_TEST_ROOT = [System.IO.Path]::GetFullPath($root).TrimEnd("\")
+        try {
+            & pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File $script:scriptPath `
+                -Path $root `
+                -GitCommand $gitStub `
+                -ChezmoiCommand $chezmoiStub `
+                -ChezmoiSource (Join-Path $script:repoRoot "chezmoi") `
+                -EnvironmentTarget Process | Out-Null
+
+            $LASTEXITCODE | Should -Be 0
+            $calls = Get-Content -LiteralPath $log
+            ($calls -join "`n") | Should -Match 'git .*rev-parse --show-toplevel'
+            ($calls -join "`n") | Should -Match 'git .*rev-parse --git-dir'
+            ($calls -join "`n") | Should -Match 'git .*remote get-url origin'
+            ($calls -join "`n") | Should -Match 'chezmoi .*init .*--source'
+            ($calls -join "`n") | Should -Match ('--promptString LIFELOG_ROOT=' + [regex]::Escape($env:CONFIGURE_LIFELOG_TEST_ROOT))
+            ($calls -join "`n") | Should -Match 'chezmoi .*apply .*--source'
+            ($calls -join "`n") | Should -Match ('LIFELOG_ROOT=' + [regex]::Escape($env:CONFIGURE_LIFELOG_TEST_ROOT))
+        }
+        finally {
+            Remove-Item Env:\CONFIGURE_LIFELOG_TEST_LOG -ErrorAction SilentlyContinue
+            Remove-Item Env:\CONFIGURE_LIFELOG_TEST_ROOT -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/scripts/powershell/tests/chezmoi/OpenClawWorkspace.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/OpenClawWorkspace.Tests.ps1
@@ -1,0 +1,112 @@
+#Requires -Module Pester
+
+BeforeAll {
+    $script:repoRoot = Resolve-Path (Join-Path $PSScriptRoot "../../../..")
+    $script:chezmoiRoot = Join-Path $script:repoRoot "chezmoi"
+    $script:scriptPath = Join-Path $script:chezmoiRoot ".chezmoiscripts/run_after_configure-openclaw-workspace_windows.ps1"
+}
+
+Describe 'OpenClaw workspace chezmoi script' {
+    It 'is managed as a chezmoi script' {
+        Test-Path -LiteralPath $script:scriptPath -PathType Leaf | Should -BeTrue
+    }
+
+    It 'requires an explicit LIFELOG_ROOT and does not search default paths' {
+        $content = Get-Content -LiteralPath $script:scriptPath -Raw
+
+        $content | Should -Match 'LIFELOG_ROOT' -Because 'lifelog root must be supplied explicitly'
+        $content | Should -Not -Match 'D:\\\\lifelog|D:/lifelog|\.openclaw\\workspace' -Because 'the script must not bake in a candidate root'
+        $content | Should -Not -Match 'Get-ChildItem.*lifelog|Resolve-Path.*lifelog' -Because 'the script must not discover lifelog by scanning the filesystem'
+    }
+
+    It 'passes LIFELOG_ROOT through chezmoi scriptEnv without a default path' {
+        $content = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot ".chezmoi.toml.tmpl") -Raw
+
+        $content | Should -Match 'promptString\s+"LIFELOG_ROOT"' -Because 'chezmoi init should persist the explicit lifelog root supplied by the caller'
+        $content | Should -Match '(?m)^\s*LIFELOG_ROOT\s*=\s*\{\{\s*\$lifelogRoot\s*\|\s*quote\s*\}\}' -Because 'scriptEnv should receive the explicit lifelog root'
+        $content | Should -Not -Match 'D:\\\\lifelog|D:/lifelog' -Because 'the source config must not define a default lifelog root'
+        $content | Should -Not -Match '(?m)^\s*LIFELOG_ROOT\s*=\s*""' -Because 'an empty active config entry would mask the real environment variable'
+    }
+
+    It 'fails when LIFELOG_ROOT is missing' {
+        $oldLifelogRoot = $env:LIFELOG_ROOT
+        $oldOpenClawConfig = $env:OPENCLAW_CONFIG
+        try {
+            Remove-Item Env:\LIFELOG_ROOT -ErrorAction SilentlyContinue
+            $env:OPENCLAW_CONFIG = Join-Path $TestDrive "openclaw.json"
+
+            $result = & pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File $script:scriptPath 2>&1
+            $LASTEXITCODE | Should -Not -Be 0
+            ($result | Out-String) | Should -Match 'LIFELOG_ROOT'
+        }
+        finally {
+            if ($null -eq $oldLifelogRoot) {
+                Remove-Item Env:\LIFELOG_ROOT -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:LIFELOG_ROOT = $oldLifelogRoot
+            }
+
+            if ($null -eq $oldOpenClawConfig) {
+                Remove-Item Env:\OPENCLAW_CONFIG -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:OPENCLAW_CONFIG = $oldOpenClawConfig
+            }
+        }
+    }
+
+    It 'writes agents.defaults.workspace while preserving existing config values' {
+        $oldLifelogRoot = $env:LIFELOG_ROOT
+        $oldOpenClawConfig = $env:OPENCLAW_CONFIG
+        try {
+            $lifelogRoot = Join-Path $TestDrive "custom-lifelog"
+            New-Item -ItemType Directory -Path $lifelogRoot -Force | Out-Null
+            Set-Content -LiteralPath (Join-Path $lifelogRoot "AGENTS.md") -Value "# lifelog" -Encoding UTF8
+
+            $configPath = Join-Path $TestDrive ".openclaw/openclaw.json"
+            New-Item -ItemType Directory -Path (Split-Path -Parent $configPath) -Force | Out-Null
+            @{
+                agents = @{
+                    defaults = @{
+                        model = @{
+                            primary = "openai/gpt-5.5"
+                        }
+                    }
+                }
+                gateway = @{
+                    port = 18789
+                    auth = @{
+                        token = "preserve-me"
+                    }
+                }
+            } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $configPath -Encoding UTF8
+
+            $env:LIFELOG_ROOT = $lifelogRoot
+            $env:OPENCLAW_CONFIG = $configPath
+
+            & pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File $script:scriptPath | Out-Null
+            $LASTEXITCODE | Should -Be 0
+
+            $config = Get-Content -LiteralPath $configPath -Raw | ConvertFrom-Json
+            $config.agents.defaults.workspace | Should -Be ([System.IO.Path]::GetFullPath($lifelogRoot).TrimEnd("\"))
+            $config.agents.defaults.model.primary | Should -Be "openai/gpt-5.5"
+            $config.gateway.auth.token | Should -Be "preserve-me"
+        }
+        finally {
+            if ($null -eq $oldLifelogRoot) {
+                Remove-Item Env:\LIFELOG_ROOT -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:LIFELOG_ROOT = $oldLifelogRoot
+            }
+
+            if ($null -eq $oldOpenClawConfig) {
+                Remove-Item Env:\OPENCLAW_CONFIG -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:OPENCLAW_CONFIG = $oldOpenClawConfig
+            }
+        }
+    }
+}

--- a/scripts/powershell/tests/chezmoi/OpenClawWorkspace.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/OpenClawWorkspace.Tests.ps1
@@ -1,5 +1,7 @@
 #Requires -Module Pester
 
+$script:hasChezmoi = $null -ne (Get-Command chezmoi -ErrorAction SilentlyContinue)
+
 BeforeAll {
     $script:repoRoot = Resolve-Path (Join-Path $PSScriptRoot "../../../..")
     $script:chezmoiRoot = Join-Path $script:repoRoot "chezmoi"
@@ -29,7 +31,7 @@ Describe 'OpenClaw workspace chezmoi script' {
         $content | Should -Not -Match '(?m)^\s*LIFELOG_ROOT\s*=\s*""' -Because 'an empty active config entry would mask the real environment variable'
     }
 
-    It 'renders without prompting when LIFELOG_ROOT is missing' {
+    It 'renders without prompting when LIFELOG_ROOT is missing' -Skip:(-not $script:hasChezmoi) {
         $oldLifelogRoot = $env:LIFELOG_ROOT
         $oldSetupRoot = $env:OPENCLAW_LIFELOG_ROOT_FOR_INIT
         try {
@@ -59,7 +61,7 @@ Describe 'OpenClaw workspace chezmoi script' {
         }
     }
 
-    It 'renders setup-provided LIFELOG_ROOT without prompting' {
+    It 'renders setup-provided LIFELOG_ROOT without prompting' -Skip:(-not $script:hasChezmoi) {
         $oldLifelogRoot = $env:LIFELOG_ROOT
         $oldSetupRoot = $env:OPENCLAW_LIFELOG_ROOT_FOR_INIT
         try {

--- a/scripts/powershell/tests/chezmoi/OpenClawWorkspace.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/OpenClawWorkspace.Tests.ps1
@@ -22,10 +22,71 @@ Describe 'OpenClaw workspace chezmoi script' {
     It 'passes LIFELOG_ROOT through chezmoi scriptEnv without a default path' {
         $content = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot ".chezmoi.toml.tmpl") -Raw
 
-        $content | Should -Match 'promptString\s+"LIFELOG_ROOT"' -Because 'chezmoi init should persist the explicit lifelog root supplied by the caller'
+        $content | Should -Match 'OPENCLAW_LIFELOG_ROOT_FOR_INIT' -Because 'the setup script needs a no-prompt channel that cannot be masked by an old scriptEnv entry'
+        $content | Should -Not -Match 'promptString\s+"LIFELOG_ROOT"' -Because 'CI renders templates without a TTY'
         $content | Should -Match '(?m)^\s*LIFELOG_ROOT\s*=\s*\{\{\s*\$lifelogRoot\s*\|\s*quote\s*\}\}' -Because 'scriptEnv should receive the explicit lifelog root'
         $content | Should -Not -Match 'D:\\\\lifelog|D:/lifelog' -Because 'the source config must not define a default lifelog root'
         $content | Should -Not -Match '(?m)^\s*LIFELOG_ROOT\s*=\s*""' -Because 'an empty active config entry would mask the real environment variable'
+    }
+
+    It 'renders without prompting when LIFELOG_ROOT is missing' {
+        $oldLifelogRoot = $env:LIFELOG_ROOT
+        $oldSetupRoot = $env:OPENCLAW_LIFELOG_ROOT_FOR_INIT
+        try {
+            Remove-Item Env:\LIFELOG_ROOT -ErrorAction SilentlyContinue
+            Remove-Item Env:\OPENCLAW_LIFELOG_ROOT_FOR_INIT -ErrorAction SilentlyContinue
+
+            $result = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot ".chezmoi.toml.tmpl") -Raw |
+                chezmoi --source $script:chezmoiRoot execute-template --init --no-tty 2>&1
+
+            $LASTEXITCODE | Should -Be 0
+            ($result | Out-String) | Should -Not -Match '(?m)^\s*LIFELOG_ROOT\s*='
+        }
+        finally {
+            if ($null -eq $oldLifelogRoot) {
+                Remove-Item Env:\LIFELOG_ROOT -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:LIFELOG_ROOT = $oldLifelogRoot
+            }
+
+            if ($null -eq $oldSetupRoot) {
+                Remove-Item Env:\OPENCLAW_LIFELOG_ROOT_FOR_INIT -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:OPENCLAW_LIFELOG_ROOT_FOR_INIT = $oldSetupRoot
+            }
+        }
+    }
+
+    It 'renders setup-provided LIFELOG_ROOT without prompting' {
+        $oldLifelogRoot = $env:LIFELOG_ROOT
+        $oldSetupRoot = $env:OPENCLAW_LIFELOG_ROOT_FOR_INIT
+        try {
+            Remove-Item Env:\LIFELOG_ROOT -ErrorAction SilentlyContinue
+            $env:OPENCLAW_LIFELOG_ROOT_FOR_INIT = "X:\explicit\lifelog"
+
+            $result = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot ".chezmoi.toml.tmpl") -Raw |
+                chezmoi --source $script:chezmoiRoot execute-template --init --no-tty 2>&1
+
+            $LASTEXITCODE | Should -Be 0
+            ($result | Out-String) | Should -Match 'LIFELOG_ROOT = "X:\\\\explicit\\\\lifelog"'
+        }
+        finally {
+            if ($null -eq $oldLifelogRoot) {
+                Remove-Item Env:\LIFELOG_ROOT -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:LIFELOG_ROOT = $oldLifelogRoot
+            }
+
+            if ($null -eq $oldSetupRoot) {
+                Remove-Item Env:\OPENCLAW_LIFELOG_ROOT_FOR_INIT -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:OPENCLAW_LIFELOG_ROOT_FOR_INIT = $oldSetupRoot
+            }
+        }
     }
 
     It 'fails when LIFELOG_ROOT is missing' {


### PR DESCRIPTION
## Summary
- Add an explicit `configure-lifelog-root.ps1` setup entrypoint that validates the supplied lifelog root with `AGENTS.md`, git top-level, and origin remote.
- Add a chezmoi run-after script that writes OpenClaw `agents.defaults.workspace` from `LIFELOG_ROOT` without hardcoding an install path.
- Add Pester coverage to ensure no default lifelog path or filesystem scanning is introduced.

## Test Plan
- `task test`
- `git diff --check`
- `rg -n "D:\\lifelog|D:/lifelog|\\.openclaw\\\\workspace|Get-ChildItem.*lifelog|Resolve-Path.*lifelog" chezmoi/.chezmoi.toml.tmpl chezmoi/.chezmoiscripts/run_after_configure-openclaw-workspace_windows.ps1 scripts/powershell/configure-lifelog-root.ps1`