### PR TITLE
[codex] support cross-platform devcontainer CLI install

### DIFF
--- a/.github/workflows/ci-consistency.yml
+++ b/.github/workflows/ci-consistency.yml
@@ -11,6 +11,7 @@ on:
       - "flake.nix"
       - "flake.lock"
       - "windows/winget/packages.json"
+      - "windows/npm/packages.json"
       - "windows/pnpm/packages.json"
       - ".github/workflows/ci-consistency.yml"
   pull_request:
@@ -22,6 +23,7 @@ on:
       - "flake.nix"
       - "flake.lock"
       - "windows/winget/packages.json"
+      - "windows/npm/packages.json"
       - "windows/pnpm/packages.json"
       - ".github/workflows/ci-consistency.yml"
 
@@ -57,6 +59,10 @@ jobs:
           diff \
             <(jq -S "$normalize" /tmp/winget-export/winget/packages.json) \
             <(jq -S "$normalize" windows/winget/packages.json)
+
+      - name: Verify npm packages.json is in sync
+        shell: bash
+        run: diff <(jq -S . /tmp/winget-export/npm/packages.json) <(jq -S . windows/npm/packages.json)
 
       - name: Verify pnpm packages.json is in sync
         shell: bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@
 1. **Nix (Home Manager) がパッケージの Single Source of Truth (SSOT)**
    - 全 CLI ツールは `nix/packages/sets.nix` に一元定義
    - Linux/macOS: Home Manager が `home.packages` としてインストール
-   - Windows: `nix build .#winget-export` で winget/pnpm の JSON を導出
+   - Windows: `nix build .#winget-export` で winget/npm/pnpm の JSON を導出
 2. **chezmoi が設定ファイルの SSOT**
    - 全 OS 共通の dotfiles をテンプレートで管理
    - OS 固有の差分は `.chezmoiignore.tmpl` とテンプレート分岐で吸収
@@ -24,7 +24,7 @@ dotfiles/
 ├── nix/                    # NixOS/Home Manager configuration
 │   ├── packages/
 │   │   ├── sets.nix        # ★ SSOT: catalog (全パッケージ + winget + category)
-│   │   └── winget.nix      # winget/pnpm JSON 生成 derivation
+│   │   └── winget.nix      # winget/npm/pnpm JSON 生成 derivation
 │   ├── home/               # Home Manager 設定
 │   │   ├── packages.nix    # sets.nix → home.packages
 │   │   └── wsl/users.nix   # WSL ユーザー HM 設定
@@ -69,14 +69,14 @@ install.ps1
 
 ## 役割分担
 
-| 役割                  | ツール       | 説明                                         |
-| --------------------- | ------------ | -------------------------------------------- |
-| パッケージ定義 (SSOT) | Nix          | `nix/packages/sets.nix` に全ツールを一元定義 |
-| パッケージ (Linux)    | Home Manager | `home.packages` で宣言的インストール         |
-| パッケージ (Windows)  | winget/pnpm  | nix から生成した JSON でインストール         |
-| ユーザー設定          | chezmoi      | dotfiles (shell, git, terminal, editor)      |
-| システム設定          | NixOS        | OS レベルの設定 (nix gc, Docker, WSL)        |
-| タスク実行            | Taskfile     | Windows から WSL コマンドを実行              |
+| 役割                  | ツール          | 説明                                         |
+| --------------------- | --------------- | -------------------------------------------- |
+| パッケージ定義 (SSOT) | Nix             | `nix/packages/sets.nix` に全ツールを一元定義 |
+| パッケージ (Linux)    | Home Manager    | `home.packages` で宣言的インストール         |
+| パッケージ (Windows)  | winget/npm/pnpm | nix から生成した JSON でインストール         |
+| ユーザー設定          | chezmoi         | dotfiles (shell, git, terminal, editor)      |
+| システム設定          | NixOS           | OS レベルの設定 (nix gc, Docker, WSL)        |
+| タスク実行            | Taskfile        | Windows から WSL コマンドを実行              |
 
 ## パッケージ管理フロー
 
@@ -90,9 +90,10 @@ nix/packages/sets.nix (SSOT)
 │
 ├── wingetMap        ─── nix/packages/winget.nix ── nix build .#winget-export
 │   (自動導出)           └── windows/winget/packages.json (generated)
+│                        └── windows/npm/packages.json    (generated)
 │                        └── windows/pnpm/packages.json  (generated)
 │
