### PR TITLE
Manage Hermes Codex model config

### DIFF
--- a/scripts/powershell/handlers/Handler.HermesAgent.ps1
+++ b/scripts/powershell/handlers/Handler.HermesAgent.ps1
@@ -4,6 +4,7 @@
 
 .DESCRIPTION
     - docker/hermes-agent/compose.yml を使って Hermes gateway/dashboard を起動
+    - ~/.hermes/config.yaml の model provider/default を初期化
     - 1Password の保存済み credential を優先して ~/.hermes/.env に dashboard Basic Auth と Slack 接続情報を初期化
     - 1Password が使えない場合は credential を生成し、password を ~/.hermes/dashboard-basic-auth-password.txt に保存
 #>
@@ -74,6 +75,7 @@ class HermesAgentHandler : SetupHandlerBase {
 
             $dataDir = $this.GetDataDir()
             $this.EnsureDirectory($dataDir)
+            $modelResult = $this.EnsureModelConfiguration($ctx, $dataDir)
 
             $envPath = Join-Path $dataDir ".env"
             $infoFilePath = Join-Path $dataDir "dashboard-basic-auth-password.txt"
@@ -99,6 +101,13 @@ class HermesAgentHandler : SetupHandlerBase {
             }
             else {
                 $this.Log("Dashboard Basic Auth は既に設定済みです", "Gray")
+            }
+
+            if ($modelResult.Changed) {
+                $this.Log("Hermes model 設定を $($modelResult.Provider)/$($modelResult.Model) に設定しました", "Green")
+            }
+            elseif ($modelResult.Source -eq "Config") {
+                $this.Log("Hermes model 設定は既に設定済みです", "Gray")
             }
 
             if ($slackResult.Changed -and $slackResult.Source -eq "1Password") {
@@ -188,6 +197,103 @@ class HermesAgentHandler : SetupHandlerBase {
         if (-not (Test-Path -LiteralPath $path -PathType Container)) {
             New-Item -ItemType Directory -Path $path -Force | Out-Null
         }
+    }
+
+    hidden [pscustomobject] EnsureModelConfiguration([SetupContext]$ctx, [string]$dataDir) {
+        if (-not $this.IsTruthy($ctx.GetOption("HermesAgentModelConfigEnabled", $true))) {
+            return [PSCustomObject]@{ Changed = $false; Source = "Disabled"; Provider = ""; Model = "" }
+        }
+
+        $provider = ([string]$ctx.GetOption("HermesAgentModelProvider", "openai-codex")).Trim()
+        if ([string]::IsNullOrWhiteSpace($provider)) {
+            $provider = "openai-codex"
+        }
+
+        $model = ([string]$ctx.GetOption("HermesAgentModelDefault", "gpt-5.5")).Trim()
+        if ([string]::IsNullOrWhiteSpace($model)) {
+            $model = "gpt-5.5"
+        }
+
+        $configPath = Join-Path $dataDir "config.yaml"
+        $existingLines = @()
+        if (Test-Path -LiteralPath $configPath) {
+            $existingLines = @(Get-Content -LiteralPath $configPath -ErrorAction Stop)
+        }
+
+        $desiredLines = @(
+            "model:",
+            "  provider: $provider",
+            "  default: $model"
+        )
+        $updatedLines = $this.SetModelConfigLines($existingLines, $desiredLines)
+        $changed = -not $this.LinesEqual($existingLines, $updatedLines)
+        if ($changed) {
+            Set-Content -LiteralPath $configPath -Encoding UTF8 -Value $updatedLines
+        }
+
+        return [PSCustomObject]@{ Changed = $changed; Source = "Config"; Provider = $provider; Model = $model }
+    }
+
+    hidden [string[]] SetModelConfigLines([string[]]$lines, [string[]]$desiredLines) {
+        $cleanedLines = @(
+            $lines | Where-Object {
+                $_ -notmatch '^model\.(default|provider)\s*:'
+            }
+        )
+
+        if ($cleanedLines.Count -eq 0) {
+            return $desiredLines
+        }
+
+        $modelStart = -1
+        for ($index = 0; $index -lt $cleanedLines.Count; $index++) {
+            if ($cleanedLines[$index] -match '^model\s*:') {
+                $modelStart = $index
+                break
+            }
+        }
+
+        if ($modelStart -lt 0) {
+            $result = @()
+            $result += $desiredLines
+            if (-not [string]::IsNullOrWhiteSpace($cleanedLines[0])) {
+                $result += ""
+            }
+            $result += $cleanedLines
+            return $result
+        }
+
+        $modelEnd = $modelStart + 1
+        while ($modelEnd -lt $cleanedLines.Count) {
+            $line = $cleanedLines[$modelEnd]
+            if ($line -match '^\S[^:]*\s*:') {
+                break
+            }
+            $modelEnd++
+        }
+
+        $result = @()
+        if ($modelStart -gt 0) {
+            $result += $cleanedLines[0..($modelStart - 1)]
+        }
+        $result += $desiredLines
+        if ($modelEnd -lt $cleanedLines.Count) {
+            $result += $cleanedLines[$modelEnd..($cleanedLines.Count - 1)]
+        }
+        return $result
+    }
+
+    hidden [bool] LinesEqual([string[]]$left, [string[]]$right) {
+        if ($left.Count -ne $right.Count) {
+            return $false
+        }
+
+        for ($index = 0; $index -lt $left.Count; $index++) {
+            if ($left[$index] -ne $right[$index]) {
+                return $false
+            }
+        }
+        return $true
     }
 
     hidden [pscustomobject] EnsureDashboardAuth([SetupContext]$ctx, [string]$envPath, [string]$infoFilePath) {

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -186,6 +186,84 @@ Describe 'HermesAgentHandler' {
             $composeCall | Should -Contain "-d"
         }
 
+        It 'should configure the default Codex model in config.yaml' {
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $configPath = Join-Path $script:userProfile ".hermes\config.yaml"
+            $configContent = Get-Content -LiteralPath $configPath -Raw
+
+            $configContent | Should -Match "(?m)^model:\r?\n  provider: openai-codex\r?\n  default: gpt-5\.5"
+        }
+
+        It 'should replace stale Hermes model config while preserving other settings' {
+            $dataDir = Join-Path $script:userProfile ".hermes"
+            New-Item -ItemType Directory -Path $dataDir -Force | Out-Null
+            $configPath = Join-Path $dataDir "config.yaml"
+            Set-Content -LiteralPath $configPath -Encoding UTF8 -Value @(
+                "model:",
+                "  default: anthropic/claude-opus-4.6",
+                "  provider: auto",
+                "  base_url: https://openrouter.ai/api/v1",
+                "terminal:",
+                "  backend: local"
+            )
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $configContent = Get-Content -LiteralPath $configPath -Raw
+            $configContent | Should -Match "(?m)^model:\r?\n  provider: openai-codex\r?\n  default: gpt-5\.5"
+            $configContent | Should -Not -Match "claude-opus-4\.6|openrouter|model\.default|model\.provider"
+            $configContent | Should -Match "(?m)^terminal:\r?\n  backend: local"
+        }
+
+        It 'should preserve nested model settings while replacing only the top-level model config' {
+            $dataDir = Join-Path $script:userProfile ".hermes"
+            New-Item -ItemType Directory -Path $dataDir -Force | Out-Null
+            $configPath = Join-Path $dataDir "config.yaml"
+            Set-Content -LiteralPath $configPath -Encoding UTF8 -Value @(
+                "auxiliary:",
+                "  vision:",
+                "    model: local-vision-model",
+                "    provider: local-provider",
+                "model:",
+                "  default: stale-main-model",
+                "  provider: auto",
+                "agent:",
+                "  max_turns: 60"
+            )
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $configContent = Get-Content -LiteralPath $configPath -Raw
+            $configContent | Should -Match "(?m)^auxiliary:\r?\n  vision:\r?\n    model: local-vision-model\r?\n    provider: local-provider"
+            $configContent | Should -Match "(?m)^model:\r?\n  provider: openai-codex\r?\n  default: gpt-5\.5"
+            $configContent | Should -Not -Match "stale-main-model"
+        }
+
+        It 'should normalize scalar and literal model keys from manual config edits' {
+            $dataDir = Join-Path $script:userProfile ".hermes"
+            New-Item -ItemType Directory -Path $dataDir -Force | Out-Null
+            $configPath = Join-Path $dataDir "config.yaml"
+            Set-Content -LiteralPath $configPath -Encoding UTF8 -Value @(
+                "model: gpt-5.5",
+                "model.default: gpt-5.5",
+                "model.provider: openai-codex",
+                "agent:",
+                "  max_turns: 60"
+            )
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $configContent = Get-Content -LiteralPath $configPath -Raw
+            $configContent | Should -Match "(?m)^model:\r?\n  provider: openai-codex\r?\n  default: gpt-5\.5"
+            $configContent | Should -Not -Match "(?m)^model\.(default|provider):"
+            $configContent | Should -Match "(?m)^agent:\r?\n  max_turns: 60"
+        }
+
         It 'should fall back to generated dashboard auth when 1Password CLI is unavailable' {
             $ctx.Options.Remove("HermesAgent1PasswordEnabled")
             Mock Get-Command { return $null } -ParameterFilter { $Name -eq "op" }


### PR DESCRIPTION
## Summary
- Manage Hermes Agent `config.yaml` model defaults from the dotfiles setup handler.
- Normalize stale scalar/literal model settings to `provider: openai-codex` and `default: gpt-5.5`.
- Add handler tests for initial creation and stale config replacement.

## Validation
- `Invoke-Pester -Path scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1 -Output Detailed`
- `task test`
- `task commit -- "Manage Hermes Codex model config"`
