### PR TITLE
fix(winget): install terminal packages normally

### DIFF
--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -631,19 +631,17 @@ lib.mapAttrs (_: names: resolve names) grouped
 
   wingetInstallTimeoutSeconds = {
     google-cloud-sdk = 900;
+    warp-terminal = 900;
   };
 
-  # Packages kept in the catalog but skipped by the non-interactive Windows
-  # installer because upstream live installers are not reliable in that mode.
-  wingetSkipInstall = {
-    wezterm = "WezTerm nightly can require InstallerHashOverride when the live hash drifts";
-    warp-terminal = "Warp installer can hang under non-interactive winget";
-  };
+  # Packages kept in the catalog but skipped by the normal Windows installer.
+  wingetSkipInstall = { };
 
   # Upstream nightly winget manifests and Microsoft Store installs can drift or
   # hang in CI. Avoid making CI depend on their live installer behavior.
   wingetCiSkipInstall = {
     wezterm = true;
+    warp-terminal = true;
     "9PLM9XGG6VKS" = true;
   };
 

--- a/scripts/powershell/handlers/Handler.Winget.ps1
+++ b/scripts/powershell/handlers/Handler.Winget.ps1
@@ -210,14 +210,24 @@ class WingetHandler : SetupHandlerBase {
                 if ($pkg.VerifyCommand) {
                     Update-ProcessEnvironmentPath
                     $this.EnsurePortableLink($pkg)
-                    $this.EnsurePathEntries($pkg)
+                    if ($verifyCommandOnly) {
+                        $this.EnsurePathEntries($pkg)
+                    }
+                    else {
+                        $this.EnsurePathEntriesQuiet($pkg)
+                    }
                     if ($this.ShouldDeferWslVerificationToAdminInstall($pkg, $ctx)) {
                         $this.LogWarning("Microsoft.WSL の検証は Phase 2b の管理者 WSL インストールに委譲します")
                         $deferred++
                         continue
                     }
-                    if ($this.TestPackageVerification($pkg.VerifyCommand)) {
-                        $verificationPassed = $true
+                    $verificationPassed = if ($verifyCommandOnly) {
+                        $this.TestPackageVerification($pkg.VerifyCommand)
+                    }
+                    else {
+                        $this.TestPackageVerificationQuiet($pkg.VerifyCommand)
+                    }
+                    if ($verificationPassed) {
                         $verified++
                         if ($verifyCommandOnly) {
                             $this.Log("スキップ (検証済み): $($pkg.Id)", "Gray")
@@ -673,8 +683,18 @@ class WingetHandler : SetupHandlerBase {
     }
 
     hidden [bool] TestPackageVerification([object]$verifyCmd) {
+        return $this.TestPackageVerificationInternal($verifyCmd, $false)
+    }
+
+    hidden [bool] TestPackageVerificationQuiet([object]$verifyCmd) {
+        return $this.TestPackageVerificationInternal($verifyCmd, $true)
+    }
+
+    hidden [bool] TestPackageVerificationInternal([object]$verifyCmd, [bool]$quiet) {
         if (-not ($verifyCmd.PSObject.Properties.Name -contains "command")) {
-            $this.LogWarning("verifyCommand に 'command' フィールドがありません")
+            if (-not $quiet) {
+                $this.LogWarning("verifyCommand に 'command' フィールドがありません")
+            }
             return $false
         }
         try {
@@ -707,16 +727,20 @@ class WingetHandler : SetupHandlerBase {
             }
 
             $displayCommand = "$command $($arguments -join ' ')".Trim()
-            $this.Log("検証コマンド失敗 (exit code: $LASTEXITCODE): $displayCommand", "Yellow")
-            foreach ($line in $output) {
-                if (-not [string]::IsNullOrWhiteSpace([string]$line)) {
-                    $this.Log("  $line", "Gray")
+            if (-not $quiet) {
+                $this.Log("検証コマンド失敗 (exit code: $LASTEXITCODE): $displayCommand", "Yellow")
+                foreach ($line in $output) {
+                    if (-not [string]::IsNullOrWhiteSpace([string]$line)) {
+                        $this.Log("  $line", "Gray")
+                    }
                 }
             }
             return $LASTEXITCODE -eq 0
         }
         catch {
-            $this.Log("検証コマンド実行エラー: $($_.Exception.Message)", "Yellow")
+            if (-not $quiet) {
+                $this.Log("検証コマンド実行エラー: $($_.Exception.Message)", "Yellow")
+            }
             return $false
         }
     }
@@ -867,6 +891,14 @@ class WingetHandler : SetupHandlerBase {
     }
 
     hidden [void] EnsurePathEntries([object]$pkg) {
+        $this.EnsurePathEntriesInternal($pkg, $false)
+    }
+
+    hidden [void] EnsurePathEntriesQuiet([object]$pkg) {
+        $this.EnsurePathEntriesInternal($pkg, $true)
+    }
+
+    hidden [void] EnsurePathEntriesInternal([object]$pkg, [bool]$quiet) {
         if (-not $pkg.PathEntries) { return }
 
         $resolvedEntries = [System.Collections.Generic.List[string]]::new()
@@ -893,7 +925,7 @@ class WingetHandler : SetupHandlerBase {
         }
 
         if ($resolvedEntries.Count -eq 0) {
-            if ($missingEntries.Count -gt 0) {
+            if ($missingEntries.Count -gt 0 -and -not $quiet) {
                 $this.LogWarning("pathEntries の候補ディレクトリが見つかりません: $($pkg.Id) ($($missingEntries -join ', '))")
             }
             return

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -34,25 +34,43 @@ Describe 'Package catalog consistency' {
             @($package.installArgs) | Should -Not -Contain '--ignore-security-hash'
         }
 
-        It 'should define volatile terminal packages as manual winget installs in the SSOT' {
+        It 'should keep terminal packages installable during normal winget runs' {
             $sets = Get-Content -LiteralPath $script:setsPath -Raw
 
-            $sets | Should -Match '(?s)wingetSkipInstall\s*=\s*\{.*?wezterm\s*='
-            $sets | Should -Match '(?s)wingetSkipInstall\s*=\s*\{.*?warp-terminal\s*='
+            $sets | Should -Not -Match '(?ms)^\s*wingetSkipInstall\s*=\s*\{[^}]*^\s*wezterm\s*='
+            $sets | Should -Not -Match '(?ms)^\s*wingetSkipInstall\s*=\s*\{[^}]*^\s*warp-terminal\s*='
         }
 
-        It 'should generate skipInstall metadata for volatile terminal packages' {
+        It 'should generate terminal packages without normal-run skipInstall metadata' {
             $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
             $wingetSource = @($json.Sources | Where-Object { $_.SourceDetails.Name -eq 'winget' }) | Select-Object -First 1
             $warp = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'Warp.Warp' }) | Select-Object -First 1
             $wezterm = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'wez.wezterm.nightly' }) | Select-Object -First 1
 
             $warp | Should -Not -BeNullOrEmpty
-            $warp.skipInstall | Should -BeTrue
-            $warp.skipReason | Should -Not -BeNullOrEmpty
+            $warp.PSObject.Properties.Name | Should -Not -Contain 'skipInstall'
+            $warp.PSObject.Properties.Name | Should -Not -Contain 'skipReason'
             $wezterm | Should -Not -BeNullOrEmpty
-            $wezterm.skipInstall | Should -BeTrue
-            $wezterm.skipReason | Should -Not -BeNullOrEmpty
+            $wezterm.PSObject.Properties.Name | Should -Not -Contain 'skipInstall'
+            $wezterm.PSObject.Properties.Name | Should -Not -Contain 'skipReason'
+        }
+
+        It 'should keep volatile terminal installers out of CI-only winget verification' {
+            $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
+            $wingetSource = @($json.Sources | Where-Object { $_.SourceDetails.Name -eq 'winget' }) | Select-Object -First 1
+            $warp = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'Warp.Warp' }) | Select-Object -First 1
+            $wezterm = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'wez.wezterm.nightly' }) | Select-Object -First 1
+
+            $warp.ciSkipInstall | Should -BeTrue
+            $wezterm.ciSkipInstall | Should -BeTrue
+        }
+
+        It 'should cap Warp install time so install.cmd cannot hang indefinitely' {
+            $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
+            $wingetSource = @($json.Sources | Where-Object { $_.SourceDetails.Name -eq 'winget' }) | Select-Object -First 1
+            $warp = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'Warp.Warp' }) | Select-Object -First 1
+
+            $warp.installTimeoutSeconds | Should -Be 900
         }
 
         It 'should update flake inputs in the Nix rebuild aliases before applying the system' {

--- a/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
@@ -1789,7 +1789,9 @@ Describe 'WingetHandler' {
             }
         }
 
-        It 'should skip manual packages when verification is unavailable' {
+        It 'should install packages when verification is unavailable and skipInstall is absent' {
+            $script:installInvoked = $false
+            $script:weztermDir = Join-Path $TestDrive "WezTerm"
             Mock Get-JsonContent {
                 return [PSCustomObject]@{
                     Sources = @(
@@ -1798,8 +1800,7 @@ Describe 'WingetHandler' {
                             Packages      = @(
                                 [PSCustomObject]@{
                                     PackageIdentifier = "wez.wezterm.nightly"
-                                    skipInstall       = $true
-                                    skipReason        = "nightly hash drifts"
+                                    pathEntries       = @($script:weztermDir)
                                     verifyCommand     = [PSCustomObject]@{ command = "wezterm"; args = @("--version") }
                                 }
                             )
@@ -1807,14 +1808,22 @@ Describe 'WingetHandler' {
                     )
                 }
             }
+            Mock Write-Host { }
             Mock Invoke-Winget {
                 param($Arguments)
                 if ($Arguments -contains "install") {
-                    throw "winget install should be skipped"
+                    $script:installInvoked = $true
+                    New-Item -ItemType Directory -Path $script:weztermDir -Force | Out-Null
+                    $global:LASTEXITCODE = 0
+                    return "installed wezterm"
                 }
                 $global:LASTEXITCODE = 1
             }
             Mock Invoke-VerifyCommand {
+                if ($script:installInvoked) {
+                    $global:LASTEXITCODE = 0
+                    return "wezterm 20260607"
+                }
                 $global:LASTEXITCODE = 127
                 throw "wezterm not found"
             }
@@ -1823,8 +1832,11 @@ Describe 'WingetHandler' {
             $result = $handler.Apply($ctx)
 
             $result.Success | Should -Be $true
-            $result.Message | Should -Match "1 個スキップ"
-            Should -Invoke Invoke-Winget -Times 0 -ParameterFilter { $Arguments -contains "install" }
+            $result.Message | Should -Match "1 個インストール"
+            Should -Invoke Invoke-Winget -Times 1 -ParameterFilter { $Arguments -contains "install" }
+            Should -Invoke Write-Host -Times 0 -ParameterFilter {
+                [string]$Object -match '検証コマンド実行エラー|pathEntries の候補ディレクトリが見つかりません'
+            }
         }
     }
 

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -213,16 +213,14 @@
           }
         },
         {
-          "PackageIdentifier": "Warp.Warp",
-          "skipInstall": true,
-          "skipReason": "Warp installer can hang under non-interactive winget"
+          "ciSkipInstall": true,
+          "installTimeoutSeconds": 900,
+          "PackageIdentifier": "Warp.Warp"
         },
         {
           "PackageIdentifier": "wez.wezterm.nightly",
           "ciSkipInstall": true,
           "pathEntries": ["%ProgramFiles%\\WezTerm"],
-          "skipInstall": true,
-          "skipReason": "WezTerm nightly can require InstallerHashOverride when the live hash drifts",
           "verifyCommand": {
             "args": ["--version"],
             "command": "wezterm"


### PR DESCRIPTION
## Summary
- Make Warp and WezTerm normal winget install targets instead of manual-skip packages.
- Keep unstable terminal installers out of CI-only winget verification, and cap Warp installs at 900 seconds.
- Quiet pre-install verification/path warnings so missing terminal binaries are handled by install instead of noisy warnings.

## Test Plan
- `task test` (787 passed, 0 failed, 5 skipped / 792 total)
- `git diff --check -- nix/packages/sets.nix scripts/powershell/handlers/Handler.Winget.ps1 scripts/powershell/tests/PackageCatalog.Tests.ps1 scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1 windows/winget/packages.json`
- `Get-Content -LiteralPath windows/winget/packages.json -Raw | ConvertFrom-Json | Out-Null`