### PR TITLE
[codex] make dcnvim clone dotfiles from repository

### DIFF
--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -446,6 +446,8 @@ function dcnvim {
     # command is missing, masking the failure to the host.
     # Use double-quoted here-string so $sessionName interpolates; escape
     # bash variables with backtick so they stay literal for the shell.
+    # Strip CR before bash -lc: Windows here-strings use CRLF, and bash
+    # treats "set -e`r" as an invalid option.
     $payload = @"
 set -e
 export PATH="`$HOME/.local/bin:`$PATH"
@@ -508,6 +510,7 @@ command -v tmux >/dev/null 2>&1 || {
 }
 tmux new -A -s $sessionNameQuoted 'nvim .'
 "@
+    $payload = $payload -replace "`r", ""
 
     & devcontainer exec --workspace-folder $Workspace -- bash -lc $payload
 }

--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -348,7 +348,7 @@ if (-not $env:CLAUDE_CODE_GIT_BASH_PATH) {
 # Requires: @devcontainers/cli on host; bootstrap.sh ran inside the
 # container to provide nvim + tmux. See bootstrap.sh at repo root.
 function ConvertTo-DcnvimBashSingleQuoted {
-    param([Parameter(Mandatory)][string]$Value)
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Value)
 
     return "'" + $Value.Replace("'", "'\''") + "'"
 }
