### PR TITLE
[codex] fix onepassword cli host shim

### DIFF
--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -730,6 +730,8 @@ lib.mapAttrs (_: names: resolve names) grouped
   # Extra PATH directories for installers that do not register CLI commands on PATH.
   # Entries may contain Windows environment variables and glob wildcards.
   wingetPathEntries = {
+    _1password-cli = [ "%LOCALAPPDATA%\\Microsoft\\WinGet\\Links" ];
+    "AgileBits.1Password.CLI" = [ "%LOCALAPPDATA%\\Microsoft\\WinGet\\Links" ];
     google-cloud-sdk = [
       "%ProgramFiles%\\Google\\Cloud SDK\\google-cloud-sdk\\bin"
       "%ProgramFiles(x86)%\\Google\\Cloud SDK\\google-cloud-sdk\\bin"
@@ -744,6 +746,14 @@ lib.mapAttrs (_: names: resolve names) grouped
 
   # Portable winget packages whose package exe name does not match the command name.
   wingetPortableLinksById = {
+    _1password-cli = {
+      linkName = "op.exe";
+      targetPattern = "op.exe";
+    };
+    "AgileBits.1Password.CLI" = {
+      linkName = "op.exe";
+      targetPattern = "op.exe";
+    };
     oxlint = {
       linkName = "oxlint.exe";
       targetPattern = "oxlint-*.exe";

--- a/scripts/powershell/handlers/Handler.OnePasswordCli.ps1
+++ b/scripts/powershell/handlers/Handler.OnePasswordCli.ps1
@@ -1,0 +1,173 @@
+<#
+.SYNOPSIS
+    1Password CLI の host-side shim 設定ハンドラー
+
+.DESCRIPTION
+    VS Code Dev Containers の initializeCommand は Windows 側の cmd.exe から
+    `op` を解決する。起動済み Code.exe は PATH 更新を拾わないため、既定で
+    PATH に入りやすい WindowsApps と WinGet Links に op.exe shim を作成する。
+
+.NOTES
+    Order = 9 (Winget/Codex/Bun の後、Chezmoi の前)
+#>
+
+$libPath = Split-Path -Parent $PSScriptRoot
+. (Join-Path $libPath "lib\Invoke-ExternalCommand.ps1")
+
+class OnePasswordCliHandler : SetupHandlerBase {
+    OnePasswordCliHandler() {
+        $this.Name = "OnePasswordCli"
+        $this.Description = "1Password CLI op.exe shim 作成"
+        $this.Order = 9
+        $this.RequiresAdmin = $false
+        $this.Phase = 1
+    }
+
+    [bool] CanApply([SetupContext]$ctx) {
+        $opExe = $this.GetOnePasswordCliExecutablePath()
+        if (-not $opExe) {
+            $this.Log("1Password CLI パッケージがインストールされていません", "Gray")
+            return $false
+        }
+
+        $windowsApps = $this.GetWindowsAppsPath()
+        $linksPath = $this.GetLinksPath()
+        $windowsAppsShim = Join-Path $windowsApps "op.exe"
+        $linksShim = Join-Path $linksPath "op.exe"
+
+        if (
+            $this.IsPortableLinkCurrent($windowsAppsShim, $opExe) -and
+            $this.IsPortableLinkCurrent($linksShim, $opExe) -and
+            $this.IsPathInUserPath($windowsApps) -and
+            $this.IsPathInUserPath($linksPath)
+        ) {
+            $this.Log("op.exe shim と PATH 設定は既に完了しています", "Gray")
+            return $false
+        }
+
+        return $true
+    }
+
+    [SetupResult] Apply([SetupContext]$ctx) {
+        try {
+            $opExe = $this.GetOnePasswordCliExecutablePath()
+            if (-not $opExe) {
+                return $this.CreateFailureResult("1Password CLI 実行ファイルが見つかりません")
+            }
+
+            $windowsApps = $this.GetWindowsAppsPath()
+            $linksPath = $this.GetLinksPath()
+            $this.EnsureDirectory($windowsApps)
+            $this.EnsureDirectory($linksPath)
+
+            $this.EnsureShimCurrent((Join-Path $windowsApps "op.exe"), $opExe)
+            $this.EnsureShimCurrent((Join-Path $linksPath "op.exe"), $opExe)
+
+            $this.EnsureUserPathEntry($windowsApps, "WindowsApps")
+            $this.EnsureUserPathEntry($linksPath, "WinGet Links")
+
+            return $this.CreateSuccessResult("op.exe shim と PATH を設定しました")
+        }
+        catch {
+            return $this.CreateFailureResult("1Password CLI shim 設定に失敗しました", $_)
+        }
+    }
+
+    hidden [void] EnsureShimCurrent([string]$linkPath, [string]$targetExe) {
+        if (-not $this.IsPortableLinkCurrent($linkPath, $targetExe)) {
+            $this.CreatePortableLink($linkPath, $targetExe)
+        }
+        else {
+            $this.Log("op.exe shim は最新です: $linkPath", "Gray")
+        }
+    }
+
+    hidden [void] EnsureDirectory([string]$path) {
+        if (-not (Test-Path -LiteralPath $path -PathType Container)) {
+            New-Item -ItemType Directory -Path $path -Force | Out-Null
+        }
+    }
+
+    hidden [string] GetOnePasswordCliExecutablePath() {
+        $packagesBase = Join-Path $this.GetLocalAppDataPath() "Microsoft\WinGet\Packages"
+        $packageDir = Get-ChildItem -Path $packagesBase -Directory -Filter "AgileBits.1Password.CLI_*" -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if (-not $packageDir) {
+            return $null
+        }
+
+        $exePath = Join-Path $packageDir.FullName "op.exe"
+        if (Test-Path $exePath) {
+            return $exePath
+        }
+
+        return $null
+    }
+
+    hidden [string] GetWindowsAppsPath() {
+        return Join-Path $this.GetLocalAppDataPath() "Microsoft\WindowsApps"
+    }
+
+    hidden [string] GetLinksPath() {
+        return Join-Path $this.GetLocalAppDataPath() "Microsoft\WinGet\Links"
+    }
+
+    hidden [string] GetLocalAppDataPath() {
+        if ($env:LOCALAPPDATA) {
+            return $env:LOCALAPPDATA
+        }
+
+        return Join-Path $this.GetHomeDir() "AppData\Local"
+    }
+
+    hidden [string] GetHomeDir() {
+        if ($env:USERPROFILE) {
+            return $env:USERPROFILE
+        }
+        if ($env:HOME) {
+            return $env:HOME
+        }
+        return [Environment]::GetFolderPath("UserProfile")
+    }
+
+    hidden [bool] IsPathInUserPath([string]$targetPath) {
+        $userPath = Get-UserEnvironmentPath
+        if (-not $userPath) { return $false }
+
+        $normalizedTarget = $this.NormalizePathForComparison($targetPath)
+        foreach ($item in @($userPath -split ";" | Where-Object { $_ })) {
+            if ($this.NormalizePathForComparison($item) -eq $normalizedTarget) {
+                return $true
+            }
+        }
+        return $false
+    }
+
+    hidden [void] EnsureUserPathEntry([string]$targetPath, [string]$label) {
+        if ($this.IsPathInUserPath($targetPath)) {
+            $this.Log("$label は既に USER PATH に含まれています", "Gray")
+        }
+        else {
+            $userPath = Get-UserEnvironmentPath
+            $userItems = if ($userPath) { @($userPath -split ";" | Where-Object { $_ }) } else { @() }
+            Set-UserEnvironmentPath -Path (($userItems + @($targetPath)) -join ";")
+            $this.Log("USER PATH に $label を追加しました: $targetPath", "Green")
+        }
+
+        $normalizedTarget = $this.NormalizePathForComparison($targetPath)
+        $processItems = if ($env:PATH) { @($env:PATH -split ";" | Where-Object { $_ }) } else { @() }
+        foreach ($item in $processItems) {
+            if ($this.NormalizePathForComparison($item) -eq $normalizedTarget) {
+                return
+            }
+        }
+
+        $env:PATH = if ($env:PATH) { "$env:PATH;$targetPath" } else { $targetPath }
+    }
+
+    hidden [string] NormalizePathForComparison([string]$path) {
+        if (-not $path) { return "" }
+        $trimChars = [char[]]@([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+        return $path.Trim('"').TrimEnd($trimChars).ToLowerInvariant()
+    }
+}

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -175,6 +175,28 @@ Describe 'Package catalog consistency' {
         }
     }
 
+    Context '1Password CLI package' {
+        It 'should define op shim metadata in the SSOT before winget verification' {
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+
+            $sets | Should -Match '(?s)wingetPathEntries\s*=\s*\{.*?_1password-cli\s*=\s*\[.*?%LOCALAPPDATA%\\\\Microsoft\\\\WinGet\\\\Links'
+            $sets | Should -Match '(?s)wingetPortableLinksById\s*=\s*\{.*?_1password-cli\s*=\s*\{.*?linkName\s*=\s*"op\.exe".*?targetPattern\s*=\s*"op\.exe"'
+        }
+
+        It 'should generate op portable link metadata into winget packages.json' {
+            $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
+            $wingetSource = @($json.Sources | Where-Object { $_.SourceDetails.Name -eq 'winget' }) | Select-Object -First 1
+            $package = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'AgileBits.1Password.CLI' }) | Select-Object -First 1
+
+            $package | Should -Not -BeNullOrEmpty
+            @($package.pathEntries) | Should -Contain '%LOCALAPPDATA%\Microsoft\WinGet\Links'
+            $package.portableLink.linkName | Should -Be 'op.exe'
+            $package.portableLink.targetPattern | Should -Be 'op.exe'
+            $package.verifyCommand.command | Should -Be 'op'
+            @($package.verifyCommand.args) | Should -Contain '--version'
+        }
+    }
+
     Context 'Codex Desktop Microsoft Store package' {
         It 'should include Codex Desktop as a Windows-only Microsoft Store package in the SSOT' {
             $sets = Get-Content -LiteralPath $script:setsPath -Raw

--- a/scripts/powershell/tests/handlers/Handler.OnePasswordCli.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.OnePasswordCli.Tests.ps1
@@ -1,0 +1,188 @@
+#Requires -Module Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../lib/SetupHandler.ps1
+    . $PSScriptRoot/../../lib/Invoke-ExternalCommand.ps1
+    . $PSScriptRoot/../../handlers/Handler.OnePasswordCli.ps1
+    $script:projectRoot = (Resolve-Path -LiteralPath "$PSScriptRoot/../../../..").Path
+
+    $script:opPkgDir = "C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\AgileBits.1Password.CLI_Microsoft.Winget.Source_8wekyb3d8bbwe"
+    $script:opExe = Join-Path $script:opPkgDir "op.exe"
+    $script:homeDir = if ($env:USERPROFILE) { $env:USERPROFILE } elseif ($env:HOME) { $env:HOME } else { [Environment]::GetFolderPath("UserProfile") }
+    $script:localAppData = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { Join-Path $script:homeDir "AppData\Local" }
+    $script:expectedLinks = Join-Path $script:localAppData "Microsoft\WinGet\Links"
+    $script:expectedWindowsApps = Join-Path $script:localAppData "Microsoft\WindowsApps"
+
+    function script:Set-OnePasswordCliPackageInstalled {
+        Mock Get-ChildItem {
+            return [PSCustomObject]@{ FullName = $script:opPkgDir }
+        } -ParameterFilter {
+            $Path -like "*WinGet\Packages" -and $Filter -like "AgileBits.1Password.CLI_*"
+        }
+    }
+}
+
+Describe 'OnePasswordCliHandler' {
+    BeforeEach {
+        $script:handler = [OnePasswordCliHandler]::new()
+        $script:ctx = [SetupContext]::new($script:projectRoot)
+    }
+
+    Context 'Constructor' {
+        It 'should set <property> correctly' -ForEach @(
+            @{ property = "Name"; expected = "OnePasswordCli"; checkType = "Be" }
+            @{ property = "Description"; expected = $null; checkType = "Not -BeNullOrEmpty" }
+            @{ property = "Order"; expected = 9; checkType = "Be" }
+            @{ property = "RequiresAdmin"; expected = $false; checkType = "Be" }
+            @{ property = "Phase"; expected = 1; checkType = "Be" }
+        ) {
+            if ($checkType -eq "Be") {
+                $handler.$property | Should -Be $expected
+            }
+            else {
+                $handler.$property | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'CanApply - 1Password CLI not installed' {
+        BeforeEach {
+            Mock Get-ChildItem { return $null } -ParameterFilter {
+                $Path -like "*WinGet\Packages" -and $Filter -like "AgileBits.1Password.CLI_*"
+            }
+            Mock Write-Host { }
+        }
+
+        It 'should return false' {
+            $handler.CanApply($ctx) | Should -Be $false
+        }
+    }
+
+    Context 'CanApply - shims are current and PATH configured' {
+        BeforeEach {
+            Set-OnePasswordCliPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*op.exe") { return $true }
+                if ($LiteralPath -like "*op.exe") { return $true }
+                return $false
+            }
+            Mock Get-Item {
+                return [PSCustomObject]@{ LinkType = "SymbolicLink"; Target = $script:opExe }
+            } -ParameterFilter { $LiteralPath -like "*op.exe" }
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedWindowsApps;$script:expectedLinks" }
+            Mock Write-Host { }
+        }
+
+        It 'should return false when both shims and PATH are already set' {
+            $handler.CanApply($ctx) | Should -Be $false
+        }
+    }
+
+    Context 'CanApply - WindowsApps shim missing' {
+        BeforeEach {
+            Set-OnePasswordCliPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*AgileBits.1Password.CLI*op.exe") { return $true }
+                if ($LiteralPath -like "*WinGet\Links\op.exe") { return $true }
+                if ($LiteralPath -like "*WindowsApps\op.exe") { return $false }
+                return $false
+            }
+            Mock Get-Item {
+                return [PSCustomObject]@{ LinkType = "SymbolicLink"; Target = $script:opExe }
+            } -ParameterFilter { $LiteralPath -like "*WinGet\Links\op.exe" }
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedWindowsApps;$script:expectedLinks" }
+            Mock Write-Host { }
+        }
+
+        It 'should return true so old VS Code processes can resolve op through WindowsApps' {
+            $handler.CanApply($ctx) | Should -Be $true
+        }
+    }
+
+    Context 'CanApply - link is stale copy from old version' {
+        BeforeEach {
+            Set-OnePasswordCliPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*op.exe") { return $true }
+                if ($LiteralPath -like "*op.exe") { return $true }
+                return $false
+            }
+            Mock Get-Item {
+                if ($LiteralPath -like "*WindowsApps\op.exe") {
+                    return [PSCustomObject]@{ LinkType = ""; Length = 100; LastWriteTimeUtc = [datetime]'2024-01-01' }
+                }
+                return [PSCustomObject]@{ LinkType = ""; Length = 200; LastWriteTimeUtc = [datetime]'2024-06-01' }
+            }
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedWindowsApps;$script:expectedLinks" }
+            Mock Write-Host { }
+        }
+
+        It 'should return true so stale shims are refreshed after winget upgrade' {
+            $handler.CanApply($ctx) | Should -Be $true
+        }
+    }
+
+    Context 'Apply - creates WindowsApps and WinGet Links shims' {
+        BeforeEach {
+            Set-OnePasswordCliPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*AgileBits.1Password.CLI*op.exe") { return $true }
+                if ($Path -like "*WindowsApps") { return $true }
+                if ($Path -like "*WinGet\Links") { return $true }
+                if ($LiteralPath -like "*op.exe") { return $false }
+                return $false
+            }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "HardLink" }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
+            Mock Remove-Item { }
+            Mock Copy-Item { }
+            Mock Get-UserEnvironmentPath { return "C:\Windows" }
+            Mock Set-UserEnvironmentPath { }
+            Mock Write-Host { }
+        }
+
+        It 'should create both shims and add stable PATH entries' {
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            Should -Invoke New-Item -Times 2 -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Should -Invoke Set-UserEnvironmentPath -Times 2
+        }
+    }
+
+    Context 'Apply - current shims but PATH missing' {
+        BeforeEach {
+            Set-OnePasswordCliPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*op.exe") { return $true }
+                if ($Path -like "*WindowsApps") { return $true }
+                if ($Path -like "*WinGet\Links") { return $true }
+                if ($LiteralPath -like "*op.exe") { return $true }
+                return $false
+            }
+            Mock Get-Item {
+                return [PSCustomObject]@{ LinkType = "SymbolicLink"; Target = $script:opExe }
+            } -ParameterFilter { $LiteralPath -like "*op.exe" }
+            Mock New-Item { throw "should not recreate current shim" } -ParameterFilter {
+                $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
+            }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
+            Mock Remove-Item { }
+            Mock Copy-Item { }
+            Mock Get-UserEnvironmentPath { return "C:\Windows" }
+            Mock Set-UserEnvironmentPath { }
+            Mock Write-Host { }
+        }
+
+        It 'should only add PATH entries without recreating shims' {
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            Should -Invoke Set-UserEnvironmentPath -Times 2
+            Should -Invoke New-Item -Times 0 -ParameterFilter {
+                $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
+            }
+        }
+    }
+}

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -5,6 +5,11 @@
       "Packages": [
         {
           "PackageIdentifier": "AgileBits.1Password.CLI",
+          "pathEntries": ["%LOCALAPPDATA%\\Microsoft\\WinGet\\Links"],
+          "portableLink": {
+            "linkName": "op.exe",
+            "targetPattern": "op.exe"
+          },
           "verifyCommand": {
             "args": ["--version"],
             "command": "op"


### PR DESCRIPTION
## Summary
- add OnePasswordCliHandler to maintain host-side op.exe shims in WindowsApps and WinGet Links
- refresh User PATH entries for those stable directories
- add handler coverage for missing, stale, current shim, and PATH-only cases

## Why
VS Code Remote Containers invokes initializeCommand through the Windows host cmd.exe. If Code.exe has an older PATH, `op inject` can fail even after 1Password CLI is installed. Stable host shims avoid relying on the versioned winget package directory.

## Validation
- task test
- task commit -- fix onepassword cli host shim
- verified op is found from PATH containing only WindowsApps or only WinGet Links