### PR TITLE
[codex] fix vscode cli wrappers

### DIFF
--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -19,10 +19,6 @@ if (-not $env:TEMP -or $env:TEMP -eq $env:USERPROFILE) { $env:TEMP = Join-Path $
 if (-not $env:TMP) { $env:TMP = $env:TEMP }
 if (-not $env:TERM -or $env:TERM -eq "dumb") { $env:TERM = "xterm-256color" }
 
-# VS Code Extension Console skips heavy init (starship/zoxide/PSReadLine) to avoid
-# session startup timeout. Basic PowerShell functionality (syntax, completion) still works.
-if ($env:VSCODE_PID -or $env:VSCODE_INJECTION) { return }
-
 # Rebuild PATH from registry to ensure User PATH is available in elevated sessions.
 # Windows Terminal with "elevate: true" may not inherit User-scope PATH entries.
 $env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [Environment]::GetEnvironmentVariable("PATH", "User")
@@ -75,6 +71,28 @@ function Invoke-CodexCli {
 }
 
 Set-Alias -Name codex -Value Invoke-CodexCli -Scope Global
+
+# claude: intercept `claude update` to run pnpm install + postinstall.
+# pnpm v10 blocks build scripts by default, so the native binary postinstall
+# never runs when using `claude update` directly, leaving a stub exe.
+function claude {
+    if ($args[0] -eq 'update') {
+        pnpm install -g "@anthropic-ai/claude-code@latest"
+        if ($LASTEXITCODE -eq 0) {
+            $pkgDir = Join-Path (pnpm root -g).Trim() "@anthropic-ai\claude-code"
+            Push-Location $pkgDir
+            try { node install.cjs } finally { Pop-Location }
+        }
+        return
+    }
+    $ps1 = Get-Command claude -CommandType ExternalScript -ErrorAction SilentlyContinue | Where-Object { $_.Source -like '*\pnpm\*' } | Select-Object -First 1
+    if ($ps1) { & $ps1.Source @args } else { & claude.exe @args }
+}
+
+# VS Code sets VSCODE_PID in integrated terminals as well as extension consoles.
+# Keep PATH repair and CLI wrappers above this return, then skip heavy init
+# (starship/zoxide/PSReadLine) to avoid extension-console startup timeouts.
+if ($env:VSCODE_PID -or $env:VSCODE_INJECTION) { return }
 
 function Import-MsvcDevEnvironment {
     [CmdletBinding()]
@@ -540,23 +558,6 @@ function dotf {
     $dotfilesDir = Split-Path -Parent (chezmoi source-path)
     Push-Location $dotfilesDir
     try { task @args } finally { Pop-Location }
-}
-
-# claude: intercept `claude update` to run pnpm install + postinstall.
-# pnpm v10 blocks build scripts by default, so the native binary postinstall
-# never runs when using `claude update` directly, leaving a stub exe.
-function claude {
-    if ($args[0] -eq 'update') {
-        pnpm install -g "@anthropic-ai/claude-code@latest"
-        if ($LASTEXITCODE -eq 0) {
-            $pkgDir = Join-Path (pnpm root -g).Trim() "@anthropic-ai\claude-code"
-            Push-Location $pkgDir
-            try { node install.cjs } finally { Pop-Location }
-        }
-        return
-    }
-    $ps1 = Get-Command claude -CommandType ExternalScript -ErrorAction SilentlyContinue | Where-Object { $_.Source -like '*\pnpm\*' } | Select-Object -First 1
-    if ($ps1) { & $ps1.Source @args } else { & claude.exe @args }
 }
 
 # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)

--- a/scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1
@@ -245,6 +245,25 @@ Describe 'PowerShell codex profile wrapper' {
     }
 }
 
+Describe 'PowerShell VS Code lightweight profile path' {
+    It 'should expose CLI wrappers before the VS Code lightweight return' {
+        $returnIndex = $script:profileContent.IndexOf('if ($env:VSCODE_PID -or $env:VSCODE_INJECTION) { return }')
+        ($returnIndex -ge 0) | Should -BeTrue
+
+        $pathIndex = $script:profileContent.IndexOf('$env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine")')
+        $codexAliasIndex = $script:profileContent.IndexOf('Set-Alias -Name codex -Value Invoke-CodexCli')
+        $claudeWrapperIndex = $script:profileContent.IndexOf('function claude')
+
+        ($pathIndex -ge 0) | Should -BeTrue
+        ($codexAliasIndex -ge 0) | Should -BeTrue
+        ($claudeWrapperIndex -ge 0) | Should -BeTrue
+
+        $pathIndex | Should -BeLessThan $returnIndex
+        $codexAliasIndex | Should -BeLessThan $returnIndex
+        $claudeWrapperIndex | Should -BeLessThan $returnIndex
+    }
+}
+
 Describe 'PowerShell dcnvim profile function' {
     BeforeEach {
         Import-DcnvimProfileFunction


### PR DESCRIPTION
## Summary

- Move PowerShell PATH repair and CLI wrappers before the VS Code lightweight profile return.
- Keep heavy profile initialization skipped for VS Code extension-console style sessions.
- Add a regression test that requires `codex` and `claude` wrappers to be defined before the early return.

## Root Cause

VS Code integrated terminals set `VSCODE_PID`, but the profile treated that the same as extension-console startup and returned before rebuilding PATH or defining the `codex`/`claude` wrappers. That made installed CLIs unavailable only in VS Code terminals.

## Validation

- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/chezmoi -MinimumCoverage 0`
- `task commit -- "fix vscode cli wrappers"` ran repo formatting and pre-commit hooks before commit.
- Verified a VS Code-like profile load resolves both CLIs: `codex-cli 0.139.0`, `Claude Code 2.1.195`.