### PR TITLE
[codex] tune shell aliases and wezterm opacity

### DIFF
--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -119,10 +119,10 @@ if (Get-Command eza -ErrorAction SilentlyContinue) {
         eza @EzaArgs @RemainingArgs
     }
 
-    function ls { Invoke-DotfilesEza -EzaArgs @("-lhaT", "--level=1", "--total-size", "--icons=auto", "--hyperlink", "-F", "--group-directories-first", "--color=auto") -RemainingArgs $args }
-    function ll { Invoke-DotfilesEza -EzaArgs @("-lhaT", "--level=2", "--total-size", "--icons=auto", "--hyperlink", "-F", "--group-directories-first", "--color=auto") -RemainingArgs $args }
-    function la { Invoke-DotfilesEza -EzaArgs @("-lhaT", "--level=2", "--total-size", "--icons=auto", "--hyperlink", "-F", "--group-directories-first", "--color=auto") -RemainingArgs $args }
-    function l { Invoke-DotfilesEza -EzaArgs @("-lhaT", "--level=2", "--total-size", "--icons=auto", "--hyperlink", "-F", "--group-directories-first", "--color=auto") -RemainingArgs $args }
+    function ls { Invoke-DotfilesEza -EzaArgs @("-lhaT", "--level=1", "--icons=auto", "--hyperlink", "-F", "--group-directories-first", "--color=auto") -RemainingArgs $args }
+    function ll { Invoke-DotfilesEza -EzaArgs @("-lhaT", "--level=2", "--icons=auto", "--hyperlink", "-F", "--group-directories-first", "--color=auto") -RemainingArgs $args }
+    function la { Invoke-DotfilesEza -EzaArgs @("-lhaT", "--level=2", "--icons=auto", "--hyperlink", "-F", "--group-directories-first", "--color=auto") -RemainingArgs $args }
+    function l { Invoke-DotfilesEza -EzaArgs @("-lhaT", "--level=2", "--icons=auto", "--hyperlink", "-F", "--group-directories-first", "--color=auto") -RemainingArgs $args }
 }
 
 # OSC 7 support (advises terminal of current working directory)

--- a/chezmoi/shells/bashrc
+++ b/chezmoi/shells/bashrc
@@ -11,10 +11,10 @@ shopt -s checkwinsize
 
 # Aliases
 if command -v eza >/dev/null 2>&1; then
-  alias ls='eza -lhaT --level=1 --total-size --icons=auto --hyperlink -F --group-directories-first --color=auto'
-  alias ll='eza -lhaT --level=2 --total-size --icons=auto --hyperlink -F --group-directories-first --color=auto'
-  alias la='eza -lhaT --level=2 --total-size --icons=auto --hyperlink -F --group-directories-first --color=auto'
-  alias l='eza -lhaT --level=2 --total-size --icons=auto --hyperlink -F --group-directories-first --color=auto'
+  alias ls='eza -lhaT --level=1 --icons=auto --hyperlink -F --group-directories-first --color=auto'
+  alias ll='eza -lhaT --level=2 --icons=auto --hyperlink -F --group-directories-first --color=auto'
+  alias la='eza -lhaT --level=2 --icons=auto --hyperlink -F --group-directories-first --color=auto'
+  alias l='eza -lhaT --level=2 --icons=auto --hyperlink -F --group-directories-first --color=auto'
 else
   alias ll='ls -alF'
   alias la='ls -A'

--- a/chezmoi/shells/profile
+++ b/chezmoi/shells/profile
@@ -14,3 +14,10 @@ if [ -d "$HOME/.bun/bin" ]; then
 fi
 
 export PATH
+
+# Load interactive bash settings for login bash shells.
+if [ -n "${BASH_VERSION:-}" ] && [ -f "$HOME/.bashrc" ]; then
+  case $- in
+    *i*) . "$HOME/.bashrc" ;;
+  esac
+fi

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -28,7 +28,7 @@ config.cell_width = 1.0
 config.use_ime = true
 
 -- Window appearance
