### PR TITLE
[codex] update wsl nixos packages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -75,11 +75,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781305496,
-        "narHash": "sha256-g8Vv4Qfc7n+lgov97REu3X6BeJtvYY0hlSUZR1GrGQQ=",
+        "lastModified": 1781906751,
+        "narHash": "sha256-6Ld1PqmptFtFKblE+SynhRgyBApUWcmrISetWqWHeeo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c87a39aa979acc4848016d2220c6238390d84779",
+        "rev": "37f21dfa5d27e71b75bacd9418b156f9265e312e",
         "type": "github"
       },
       "original": {
@@ -173,11 +173,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Update the WSL/NixOS flake lock entries.
- Advance `home-manager` and the NixOS `nixpkgs` input.
- Apply the new NixOS generation via `task rebuild`.

## Validation

- `task rebuild`
- `task commit -- "update wsl nixos packages"`
  - `nix fmt`
  - `pre-commit run --all-files`
  - commit hooks
- Verified current WSL/NixOS system: `26.11.20260616.567a49d (Zokor)`
- Verified `home-manager-nixos.service`: `active`
