### PR TITLE
Configure OpenClaw browser setup

### DIFF
--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -7,11 +7,10 @@
 #    ("config file template has changed, run chezmoi init to regenerate
 #    config file") but does not block the apply.
 #
-# ⚠️ For `onepasswordRead`, always pass the account as the 2nd argument
-#    (e.g. `onepasswordRead "op://Private/..." .op_account_personal`).
-#    chezmoi 2.70.x silently ignores `[onepassword] account = "..."` in
-#    its flat form, so this is the only reliable way to disambiguate
-#    multi-account 1Password setups. See LIF-210.
+# ⚠️ Do not call `onepasswordRead` from .tmpl files. Runtime deploy scripts
+#    should use bounded, non-fatal `op read --account ...` calls, or shell
+#    launchers should use `op run --env-file ...`. This keeps `chezmoi apply`
+#    usable when 1Password CLI integration is temporarily unavailable.
 
 sourceDir = {{ .chezmoi.sourceDir | quote }}
 
@@ -26,11 +25,9 @@ sourceDir = {{ .chezmoi.sourceDir | quote }}
     command = "op"
 {{- end }}
 
-# Account UUIDs exposed as template data so onepasswordRead "op://..." can
-# pass the account explicitly as its 2nd argument. chezmoi's flat
-# [onepassword] account field is silently ignored in 2.70.x, so this is the
-# only reliable way to disambiguate when multiple 1Password accounts are
-# signed in. See LIF-210.
+# Account UUIDs exposed as template data for runtime deploy scripts. Always
+# pass the account explicitly to `op read --account ...` in multi-account
+# setups instead of relying on chezmoi's [onepassword] account default.
 [data]
     op_account_personal = "EJLA3HRAVZBCXIQ7SRSFGQBTNU"
     op_account_work = "FXVKKR2KWFCMHGMEA7HQYK6XRE"

--- a/chezmoi/.chezmoiscripts/run_after_configure-openclaw-workspace_windows.ps1
+++ b/chezmoi/.chezmoiscripts/run_after_configure-openclaw-workspace_windows.ps1
@@ -207,7 +207,11 @@ $config = Read-OpenClawConfig -ConfigPath $configPath
 $agents = Get-JsonObjectProperty -Object $config -Name "agents"
 $defaults = Get-JsonObjectProperty -Object $agents -Name "defaults"
 Set-JsonProperty -Object $defaults -Name "workspace" -Value $lifelogRoot
+$browser = Get-JsonObjectProperty -Object $config -Name "browser"
+Set-JsonProperty -Object $browser -Name "enabled" -Value $true
 Write-OpenClawConfig -Config $config -ConfigPath $configPath
 
 Write-Host "OpenClaw agents.defaults.workspace: $lifelogRoot"
+Write-Host "OpenClaw browser.enabled: true"
+Write-Host "If browser commands report a scope upgrade, run: openclaw devices list; openclaw devices approve <requestId>"
 Restart-OpenClawGateway

--- a/docs/chezmoi/secrets.md
+++ b/docs/chezmoi/secrets.md
@@ -1,92 +1,83 @@
 # シークレット管理
 
-chezmoi でのシークレット（秘密情報）の管理方法。
+この dotfiles では、実シークレットを repository に保存しない。source of truth は
+1Password に置き、dotfiles には `op://...` 参照、非秘密設定、取得手順だけを置く。
 
-## 概要
+## 基本方針
 
-chezmoi は age または gpg を使って暗号化されたファイルを管理できます。
+1. 実シークレット、token、API key、cookie、pairing token はコミットしない。
+2. `chezmoi/*.tmpl` では `onepasswordRead` を呼ばない。
+3. 1Password が必要な deploy script は、実行時に `op read --account ...` を呼ぶ。
+4. `op read` は timeout 付きにし、失敗時は警告または skip で `chezmoi apply` を止めない。
+5. Shell に常時必要な値は `op run --env-file ...` で注入する。
+6. 複数 1Password account があるため、`--account` を明示する。
 
-## セットアップ
+## 配置
 
