### PR TITLE
[codex] unify terminal theme and font checks

### DIFF
--- a/.github/workflows/ci-chezmoi.yml
+++ b/.github/workflows/ci-chezmoi.yml
@@ -86,11 +86,52 @@ jobs:
           }
           Write-Host "BOM check passed: $(@($files).Count) .tmpl file(s) checked"
 
+  font-install:
+    name: Font install smoke (Windows)
+    runs-on: windows-2025
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run UDEV Gothic NF installer
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          $templatePath = Join-Path $env:GITHUB_WORKSPACE 'chezmoi/.chezmoiscripts/setup/fonts/run_onchange_before_00-install-udev-gothic.ps1.tmpl'
+          $scriptPath = Join-Path $env:RUNNER_TEMP 'install-udev-gothic.ps1'
+          $template = Get-Content -LiteralPath $templatePath -Raw
+          $script = $template `
+            -replace '^\{\{ if eq \.chezmoi\.os "windows" -\}\}\r?\n', '' `
+            -replace '\r?\n\{\{ end -\}\}\s*$', ''
+          [System.IO.File]::WriteAllText($scriptPath, $script, [System.Text.UTF8Encoding]::new($false))
+
+          & pwsh -NoProfile -File $scriptPath
+
+          $regPath = 'HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts'
+          $key = Get-ItemProperty -Path $regPath -ErrorAction Stop
+          $entries = @($key.PSObject.Properties | Where-Object {
+            $fontPath = [string]$_.Value
+            $_.Name -like 'UDEVGothic*NF*' -and
+              -not [string]::IsNullOrWhiteSpace($fontPath) -and
+              (Test-Path -LiteralPath $fontPath -PathType Leaf)
+          })
+          if ($entries.Count -eq 0) {
+            throw 'UDEV Gothic NF was not installed with a registry entry pointing to an existing font file.'
+          }
+          $entries | ForEach-Object { Write-Host "Verified font: $($_.Name) -> $($_.Value)" }
+
   test:
     name: Test (Pester + Codecov)
     runs-on: windows-2025
     timeout-minutes: 20
-    needs: [lint, fmt]
+    needs: [lint, fmt, font-install]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -200,6 +200,19 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Free runner disk space
+        run: |
+          set -euo pipefail
+          df -h /
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /usr/local/share/boost \
+            /opt/ghc \
+            /opt/hostedtoolcache
+          sudo docker image prune --all --force || true
+          df -h /
+
       - name: Check flake evaluation
         run: |
           set -o pipefail

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -214,6 +214,7 @@ jobs:
           nix build .#minimal
           nix build .#default
           nix build .#full
+          nix build .#fonts
 
       - name: Build NixOS WSL system
         run: nix build .#nixosConfigurations.nixos.config.system.build.toplevel --no-link

