### PR TITLE
[codex] enable nvim format on save

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/options.lua
+++ b/chezmoi/dot_config/nvim/lua/config/options.lua
@@ -94,6 +94,15 @@ opt.backup = false
 -- winget installs to versioned dirs that may not reach nvim when launched from a shell
 -- whose profile has not yet rebuilt PATH from the registry.
 if vim.fn.has("win32") == 1 then
+    local function prepend_path(dir)
+        if vim.fn.isdirectory(dir) == 1 then
+            vim.env.PATH = dir .. ";" .. vim.env.PATH
+        end
+    end
+
+    prepend_path(vim.fn.expand("$LOCALAPPDATA") .. "/Microsoft/WinGet/Links")
+    prepend_path(vim.fn.expand("$USERPROFILE") .. "/.cargo/bin")
+
     if vim.fn.executable("magick") == 0 then
         for _, dir in ipairs(vim.fn.glob("C:/Program Files/ImageMagick*", false, true)) do
             if vim.fn.isdirectory(dir) == 1 then

--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -617,6 +617,49 @@ return {
                 end,
             })
 
+            local format_on_save_clients = {
+                python = { ruff = true },
+                rust = { rust_analyzer = true },
+            }
+
+            vim.api.nvim_create_autocmd("BufWritePre", {
+                group = vim.api.nvim_create_augroup("DotfilesFormatOnSave", { clear = true }),
+                pattern = { "*.py", "*.rs" },
+                callback = function(args)
+                    local ft = vim.bo[args.buf].filetype
+                    local allowed_clients = format_on_save_clients[ft]
+                    if not allowed_clients then
+                        return
+                    end
+
+                    local has_formatter = false
+                    for _, client in
+                        ipairs(vim.lsp.get_clients({
+                            bufnr = args.buf,
+                            method = "textDocument/formatting",
+                        }))
+                    do
+                        if allowed_clients[client.name] then
+                            has_formatter = true
+                            break
+                        end
+                    end
+
+                    if not has_formatter then
+                        return
+                    end
+
+                    vim.lsp.buf.format({
+                        bufnr = args.buf,
+                        async = false,
+                        timeout_ms = 3000,
+                        filter = function(client)
+                            return allowed_clients[client.name] == true
+                        end,
+                    })
+                end,
+            })
+
             -- Defaults applied to every server via the '*' wildcard.
             vim.lsp.config("*", {
                 capabilities = capabilities,

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -115,6 +115,11 @@ let
       winget = "GoLang.Go";
       category = "dev";
     };
+    rustup = {
+      pkg = pkgs.rustup;
+      winget = "Rustlang.Rustup";
+      category = "dev";
+    };
     gnumake = {
       pkg = pkgs.gnumake;
       winget = null;
@@ -366,7 +371,7 @@ let
     };
     ruff = {
       pkg = pkgs.ruff;
-      winget = null;
+      winget = "astral-sh.ruff";
       category = "lsp";
     };
     yaml-language-server = {
@@ -405,7 +410,12 @@ let
       category = "lsp";
     };
     rust-analyzer = {
-      pkg = pkgs.rust-analyzer;
+      pkg = lib.hiPrio pkgs.rust-analyzer;
+      winget = "Rustlang.rust-analyzer";
+      category = "lsp";
+    };
+    rustfmt = {
+      pkg = lib.hiPrio pkgs.rustfmt;
       winget = null;
       category = "lsp";
     };
@@ -610,6 +620,10 @@ lib.mapAttrs (_: names: resolve names) grouped
       command = "go";
       args = [ "version" ];
     };
+    rustup = {
+      command = "rustup";
+      args = [ "--version" ];
+    };
     ghq = {
       command = "ghq";
       args = [ "--version" ];
@@ -634,9 +648,21 @@ lib.mapAttrs (_: names: resolve names) grouped
       command = "ty";
       args = [ "--version" ];
     };
+    ruff = {
+      command = "ruff";
+      args = [ "--version" ];
+    };
     taplo = {
       command = "taplo";
       args = [ "--version" ];
+    };
+    rust-analyzer = {
+      command = "pwsh";
+      args = [
+        "-NoProfile"
+        "-Command"
+        "& (Join-Path $env:LOCALAPPDATA 'Microsoft/WinGet/Links/rust-analyzer.exe') --version"
+      ];
     };
     opencode = {
       command = "opencode";
@@ -703,6 +729,7 @@ lib.mapAttrs (_: names: resolve names) grouped
     poppler-utils = [
       "%LOCALAPPDATA%\\Microsoft\\WinGet\\Packages\\oschwartz10612.Poppler*\\*\\Library\\bin"
     ];
+    rustup = [ "%USERPROFILE%\\.cargo\\bin" ];
     wezterm = [ "%ProgramFiles%\\WezTerm" ];
   };
 

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -182,6 +182,32 @@
           }
         },
         {
+          "PackageIdentifier": "astral-sh.ruff",
+          "verifyCommand": {
+            "args": ["--version"],
+            "command": "ruff"
+          }
+        },
+        {
+          "PackageIdentifier": "Rustlang.rust-analyzer",
+          "verifyCommand": {
+            "args": [
+              "-NoProfile",
+              "-Command",
+              "& (Join-Path $env:LOCALAPPDATA Microsoft/WinGet/Links/rust-analyzer.exe) --version"
+            ],
+            "command": "pwsh"
+          }
+        },
+        {
+          "PackageIdentifier": "Rustlang.Rustup",
+          "pathEntries": ["%USERPROFILE%\\.cargo\\bin"],
+          "verifyCommand": {
+            "args": ["--version"],
+            "command": "rustup"
+          }
+        },
+        {
           "PackageIdentifier": "SlackTechnologies.Slack"
         },
         {
@@ -213,13 +239,13 @@
           }
         },
         {
+          "PackageIdentifier": "Warp.Warp",
           "ciSkipInstall": true,
           "directInstaller": {
             "installerArgs": ["/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/CURRENTUSER"],
             "timeoutSeconds": 900,
             "type": "warpInnoLatest"
-          },
-          "PackageIdentifier": "Warp.Warp"
+          }
         },
         {
           "PackageIdentifier": "wez.wezterm.nightly",
@@ -328,8 +354,8 @@
           "PackageIdentifier": "9NT1R1C2HH7J"
         },
         {
-          "ciSkipInstall": true,
           "PackageIdentifier": "9PLM9XGG6VKS",
+          "ciSkipInstall": true,
           "verifyCommand": {
             "args": ["OpenAI.Codex_2p2nqsd0c76g0!App"],
             "command": "OpenAI.Codex",


### PR DESCRIPTION
## Summary
- Add Neovim format-on-save for Python and Rust via attached LSP formatters.
- Add Windows PATH fallbacks for WinGet Links and Rustup cargo bin so Neovim can find formatter tools.
- Add Ruff, rust-analyzer, Rustup, and rustfmt to the package catalog and regenerate the winget package JSON.

## Validation
- `nvim --headless --clean -u NONE ...` for source Lua syntax
- `nvim --headless -u C:/Users/KoheiMiki/.config/nvim/init.lua ...` for deployed format-on-save autocmd patterns
- `nix fmt -- --ci chezmoi/dot_config/nvim/lua/config/options.lua chezmoi/dot_config/nvim/lua/plugins/init.lua nix/packages/sets.nix`
- `nix build .#winget-export --no-link`
- `pwsh -NoProfile -Command "& ./scripts/powershell/tests/Invoke-Tests.ps1 -Path ./scripts/powershell/tests/PackageCatalog.Tests.ps1 -MinimumCoverage 0"`
- `pre-commit run --all-files`