-### 1. 暗号化キーの準備
+- `chezmoi/secret/secrets.env`
+  - `op run --env-file` 用。値は `op://...` 参照のみ。
+- `chezmoi/secret/env.sh`
+  - WSL / Linux の fallback loader。`op inject --account ...` を実行時に呼ぶ。
+- `chezmoi/secret/env.ps1`
+  - PowerShell 用。通常は WezTerm launcher から注入済みの環境変数を受け取る。
+- `chezmoi/.chezmoidata/mcp_servers.yaml`
+  - MCP の `op_env` 参照を置く。client template は失敗しても env fallback を使う。
+- `chezmoi/.chezmoiscripts/**`
+  - どうしてもファイル配置が必要なものだけ、runtime `op read --account ...` で取得する。
 
-**age を使用する場合（推奨）:**
+## OpenClaw
 
-```bash
-# age キーの生成
-age-keygen -o ~/.config/chezmoi/key.txt
+OpenClaw は local state に pairing 情報と device token を持つ。これらは端末ごとに承認されるため、
+dotfiles へ実体を保存しない。
+
+dotfiles 側で管理するもの:
+
+- `agents.defaults.workspace`
+- `browser.enabled`
+- 再セットアップ時の手順
+
+1Password 側へ控えてよいもの:
+
+- Gateway token: `op://openclaw/openclaw/gateway token`
+- OpenClaw 用 provider API keys
+  - `op://openclaw/ExaUsedOpenclawPAT/credential`
+  - `op://openclaw/TavilyUsedOpenclawPAT/credential`
+  - `op://openclaw/FirecrawlUsedOpenclawPAT/credential`
+
+新しい端末、初期化後、または browser scope が追加された後は、端末ごとに pairing / scope
+upgrade を承認する。
+
+```powershell
+openclaw devices list
+openclaw devices approve <requestId>
+openclaw browser status
+openclaw browser start
+openclaw browser open https://example.com
+openclaw browser snapshot
 ```
 
-**gpg を使用する場合:**
+`openclaw devices approve --latest` は最新 request を表示して明示コマンドを案内する確認用として扱う。
+承認は表示された requestId を `openclaw devices approve <requestId>` で実行する。
 
-```bash
-# 既存の GPG キーを使用
-gpg --list-keys
+## パターン
+
+PowerShell deploy script で値を取得する場合:
+
+```powershell
+$account = "EJLA3HRAVZBCXIQ7SRSFGQBTNU"
+$secretRef = "op://Private/Example/credential"
+op read --account $account $secretRef
 ```
 
-### 2. chezmoi 設定
+Shell 起動時に環境変数として渡す場合:
 
-`~/.config/chezmoi/chezmoi.toml` を作成:
-
-**age の場合:**
-
-```toml
-encryption = "age"
-[age]
-  identity = "~/.config/chezmoi/key.txt"
-  recipient = "age1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```powershell
+op run --env-file="$env:USERPROFILE\.config\shell\secrets.env" -- pwsh
 ```
 
-**gpg の場合:**
+## 検証
 
-```toml
-encryption = "gpg"
-[gpg]
-  recipient = "your-email@example.com"
-```
-
-## シークレットの追加
-
-### 暗号化ファイルの追加
-
-```bash
-chezmoi add --encrypt ~/.ssh/id_rsa
-chezmoi add --encrypt ~/.config/secret.json
-```
-
-これにより、ソースディレクトリに `encrypted_` プレフィックス付きのファイルが作成されます。
-
-### テンプレートでのシークレット
-
-`.tmpl` ファイル内で 1Password, Bitwarden, pass などからシークレットを取得できます:
-
-```
-# 1Password
-{{ onepassword "item-name" }}
-
-# Bitwarden
-{{ bitwarden "item-name" }}
-
-# pass
-{{ pass "path/to/secret" }}
-```
-
-## ベストプラクティス
-
-1. **暗号化キーをリポジトリにコミットしない**
-2. **キーのバックアップを取る** - キーを紛失するとファイルを復号できなくなる
-3. **`.gitignore` でキーファイルを除外**
-
-## 確認
-
-暗号化されたファイルの一覧:
-
-```bash
-chezmoi managed --include=encrypted
-```
-
-復号テスト:
-
-```bash
-chezmoi cat ~/.ssh/id_rsa
+```powershell
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/chezmoi/OpenClawWorkspace.Tests.ps1
 ```

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -36,6 +36,16 @@ Describe 'chezmoi テンプレート バリデーション' {
             )
         }
 