@@ -402,7 +402,14 @@ function dcnvim {
     else {
         'https://github.com/rurusasu/dotfiles'
     }
+    $dotfilesRef = if ($env:DOTFILES_REPOSITORY_REF) {
+        $env:DOTFILES_REPOSITORY_REF
+    }
+    else {
+        ''
+    }
     $dotfilesUrlQuoted = ConvertTo-DcnvimBashSingleQuoted $dotfilesUrl
+    $dotfilesRefQuoted = ConvertTo-DcnvimBashSingleQuoted $dotfilesRef
     & devcontainer up `
         --workspace-folder $Workspace | Out-Null
     if ($LASTEXITCODE -ne 0) {
@@ -443,24 +450,38 @@ function dcnvim {
 set -e
 export PATH="`$HOME/.local/bin:`$PATH"
 dotfiles_url=$dotfilesUrlQuoted
+dotfiles_ref=$dotfilesRefQuoted
 dotfiles_dir="`$HOME/.dotfiles"
-dotfiles_needs_bootstrap=0
-if [ ! -e "`$dotfiles_dir" ] && [ ! -L "`$dotfiles_dir" ] && [ -x "`$HOME/dotfiles/bootstrap.sh" ]; then
-  ln -s "`$HOME/dotfiles" "`$dotfiles_dir"
-  dotfiles_needs_bootstrap=1
-fi
-if [ ! -x "`$dotfiles_dir/bootstrap.sh" ]; then
-  command -v git >/dev/null 2>&1 || {
-    echo 'dcnvim: git not installed in container; cannot clone dotfiles' >&2
-    exit 127
-  }
+command -v git >/dev/null 2>&1 || {
+  echo 'dcnvim: git not installed in container; cannot clone dotfiles' >&2
+  exit 127
+}
+if [ -L "`$dotfiles_dir" ] || [ ! -d "`$dotfiles_dir/.git" ]; then
   rm -rf "`$dotfiles_dir"
   git clone --depth=1 "`$dotfiles_url" "`$dotfiles_dir"
-  dotfiles_needs_bootstrap=1
 fi
-if [ "`$dotfiles_needs_bootstrap" -eq 1 ] || ! command -v nvim >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
-  "`$dotfiles_dir/bootstrap.sh"
+current_url="`$(git -C "`$dotfiles_dir" config --get remote.origin.url || true)"
+if [ "`$current_url" != "`$dotfiles_url" ]; then
+  rm -rf "`$dotfiles_dir"
+  git clone --depth=1 "`$dotfiles_url" "`$dotfiles_dir"
 fi
+if [ ! -x "`$dotfiles_dir/bootstrap.sh" ]; then
+  echo 'dcnvim: bootstrap.sh not found in dotfiles repository' >&2
+  exit 127
+fi
+if [ -n "`$dotfiles_ref" ]; then
+  git -C "`$dotfiles_dir" fetch --depth=1 origin "`$dotfiles_ref"
+  git -C "`$dotfiles_dir" checkout --force FETCH_HEAD
+else
+  git -C "`$dotfiles_dir" fetch --depth=1 origin
+  if ! git -C "`$dotfiles_dir" pull --ff-only --depth=1; then
+    default_ref="`$(git -C "`$dotfiles_dir" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+    if [ -n "`$default_ref" ]; then
+      git -C "`$dotfiles_dir" reset --hard "`$default_ref"
+    fi
+  fi
+fi
+"`$dotfiles_dir/bootstrap.sh"
 command -v nvim >/dev/null 2>&1 || {
   echo 'dcnvim: nvim not installed in container — run ~/.dotfiles/bootstrap.sh first' >&2
   exit 127

--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -452,6 +452,7 @@ export PATH="`$HOME/.local/bin:`$PATH"
 dotfiles_url=$dotfilesUrlQuoted
 dotfiles_ref=$dotfilesRefQuoted
 dotfiles_dir="`$HOME/.dotfiles"
+dotfiles_needs_bootstrap=0
 command -v git >/dev/null 2>&1 || {
   echo 'dcnvim: git not installed in container; cannot clone dotfiles' >&2
   exit 127
@@ -459,29 +460,44 @@ command -v git >/dev/null 2>&1 || {
 if [ -L "`$dotfiles_dir" ] || [ ! -d "`$dotfiles_dir/.git" ]; then
   rm -rf "`$dotfiles_dir"
   git clone --depth=1 "`$dotfiles_url" "`$dotfiles_dir"
+  dotfiles_needs_bootstrap=1
 fi
 current_url="`$(git -C "`$dotfiles_dir" config --get remote.origin.url || true)"
 if [ "`$current_url" != "`$dotfiles_url" ]; then
   rm -rf "`$dotfiles_dir"
   git clone --depth=1 "`$dotfiles_url" "`$dotfiles_dir"
+  dotfiles_needs_bootstrap=1
 fi
 if [ ! -x "`$dotfiles_dir/bootstrap.sh" ]; then
   echo 'dcnvim: bootstrap.sh not found in dotfiles repository' >&2
   exit 127
 fi
 if [ -n "`$dotfiles_ref" ]; then
-  git -C "`$dotfiles_dir" fetch --depth=1 origin "`$dotfiles_ref"
-  git -C "`$dotfiles_dir" checkout --force FETCH_HEAD
+  if git -C "`$dotfiles_dir" fetch --depth=1 origin "`$dotfiles_ref" &&
+    git -C "`$dotfiles_dir" checkout --force FETCH_HEAD; then
+    dotfiles_needs_bootstrap=1
+  else
+    echo 'dcnvim: warning: failed to fetch dotfiles ref; using existing checkout' >&2
+  fi
 else
-  git -C "`$dotfiles_dir" fetch --depth=1 origin
-  if ! git -C "`$dotfiles_dir" pull --ff-only --depth=1; then
-    default_ref="`$(git -C "`$dotfiles_dir" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
-    if [ -n "`$default_ref" ]; then
-      git -C "`$dotfiles_dir" reset --hard "`$default_ref"
+  if git -C "`$dotfiles_dir" fetch --depth=1 origin; then
+    if git -C "`$dotfiles_dir" pull --ff-only --depth=1; then
+      dotfiles_needs_bootstrap=1
+    else
+      default_ref="`$(git -C "`$dotfiles_dir" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+      if [ -n "`$default_ref" ] && git -C "`$dotfiles_dir" reset --hard "`$default_ref"; then
+        dotfiles_needs_bootstrap=1
+      else
+        echo 'dcnvim: warning: failed to update dotfiles repository; using existing checkout' >&2
+      fi
     fi
+  else
+    echo 'dcnvim: warning: failed to update dotfiles repository; using existing checkout' >&2
   fi
 fi
-"`$dotfiles_dir/bootstrap.sh"
+if [ "`$dotfiles_needs_bootstrap" -eq 1 ] || ! command -v nvim >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
+  "`$dotfiles_dir/bootstrap.sh"
+fi
 command -v nvim >/dev/null 2>&1 || {
   echo 'dcnvim: nvim not installed in container — run ~/.dotfiles/bootstrap.sh first' >&2
   exit 127

--- a/scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1
@@ -263,7 +263,9 @@ Describe 'PowerShell dcnvim profile function' {
         $script:fzfExitCode = 0
         $script:fzfCallCount = 0
         $script:oldDotfilesRepositoryUrl = $env:DOTFILES_REPOSITORY_URL
+        $script:oldDotfilesRepositoryRef = $env:DOTFILES_REPOSITORY_REF
         Remove-Item Env:\DOTFILES_REPOSITORY_URL -ErrorAction SilentlyContinue
+        Remove-Item Env:\DOTFILES_REPOSITORY_REF -ErrorAction SilentlyContinue
 
         function global:Get-Command {
             [CmdletBinding()]
@@ -392,11 +394,19 @@ Describe 'PowerShell dcnvim profile function' {
         else {
             $env:DOTFILES_REPOSITORY_URL = $script:oldDotfilesRepositoryUrl
         }
+
+        if ($null -eq $script:oldDotfilesRepositoryRef) {
+            Remove-Item Env:\DOTFILES_REPOSITORY_REF -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:DOTFILES_REPOSITORY_REF = $script:oldDotfilesRepositoryRef
+        }
     }
 
     It 'should quote tmux session names for bash payloads' {
         ConvertTo-DcnvimBashSingleQuoted "plain" | Should -Be "'plain'"
         ConvertTo-DcnvimBashSingleQuoted "team's repo" | Should -Be "'team'\''s repo'"
+        ConvertTo-DcnvimBashSingleQuoted "" | Should -Be "''"
     }
 
     It 'should run plain devcontainer up then bootstrap before nvim tmux payload' {
@@ -423,11 +433,16 @@ Describe 'PowerShell dcnvim profile function' {
         Get-ArgumentValue $exec.Args "--workspace-folder" | Should -Be $workspace
         $exec.Payload | Should -Match ([regex]::Escape('export PATH="$HOME/.local/bin:$PATH"'))
         $exec.Payload | Should -Match ([regex]::Escape("dotfiles_url='https://github.com/rurusasu/dotfiles'"))
+        $exec.Payload | Should -Match ([regex]::Escape("dotfiles_ref=''"))
         $exec.Payload | Should -Match ([regex]::Escape('dotfiles_dir="$HOME/.dotfiles"'))
-        $exec.Payload | Should -Match ([regex]::Escape('dotfiles_needs_bootstrap=0'))
+        $exec.Payload | Should -Not -Match ([regex]::Escape('HOME/dotfiles'))
+        $exec.Payload | Should -Not -Match 'dotfiles_needs_bootstrap'
+        $exec.Payload | Should -Match ([regex]::Escape('if [ -L "$dotfiles_dir" ] || [ ! -d "$dotfiles_dir/.git" ]; then'))
         $exec.Payload | Should -Match ([regex]::Escape('git clone --depth=1 "$dotfiles_url" "$dotfiles_dir"'))
-        $exec.Payload | Should -Match ([regex]::Escape('dotfiles_needs_bootstrap=1'))
-        $exec.Payload | Should -Match ([regex]::Escape('if [ "$dotfiles_needs_bootstrap" -eq 1 ] || ! command -v nvim'))
+        $exec.Payload | Should -Match ([regex]::Escape('current_url="$(git -C "$dotfiles_dir" config --get remote.origin.url || true)"'))
+        $exec.Payload | Should -Match ([regex]::Escape('if [ "$current_url" != "$dotfiles_url" ]; then'))
+        $exec.Payload | Should -Match ([regex]::Escape('git -C "$dotfiles_dir" fetch --depth=1 origin'))
+        $exec.Payload | Should -Match ([regex]::Escape('git -C "$dotfiles_dir" pull --ff-only --depth=1'))
         $exec.Payload | Should -Match ([regex]::Escape('"$dotfiles_dir/bootstrap.sh"'))
         $exec.Payload | Should -Match "command -v nvim"
         $exec.Payload | Should -Match "command -v tmux"
@@ -444,6 +459,18 @@ Describe 'PowerShell dcnvim profile function' {
         $exec = $script:devcontainerCalls[1]
         Get-ArgumentValue $up.Args "--dotfiles-repository" | Should -BeNullOrEmpty
         $exec.Payload | Should -Match ([regex]::Escape("dotfiles_url='https://example.invalid/dotfiles.git'"))
+    }
+
+    It 'should use custom dotfiles repo ref in bootstrap payload' {
+        $workspace = New-DcnvimWorkspace (Join-Path $TestDrive "repo")
+        $env:DOTFILES_REPOSITORY_REF = "feature/test-ref"
+
+        dcnvim -Workspace $workspace
+
+        $exec = $script:devcontainerCalls[1]
+        $exec.Payload | Should -Match ([regex]::Escape("dotfiles_ref='feature/test-ref'"))
+        $exec.Payload | Should -Match ([regex]::Escape('git -C "$dotfiles_dir" fetch --depth=1 origin "$dotfiles_ref"'))
+        $exec.Payload | Should -Match ([regex]::Escape('git -C "$dotfiles_dir" checkout --force FETCH_HEAD'))
     }
 
     It 'should use ghq and fzf picker when cwd has no devcontainer config' {

--- a/scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1
@@ -431,6 +431,7 @@ Describe 'PowerShell dcnvim profile function' {
 
         $exec.Command | Should -Be "exec"
         Get-ArgumentValue $exec.Args "--workspace-folder" | Should -Be $workspace
+        $exec.Payload.Contains("`r") | Should -BeFalse
         $exec.Payload | Should -Match ([regex]::Escape('export PATH="$HOME/.local/bin:$PATH"'))
         $exec.Payload | Should -Match ([regex]::Escape("dotfiles_url='https://github.com/rurusasu/dotfiles'"))
         $exec.Payload | Should -Match ([regex]::Escape("dotfiles_ref=''"))

--- a/scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1
@@ -436,13 +436,15 @@ Describe 'PowerShell dcnvim profile function' {
         $exec.Payload | Should -Match ([regex]::Escape("dotfiles_ref=''"))
         $exec.Payload | Should -Match ([regex]::Escape('dotfiles_dir="$HOME/.dotfiles"'))
         $exec.Payload | Should -Not -Match ([regex]::Escape('HOME/dotfiles'))
-        $exec.Payload | Should -Not -Match 'dotfiles_needs_bootstrap'
+        $exec.Payload | Should -Match 'dotfiles_needs_bootstrap=0'
         $exec.Payload | Should -Match ([regex]::Escape('if [ -L "$dotfiles_dir" ] || [ ! -d "$dotfiles_dir/.git" ]; then'))
         $exec.Payload | Should -Match ([regex]::Escape('git clone --depth=1 "$dotfiles_url" "$dotfiles_dir"'))
         $exec.Payload | Should -Match ([regex]::Escape('current_url="$(git -C "$dotfiles_dir" config --get remote.origin.url || true)"'))
         $exec.Payload | Should -Match ([regex]::Escape('if [ "$current_url" != "$dotfiles_url" ]; then'))
-        $exec.Payload | Should -Match ([regex]::Escape('git -C "$dotfiles_dir" fetch --depth=1 origin'))
-        $exec.Payload | Should -Match ([regex]::Escape('git -C "$dotfiles_dir" pull --ff-only --depth=1'))
+        $exec.Payload | Should -Match ([regex]::Escape('if git -C "$dotfiles_dir" fetch --depth=1 origin; then'))
+        $exec.Payload | Should -Match ([regex]::Escape('if git -C "$dotfiles_dir" pull --ff-only --depth=1; then'))
+        $exec.Payload | Should -Match ([regex]::Escape('dcnvim: warning: failed to update dotfiles repository; using existing checkout'))
+        $exec.Payload | Should -Match ([regex]::Escape('if [ "$dotfiles_needs_bootstrap" -eq 1 ] || ! command -v nvim >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then'))
         $exec.Payload | Should -Match ([regex]::Escape('"$dotfiles_dir/bootstrap.sh"'))
         $exec.Payload | Should -Match "command -v nvim"
         $exec.Payload | Should -Match "command -v tmux"
@@ -469,8 +471,21 @@ Describe 'PowerShell dcnvim profile function' {
 
         $exec = $script:devcontainerCalls[1]
         $exec.Payload | Should -Match ([regex]::Escape("dotfiles_ref='feature/test-ref'"))
-        $exec.Payload | Should -Match ([regex]::Escape('git -C "$dotfiles_dir" fetch --depth=1 origin "$dotfiles_ref"'))
+        $exec.Payload | Should -Match ([regex]::Escape('if git -C "$dotfiles_dir" fetch --depth=1 origin "$dotfiles_ref" &&'))
         $exec.Payload | Should -Match ([regex]::Escape('git -C "$dotfiles_dir" checkout --force FETCH_HEAD'))
+        $exec.Payload | Should -Match ([regex]::Escape('dcnvim: warning: failed to fetch dotfiles ref; using existing checkout'))
+    }
+
+    It 'should make dotfiles update failures best effort when checkout already exists' {
+        $workspace = New-DcnvimWorkspace (Join-Path $TestDrive "repo")
+
+        dcnvim -Workspace $workspace
+
+        $exec = $script:devcontainerCalls[1]
+        $exec.Payload | Should -Match ([regex]::Escape('if git -C "$dotfiles_dir" fetch --depth=1 origin; then'))
+        $exec.Payload | Should -Match ([regex]::Escape('dcnvim: warning: failed to update dotfiles repository; using existing checkout'))
+        $exec.Payload | Should -Match ([regex]::Escape('if [ "$dotfiles_needs_bootstrap" -eq 1 ] || ! command -v nvim >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then'))
+        $exec.Payload | Should -Match ([regex]::Escape("tmux new -A -s 'repo' 'nvim .'"))
     }
 
     It 'should use ghq and fzf picker when cwd has no devcontainer config' {

--- a/scripts/sh/dcnvim.sh
+++ b/scripts/sh/dcnvim.sh
@@ -102,6 +102,7 @@ dcnvim() {
       dotfiles_url=$dotfiles_url_quoted
       dotfiles_ref=$dotfiles_ref_quoted
       dotfiles_dir=\"\$HOME/.dotfiles\"
+      dotfiles_needs_bootstrap=0
       command -v git >/dev/null 2>&1 || {
         echo 'dcnvim: git not installed in container; cannot clone dotfiles' >&2
         exit 127
@@ -109,29 +110,44 @@ dcnvim() {
       if [ -L \"\$dotfiles_dir\" ] || [ ! -d \"\$dotfiles_dir/.git\" ]; then
         rm -rf \"\$dotfiles_dir\"
         git clone --depth=1 \"\$dotfiles_url\" \"\$dotfiles_dir\"
+        dotfiles_needs_bootstrap=1
       fi
       current_url=\"\$(git -C \"\$dotfiles_dir\" config --get remote.origin.url || true)\"
       if [ \"\$current_url\" != \"\$dotfiles_url\" ]; then
         rm -rf \"\$dotfiles_dir\"
         git clone --depth=1 \"\$dotfiles_url\" \"\$dotfiles_dir\"
+        dotfiles_needs_bootstrap=1
       fi
       if [ ! -x \"\$dotfiles_dir/bootstrap.sh\" ]; then
         echo 'dcnvim: bootstrap.sh not found in dotfiles repository' >&2
         exit 127
       fi
       if [ -n \"\$dotfiles_ref\" ]; then
-        git -C \"\$dotfiles_dir\" fetch --depth=1 origin \"\$dotfiles_ref\"
-        git -C \"\$dotfiles_dir\" checkout --force FETCH_HEAD
+        if git -C \"\$dotfiles_dir\" fetch --depth=1 origin \"\$dotfiles_ref\" &&
+          git -C \"\$dotfiles_dir\" checkout --force FETCH_HEAD; then
+          dotfiles_needs_bootstrap=1
+        else
+          echo 'dcnvim: warning: failed to fetch dotfiles ref; using existing checkout' >&2
+        fi
       else
-        git -C \"\$dotfiles_dir\" fetch --depth=1 origin
-        if ! git -C \"\$dotfiles_dir\" pull --ff-only --depth=1; then
-          default_ref=\"\$(git -C \"\$dotfiles_dir\" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)\"
-          if [ -n \"\$default_ref\" ]; then
-            git -C \"\$dotfiles_dir\" reset --hard \"\$default_ref\"
+        if git -C \"\$dotfiles_dir\" fetch --depth=1 origin; then
+          if git -C \"\$dotfiles_dir\" pull --ff-only --depth=1; then
+            dotfiles_needs_bootstrap=1
+          else
+            default_ref=\"\$(git -C \"\$dotfiles_dir\" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)\"
+            if [ -n \"\$default_ref\" ] && git -C \"\$dotfiles_dir\" reset --hard \"\$default_ref\"; then
+              dotfiles_needs_bootstrap=1
+            else
+              echo 'dcnvim: warning: failed to update dotfiles repository; using existing checkout' >&2
+            fi
           fi
+        else
+          echo 'dcnvim: warning: failed to update dotfiles repository; using existing checkout' >&2
         fi
       fi
-      \"\$dotfiles_dir/bootstrap.sh\"
+      if [ \"\$dotfiles_needs_bootstrap\" -eq 1 ] || ! command -v nvim >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
+        \"\$dotfiles_dir/bootstrap.sh\"
+      fi
       command -v nvim >/dev/null 2>&1 || {
         echo 'dcnvim: nvim not installed in container — run ~/.dotfiles/bootstrap.sh first' >&2
         exit 127

--- a/scripts/sh/dcnvim.sh
+++ b/scripts/sh/dcnvim.sh
@@ -73,8 +73,10 @@ dcnvim() {
   # below because the devcontainers CLI dotfiles marker path can fail on
   # Windows/zsh with "numeric argument required" before exec is reached.
   local dotfiles_url="${DOTFILES_REPOSITORY_URL:-https://github.com/rurusasu/dotfiles}"
-  local dotfiles_url_quoted
+  local dotfiles_ref="${DOTFILES_REPOSITORY_REF:-}"
+  local dotfiles_url_quoted dotfiles_ref_quoted
   dotfiles_url_quoted="$(_dcnvim_shell_quote "$dotfiles_url")"
+  dotfiles_ref_quoted="$(_dcnvim_shell_quote "$dotfiles_ref")"
   devcontainer up \
     --workspace-folder "$workspace" \
     >/dev/null || {
@@ -98,24 +100,38 @@ dcnvim() {
       set -e
       export PATH=\"\$HOME/.local/bin:\$PATH\"
       dotfiles_url=$dotfiles_url_quoted
+      dotfiles_ref=$dotfiles_ref_quoted
       dotfiles_dir=\"\$HOME/.dotfiles\"
-      dotfiles_needs_bootstrap=0
-      if [ ! -e \"\$dotfiles_dir\" ] && [ ! -L \"\$dotfiles_dir\" ] && [ -x \"\$HOME/dotfiles/bootstrap.sh\" ]; then
-        ln -s \"\$HOME/dotfiles\" \"\$dotfiles_dir\"
-        dotfiles_needs_bootstrap=1
-      fi
-      if [ ! -x \"\$dotfiles_dir/bootstrap.sh\" ]; then
-        command -v git >/dev/null 2>&1 || {
-          echo 'dcnvim: git not installed in container; cannot clone dotfiles' >&2
-          exit 127
-        }
+      command -v git >/dev/null 2>&1 || {
+        echo 'dcnvim: git not installed in container; cannot clone dotfiles' >&2
+        exit 127
+      }
+      if [ -L \"\$dotfiles_dir\" ] || [ ! -d \"\$dotfiles_dir/.git\" ]; then
         rm -rf \"\$dotfiles_dir\"
         git clone --depth=1 \"\$dotfiles_url\" \"\$dotfiles_dir\"
-        dotfiles_needs_bootstrap=1
       fi
-      if [ \"\$dotfiles_needs_bootstrap\" -eq 1 ] || ! command -v nvim >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
-        \"\$dotfiles_dir/bootstrap.sh\"
+      current_url=\"\$(git -C \"\$dotfiles_dir\" config --get remote.origin.url || true)\"
+      if [ \"\$current_url\" != \"\$dotfiles_url\" ]; then
+        rm -rf \"\$dotfiles_dir\"
+        git clone --depth=1 \"\$dotfiles_url\" \"\$dotfiles_dir\"
       fi
+      if [ ! -x \"\$dotfiles_dir/bootstrap.sh\" ]; then
+        echo 'dcnvim: bootstrap.sh not found in dotfiles repository' >&2
+        exit 127
+      fi
+      if [ -n \"\$dotfiles_ref\" ]; then
+        git -C \"\$dotfiles_dir\" fetch --depth=1 origin \"\$dotfiles_ref\"
+        git -C \"\$dotfiles_dir\" checkout --force FETCH_HEAD
+      else
+        git -C \"\$dotfiles_dir\" fetch --depth=1 origin
+        if ! git -C \"\$dotfiles_dir\" pull --ff-only --depth=1; then
+          default_ref=\"\$(git -C \"\$dotfiles_dir\" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)\"
+          if [ -n \"\$default_ref\" ]; then
+            git -C \"\$dotfiles_dir\" reset --hard \"\$default_ref\"
+          fi
+        fi
+      fi
+      \"\$dotfiles_dir/bootstrap.sh\"
       command -v nvim >/dev/null 2>&1 || {
         echo 'dcnvim: nvim not installed in container — run ~/.dotfiles/bootstrap.sh first' >&2
         exit 127

--- a/tests/bash/dcnvim.bats
+++ b/tests/bash/dcnvim.bats
@@ -98,11 +98,16 @@ printf "%s\n" "$FZF_SELECTED"
 	payload="$(cat "$DEVCONTAINER_PAYLOAD_LOG")"
 	[[ "$payload" == *'export PATH="$HOME/.local/bin:$PATH"'* ]]
 	[[ "$payload" == *"dotfiles_url='https://github.com/rurusasu/dotfiles'"* ]]
+	[[ "$payload" == *"dotfiles_ref=''"* ]]
 	[[ "$payload" == *'dotfiles_dir="$HOME/.dotfiles"'* ]]
-	[[ "$payload" == *"dotfiles_needs_bootstrap=0"* ]]
+	[[ "$payload" != *'HOME/dotfiles'* ]]
+	[[ "$payload" != *"dotfiles_needs_bootstrap"* ]]
+	[[ "$payload" == *'if [ -L "$dotfiles_dir" ] || [ ! -d "$dotfiles_dir/.git" ]; then'* ]]
 	[[ "$payload" == *'git clone --depth=1 "$dotfiles_url" "$dotfiles_dir"'* ]]
-	[[ "$payload" == *'dotfiles_needs_bootstrap=1'* ]]
-	[[ "$payload" == *'if [ "$dotfiles_needs_bootstrap" -eq 1 ] || ! command -v nvim'* ]]
+	[[ "$payload" == *'current_url="$(git -C "$dotfiles_dir" config --get remote.origin.url || true)"'* ]]
+	[[ "$payload" == *'if [ "$current_url" != "$dotfiles_url" ]; then'* ]]
+	[[ "$payload" == *'git -C "$dotfiles_dir" fetch --depth=1 origin'* ]]
+	[[ "$payload" == *'git -C "$dotfiles_dir" pull --ff-only --depth=1'* ]]
 	[[ "$payload" == *'"$dotfiles_dir/bootstrap.sh"'* ]]
 	[[ "$payload" == *"command -v nvim"* ]]
 	[[ "$payload" == *"command -v tmux"* ]]
@@ -145,6 +150,21 @@ printf "%s\n" "$FZF_SELECTED"
 	[[ "$log" != *"arg=https://example.invalid/dotfiles.git"* ]]
 	payload="$(cat "$DEVCONTAINER_PAYLOAD_LOG")"
 	[[ "$payload" == *"dotfiles_url='https://example.invalid/dotfiles.git'"* ]]
+}
+
+@test "custom dotfiles repository ref is checked out by bootstrap payload" {
+	workspace="$BATS_TEST_TMPDIR/project"
+	mkdir -p "$workspace/.devcontainer"
+	export DOTFILES_REPOSITORY_REF="feature/test-ref"
+	write_devcontainer_stub
+
+	run dcnvim "$workspace"
+
+	[ "$status" -eq 0 ]
+	payload="$(cat "$DEVCONTAINER_PAYLOAD_LOG")"
+	[[ "$payload" == *"dotfiles_ref='feature/test-ref'"* ]]
+	[[ "$payload" == *'git -C "$dotfiles_dir" fetch --depth=1 origin "$dotfiles_ref"'* ]]
+	[[ "$payload" == *'git -C "$dotfiles_dir" checkout --force FETCH_HEAD'* ]]
 }
 
 @test "missing devcontainer config fails before devcontainer up" {

--- a/tests/bash/dcnvim.bats
+++ b/tests/bash/dcnvim.bats
@@ -101,13 +101,15 @@ printf "%s\n" "$FZF_SELECTED"
 	[[ "$payload" == *"dotfiles_ref=''"* ]]
 	[[ "$payload" == *'dotfiles_dir="$HOME/.dotfiles"'* ]]
 	[[ "$payload" != *'HOME/dotfiles'* ]]
-	[[ "$payload" != *"dotfiles_needs_bootstrap"* ]]
+	[[ "$payload" == *"dotfiles_needs_bootstrap=0"* ]]
 	[[ "$payload" == *'if [ -L "$dotfiles_dir" ] || [ ! -d "$dotfiles_dir/.git" ]; then'* ]]
 	[[ "$payload" == *'git clone --depth=1 "$dotfiles_url" "$dotfiles_dir"'* ]]
 	[[ "$payload" == *'current_url="$(git -C "$dotfiles_dir" config --get remote.origin.url || true)"'* ]]
 	[[ "$payload" == *'if [ "$current_url" != "$dotfiles_url" ]; then'* ]]
-	[[ "$payload" == *'git -C "$dotfiles_dir" fetch --depth=1 origin'* ]]
-	[[ "$payload" == *'git -C "$dotfiles_dir" pull --ff-only --depth=1'* ]]
+	[[ "$payload" == *'if git -C "$dotfiles_dir" fetch --depth=1 origin; then'* ]]
+	[[ "$payload" == *'if git -C "$dotfiles_dir" pull --ff-only --depth=1; then'* ]]
+	[[ "$payload" == *"dcnvim: warning: failed to update dotfiles repository; using existing checkout"* ]]
+	[[ "$payload" == *'if [ "$dotfiles_needs_bootstrap" -eq 1 ] || ! command -v nvim >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then'* ]]
 	[[ "$payload" == *'"$dotfiles_dir/bootstrap.sh"'* ]]
 	[[ "$payload" == *"command -v nvim"* ]]
 	[[ "$payload" == *"command -v tmux"* ]]
@@ -163,8 +165,24 @@ printf "%s\n" "$FZF_SELECTED"
 	[ "$status" -eq 0 ]
 	payload="$(cat "$DEVCONTAINER_PAYLOAD_LOG")"
 	[[ "$payload" == *"dotfiles_ref='feature/test-ref'"* ]]
-	[[ "$payload" == *'git -C "$dotfiles_dir" fetch --depth=1 origin "$dotfiles_ref"'* ]]
+	[[ "$payload" == *'if git -C "$dotfiles_dir" fetch --depth=1 origin "$dotfiles_ref" &&'* ]]
 	[[ "$payload" == *'git -C "$dotfiles_dir" checkout --force FETCH_HEAD'* ]]
+	[[ "$payload" == *"dcnvim: warning: failed to fetch dotfiles ref; using existing checkout"* ]]
+}
+
+@test "dotfiles update failures are best effort when checkout already exists" {
+	workspace="$BATS_TEST_TMPDIR/project"
+	mkdir -p "$workspace/.devcontainer"
+	write_devcontainer_stub
+
+	run dcnvim "$workspace"
+
+	[ "$status" -eq 0 ]
+	payload="$(cat "$DEVCONTAINER_PAYLOAD_LOG")"
+	[[ "$payload" == *'if git -C "$dotfiles_dir" fetch --depth=1 origin; then'* ]]
+	[[ "$payload" == *"dcnvim: warning: failed to update dotfiles repository; using existing checkout"* ]]
+	[[ "$payload" == *'if [ "$dotfiles_needs_bootstrap" -eq 1 ] || ! command -v nvim >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then'* ]]
+	[[ "$payload" == *"tmux new -A -s 'project' 'nvim .'"* ]]
 }
 
 @test "missing devcontainer config fails before devcontainer up" {


### PR DESCRIPTION
## Summary
- Manage devcontainer dotfiles setup inside dcnvim by cloning/updating the configured repository URL.
- Add `DOTFILES_REPOSITORY_REF` support for reproducible branch/tag/SHA checkout.
- Keep Dev Containers CLI dotfiles flags out of `devcontainer up` to avoid relying on its marker behavior.

## Why
The previous container-side fallback could make the dotfiles source implicit. This makes the source explicit and reproducible while keeping `devcontainer up` behavior stable.

## Validation
- `wsl -d NixOS -- bash -lc "cd ~/.dotfiles && bats tests/bash/dcnvim.bats"`
- `pwsh -NoLogo -NoProfile -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1`
- `task fmt:check`
- `task test:bash`
- `task test`
- `task lint`
- `task chezmoi`