### PR TITLE
Configure WezTerm Catppuccin opacity

### DIFF
--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -24,17 +24,11 @@ config.font_size = 11.0
 config.line_height = 1.0
 config.cell_width = 1.0
 
--- WebGpu renders text more sharply than the legacy OpenGL front end on Windows.
-config.front_end = "WebGpu"
-
 -- IME support
 config.use_ime = true
 
 -- Window appearance
-config.window_background_opacity = 0.75
-if is_windows then
-    config.win32_system_backdrop = "Acrylic"
-end
+config.window_background_opacity = 0.85
 config.window_decorations = "TITLE|RESIZE"
 config.window_padding = {
     left = 8,


### PR DESCRIPTION
## Summary
- keep WezTerm on the built-in Catppuccin Mocha color scheme
- remove the explicit WebGPU frontend override
- remove Windows Acrylic backdrop and set only `window_background_opacity = 0.85`

## Verification
- `wezterm --config-file C:\Users\rurus\.config\wezterm\wezterm.lua ls-fonts --text test`

Note: `task commit` / `dotf chezmoi` could not run in this Codex environment because the configured `NixOS` WSL distro is unavailable, so this branch was created via GitHub API instead of a Windows-side `git commit`.