### PR TITLE
[codex] manage Windows Rust browser tools

### DIFF
--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -76,6 +76,79 @@ function Invoke-CodexCli {
 
 Set-Alias -Name codex -Value Invoke-CodexCli -Scope Global
 
+function Import-MsvcDevEnvironment {
+    [CmdletBinding()]
+    param(
+        [ValidateSet("x64", "x86", "arm64")]
+        [string]$Arch = "x64",
+
+        [ValidateSet("x64", "x86")]
+        [string]$HostArch = "x64"
+    )
+
+    $programFilesX86 = ${env:ProgramFiles(x86)}
+    if (-not $programFilesX86) {
+        $programFilesX86 = Join-Path $env:SystemDrive "Program Files (x86)"
+    }
+
+    $installPath = $null
+    $vswhere = Join-Path $programFilesX86 "Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path -LiteralPath $vswhere -PathType Leaf) {
+        $installPath = & $vswhere `
+            -all `
+            -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -property installationPath 2>$null |
+            Select-Object -First 1
+    }
+
+    if (-not $installPath) {
+        $candidate = Join-Path $programFilesX86 "Microsoft Visual Studio\2022\BuildTools"
+        if (Test-Path -LiteralPath (Join-Path $candidate "Common7\Tools\VsDevCmd.bat") -PathType Leaf) {
+            $installPath = $candidate
+        }
+    }
+
+    if (-not $installPath) {
+        throw "MSVC Build Tools not found. Install Microsoft.VisualStudio.2022.BuildTools with the VCTools workload."
+    }
+
+    $vsDevCmd = Join-Path $installPath "Common7\Tools\VsDevCmd.bat"
+    if (-not (Test-Path -LiteralPath $vsDevCmd -PathType Leaf)) {
+        throw "VsDevCmd.bat not found: $vsDevCmd"
+    }
+
+    $cmdLine = "call `"$vsDevCmd`" -arch=$Arch -host_arch=$HostArch >nul && set"
+    $envLines = & cmd.exe /d /v:on /c $cmdLine
+    if ($LASTEXITCODE -ne 0) {
+        throw "VsDevCmd.bat failed with exit code $LASTEXITCODE"
+    }
+
+    foreach ($line in $envLines) {
+        $text = [string]$line
+        $separatorIndex = $text.IndexOf("=")
+        if ($separatorIndex -le 0) { continue }
+
+        $name = $text.Substring(0, $separatorIndex)
+        $value = $text.Substring($separatorIndex + 1)
+        Set-Item -Path "Env:\$name" -Value $value
+    }
+}
+
+Set-Alias -Name msvcdev -Value Import-MsvcDevEnvironment -Scope Global
+
+function cargo-msvc {
+    $cargoArgs = [string[]]$args
+    Import-MsvcDevEnvironment
+    & cargo @cargoArgs
+}
+
+function nvim-msvc {
+    $nvimArgs = [string[]]$args
+    Import-MsvcDevEnvironment
+    & nvim @nvimArgs
+}
+
 # Aliases
 if (Get-Command rg -ErrorAction SilentlyContinue) {
     Set-Alias -Name grep -Value rg -Scope Global

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -462,6 +462,10 @@ lib.mapAttrs (_: names: resolve names) grouped
   # Post-install verification commands for npm packages.
   # Keys match catalog attr names from npmMap.
   npmVerify = {
+    "agent-browser" = {
+      command = "agent-browser";
+      args = [ "--version" ];
+    };
     devcontainer = {
       command = "devcontainer";
       args = [ "--version" ];
@@ -658,6 +662,10 @@ lib.mapAttrs (_: names: resolve names) grouped
 
   # Extra winget install arguments for packages that need a specific installer.
   wingetInstallArgs = {
+    "Microsoft.VisualStudio.2022.BuildTools" = [
+      "--override"
+      "--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --passive --norestart"
+    ];
     powershell = [
       "--installer-type"
       "wix"
@@ -666,6 +674,7 @@ lib.mapAttrs (_: names: resolve names) grouped
 
   wingetInstallTimeoutSeconds = {
     google-cloud-sdk = 900;
+    "Microsoft.VisualStudio.2022.BuildTools" = 1800;
   };
 
   wingetDirectInstallers = {
@@ -772,6 +781,7 @@ lib.mapAttrs (_: names: resolve names) grouped
       "Google.Chrome"
       "Microsoft.PowerToys"
       "Microsoft.VCRedist.2015+.x64"
+      "Microsoft.VisualStudio.2022.BuildTools"
       "Microsoft.VisualStudioCode"
       "Microsoft.WindowsTerminal"
       "Microsoft.WSL"
@@ -784,7 +794,9 @@ lib.mapAttrs (_: names: resolve names) grouped
       "9NT1R1C2HH7J"
       "9PLM9XGG6VKS"
     ];
-    npm = [ ];
+    npm = [
+      "agent-browser@0.19.0"
+    ];
     pnpm = [
       "@google/gemini-cli"
     ];

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -664,7 +664,7 @@ lib.mapAttrs (_: names: resolve names) grouped
   wingetInstallArgs = {
     "Microsoft.VisualStudio.2022.BuildTools" = [
       "--override"
-      "--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --passive --norestart"
+      "--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --passive --wait --norestart"
     ];
     powershell = [
       "--installer-type"

--- a/nix/packages/winget.nix
+++ b/nix/packages/winget.nix
@@ -158,7 +158,11 @@ let
         attachPathEntries sets.wingetPathEntries id (
           attachPortableLink sets.wingetPortableLinksById id (
             attachDirectInstaller sets.wingetDirectInstallers id (
-              attachVerify sets.wingetVerifyById id { PackageIdentifier = id; }
+              attachInstallTimeout sets.wingetInstallTimeoutSeconds id (
+                attachInstallArgs sets.wingetInstallArgs id (
+                  attachVerify sets.wingetVerifyById id { PackageIdentifier = id; }
+                )
+              )
             )
           )
         )

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -254,7 +254,7 @@ Describe 'Package catalog consistency' {
             $sets = Get-Content -LiteralPath $script:setsPath -Raw
 
             $sets | Should -Match '(?s)windowsOnly\s*=\s*\{.*?winget\s*=\s*\[.*?"Microsoft\.VisualStudio\.2022\.BuildTools".*?\]'
-            $sets | Should -Match '(?s)wingetInstallArgs\s*=\s*\{.*?"Microsoft\.VisualStudio\.2022\.BuildTools"\s*=\s*\[.*?"--override".*?"--add Microsoft\.VisualStudio\.Workload\.VCTools --includeRecommended --passive --norestart"'
+            $sets | Should -Match '(?s)wingetInstallArgs\s*=\s*\{.*?"Microsoft\.VisualStudio\.2022\.BuildTools"\s*=\s*\[.*?"--override".*?"--add Microsoft\.VisualStudio\.Workload\.VCTools --includeRecommended --passive --wait --norestart"'
             $sets | Should -Match '(?s)wingetInstallTimeoutSeconds\s*=\s*\{.*?"Microsoft\.VisualStudio\.2022\.BuildTools"\s*=\s*1800'
         }
 
@@ -265,7 +265,7 @@ Describe 'Package catalog consistency' {
 
             $package | Should -Not -BeNullOrEmpty
             @($package.installArgs) | Should -Contain '--override'
-            @($package.installArgs) | Should -Contain '--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --passive --norestart'
+            @($package.installArgs) | Should -Contain '--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --passive --wait --norestart'
             $package.installTimeoutSeconds | Should -Be 1800
         }
     }

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -232,4 +232,41 @@ Describe 'Package catalog consistency' {
             $exporter | Should -Match '\$out/npm/packages\.json'
         }
     }
+
+    Context 'Windows native Rust browser automation tools' {
+        It 'should manage agent-browser as a Windows npm global package with verification' {
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+
+            $sets | Should -Match '(?s)windowsOnly\s*=\s*\{.*?npm\s*=\s*\[.*?"agent-browser@0\.19\.0".*?\]'
+            $sets | Should -Match '(?s)npmVerify\s*=\s*\{.*?"agent-browser"\s*=\s*\{.*?command\s*=\s*"agent-browser".*?args\s*=\s*\[\s*"--version"\s*\]'
+        }
+
+        It 'should generate agent-browser into the Windows npm package catalog with verification' {
+            $json = Get-Content -LiteralPath $script:npmJsonPath -Raw | ConvertFrom-Json
+            $package = @($json.globalPackages | Where-Object { $_.name -eq 'agent-browser@0.19.0' }) | Select-Object -First 1
+
+            $package | Should -Not -BeNullOrEmpty
+            $package.verifyCommand.command | Should -Be 'agent-browser'
+            @($package.verifyCommand.args) | Should -Contain '--version'
+        }
+
+        It 'should include Visual Studio Build Tools with C++ workload install metadata in the SSOT' {
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+
+            $sets | Should -Match '(?s)windowsOnly\s*=\s*\{.*?winget\s*=\s*\[.*?"Microsoft\.VisualStudio\.2022\.BuildTools".*?\]'
+            $sets | Should -Match '(?s)wingetInstallArgs\s*=\s*\{.*?"Microsoft\.VisualStudio\.2022\.BuildTools"\s*=\s*\[.*?"--override".*?"--add Microsoft\.VisualStudio\.Workload\.VCTools --includeRecommended --passive --norestart"'
+            $sets | Should -Match '(?s)wingetInstallTimeoutSeconds\s*=\s*\{.*?"Microsoft\.VisualStudio\.2022\.BuildTools"\s*=\s*1800'
+        }
+
+        It 'should generate Visual Studio Build Tools with C++ workload install metadata' {
+            $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
+            $wingetSource = @($json.Sources | Where-Object { $_.SourceDetails.Name -eq 'winget' }) | Select-Object -First 1
+            $package = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'Microsoft.VisualStudio.2022.BuildTools' }) | Select-Object -First 1
+
+            $package | Should -Not -BeNullOrEmpty
+            @($package.installArgs) | Should -Contain '--override'
+            @($package.installArgs) | Should -Contain '--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --passive --norestart'
+            $package.installTimeoutSeconds | Should -Be 1800
+        }
+    }
 }

--- a/scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1
@@ -17,7 +17,7 @@ BeforeAll {
     }
 
     $script:functionScriptBlockByName = @{}
-    foreach ($name in @("Reset-DotfilesTerminalInputMode", "Invoke-CodexCli", "ConvertTo-DcnvimBashSingleQuoted", "dcnvim")) {
+    foreach ($name in @("Reset-DotfilesTerminalInputMode", "Invoke-CodexCli", "Import-MsvcDevEnvironment", "cargo-msvc", "nvim-msvc", "ConvertTo-DcnvimBashSingleQuoted", "dcnvim")) {
         $functionAst = $profileAst.Find(
             {
                 param($node)
@@ -44,6 +44,12 @@ BeforeAll {
         }
     }
 
+    function Import-MsvcProfileFunction {
+        foreach ($name in @("Import-MsvcDevEnvironment", "cargo-msvc", "nvim-msvc")) {
+            Set-Item -Path "Function:\global:$name" -Value $script:functionScriptBlockByName[$name]
+        }
+    }
+
     function Get-ArgumentValue {
         param(
             [Parameter(Mandatory)][object[]]$Arguments,
@@ -63,6 +69,100 @@ BeforeAll {
 
         New-Item -ItemType Directory -Path (Join-Path $Path ".devcontainer") -Force | Out-Null
         return (Resolve-Path -LiteralPath $Path).Path
+    }
+}
+
+Describe 'PowerShell MSVC dev environment helpers' {
+    BeforeEach {
+        Import-MsvcProfileFunction
+
+        $script:oldProgramFilesX86 = ${env:ProgramFiles(x86)}
+        $script:oldPath = $env:PATH
+        $script:oldLibExists = Test-Path Env:\LIB
+        $script:oldLib = $env:LIB
+        $script:oldIncludeExists = Test-Path Env:\INCLUDE
+        $script:oldInclude = $env:INCLUDE
+        $script:oldVscmdExists = Test-Path Env:\VSCMD_VER
+        $script:oldVscmd = $env:VSCMD_VER
+        $script:cmdArgs = $null
+        $script:cargoArgs = $null
+        $script:nvimArgs = $null
+
+        ${env:ProgramFiles(x86)} = $TestDrive
+        $toolsDir = Join-Path $TestDrive "Microsoft Visual Studio\2022\BuildTools\Common7\Tools"
+        New-Item -ItemType Directory -Path $toolsDir -Force | Out-Null
+        New-Item -ItemType File -Path (Join-Path $toolsDir "VsDevCmd.bat") -Force | Out-Null
+
+        function global:cmd.exe {
+            $script:cmdArgs = [string[]]$args
+            $global:LASTEXITCODE = 0
+            @(
+                "PATH=C:\msvc\bin;C:\Windows\System32",
+                "LIB=C:\msvc\lib;C:\sdk\lib",
+                "INCLUDE=C:\msvc\include;C:\sdk\include",
+                "VSCMD_VER=17.14.35",
+                "VALUE_WITH_EQUALS=left=right"
+            )
+        }
+
+        function global:cargo {
+            $script:cargoArgs = [string[]]$args
+            $global:LASTEXITCODE = 11
+        }
+
+        function global:nvim {
+            $script:nvimArgs = [string[]]$args
+            $global:LASTEXITCODE = 12
+        }
+    }
+
+    AfterEach {
+        foreach ($functionName in @(
+                "Import-MsvcDevEnvironment",
+                "cargo-msvc",
+                "nvim-msvc",
+                "cmd.exe",
+                "cargo",
+                "nvim"
+            )) {
+            Remove-Item "Function:\$functionName" -ErrorAction SilentlyContinue
+        }
+
+        ${env:ProgramFiles(x86)} = $script:oldProgramFilesX86
+        $env:PATH = $script:oldPath
+
+        if ($script:oldLibExists) { $env:LIB = $script:oldLib } else { Remove-Item Env:\LIB -ErrorAction SilentlyContinue }
+        if ($script:oldIncludeExists) { $env:INCLUDE = $script:oldInclude } else { Remove-Item Env:\INCLUDE -ErrorAction SilentlyContinue }
+        if ($script:oldVscmdExists) { $env:VSCMD_VER = $script:oldVscmd } else { Remove-Item Env:\VSCMD_VER -ErrorAction SilentlyContinue }
+        Remove-Item Env:\VALUE_WITH_EQUALS -ErrorAction SilentlyContinue
+    }
+
+    It 'should import MSVC developer environment variables into the current PowerShell process' {
+        Import-MsvcDevEnvironment
+
+        $script:cmdArgs | Should -Contain "/d"
+        $script:cmdArgs | Should -Contain "/v:on"
+        ($script:cmdArgs -join " ") | Should -Match "VsDevCmd\.bat"
+        ($script:cmdArgs -join " ") | Should -Match "-arch=x64"
+        $env:PATH | Should -Be "C:\msvc\bin;C:\Windows\System32"
+        $env:LIB | Should -Be "C:\msvc\lib;C:\sdk\lib"
+        $env:INCLUDE | Should -Be "C:\msvc\include;C:\sdk\include"
+        $env:VSCMD_VER | Should -Be "17.14.35"
+        $env:VALUE_WITH_EQUALS | Should -Be "left=right"
+    }
+
+    It 'should run cargo and nvim through the MSVC developer environment wrappers' {
+        cargo-msvc test --locked
+        $script:cargoArgs | Should -Be @("test", "--locked")
+        $global:LASTEXITCODE | Should -Be 11
+
+        nvim-msvc .
+        $script:nvimArgs | Should -Be @(".")
+        $global:LASTEXITCODE | Should -Be 12
+    }
+
+    It 'should expose an msvcdev alias for loading the current shell' {
+        $script:profileContent | Should -Match 'Set-Alias\s+-Name\s+msvcdev\s+-Value\s+Import-MsvcDevEnvironment'
     }
 }
 

--- a/windows/npm/packages.json
+++ b/windows/npm/packages.json
@@ -8,6 +8,13 @@
         "args": ["--version"],
         "command": "devcontainer"
       }
+    },
+    {
+      "name": "agent-browser@0.19.0",
+      "verifyCommand": {
+        "args": ["--version"],
+        "command": "agent-browser"
+      }
     }
   ]
 }

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -213,13 +213,13 @@
           }
         },
         {
+          "PackageIdentifier": "Warp.Warp",
           "ciSkipInstall": true,
           "directInstaller": {
             "installerArgs": ["/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/CURRENTUSER"],
             "timeoutSeconds": 900,
             "type": "warpInnoLatest"
-          },
-          "PackageIdentifier": "Warp.Warp"
+          }
         },
         {
           "PackageIdentifier": "wez.wezterm.nightly",
@@ -276,6 +276,14 @@
           "PackageIdentifier": "Microsoft.VCRedist.2015+.x64"
         },
         {
+          "PackageIdentifier": "Microsoft.VisualStudio.2022.BuildTools",
+          "installArgs": [
+            "--override",
+            "--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --passive --norestart"
+          ],
+          "installTimeoutSeconds": 1800
+        },
+        {
           "PackageIdentifier": "Microsoft.VisualStudioCode"
         },
         {
@@ -328,8 +336,8 @@
           "PackageIdentifier": "9NT1R1C2HH7J"
         },
         {
-          "ciSkipInstall": true,
           "PackageIdentifier": "9PLM9XGG6VKS",
+          "ciSkipInstall": true,
           "verifyCommand": {
             "args": ["OpenAI.Codex_2p2nqsd0c76g0!App"],
             "command": "OpenAI.Codex",

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -279,7 +279,7 @@
           "PackageIdentifier": "Microsoft.VisualStudio.2022.BuildTools",
           "installArgs": [
             "--override",
-            "--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --passive --norestart"
+            "--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --passive --wait --norestart"
           ],
           "installTimeoutSeconds": 1800
         },


### PR DESCRIPTION
## Summary
- manage Windows `agent-browser@0.19.0` as a dotfiles npm global package
- add Visual Studio Build Tools 2022 with the C++ VCTools workload metadata to the Windows winget catalog
- propagate install args/timeouts for Windows-only winget packages
- add PowerShell helpers for MSVC-backed Rust development: `msvcdev`, `cargo-msvc`, and `nvim-msvc`

## Why
The jobsite CLI needs Windows-native browser automation through agent-browser, and the Rust MSVC toolchain needs a repeatable dotfiles-managed way to install and load the Visual C++ linker environment.

## Validation
- `task lint`
- `task test`
- `task fmt:check`
- `cargo-msvc test --quiet` in `D:\jobsite-filter-cli`