-└── windowsOnly      ─── Windows 専用 GUI アプリ (winget/msstore/pnpm)
+└── windowsOnly      ─── Windows 専用パッケージ (winget/msstore/npm/pnpm)
     (nix対応なし)
 ```
 
@@ -103,7 +104,7 @@ nix/packages/sets.nix (SSOT)
    mypackage = { pkg = pkgs.mypackage; winget = "Publisher.Package"; category = "dev"; };
    ```
    Set `winget = null` if there is no Windows equivalent.
-2. `nix build .#winget-export` で winget/pnpm JSON を再生成
+2. `nix build .#winget-export` で winget/npm/pnpm JSON を再生成
 3. `nixos-rebuild switch` で Linux 反映、`winget import` で Windows 反映
 
 ### Windows 専用アプリの追加

--- a/docs/nix/package-management.md
+++ b/docs/nix/package-management.md
@@ -7,10 +7,11 @@
 
 ```
 nix/packages/sets.nix
-├── catalog        → { pkg, winget, category } の attrset
+├── catalog        → { pkg, winget, npm, category } の attrset
 ├── packages       → Home Manager で Linux/macOS にインストール
 ├── wingetMap      → nix attr → winget PackageIdentifier の対応表
-└── windowsOnly    → Windows 専用アプリ (winget/msstore/pnpm)
+├── npmMap         → nix attr → npm package spec の対応表
+└── windowsOnly    → Windows 専用アプリ (winget/msstore/npm/pnpm)
 ```
 
 ## パッケージ追加
@@ -57,10 +58,11 @@ sudo nixos-rebuild switch --flake ~/.dotfiles#nixos
 # WSL 上で実行
 nix build .#winget-export -o /tmp/winget-export
 cp /tmp/winget-export/winget/packages.json /mnt/d/ruru/dotfiles/windows/winget/packages.json
+cp /tmp/winget-export/npm/packages.json /mnt/d/ruru/dotfiles/windows/npm/packages.json
 cp /tmp/winget-export/pnpm/packages.json /mnt/d/ruru/dotfiles/windows/pnpm/packages.json
 
 # Windows 上で反映
-winget import -i windows/winget/packages.json --accept-package-agreements
+pwsh -File scripts/powershell/install.ps1 -UserPhaseOnly -NoPause
 ```
 
 ## ファイル構成
@@ -86,13 +88,13 @@ winget import -i windows/winget/packages.json --accept-package-agreements
 
 `test-consistency.yml` が以下を検証:
 
-1. `nix build .#winget-export` で winget JSON を生成
-2. `windows/winget/packages.json` との diff をチェック
+1. `nix build .#winget-export` で Windows package JSON を生成
+2. `windows/winget/packages.json`, `windows/npm/packages.json`, `windows/pnpm/packages.json` との diff をチェック
 3. 差分があれば CI が失敗 → `nix build .#winget-export` の再実行を促す
 
 ## 注意点
 
-- `windows/winget/packages.json` と `windows/pnpm/packages.json` は **生成ファイル**。直接編集しない
+- `windows/winget/packages.json`, `windows/npm/packages.json`, `windows/pnpm/packages.json` は **生成ファイル**。直接編集しない
 - WSL では `flake.lock` が `~/.dotfiles` に作られる
 - `allowUnfree` は NixOS config (`nix/modules/host/default.nix`) で設定済み
 - `nix profile install .#default` で使える package sets は `nix/flakes/packages.nix` の perSystem で定義

--- a/nix/packages/AGENTS.md
+++ b/nix/packages/AGENTS.md
@@ -3,7 +3,7 @@
 ## 管理対象
 
 - `sets.nix`: catalog-based SSOT (全パッケージ + winget 対応 + カテゴリ)
-- `winget.nix`: winget/pnpm JSON 生成 derivation
+- `winget.nix`: winget/npm/pnpm JSON 生成 derivation
 - 必要に応じて `<package>/default.nix`: custom package build
 
 ## 利用コマンド

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -1,11 +1,13 @@
 # Single Source of Truth for all packages across platforms.
-# Each entry defines: nix derivation, winget ID (null if none), category.
+# Each entry defines: nix derivation, optional Windows package IDs, category.
 #
 # Exported attributes:
 #   - catalog categories (core, dev, terminal, editors, llm, …) → lists of derivations
 #   - all                → flat list of all derivations
 #   - wingetMap          → nix attr name → winget PackageIdentifier
+#   - npmMap             → nix attr name → npm package spec
 #   - pnpmGlobal         → cross-platform pnpm global package names
+#   - npmVerify          → catalog attr name → { command, args } for npm verification
 #   - pnpmVerify         → package name → { command, args } for post-install verification
 #   - pnpmPostInstall    → package name → { command, args } to run after pnpm add -g
 #   - pnpmInstallArgs    → package name → extra pnpm add -g arguments