--- a/chezmoi/.chezmoiscripts/setup/fonts/run_onchange_before_00-install-udev-gothic.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/setup/fonts/run_onchange_before_00-install-udev-gothic.ps1.tmpl
@@ -37,7 +37,15 @@ $HWND_BROADCAST = [IntPtr]0xffff
 function Test-FontInstalled {
   $key = Get-ItemProperty -Path $RegistryPath -ErrorAction SilentlyContinue
   if ($null -eq $key) { return $false }
-  return ($key.PSObject.Properties.Name | Where-Object { $_ -like "*UDEVGothic*NF*" }).Count -gt 0
+  $installedEntries = @(
+    $key.PSObject.Properties | Where-Object {
+      $fontPath = [string]$_.Value
+      $_.Name -like "*UDEVGothic*NF*" -and
+      -not [string]::IsNullOrWhiteSpace($fontPath) -and
+      (Test-Path -LiteralPath $fontPath -PathType Leaf)
+    }
+  )
+  return $installedEntries.Count -gt 0
 }
 
 function Remove-TempFontDirectory {
@@ -76,6 +84,9 @@ try {
   if (-not (Test-Path -LiteralPath $FontsDir)) {
     New-Item -ItemType Directory -Path $FontsDir -Force | Out-Null
   }
+  if (-not (Test-Path -LiteralPath $RegistryPath)) {
+    New-Item -Path $RegistryPath -Force | Out-Null
+  }
 
   Get-ChildItem -LiteralPath $TempDir -Filter "*.ttf" -Recurse | ForEach-Object {
     $destPath = Join-Path $FontsDir $_.Name
@@ -106,6 +117,10 @@ try {
     Write-Warning "Font change broadcast timed out or failed (lastError=$lastError). Restart terminals/editors if the font is not visible yet."
   } else {
     Write-Host "Font change broadcasted to all windows."
+  }
+
+  if (-not (Test-FontInstalled)) {
+    throw "$FontName installation verification failed: no matching registry entry points to an existing font file."
   }
 } finally {
   Remove-TempFontDirectory

--- a/chezmoi/editors/zed/settings.json
+++ b/chezmoi/editors/zed/settings.json
@@ -29,8 +29,9 @@
   "theme": {
     "mode": "dark",
     "dark": "Catppuccin Mocha",
-    "light": "Catppuccin Latte"
+    "light": "Catppuccin Mocha"
   },
+  "ui_font_family": "UDEV Gothic NF",
   "ui_font_size": 10,
   "buffer_font_size": 10,
   "buffer_font_family": "UDEV Gothic NF",
@@ -71,6 +72,7 @@
     "shell": {
       "program": "pwsh"
     },
+    "font_family": "UDEV Gothic NF",
     "font_size": 10,
     "line_height": "comfortable",
     "copy_on_select": false,

--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -183,7 +183,7 @@ if (Get-Command fd -ErrorAction SilentlyContinue) {
     $env:FZF_DEFAULT_COMMAND = "fd --hidden --follow --no-ignore-vcs --max-depth 10 --absolute-path --type f . ."
 }
 
-# Interactive widgets (Alt+Q / Alt+D / Alt+T / Alt+R)
+# Interactive widgets (Alt+Z / Alt+D / Alt+T / Alt+R)
 # PSReadLine is bundled with the standard PS7 installer; skip the slow -ListAvailable scan.
 # On PS7, load failure is unexpected and should surface as an error, not be silently swallowed.
 if ($PSVersionTable.PSVersion.Major -ge 7) {
@@ -234,7 +234,7 @@ if ((Get-Command fzf -ErrorAction SilentlyContinue) -and (Get-Module PSReadLine)
         }
     }
 
-    Set-PSReadLineKeyHandler -Chord Alt+q -ScriptBlock { Invoke-ZoxideInteractive }
+    Set-PSReadLineKeyHandler -Chord Alt+z -ScriptBlock { Invoke-ZoxideInteractive }
     Set-PSReadLineKeyHandler -Chord Alt+d -ScriptBlock { Invoke-FzfDirectory }
     Set-PSReadLineKeyHandler -Chord Alt+t -ScriptBlock { Invoke-FzfInsertFile }
     Set-PSReadLineKeyHandler -Chord Alt+r -ScriptBlock { Invoke-FzfHistory }

--- a/chezmoi/shells/bashrc
+++ b/chezmoi/shells/bashrc
@@ -100,7 +100,7 @@ if ! nc -z localhost 22 2>/dev/null; then
   eval "$(ssh-agent -s)" > /dev/null
 fi
 
-# Alt+q: zoxide interactive (history-based directory jump)
+# Alt+Z: zoxide interactive (history-based directory jump)
 __zoxide_zi_widget() {
   local result
   result="$(zoxide query -i)" || return
@@ -112,7 +112,7 @@ __zoxide_zi_widget() {
   READLINE_LINE=""
   READLINE_POINT=0
 }
-bind -x '"\eq": __zoxide_zi_widget'
+bind -x '"\ez": __zoxide_zi_widget'
 
 # Alt+D: fzf directory search and cd
 __fzf_cd_widget() {

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -20,7 +20,7 @@ config.color_scheme = "Catppuccin Mocha"
 
 -- Font settings
 config.font = wezterm.font("UDEV Gothic NF")
-config.font_size = 11.0
+config.font_size = 10.0
 config.line_height = 1.0
 config.cell_width = 1.0
 

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -87,14 +87,14 @@ in
       }
       add-zsh-hook precmd __disable_mouse_reporting
 
-      # Alt+q: zoxide interactive (history-based directory jump)
+      # Alt+Z: zoxide interactive (history-based directory jump)
       __zoxide_zi_widget() {
         local result
         result="$(zoxide query -i)" && cd "$result"
         zle reset-prompt
       }
       zle -N __zoxide_zi_widget
-      bindkey '^[q' __zoxide_zi_widget
+      bindkey '^[z' __zoxide_zi_widget
 
       # Alt+D: fzf directory search and cd
       __fzf_cd_widget() {

--- a/scripts/powershell/ci/Invoke-NixosWslE2E.ps1
+++ b/scripts/powershell/ci/Invoke-NixosWslE2E.ps1
@@ -221,6 +221,12 @@ try {
             "bash", "-lc",
             "command -v zsh && command -v chezmoi && command -v task && command -v git"
         ) -TimeoutSeconds 300 | Out-Null
+
+        Invoke-WslChecked -Arguments @(
+            "-d", $DistroName, "-u", "nixos", "--",
+            "bash", "-lc",
+            'GH_TOKEN=ci TAVILY_API_KEY=ci GITHUB_WORK_TOKEN=ci zsh -ic "type z >/dev/null && bindkey" | rg "\"\^\[z\" __zoxide_zi_widget"'
+        ) -TimeoutSeconds 300 | Out-Null
     }
     finally {
         Complete-CiSection

--- a/scripts/powershell/tests/CiWorkflow.Tests.ps1
+++ b/scripts/powershell/tests/CiWorkflow.Tests.ps1
@@ -72,6 +72,18 @@ Describe 'CI workflow configuration' {
         $nixWorkflow | Should -Match 'nix build \.#fonts'
     }
 
+    It 'should free hosted runner disk space before Nix package builds' {
+        $nixWorkflow = Get-Content -LiteralPath (Join-Path $script:repoRoot ".github/workflows/ci-nix.yml") -Raw
+
+        $nixWorkflow | Should -Match 'Free runner disk space'
+        $nixWorkflow | Should -Match '/usr/share/dotnet'
+        $nixWorkflow | Should -Match '/usr/local/lib/android'
+        $nixWorkflow | Should -Match '/usr/local/share/boost'
+        $nixWorkflow | Should -Match '/opt/ghc'
+        $nixWorkflow | Should -Match '/opt/hostedtoolcache'
+        $nixWorkflow | Should -Match 'docker image prune --all --force'
+    }
+
     It 'should smoke test the Windows UDEV Gothic NF installer in chezmoi CI' {
         $chezmoiWorkflow = Get-Content -LiteralPath (Join-Path $script:repoRoot ".github/workflows/ci-chezmoi.yml") -Raw
 

--- a/scripts/powershell/tests/CiWorkflow.Tests.ps1
+++ b/scripts/powershell/tests/CiWorkflow.Tests.ps1
@@ -66,6 +66,23 @@ Describe 'CI workflow configuration' {
         $nixWorkflow | Should -Match 'nix build \.#nixosConfigurations\.nixos\.config\.system\.build\.toplevel --no-link'
     }
 
+    It 'should build the font package set on hosted Nix CI' {
+        $nixWorkflow = Get-Content -LiteralPath (Join-Path $script:repoRoot ".github/workflows/ci-nix.yml") -Raw
+
+        $nixWorkflow | Should -Match 'nix build \.#fonts'
+    }
+
+    It 'should smoke test the Windows UDEV Gothic NF installer in chezmoi CI' {
+        $chezmoiWorkflow = Get-Content -LiteralPath (Join-Path $script:repoRoot ".github/workflows/ci-chezmoi.yml") -Raw
+
+        $chezmoiWorkflow | Should -Match 'Font install smoke \(Windows\)'
+        $chezmoiWorkflow | Should -Match 'run_onchange_before_00-install-udev-gothic\.ps1\.tmpl'
+        $chezmoiWorkflow | Should -Match '& pwsh -NoProfile -File \$scriptPath'
+        $chezmoiWorkflow | Should -Match 'UDEVGothic\*NF\*'
+        $chezmoiWorkflow | Should -Match 'Test-Path -LiteralPath \$fontPath -PathType Leaf'
+        $chezmoiWorkflow | Should -Match 'needs: \[lint, fmt, font-install\]'
+    }
+
     It 'should run nixos-rebuild switch in a hosted WSL2 E2E workflow' {
         $workflowPath = Join-Path $script:repoRoot ".github/workflows/ci-nixos-wsl.yml"
         $scriptPath = Join-Path $script:repoRoot "scripts/powershell/ci/Invoke-NixosWslE2E.ps1"
@@ -86,6 +103,8 @@ Describe 'CI workflow configuration' {
         $script | Should -Not -Match 'SkipFlakeUpdate"\] = \$true'
         $script | Should -Match 'Welcome to your new NixOS-WSL system'
         $script | Should -Match 'nixos-rebuild list-generations'
+        $script | Should -Match ([regex]::Escape('GH_TOKEN=ci TAVILY_API_KEY=ci GITHUB_WORK_TOKEN=ci zsh -ic "type z >/dev/null && bindkey"'))
+        $script | Should -Match ([regex]::Escape('rg "\"\^\[z\" __zoxide_zi_widget"'))
         $script | Should -Match 'Remove-TemporaryDistro'
     }
 

--- a/scripts/powershell/tests/Integration.Tests.ps1
+++ b/scripts/powershell/tests/Integration.Tests.ps1
@@ -95,9 +95,14 @@ Describe 'Integration Verification - Windows Environment' {
             $regPath = "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts"
             $key = Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue
             if ($null -eq $key) { throw "フォント 'UDEVGothic NF' がインストールされていません。chezmoi apply を実行してください。" }
-            $found = @($key.PSObject.Properties | Where-Object { $_.Name -like "UDEVGothic*NF*" })
+            $found = @($key.PSObject.Properties | Where-Object {
+                    $fontPath = [string]$_.Value
+                    $_.Name -like "UDEVGothic*NF*" -and
+                    -not [string]::IsNullOrWhiteSpace($fontPath) -and
+                    (Test-Path -LiteralPath $fontPath -PathType Leaf)
+                })
             if ($found.Count -eq 0) {
-                throw "フォント 'UDEVGothic NF' がインストールされていません。chezmoi apply を実行してください。"
+                throw "フォント 'UDEVGothic NF' のレジストリエントリと実ファイルが揃っていません。chezmoi apply を実行してください。"
             }
             Write-Host "確認完了: フォント '$($found[0].Name)' がインストール済み ($($found.Count) 件)"
         }

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -140,6 +140,21 @@ Describe 'chezmoi テンプレート バリデーション' {
         }
     }
 
+    Context 'Shell keybindings' {
+        It 'zoxide interactive jump should use Alt+Z consistently' {
+            $bashrc = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot "shells/bashrc") -Raw
+            $powershellProfile = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot "shells/Microsoft.PowerShell_profile.ps1") -Raw
+            $homeManagerZsh = Get-Content -LiteralPath (Join-Path $script:repoRoot "nix/home/common.nix") -Raw
+
+            $bashrc | Should -Match 'bind -x ''"\\ez": __zoxide_zi_widget'''
+            $bashrc | Should -Not -Match 'bind -x ''"\\eq": __zoxide_zi_widget'''
+            $powershellProfile | Should -Match 'Set-PSReadLineKeyHandler -Chord Alt\+z -ScriptBlock \{ Invoke-ZoxideInteractive \}'
+            $powershellProfile | Should -Not -Match 'Set-PSReadLineKeyHandler -Chord Alt\+q -ScriptBlock \{ Invoke-ZoxideInteractive \}'
+            $homeManagerZsh | Should -Match "bindkey '\^\[z' __zoxide_zi_widget"
+            $homeManagerZsh | Should -Not -Match "bindkey '\^\[q' __zoxide_zi_widget"
+        }
+    }
+
     Context 'Docker MCP SDK サーバーの設定整合性' {
         BeforeAll {
             $script:mcpServersPath = Join-Path $script:chezmoiRoot ".chezmoidata/mcp_servers.yaml"

--- a/scripts/powershell/tests/chezmoi/FontConsistency.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/FontConsistency.Tests.ps1
@@ -128,13 +128,21 @@ Describe 'フォント設定の一貫性' {
             )
         }
 
-        It 'installer のレジストリ検出パターンが UDEV Gothic NF を捉えること' {
+        It 'installer のインストール済み判定はレジストリと実ファイルの両方を確認すること' {
             $full = Join-Path $script:repoRoot $script:windowsInstaller
             $content = Get-Content -LiteralPath $full -Raw
 
-            # Test-FontInstalled の Where-Object パターンが新フォントを検出するパターンであること
             $content | Should -Match 'UDEVGothic\*NF\*' -Because (
                 "installer の Test-FontInstalled が UDEVGothic*NF* を検出するパターンになっていない"
+            )
+            $content | Should -Match 'Test-Path -LiteralPath \$fontPath -PathType Leaf' -Because (
+                "registry だけでなく実ファイルの存在も確認しないと、壊れたインストールを見逃す"
+            )
+            $content | Should -Match 'installation verification failed' -Because (
+                "インストール後に registry/file の検証が失敗したら CI と chezmoi apply で失敗させる"
+            )
+            $content | Should -Match 'New-Item -Path \$RegistryPath -Force' -Because (
+                "fresh user profile でも HKCU font registry path を作成できる必要がある"
             )
         }
 


### PR DESCRIPTION
## Summary
- Align WezTerm/Zed terminal and editor UI on Catppuccin Mocha with UDEV Gothic NF.
- Harden the Windows UDEV Gothic NF installer so it verifies registry entries and backing font files after install.
- Add CI coverage for the Windows font installer smoke test and Nix font package builds.
- Align zoxide interactive keybindings on Alt+Z across PowerShell, Bash, Zsh, and WSL E2E assertions.
- Free hosted runner disk before heavyweight Nix builds to avoid disk exhaustion on GitHub Actions.

## Validation
- `pwsh -NoProfile -Command "& .\Invoke-Tests.ps1 -Path @('.\chezmoi\FontConsistency.Tests.ps1', '.\CiWorkflow.Tests.ps1') -MinimumCoverage 0"`
- `pwsh -NoProfile -Command "& .\Invoke-Tests.ps1 -Path @('.\CiWorkflow.Tests.ps1', '.\chezmoi\ChezmoiTemplate.Tests.ps1') -MinimumCoverage 0"`
- `pwsh -NoProfile -Command "& .\Invoke-Tests.ps1 -Path @('.\CiWorkflow.Tests.ps1') -MinimumCoverage 0"`
- `python -c "import yaml, pathlib; [yaml.safe_load(pathlib.Path(p).read_text(encoding='utf-8')) for p in ['.github/workflows/ci-nix.yml','.github/workflows/ci-chezmoi.yml']]; print('workflow yaml parse: ok')"`
- `git -c safe.directory=D:/ruru/dotfiles diff --check`
- rendered and parsed the Windows font installer script
- rendered and executed the Windows font installer smoke path locally
- WSL temp-copy `nix build .#fonts --no-link`
