### PR TITLE
[codex] Add PowerShell 1Password secret fallback

### DIFF
--- a/chezmoi/secret/env.ps1
+++ b/chezmoi/secret/env.ps1
@@ -5,7 +5,174 @@
 #   op run --env-file injects GH_TOKEN/TAVILY_API_KEY/GITHUB_WORK_TOKEN once at WezTerm startup;
 #   all tabs inherit them and this guard exits immediately.
 #
-# For standalone pwsh outside WezTerm:
-#   op run --env-file="$env:USERPROFILE\.config\shell\secrets.env" -- pwsh
+# Fallback: standalone pwsh attempts bounded op inject calls when values are missing.
 
 if ($env:GH_TOKEN -and $env:TAVILY_API_KEY -and $env:GITHUB_WORK_TOKEN) { return }
+if (-not $env:DOTFILES_FORCE_SECRET_LOAD) {
+    $dotfilesPowerShellArgs = [Environment]::GetCommandLineArgs()
+    $dotfilesSecretLoadIsCommandMode = $false
+    foreach ($arg in $dotfilesPowerShellArgs) {
+        if ($arg -match '^-{1,2}(command|c|encodedcommand|ec|file|f|noninteractive)$') {
+            $dotfilesSecretLoadIsCommandMode = $true
+            break
+        }
+    }
+
+    Remove-Variable dotfilesPowerShellArgs -ErrorAction SilentlyContinue
+    if ($dotfilesSecretLoadIsCommandMode) {
+        Remove-Variable dotfilesSecretLoadIsCommandMode -ErrorAction SilentlyContinue
+        return
+    }
+    Remove-Variable dotfilesSecretLoadIsCommandMode -ErrorAction SilentlyContinue
+}
+
+function Resolve-DotfilesOpCli {
+    [CmdletBinding()]
+    param()
+
+    if ($env:DOTFILES_OP_BIN) {
+        return $env:DOTFILES_OP_BIN
+    }
+
+    $command = Get-Command op -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $command) {
+        $command = Get-Command op.exe -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+    }
+
+    if (-not $command) {
+        return $null
+    }
+
+    return $command.Source
+}
+
+function Get-DotfilesSecretLoadTimeoutSeconds {
+    [CmdletBinding()]
+    param()
+
+    $timeoutSeconds = 8
+    if ($env:DOTFILES_SECRET_LOAD_TIMEOUT_SECONDS) {
+        $parsedTimeout = 0
+        if ([int]::TryParse($env:DOTFILES_SECRET_LOAD_TIMEOUT_SECONDS, [ref]$parsedTimeout) -and $parsedTimeout -gt 0) {
+            $timeoutSeconds = $parsedTimeout
+        }
+    }
+
+    return $timeoutSeconds
+}
+
+function Invoke-DotfilesOpInject {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Template,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Account,
+
+        [Parameter(Mandatory = $true)]
+        [int]$TimeoutSeconds
+    )
+
+    $opBin = Resolve-DotfilesOpCli
+    if (-not $opBin) {
+        return $null
+    }
+
+    $stdin = [System.IO.Path]::GetTempFileName()
+    $stdout = [System.IO.Path]::GetTempFileName()
+    $stderr = [System.IO.Path]::GetTempFileName()
+
+    try {
+        Set-Content -LiteralPath $stdin -Value $Template -Encoding utf8 -NoNewline
+        $process = Start-Process `
+            -FilePath $opBin `
+            -ArgumentList @('inject', '--in-file', $stdin, '--account', $Account) `
+            -PassThru `
+            -WindowStyle Hidden `
+            -RedirectStandardOutput $stdout `
+            -RedirectStandardError $stderr
+
+        if ($process.WaitForExit($TimeoutSeconds * 1000) -and $process.ExitCode -eq 0) {
+            return Get-Content -LiteralPath $stdout -Raw -ErrorAction SilentlyContinue
+        }
+
+        if (-not $process.HasExited) {
+            Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+            Write-Warning "1Password secret injection timed out after $TimeoutSeconds seconds; continuing without injected secrets."
+        }
+        else {
+            $errorContent = Get-Content -LiteralPath $stderr -Raw -ErrorAction SilentlyContinue
+            $errorText = if ($null -ne $errorContent) { $errorContent.Trim() } else { '' }
+            if ($errorText) {
+                Write-Warning "1Password secret injection failed: $errorText"
+            }
+            else {
+                Write-Warning "1Password secret injection failed with exit code $($process.ExitCode)."
+            }
+        }
+    }
+    catch {
+        Write-Warning "1Password secret injection failed: $($_.Exception.Message)"
+    }
+    finally {
+        Remove-Item -LiteralPath $stdin, $stdout, $stderr -Force -ErrorAction SilentlyContinue
+    }
+
+    return $null
+}
+
+function Set-DotfilesSecretEnvironment {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]$Content
+    )
+
+    if (-not $Content) {
+        return
+    }
+
+    $allowedNames = @('GH_TOKEN', 'TAVILY_API_KEY', 'GITHUB_WORK_TOKEN')
+    foreach ($line in ($Content -split '\r?\n')) {
+        if ($line -notmatch '^([A-Za-z_][A-Za-z0-9_]*)=(.*)$') {
+            continue
+        }
+
+        $name = $Matches[1]
+        if ($name -notin $allowedNames) {
+            continue
+        }
+
+        [Environment]::SetEnvironmentVariable($name, $Matches[2], 'Process')
+    }
+}
+
+try {
+    $timeoutSeconds = Get-DotfilesSecretLoadTimeoutSeconds
+    $personalAccount = if ($env:OP_ACCOUNT) { $env:OP_ACCOUNT } else { 'EJLA3HRAVZBCXIQ7SRSFGQBTNU' }
+    $workAccount = 'aimatecoltd.1password.com'
+
+    if (-not ($env:GH_TOKEN -and $env:TAVILY_API_KEY)) {
+        $personalTemplate = @'
+GH_TOKEN={{ op://Private/GitHubUsedUserPAT/credential }}
+TAVILY_API_KEY={{ op://Private/TavilyUsedUserPAT/credential }}
+'@
+        Set-DotfilesSecretEnvironment -Content (Invoke-DotfilesOpInject -Template $personalTemplate -Account $personalAccount -TimeoutSeconds $timeoutSeconds)
+    }
+
+    if (-not $env:GITHUB_WORK_TOKEN) {
+        $workTemplate = @'
+GITHUB_WORK_TOKEN={{ op://devcontainer/GITHUB_PERSONAL_ACCESS_TOKEN_KOHEI-MIKI-IM8/credential }}
+'@
+        Set-DotfilesSecretEnvironment -Content (Invoke-DotfilesOpInject -Template $workTemplate -Account $workAccount -TimeoutSeconds $timeoutSeconds)
+    }
+}
+finally {
+    Remove-Item Function:\Resolve-DotfilesOpCli -ErrorAction SilentlyContinue
+    Remove-Item Function:\Get-DotfilesSecretLoadTimeoutSeconds -ErrorAction SilentlyContinue
+    Remove-Item Function:\Invoke-DotfilesOpInject -ErrorAction SilentlyContinue
+    Remove-Item Function:\Set-DotfilesSecretEnvironment -ErrorAction SilentlyContinue
+
+    Remove-Variable timeoutSeconds, personalAccount, workAccount, personalTemplate, workTemplate -ErrorAction SilentlyContinue
+}

--- a/docs/chezmoi/secrets.md
+++ b/docs/chezmoi/secrets.md
@@ -19,7 +19,7 @@
 - `chezmoi/secret/env.sh`
   - WSL / Linux の fallback loader。`op inject --account ...` を実行時に呼ぶ。
 - `chezmoi/secret/env.ps1`
-  - PowerShell 用。通常は WezTerm launcher から注入済みの環境変数を受け取る。
+  - PowerShell 用。通常は WezTerm launcher から注入済みの環境変数を受け取り、未設定なら timeout 付きで `op inject --account ...` を呼ぶ。
 - `chezmoi/.chezmoidata/mcp_servers.yaml`
   - MCP の `op_env` 参照を置く。client template は失敗しても env fallback を使う。
 - `chezmoi/.chezmoiscripts/**`

--- a/scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1
@@ -4,6 +4,7 @@ BeforeAll {
     $script:repoRoot = Join-Path $PSScriptRoot "../../../../"
     $script:chezmoiRoot = Join-Path $script:repoRoot "chezmoi"
     $script:helperPath = Join-Path $script:chezmoiRoot "dot_config/shell/gh-token-switch.ps1"
+    $script:secretLoaderPath = Join-Path $script:chezmoiRoot "secret/env.ps1"
     $script:weztermLaunch = Join-Path $script:chezmoiRoot "secret/wezterm-launch.cmd"
 }
 
@@ -12,6 +13,144 @@ AfterAll {
     Remove-Item Function:\Invoke-DotfilesGitHubCli -ErrorAction SilentlyContinue
     Remove-Item Function:\Resolve-DotfilesGitHubCli -ErrorAction SilentlyContinue
     Remove-Item Function:\Test-DotfilesWorkGitHubRepository -ErrorAction SilentlyContinue
+}
+
+Describe 'PowerShell secret loader' {
+    BeforeEach {
+        $script:previousGhToken = [Environment]::GetEnvironmentVariable('GH_TOKEN', 'Process')
+        $script:previousTavilyApiKey = [Environment]::GetEnvironmentVariable('TAVILY_API_KEY', 'Process')
+        $script:previousWorkToken = [Environment]::GetEnvironmentVariable('GITHUB_WORK_TOKEN', 'Process')
+        $script:previousOpBin = [Environment]::GetEnvironmentVariable('DOTFILES_OP_BIN', 'Process')
+        $script:previousSecretTimeout = [Environment]::GetEnvironmentVariable('DOTFILES_SECRET_LOAD_TIMEOUT_SECONDS', 'Process')
+        $script:previousForceSecretLoad = [Environment]::GetEnvironmentVariable('DOTFILES_FORCE_SECRET_LOAD', 'Process')
+
+        Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
+        Remove-Item Env:TAVILY_API_KEY -ErrorAction SilentlyContinue
+        Remove-Item Env:GITHUB_WORK_TOKEN -ErrorAction SilentlyContinue
+        $env:DOTFILES_SECRET_LOAD_TIMEOUT_SECONDS = '3'
+        $env:DOTFILES_FORCE_SECRET_LOAD = '1'
+    }
+
+    AfterEach {
+        if ($null -eq $script:previousGhToken) {
+            Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:GH_TOKEN = $script:previousGhToken
+        }
+
+        if ($null -eq $script:previousTavilyApiKey) {
+            Remove-Item Env:TAVILY_API_KEY -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:TAVILY_API_KEY = $script:previousTavilyApiKey
+        }
+
+        if ($null -eq $script:previousWorkToken) {
+            Remove-Item Env:GITHUB_WORK_TOKEN -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:GITHUB_WORK_TOKEN = $script:previousWorkToken
+        }
+
+        if ($null -eq $script:previousOpBin) {
+            Remove-Item Env:DOTFILES_OP_BIN -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:DOTFILES_OP_BIN = $script:previousOpBin
+        }
+
+        if ($null -eq $script:previousSecretTimeout) {
+            Remove-Item Env:DOTFILES_SECRET_LOAD_TIMEOUT_SECONDS -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:DOTFILES_SECRET_LOAD_TIMEOUT_SECONDS = $script:previousSecretTimeout
+        }
+
+        if ($null -eq $script:previousForceSecretLoad) {
+            Remove-Item Env:DOTFILES_FORCE_SECRET_LOAD -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:DOTFILES_FORCE_SECRET_LOAD = $script:previousForceSecretLoad
+        }
+    }
+
+    It '環境変数が未設定なら op inject から PowerShell process 環境に読み込むこと' {
+        $fakeOp = Join-Path $TestDrive 'op.cmd'
+        Set-Content -LiteralPath $fakeOp -Encoding ascii -Value @'
+@echo off
+if "%1"=="inject" if "%2"=="--in-file" if exist "%3" if "%4"=="--account" if "%5"=="EJLA3HRAVZBCXIQ7SRSFGQBTNU" (
+  echo GH_TOKEN=personal-token
+  echo TAVILY_API_KEY=tavily-token
+  exit /b 0
+)
+if "%1"=="inject" if "%2"=="--in-file" if exist "%3" if "%4"=="--account" if "%5"=="aimatecoltd.1password.com" (
+  echo GITHUB_WORK_TOKEN=work-token
+  exit /b 0
+)
+exit /b 1
+'@
+        $env:DOTFILES_OP_BIN = $fakeOp
+
+        . $script:secretLoaderPath
+
+        $env:GH_TOKEN | Should -Be 'personal-token'
+        $env:TAVILY_API_KEY | Should -Be 'tavily-token'
+        $env:GITHUB_WORK_TOKEN | Should -Be 'work-token'
+    }
+
+    It 'op inject が失敗しても shell 起動を例外で止めないこと' {
+        $fakeOp = Join-Path $TestDrive 'op-fail.cmd'
+        Set-Content -LiteralPath $fakeOp -Encoding ascii -Value @'
+@echo off
+exit /b 42
+'@
+        $env:DOTFILES_OP_BIN = $fakeOp
+
+        $previousWarningPreference = $WarningPreference
+        try {
+            $WarningPreference = 'SilentlyContinue'
+            { . $script:secretLoaderPath } | Should -Not -Throw
+        }
+        finally {
+            $WarningPreference = $previousWarningPreference
+        }
+
+        $env:GH_TOKEN | Should -BeNullOrEmpty
+        $env:GITHUB_WORK_TOKEN | Should -BeNullOrEmpty
+    }
+
+    It 'pwsh -Command では force 未設定なら fallback を起動しないこと' {
+        $fakeOp = Join-Path $TestDrive 'op-marker.cmd'
+        $marker = Join-Path $TestDrive 'op-called.txt'
+        Set-Content -LiteralPath $fakeOp -Encoding ascii -Value @"
+@echo off
+echo called>"$marker"
+echo GH_TOKEN=personal-token
+echo TAVILY_API_KEY=tavily-token
+echo GITHUB_WORK_TOKEN=work-token
+exit /b 0
+"@
+        Remove-Item Env:DOTFILES_FORCE_SECRET_LOAD -ErrorAction SilentlyContinue
+
+        $loader = $script:secretLoaderPath.Replace("'", "''")
+        $fakeOpLiteral = $fakeOp.Replace("'", "''")
+        $command = @"
+`$env:DOTFILES_OP_BIN = '$fakeOpLiteral'
+`$env:DOTFILES_SECRET_LOAD_TIMEOUT_SECONDS = '3'
+Remove-Item Env:DOTFILES_FORCE_SECRET_LOAD -ErrorAction SilentlyContinue
+Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
+Remove-Item Env:TAVILY_API_KEY -ErrorAction SilentlyContinue
+Remove-Item Env:GITHUB_WORK_TOKEN -ErrorAction SilentlyContinue
+. '$loader'
+[Console]::WriteLine('gh=' + [bool]`$env:GH_TOKEN)
+"@
+
+        $output = & pwsh -NoLogo -NoProfile -Command $command
+
+        $output | Should -Contain 'gh=False'
+        Test-Path -LiteralPath $marker | Should -BeFalse
+    }
 }
 
 Describe 'GitHub token switching helper (PowerShell)' {


### PR DESCRIPTION
## Summary

- Add a bounded PowerShell fallback loader for 1Password-managed shell secrets when `GH_TOKEN`, `TAVILY_API_KEY`, or `GITHUB_WORK_TOKEN` are missing.
- Skip fallback loading for non-interactive `pwsh -Command`, `pwsh -File`, and `-NonInteractive` runs unless `DOTFILES_FORCE_SECRET_LOAD=1` is set.
- Document the Windows PowerShell fallback behavior and add Pester coverage for success, failure, and non-interactive skip paths.

## Why

The existing launcher-based `op run --env-file` path works when terminals are started through the configured launcher, but standalone interactive PowerShell sessions could start without GitHub-related secrets. The fallback keeps interactive shells useful without making script/Codex invocations wait on 1Password prompts.

## Validation

- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1`
- `task commit -- "Add PowerShell 1Password secret fallback"` ran `nix fmt`, `pre-commit run --all-files`, and commit hooks successfully after regenerating the local WSL pre-commit hook with `task hooks:install`.