### PR TITLE
fix WezTerm window resizing when switching focus to another window

### DIFF
--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -23,7 +23,8 @@ local function focus_adjacent_window(direction)
             "public class U{",
             "[DllImport(\"user32\")]public static extern IntPtr GetForegroundWindow();",
             "[DllImport(\"user32\")]public static extern bool SetForegroundWindow(IntPtr h);",
-            "[DllImport(\"user32\")]public static extern bool ShowWindow(IntPtr h,int n);}';",
+            "[DllImport(\"user32\")]public static extern bool ShowWindow(IntPtr h,int n);",
+            "[DllImport(\"user32\")]public static extern bool IsIconic(IntPtr h);}';",
             "$d=" .. offset .. ";",
             "$p=@(Get-Process wezterm-gui -EA 0|Where-Object{$_.MainWindowHandle -ne 0}|Sort-Object Id);",
             "if($p.Count -lt 2){exit};",
@@ -32,7 +33,7 @@ local function focus_adjacent_window(direction)
             "$i=[Array]::IndexOf($h,$c);",
             "if($i -lt 0){exit};",
             "$n=(($i+$d)%$p.Count+$p.Count)%$p.Count;",
-            "[U]::ShowWindow($h[$n],9);",
+            "if([U]::IsIconic($h[$n])){[U]::ShowWindow($h[$n],9)};",
             "[void][U]::SetForegroundWindow($h[$n])",
         })
         wezterm.run_child_process({ "pwsh.exe", "-NoProfile", "-NonInteractive", "-Command", ps })


### PR DESCRIPTION
## Summary

- ウィンドウ切り替え時にサイズがデフォルトに戻る問題を修正
- `ShowWindow(SW_RESTORE)` を最小化されているウィンドウにのみ呼ぶよう変更
- 通常状態のウィンドウには `SW_RESTORE` を呼ばないのでサイズが維持される

## Test plan

- [ ] 2枚のWezTermウィンドウをリサイズした状態で `CTRL+ALT+SHIFT+H/L` を押してもサイズが変わらないことを確認
- [ ] 最小化されたウィンドウへの切り替えは引き続き正常に復元されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)