+        It 'should not recommend template-time 1Password lookup in secret docs' {
+            $secretsDocPath = Join-Path $script:repoRoot "docs/chezmoi/secrets.md"
+            $content = Get-Content -LiteralPath $secretsDocPath -Raw
+
+            $content | Should -Not -Match '\{\{\s*onepassword(Read)?\b' -Because 'docs must not recommend template-time 1Password lookups'
+            $content | Should -Match 'op read --account' -Because 'docs should describe explicit-account runtime reads'
+            $content | Should -Match 'op run --env-file' -Because 'docs should describe the official env-file injection pattern'
+            $content | Should -Match 'OpenClaw' -Because 'OpenClaw tokens and browser scope approval are part of the current secret policy'
+        }
+
     }
 
     Context 'mcp_servers.yaml の op_env は env キーと一致すること' {

--- a/scripts/powershell/tests/chezmoi/OpenClawWorkspace.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/OpenClawWorkspace.Tests.ps1
@@ -148,7 +148,15 @@ Describe 'OpenClaw workspace chezmoi script' {
         }
     }
 
-    It 'writes agents.defaults.workspace while preserving existing config values' {
+    It 'should not manage OpenClaw secrets or pairing tokens' {
+        $content = Get-Content -LiteralPath $script:scriptPath -Raw
+
+        $content | Should -Not -Match 'op://|onepasswordRead|op\s+read' -Because 'OpenClaw config patching must not resolve or write secrets'
+        $content | Should -Not -Match 'gateway\.auth\.token|OPENCLAW_GATEWAY_TOKEN|apiKey|botToken|appToken' -Because 'tokens and API keys must stay in local OpenClaw state or 1Password'
+        $content | Should -Match 'scope upgrade' -Because 'device pairing scope upgrades remain an explicit per-device approval step'
+    }
+
+    It 'should write agents.defaults.workspace and enable browser while preserving existing config values' {
         $oldLifelogRoot = $env:LIFELOG_ROOT
         $oldOpenClawConfig = $env:OPENCLAW_CONFIG
         $oldGatewayRestartCommand = $env:OPENCLAW_GATEWAY_RESTART_COMMAND
@@ -164,6 +172,15 @@ Describe 'OpenClaw workspace chezmoi script' {
                     defaults = @{
                         model = @{
                             primary = "openai/gpt-5.5"
+                        }
+                    }
+                }
+                browser = @{
+                    defaultProfile = "openclaw"
+                    profiles = @{
+                        openclaw = @{
+                            cdpPort = 18800
+                            color = "#FF4500"
                         }
                     }
                 }
@@ -192,6 +209,9 @@ Describe 'OpenClaw workspace chezmoi script' {
             $config = Get-Content -LiteralPath $configPath -Raw | ConvertFrom-Json
             $config.agents.defaults.workspace | Should -Be ([System.IO.Path]::GetFullPath($lifelogRoot).TrimEnd("\"))
             $config.agents.defaults.model.primary | Should -Be "openai/gpt-5.5"
+            $config.browser.enabled | Should -BeTrue
+            $config.browser.defaultProfile | Should -Be "openclaw"
+            $config.browser.profiles.openclaw.cdpPort | Should -Be 18800
             $config.gateway.auth.token | Should -Be "preserve-me"
             Get-Content -LiteralPath $restartLogPath -Raw | Should -Match 'restarted'
         }


### PR DESCRIPTION
## Summary
- enable OpenClaw browser wiring in the chezmoi workspace script
- document the 1Password-backed OpenClaw secret and scope approval policy
- add regression coverage for template-time 1Password lookup guidance and OpenClaw secret handling

## Local verification
- `OpenClawWorkspace.Tests.ps1` passed
- `ChezmoiTemplate.Tests.ps1` passed
- `GhTokenSwitch.Tests.ps1` passed individually
- `git diff --check` passed