-config.window_background_opacity = 0.85
+config.window_background_opacity = 0.75
 config.window_decorations = "TITLE|RESIZE"
 config.window_padding = {
     left = 8,

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -33,10 +33,10 @@ in
     shellAliases = {
       find = "fd";
       grep = "rg";
-      l = "eza -lhaT --level=2 --total-size --icons=auto --hyperlink -F --group-directories-first --color=auto";
-      la = "eza -lhaT --level=2 --total-size --icons=auto --hyperlink -F --group-directories-first --color=auto";
-      ll = "eza -lhaT --level=2 --total-size --icons=auto --hyperlink -F --group-directories-first --color=auto";
-      ls = "eza -lhaT --level=1 --total-size --icons=auto --hyperlink -F --group-directories-first --color=auto";
+      l = "eza -lhaT --level=2 --icons=auto --hyperlink -F --group-directories-first --color=auto";
+      la = "eza -lhaT --level=2 --icons=auto --hyperlink -F --group-directories-first --color=auto";
+      ll = "eza -lhaT --level=2 --icons=auto --hyperlink -F --group-directories-first --color=auto";
+      ls = "eza -lhaT --level=1 --icons=auto --hyperlink -F --group-directories-first --color=auto";
     };
 
     initContent = ''

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -141,15 +141,15 @@ Describe 'chezmoi テンプレート バリデーション' {
     }
 
     Context 'Shell keybindings' {
-        It 'profile should source bashrc for interactive login bash' {
-            $profile = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot "shells/profile") -Raw
+        It 'should source bashrc from profile for interactive login bash' {
+            $profileContent = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot "shells/profile") -Raw
 
-            $profile | Should -Match '\$\{BASH_VERSION:-\}' -Because "profile is read by multiple POSIX shells and should guard bash-specific startup"
-            $profile | Should -Match '\$HOME/\.bashrc' -Because "login bash must load the managed bash aliases"
-            $profile | Should -Match '\*i\*\)' -Because "non-interactive login shells should not load interactive bashrc"
+            $profileContent | Should -Match '\$\{BASH_VERSION:-\}' -Because "profile is read by multiple POSIX shells and should guard bash-specific startup"
+            $profileContent | Should -Match '\$HOME/\.bashrc' -Because "login bash must load the managed bash aliases"
+            $profileContent | Should -Match '\*i\*\)' -Because "non-interactive login shells should not load interactive bashrc"
         }
 
-        It 'eza aliases should not calculate total directory size by default' {
+        It 'should not calculate total directory size in eza aliases by default' {
             $shellFiles = @(
                 Join-Path $script:chezmoiRoot "shells/bashrc"
                 Join-Path $script:chezmoiRoot "shells/Microsoft.PowerShell_profile.ps1"

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -141,6 +141,27 @@ Describe 'chezmoi テンプレート バリデーション' {
     }
 
     Context 'Shell keybindings' {
+        It 'profile should source bashrc for interactive login bash' {
+            $profile = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot "shells/profile") -Raw
+
+            $profile | Should -Match '\$\{BASH_VERSION:-\}' -Because "profile is read by multiple POSIX shells and should guard bash-specific startup"
+            $profile | Should -Match '\$HOME/\.bashrc' -Because "login bash must load the managed bash aliases"
+            $profile | Should -Match '\*i\*\)' -Because "non-interactive login shells should not load interactive bashrc"
+        }
+
+        It 'eza aliases should not calculate total directory size by default' {
+            $shellFiles = @(
+                Join-Path $script:chezmoiRoot "shells/bashrc"
+                Join-Path $script:chezmoiRoot "shells/Microsoft.PowerShell_profile.ps1"
+                Join-Path $script:repoRoot "nix/home/common.nix"
+            )
+
+            foreach ($path in $shellFiles) {
+                $content = Get-Content -LiteralPath $path -Raw
+                $content | Should -Not -Match '--total-size' -Because "$path default ls aliases must stay fast on large WSL-mounted Windows directories"
+            }
+        }
+
         It 'zoxide interactive jump should use Alt+Z consistently' {
             $bashrc = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot "shells/bashrc") -Raw
             $powershellProfile = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot "shells/Microsoft.PowerShell_profile.ps1") -Raw


### PR DESCRIPTION
## Summary
- Remove `--total-size` from default eza aliases across Bash, PowerShell, and Nix home aliases so directory listings stay fast on large mounted directories.
- Load managed `.bashrc` from interactive login Bash shells.
- Increase WezTerm transparency by lowering `window_background_opacity` to `0.75`.
- Add template tests covering the login Bash behavior and fast eza aliases.

## Validation
- `task commit -- "tune shell aliases and wezterm opacity"`
  - `nix fmt`
  - `pre-commit run --all-files`
  - PowerShell tests
  - chezmoi template lint