### PR TITLE
feat: enable transparent background in Neovim

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -8,7 +8,7 @@ return {
         lazy = false,
         priority = 1000,
         config = function()
-            require("catppuccin").setup({ flavour = "mocha" })
+            require("catppuccin").setup({ flavour = "mocha", transparent_background = true })
             vim.cmd.colorscheme("catppuccin-mocha")
         end,
     },

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -7,7 +7,9 @@ local config = wezterm.config_builder()
 local function focus_adjacent_window(direction)
     return wezterm.action_callback(function(window, pane)
         local wins = wezterm.gui.gui_windows()
-        table.sort(wins, function(a, b) return a:window_id() < b:window_id() end)
+        table.sort(wins, function(a, b)
+            return a:window_id() < b:window_id()
+        end)
         if #wins > 1 then
             for i, w in ipairs(wins) do
                 if w:window_id() == window:window_id() then
@@ -21,10 +23,10 @@ local function focus_adjacent_window(direction)
         local ps = table.concat({
             "Add-Type -TypeDef 'using System;using System.Runtime.InteropServices;",
             "public class U{",
-            "[DllImport(\"user32\")]public static extern IntPtr GetForegroundWindow();",
-            "[DllImport(\"user32\")]public static extern bool SetForegroundWindow(IntPtr h);",
-            "[DllImport(\"user32\")]public static extern bool ShowWindow(IntPtr h,int n);",
-            "[DllImport(\"user32\")]public static extern bool IsIconic(IntPtr h);}';",
+            '[DllImport("user32")]public static extern IntPtr GetForegroundWindow();',
+            '[DllImport("user32")]public static extern bool SetForegroundWindow(IntPtr h);',
+            '[DllImport("user32")]public static extern bool ShowWindow(IntPtr h,int n);',
+            '[DllImport("user32")]public static extern bool IsIconic(IntPtr h);}\';',
             "$d=" .. offset .. ";",
             "$p=@(Get-Process wezterm-gui -EA 0|Where-Object{$_.MainWindowHandle -ne 0}|Sort-Object Id);",
             "if($p.Count -lt 2){exit};",


### PR DESCRIPTION
## Summary
- catppuccin テーマに `transparent_background = true` を追加
- WezTerm の `window_background_opacity = 0.75` と連動して nvim の背景が透過される

## Test plan
- [ ] nvim を再起動して背景が透過されることを確認
- [ ] カラースキームが正常に表示されることを確認