@@ -17,12 +19,12 @@
 #   - wingetSkipInstall → catalog attr name or winget/msstore ID → skip normal automated install
 #   - wingetCiSkipInstall → catalog attr name or winget/msstore ID → skip CI winget install smoke test
 #   - wingetPathEntries  → catalog attr name or winget ID → extra Windows PATH directories
-#   - windowsOnly        → packages with no nix equivalent (winget/msstore/pnpm)
+#   - windowsOnly        → packages with no nix equivalent (winget/msstore/npm/pnpm)
 #
 # Imported by:
 #   - nix/flakes/packages.nix → perSystem buildEnv outputs
 #   - nix/home/packages.nix   → home.packages
-#   - nix/packages/winget.nix → winget/pnpm JSON generation
+#   - nix/packages/winget.nix → winget/npm/pnpm JSON generation
 {
   pkgs,
   lib,
@@ -148,6 +150,7 @@ let
     devcontainer = {
       pkg = pkgs.devcontainer;
       winget = null;
+      npm = "@devcontainers/cli";
       category = "dev";
     };
     lazygit = {
@@ -444,6 +447,7 @@ let
 
   # Extract winget mappings (non-null only)
   wingetMap = lib.filterAttrs (_: v: v != null) (lib.mapAttrs (_: v: v.winget) catalog);
+  npmMap = lib.filterAttrs (_: v: v != null) (lib.mapAttrs (_: v: v.npm or null) catalog);
 
 in
 # Category-resolved package lists (auto-derived from catalog)
@@ -453,7 +457,16 @@ lib.mapAttrs (_: names: resolve names) grouped
   all = resolve (lib.attrNames catalog);
 
   # Windows: nix attr name → winget PackageIdentifier
-  inherit wingetMap;
+  inherit wingetMap npmMap;
+
+  # Post-install verification commands for npm packages.
+  # Keys match catalog attr names from npmMap.
+  npmVerify = {
+    devcontainer = {
+      command = "devcontainer";
+      args = [ "--version" ];
+    };
+  };
 
   # Cross-platform pnpm global packages
   pnpmGlobal = [
@@ -771,6 +784,7 @@ lib.mapAttrs (_: names: resolve names) grouped
       "9NT1R1C2HH7J"
       "9PLM9XGG6VKS"
     ];
+    npm = [ ];
     pnpm = [
       "@google/gemini-cli"
     ];

--- a/nix/packages/winget.nix
+++ b/nix/packages/winget.nix
@@ -1,9 +1,11 @@
-# Generate windows/winget/packages.json and windows/pnpm/packages.json
+# Generate windows/winget/packages.json, windows/npm/packages.json,
+# and windows/pnpm/packages.json
 # from the SSOT (sets.nix).
 #
 # Usage:
 #   nix build .#winget-export
 #   cp result/winget/packages.json windows/winget/packages.json
+#   cp result/npm/packages.json windows/npm/packages.json
 #   cp result/pnpm/packages.json windows/pnpm/packages.json
 {
   pkgs,
@@ -198,7 +200,28 @@ let
 
   pnpmPackages = pnpmFromGlobal ++ pnpmFromWindowsOnly;
 
+  # --- npm ---
+  npmFromMap = lib.mapAttrsToList (
+    name: spec: attachVerify sets.npmVerify name { name = spec; }
+  ) sets.npmMap;
+
+  npmFromWindowsOnly = map (
+    spec:
+    let
+      key = pnpmPackageKey spec;
+    in
+    attachVerify sets.npmVerify key { name = spec; }
+  ) sets.windowsOnly.npm;
+
+  npmPackages = npmFromMap ++ npmFromWindowsOnly;
+
   # --- outputs ---
+  npmOutput = {
+    "$schema" = "https://json.schemastore.org/package.json";
+    description = "npm global packages to install on Windows";
+    globalPackages = npmPackages;
+  };
+
   pnpmOutput = {
     "$schema" = "https://json.schemastore.org/package.json";
     description = "pnpm global packages to install on Windows";
@@ -232,11 +255,13 @@ let
   };
 
   wingetJson = builtins.toJSON wingetOutput;
+  npmJson = builtins.toJSON npmOutput;
   pnpmJson = builtins.toJSON pnpmOutput;
 
 in
 pkgs.runCommand "winget-export" { } ''
-  mkdir -p $out/winget $out/pnpm
+  mkdir -p $out/winget $out/npm $out/pnpm
   echo '${wingetJson}' | ${pkgs.jq}/bin/jq . > $out/winget/packages.json
+  echo '${npmJson}' | ${pkgs.jq}/bin/jq . > $out/npm/packages.json
   echo '${pnpmJson}' | ${pkgs.jq}/bin/jq . > $out/pnpm/packages.json
 ''

--- a/scripts/powershell/tests/CiWorkflow.Tests.ps1
+++ b/scripts/powershell/tests/CiWorkflow.Tests.ps1
@@ -130,6 +130,14 @@ Describe 'CI workflow configuration' {
         $wingetWorkflow | Should -Match 'throw "winget source update did not complete after \$Attempts attempts"'
     }
 
+    It 'should verify generated npm package catalog consistency' {
+        $consistencyWorkflow = Get-Content -LiteralPath (Join-Path $script:repoRoot ".github/workflows/ci-consistency.yml") -Raw
+
+        $consistencyWorkflow | Should -Match '"windows/npm/packages\.json"'
+        $consistencyWorkflow | Should -Match '/tmp/winget-export/npm/packages\.json'
+        $consistencyWorkflow | Should -Match 'windows/npm/packages\.json'
+    }
+
     It 'should trigger entrypoint tests when install.cmd or bootstrap tests change' {
         $powershellWorkflow = Get-Content -LiteralPath (Join-Path $script:repoRoot ".github/workflows/ci-powershell.yml") -Raw
         $devcontainerWorkflow = Get-Content -LiteralPath (Join-Path $script:repoRoot ".github/workflows/ci-devcontainer.yml") -Raw

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -4,6 +4,7 @@ BeforeAll {
     $script:repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
     $script:setsPath = Join-Path $script:repoRoot "nix/packages/sets.nix"
     $script:wingetJsonPath = Join-Path $script:repoRoot "windows/winget/packages.json"
+    $script:npmJsonPath = Join-Path $script:repoRoot "windows/npm/packages.json"
 }
 
 Describe 'Package catalog consistency' {
@@ -203,6 +204,32 @@ Describe 'Package catalog consistency' {
             $package.verifyCommand.type | Should -Be 'appxLaunchTarget'
             $package.verifyCommand.command | Should -Be 'OpenAI.Codex'
             @($package.verifyCommand.args) | Should -Contain 'OpenAI.Codex_2p2nqsd0c76g0!App'
+        }
+    }
+
+    Context 'Devcontainer CLI package' {
+        It 'should define devcontainer with both Nix and Windows npm package mappings in the SSOT' {
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+
+            $sets | Should -Match '(?s)devcontainer\s*=\s*\{.*?pkg\s*=\s*pkgs\.devcontainer;.*?npm\s*=\s*"@devcontainers/cli"'
+            $sets | Should -Match '(?s)npmVerify\s*=\s*\{.*?devcontainer\s*=\s*\{.*?command\s*=\s*"devcontainer".*?args\s*=\s*\[\s*"--version"\s*\]'
+        }
+
+        It 'should generate @devcontainers/cli into the Windows npm package catalog with verification' {
+            $json = Get-Content -LiteralPath $script:npmJsonPath -Raw | ConvertFrom-Json
+            $package = @($json.globalPackages | Where-Object { $_.name -eq '@devcontainers/cli' }) | Select-Object -First 1
+
+            $package | Should -Not -BeNullOrEmpty
+            $package.verifyCommand.command | Should -Be 'devcontainer'
+            @($package.verifyCommand.args) | Should -Contain '--version'
+        }
+
+        It 'should have winget-export generate npm packages.json from the SSOT' {
+            $exporter = Get-Content -LiteralPath (Join-Path $script:repoRoot "nix/packages/winget.nix") -Raw
+
+            $exporter | Should -Match 'windows/npm/packages\.json'
+            $exporter | Should -Match 'npmFromMap'
+            $exporter | Should -Match '\$out/npm/packages\.json'
         }
     }
 }

--- a/windows/npm/packages.json
+++ b/windows/npm/packages.json
@@ -1,5 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "description": "npm global packages to install on Windows",
-  "globalPackages": []
+  "globalPackages": [
+    {
+      "name": "@devcontainers/cli",
+      "verifyCommand": {
+        "args": ["--version"],
+        "command": "devcontainer"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add an npm mapping for the devcontainer CLI in the Nix package SSOT.
- Extend winget-export to generate windows/npm/packages.json alongside winget and pnpm catalogs.
- Add package catalog and CI consistency tests for the generated npm catalog.
- Update package-management docs to describe winget/npm/pnpm generation.

## Validation
- devcontainer --version => 0.87.0
- nix build .#winget-export via WSL
- nix fmt -- --fail-on-change on changed files via WSL
- task test: 818 passed, 0 failed, 5 skipped