### PR TITLE
[codex] update dotfiles dependencies and actions

### DIFF
--- a/.github/workflows/ci-chezmoi.yml
+++ b/.github/workflows/ci-chezmoi.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -63,7 +63,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -94,7 +94,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -136,7 +136,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -215,7 +215,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci-consistency.yml
+++ b/.github/workflows/ci-consistency.yml
@@ -39,7 +39,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci-devcontainer.yml
+++ b/.github/workflows/ci-devcontainer.yml
@@ -32,7 +32,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -94,7 +94,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -143,7 +143,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -31,7 +31,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -128,7 +128,7 @@ jobs:
           PYEOF
 
       - name: Upload SARIF to Security tab
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           sarif_file: statix.sarif
@@ -151,7 +151,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -191,7 +191,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -128,7 +128,7 @@ jobs:
           PYEOF
 
       - name: Upload SARIF to Security tab
-        uses: github/codeql-action/upload-sarif@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           sarif_file: statix.sarif

--- a/.github/workflows/ci-nixos-wsl.yml
+++ b/.github/workflows/ci-nixos-wsl.yml
@@ -39,7 +39,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci-powershell.yml
+++ b/.github/workflows/ci-powershell.yml
@@ -138,7 +138,7 @@ jobs:
           Set-Content pssa_errors.txt $errors
 
       - name: Upload SARIF to Security tab
-        uses: github/codeql-action/upload-sarif@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           sarif_file: pssa.sarif

--- a/.github/workflows/ci-powershell.yml
+++ b/.github/workflows/ci-powershell.yml
@@ -33,7 +33,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -138,7 +138,7 @@ jobs:
           Set-Content pssa_errors.txt $errors
 
       - name: Upload SARIF to Security tab
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           sarif_file: pssa.sarif
@@ -167,7 +167,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -294,7 +294,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci-winget.yml
+++ b/.github/workflows/ci-winget.yml
@@ -53,7 +53,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,16 +30,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/init@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
         with:
           languages: actions
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/analyze@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
         with:
           category: /language:actions

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,11 +35,11 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: actions
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: /language:actions

--- a/chezmoi/github/workflows/ci.yml
+++ b/chezmoi/github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup
         run: echo "Add your setup steps here"

--- a/flake.lock
+++ b/flake.lock
@@ -75,11 +75,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781305496,
-        "narHash": "sha256-g8Vv4Qfc7n+lgov97REu3X6BeJtvYY0hlSUZR1GrGQQ=",
+        "lastModified": 1782134359,
+        "narHash": "sha256-dh0RDcJ17Rubgk3hGTugYmTu6rnUPfRu5vA7MA1Pdo0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c87a39aa979acc4848016d2220c6238390d84779",
+        "rev": "979bfee6e1a7996fc395270d54c9b59e88762494",
         "type": "github"
       },
       "original": {
@@ -173,11 +173,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -486,8 +486,8 @@ lib.mapAttrs (_: names: resolve names) grouped
   pnpmGlobal = [
     "@prisma/language-server"
     "@agentclientprotocol/claude-agent-acp"
-    "@playwright/cli@0.1.13"
-    "playwright@1.60.0"
+    "@playwright/cli@0.1.14"
+    "playwright@1.61.0"
     "typescript-language-server"
     "typescript"
   ];
@@ -822,7 +822,7 @@ lib.mapAttrs (_: names: resolve names) grouped
       "9PLM9XGG6VKS"
     ];
     npm = [
-      "agent-browser@0.19.0"
+      "agent-browser@0.29.1"
     ];
     pnpm = [
       "@google/gemini-cli"

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -237,13 +237,13 @@ Describe 'Package catalog consistency' {
         It 'should manage agent-browser as a Windows npm global package with verification' {
             $sets = Get-Content -LiteralPath $script:setsPath -Raw
 
-            $sets | Should -Match '(?s)windowsOnly\s*=\s*\{.*?npm\s*=\s*\[.*?"agent-browser@0\.19\.0".*?\]'
+            $sets | Should -Match '(?s)windowsOnly\s*=\s*\{.*?npm\s*=\s*\[.*?"agent-browser@0\.29\.1".*?\]'
             $sets | Should -Match '(?s)npmVerify\s*=\s*\{.*?"agent-browser"\s*=\s*\{.*?command\s*=\s*"agent-browser".*?args\s*=\s*\[\s*"--version"\s*\]'
         }
 
         It 'should generate agent-browser into the Windows npm package catalog with verification' {
             $json = Get-Content -LiteralPath $script:npmJsonPath -Raw | ConvertFrom-Json
-            $package = @($json.globalPackages | Where-Object { $_.name -eq 'agent-browser@0.19.0' }) | Select-Object -First 1
+            $package = @($json.globalPackages | Where-Object { $_.name -eq 'agent-browser@0.29.1' }) | Select-Object -First 1
 
             $package | Should -Not -BeNullOrEmpty
             $package.verifyCommand.command | Should -Be 'agent-browser'

--- a/scripts/powershell/tests/handlers/Handler.Pnpm.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Pnpm.Tests.ps1
@@ -1053,7 +1053,7 @@ Describe 'PnpmHandler' {
                 return @{
                     globalPackages = @(
                         @{
-                            name               = "playwright@1.60.0"
+                            name               = "playwright@1.61.0"
                             postInstallCommand = @{
                                 command        = "playwright"
                                 args           = @("install", "chromium")
@@ -1125,7 +1125,7 @@ Describe 'PnpmHandler' {
                 return @{
                     globalPackages = @(
                         @{
-                            name               = "playwright@1.60.0"
+                            name               = "playwright@1.61.0"
                             postInstallCommand = @{
                                 command        = "playwright"
                                 args           = @("install", "chromium")

--- a/windows/npm/packages.json
+++ b/windows/npm/packages.json
@@ -10,7 +10,7 @@
       }
     },
     {
-      "name": "agent-browser@0.19.0",
+      "name": "agent-browser@0.29.1",
       "verifyCommand": {
         "args": ["--version"],
         "command": "agent-browser"

--- a/windows/pnpm/packages.json
+++ b/windows/pnpm/packages.json
@@ -18,14 +18,14 @@
       }
     },
     {
-      "name": "@playwright/cli@0.1.13",
+      "name": "@playwright/cli@0.1.14",
       "verifyCommand": {
         "args": ["--version"],
         "command": "playwright-cli"
       }
     },
     {
-      "name": "playwright@1.60.0",
+      "name": "playwright@1.61.0",
       "postInstallCommand": {
         "args": ["install", "chromium"],
         "command": "playwright",


### PR DESCRIPTION
## Summary

- Update Nix flake inputs for `home-manager` and `nixpkgs`.
- Update pinned npm/pnpm global tool versions for `agent-browser`, `@playwright/cli`, and `playwright`.
- Update GitHub Actions pins for `actions/checkout` and `github/codeql-action`.

## Validation

- `task commit -- "update dotfiles dependencies and actions"`
- pre-commit hooks passed: UTF-8 BOM check, treefmt, PowerShell tests, chezmoi template lint
- Earlier local validation also passed: `task fmt:check`, `task test`, `task test:bash`, `task lint`, `task build`, and `winget-export` JSON consistency check
