### PR TITLE
fix windows setup shims

### DIFF
--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -754,6 +754,10 @@ lib.mapAttrs (_: names: resolve names) grouped
       linkName = "op.exe";
       targetPattern = "op.exe";
     };
+    "OpenAI.Codex" = {
+      linkName = "codex.exe";
+      targetPattern = "codex-x86_64-pc-windows-msvc.exe";
+    };
     oxlint = {
       linkName = "oxlint.exe";
       targetPattern = "oxlint-*.exe";

--- a/scripts/powershell/handlers/Handler.Codex.ps1
+++ b/scripts/powershell/handlers/Handler.Codex.ps1
@@ -5,7 +5,7 @@
 .DESCRIPTION
     winget の OpenAI.Codex パッケージは portable インストーラーで
     実行ファイル名が codex-x86_64-pc-windows-msvc.exe となっている。
-    このハンドラーは WinGet\Links に codex.exe シンボリックリンクを作成する。
+    このハンドラーは WinGet\Links に codex.exe shim を作成する。
     また、Codex MCP から uv tool のエントリポイント（mempalace-mcp 等）を
     起動できるよう ~/.local/bin を USER PATH に追加する。
 
@@ -19,7 +19,7 @@ $libPath = Split-Path -Parent $PSScriptRoot
 class CodexHandler : SetupHandlerBase {
     CodexHandler() {
         $this.Name = "Codex"
-        $this.Description = "Codex CLI シンボリックリンクと MCP PATH 設定"
+        $this.Description = "Codex CLI shim と MCP PATH 設定"
         $this.Order = 6
         $this.RequiresAdmin = $false
         $this.Phase = 1
@@ -47,11 +47,11 @@ class CodexHandler : SetupHandlerBase {
         # リンクが最新でも PATH 設定が欠けていれば適用する。
         # (winget upgrade 後の陳腐化, copy フォールバック後, 過去の部分実行を想定。)
         if (
-            $this.IsCodexSymlinkCurrent($linkPath, $codexExe) -and
+            $this.IsPortableLinkCurrent($linkPath, $codexExe) -and
             $this.IsPathInUserPath($linksPath) -and
             $this.IsPathInUserPath($localBin)
         ) {
-            $this.Log("codex.exe リンクと PATH 設定は既に完了しています", "Gray")
+            $this.Log("codex.exe shim と PATH 設定は既に完了しています", "Gray")
             return $false
         }
 
@@ -60,7 +60,7 @@ class CodexHandler : SetupHandlerBase {
 
     <#
     .SYNOPSIS
-        codex.exe シンボリックリンクを作成する
+        codex.exe shim を作成する
     #>
     [SetupResult] Apply([SetupContext]$ctx) {
         try {
@@ -76,13 +76,13 @@ class CodexHandler : SetupHandlerBase {
 
             $linkPath = Join-Path $linksPath "codex.exe"
 
-            # Codex CLI は更新頻度が高いため、copy/hardlink は許可しない。
-            # Links\codex.exe が本体への symlink でない場合は必ず貼り直す。
-            if (-not $this.IsCodexSymlinkCurrent($linkPath, $codexExe)) {
-                $this.CreateCodexSymlink($linkPath, $codexExe)
+            # リンクが陳腐化している（旧バージョンを指すコピー等）場合のみ貼り直す。
+            # 非昇格環境では symlink が失敗するため、共通 portable shim fallback を使う。
+            if (-not $this.IsPortableLinkCurrent($linkPath, $codexExe)) {
+                $this.CreatePortableLink($linkPath, $codexExe)
             }
             else {
-                $this.Log("codex.exe リンクは最新です", "Gray")
+                $this.Log("codex.exe shim は最新です", "Gray")
             }
 
             # PATH は常に冪等チェック。リンクが既存でも PATH 未設定なら追加する。
@@ -92,48 +92,10 @@ class CodexHandler : SetupHandlerBase {
             # uv tool が作成する mempalace-mcp.exe 等を解決できるようにする。
             $this.EnsureUserPathEntry($this.GetLocalBinPath(), $true, "~/.local/bin")
 
-            return $this.CreateSuccessResult("codex.exe リンクと MCP PATH を設定しました")
+            return $this.CreateSuccessResult("codex.exe shim と MCP PATH を設定しました")
         }
         catch {
-            return $this.CreateFailureResult("Codex シンボリックリンク設定に失敗しました", $_.Exception)
-        }
-    }
-
-    <#
-    .SYNOPSIS
-        Links\codex.exe が現行 Codex 実行ファイルへのシンボリックリンクか判定する
-    .DESCRIPTION
-        copy/hardlink は一時的に本体と一致していても winget upgrade 後に陳腐化するため、
-        Codex では current とみなさない。
-    #>
-    hidden [bool] IsCodexSymlinkCurrent([string]$linkPath, [string]$targetExe) {
-        if (-not (Test-Path -LiteralPath $linkPath)) { return $false }
-
-        $link = Get-Item -LiteralPath $linkPath -Force
-        if ($link.LinkType -ne "SymbolicLink") { return $false }
-
-        return $this.NormalizePathForComparison(@($link.Target)[0]) -eq
-        $this.NormalizePathForComparison($targetExe)
-    }
-
-    <#
-    .SYNOPSIS
-        Codex CLI 用のシンボリックリンクを作成する
-    .DESCRIPTION
-        hardlink/copy fallback は使わない。symlink を作れない環境では失敗させ、
-        古いコピーが PATH 上に残る状態を防ぐ。
-    #>
-    hidden [void] CreateCodexSymlink([string]$linkPath, [string]$targetExe) {
-        if (Test-Path -LiteralPath $linkPath) {
-            Remove-Item -LiteralPath $linkPath -Force -ErrorAction Stop
-        }
-
-        try {
-            New-Item -ItemType SymbolicLink -Path $linkPath -Target $targetExe -Force -ErrorAction Stop | Out-Null
-            $this.Log("codex.exe シンボリックリンクを作成しました: $linkPath -> $targetExe", "Green")
-        }
-        catch {
-            throw "codex.exe のシンボリックリンク作成に失敗しました。Windows の開発者モードを有効化するか、シンボリックリンク作成可能な権限で再実行してください: $($_.Exception.Message)"
+            return $this.CreateFailureResult("Codex 設定に失敗しました", $_.Exception)
         }
     }
 

--- a/scripts/powershell/handlers/Handler.Winget.ps1
+++ b/scripts/powershell/handlers/Handler.Winget.ps1
@@ -393,6 +393,12 @@ class WingetHandler : SetupHandlerBase {
                         continue
                     }
 
+                    if ($pkg.DirectInstaller -and $this.TestDirectInstallerCurrent($pkg)) {
+                        $succeeded++
+                        $this.Log("✓ $($pkg.Id) (direct installer は失敗扱いでしたが最新版検証済み)", "Green")
+                        continue
+                    }
+
                     $failed++
                     $this.LogWarning("✗ $($pkg.Id) のインストールに失敗しました")
                     continue
@@ -531,6 +537,54 @@ class WingetHandler : SetupHandlerBase {
         }
 
         return @()
+    }
+
+    hidden [bool] TestDirectInstallerCurrent([object]$pkg) {
+        $type = $this.GetDirectInstallerType($pkg.DirectInstaller)
+        switch ($type) {
+            "warpInnoLatest" {
+                return $this.TestWarpInstalledLatest($pkg.Id)
+            }
+            default {
+                return $false
+            }
+        }
+
+        return $false
+    }
+
+    hidden [bool] TestWarpInstalledLatest([string]$packageId) {
+        try {
+            $latestVersion = $this.GetWarpLatestVersion()
+            $installedVersion = $this.GetWingetInstalledPackageVersion($packageId)
+            return -not [string]::IsNullOrWhiteSpace($installedVersion) -and $installedVersion -eq $latestVersion
+        }
+        catch {
+            $this.LogWarning("Warp.Warp のインストール済みバージョン検証に失敗しました: $($_.Exception.Message)")
+            return $false
+        }
+    }
+
+    hidden [string] GetWingetInstalledPackageVersion([string]$packageId) {
+        $output = @(Invoke-Winget -Arguments @("list", "-e", "--id", $packageId, "--accept-source-agreements") -TimeoutSeconds 60)
+        if ($LASTEXITCODE -ne 0) {
+            return ""
+        }
+
+        foreach ($line in $output) {
+            $text = ([string]$line).Trim()
+            if ($text -notmatch [regex]::Escape($packageId)) {
+                continue
+            }
+
+            $tokens = @($text -split "\s+" | Where-Object { $_ })
+            $idIndex = [array]::IndexOf($tokens, $packageId)
+            if ($idIndex -ge 0 -and ($idIndex + 1) -lt $tokens.Count) {
+                return [string]$tokens[$idIndex + 1]
+            }
+        }
+
+        return ""
     }
 
     hidden [object[]] InvokeWarpInnoLatestInstaller([object]$pkg) {

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -197,6 +197,26 @@ Describe 'Package catalog consistency' {
         }
     }
 
+    Context 'Codex CLI package' {
+        It 'should define Codex portable link metadata in the SSOT before winget verification' {
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+
+            $sets | Should -Match '(?s)wingetPortableLinksById\s*=\s*\{.*?"OpenAI\.Codex"\s*=\s*\{.*?linkName\s*=\s*"codex\.exe".*?targetPattern\s*=\s*"codex-x86_64-pc-windows-msvc\.exe"'
+        }
+
+        It 'should generate Codex portable link metadata into winget packages.json' {
+            $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
+            $wingetSource = @($json.Sources | Where-Object { $_.SourceDetails.Name -eq 'winget' }) | Select-Object -First 1
+            $package = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'OpenAI.Codex' }) | Select-Object -First 1
+
+            $package | Should -Not -BeNullOrEmpty
+            $package.portableLink.linkName | Should -Be 'codex.exe'
+            $package.portableLink.targetPattern | Should -Be 'codex-x86_64-pc-windows-msvc.exe'
+            $package.verifyCommand.command | Should -Be 'codex'
+            @($package.verifyCommand.args) | Should -Contain '--version'
+        }
+    }
+
     Context 'Codex Desktop Microsoft Store package' {
         It 'should include Codex Desktop as a Windows-only Microsoft Store package in the SSOT' {
             $sets = Get-Content -LiteralPath $script:setsPath -Raw

--- a/scripts/powershell/tests/handlers/Handler.Codex.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Codex.Tests.ps1
@@ -116,7 +116,7 @@ Describe 'CodexHandler' {
         }
     }
 
-    Context 'CanApply - link is matching copy instead of symlink' {
+    Context 'CanApply - link is matching portable link instead of symlink' {
         BeforeEach {
             Set-CodexPackageInstalled
             Mock Test-Path {
@@ -124,7 +124,7 @@ Describe 'CodexHandler' {
                 if ($LiteralPath -like "*Links\codex.exe") { return $true }
                 return $false
             }
-            # 現行 exe と一致するコピーでも、winget upgrade 後に陳腐化する。
+            # 現行 exe と一致する hardlink/copy は、非昇格環境での fallback 結果として許可する。
             Mock Get-Item {
                 return [PSCustomObject]@{ LinkType = ""; Length = 246156592; LastWriteTimeUtc = [datetime]'2024-06-01' }
             }
@@ -132,9 +132,9 @@ Describe 'CodexHandler' {
             Mock Write-Host { }
         }
 
-        It 'should return true so the copy is replaced with a symlink' {
+        It 'should return false when the portable link and PATH are current' {
             $result = $handler.CanApply($ctx)
-            $result | Should -Be $true
+            $result | Should -Be $false
         }
     }
 
@@ -240,17 +240,26 @@ Describe 'CodexHandler' {
         }
     }
 
-    Context 'Apply - fails when symlink cannot be created' {
+    Context 'Apply - fallback to hardlink when symlink cannot be created' {
         BeforeEach {
             Set-CodexPackageInstalled
+            $script:newItemTypes = @()
             Mock Test-Path {
                 if ($Path -like "*codex-x86_64-pc-windows-msvc.exe") { return $true }
                 if ($Path -like "*Links") { return $true }
                 if ($LiteralPath -like "*Links\codex.exe") { return $false }
                 return $false
             }
-            Mock New-Item { throw "Administrator privilege required" } -ParameterFilter {
-                $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
+            Mock New-Item {
+                $script:newItemTypes += $ItemType
+                throw "Administrator privilege required"
+            } -ParameterFilter {
+                $ItemType -eq "SymbolicLink"
+            }
+            Mock New-Item {
+                $script:newItemTypes += $ItemType
+            } -ParameterFilter {
+                $ItemType -eq "HardLink"
             }
             Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
             Mock Remove-Item { }
@@ -260,12 +269,11 @@ Describe 'CodexHandler' {
             Mock Write-Host { }
         }
 
-        It 'should not fallback to hardlink or copy' {
+        It 'should fallback to hardlink and return success' {
             $result = $handler.Apply($ctx)
-            $result.Success | Should -Be $false
-            $result.Message | Should -Match "シンボリックリンク"
-            Should -Invoke New-Item -Times 1 -ParameterFilter { $ItemType -eq "SymbolicLink" }
-            Should -Invoke New-Item -Times 0 -ParameterFilter { $ItemType -eq "HardLink" }
+            $result.Success | Should -Be $true
+            $script:newItemTypes | Should -Contain "SymbolicLink"
+            $script:newItemTypes | Should -Contain "HardLink"
             Should -Invoke Copy-Item -Times 0
         }
     }
@@ -365,6 +373,32 @@ Describe 'CodexHandler' {
             Should -Invoke Set-UserEnvironmentPath -Times 1 -ParameterFilter { $Path -like "$script:expectedLocalBin*" }
             Should -Invoke Copy-Item -Times 0
             Should -Invoke New-Item -Times 0 -ParameterFilter { $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink" }
+        }
+    }
+
+    Context 'Apply - PATH update throws' {
+        BeforeEach {
+            Set-CodexPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*codex-x86_64-pc-windows-msvc.exe") { return $true }
+                if ($Path -like "*Links") { return $true }
+                if ($LiteralPath -like "*Links\codex.exe") { return $true }
+                return $false
+            }
+            Mock Get-Item {
+                return [PSCustomObject]@{ LinkType = "SymbolicLink"; Target = $script:codexExe }
+            } -ParameterFilter { $LiteralPath -like "*Links\codex.exe" }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
+            Mock Get-UserEnvironmentPath { return "C:\Windows" }
+            Mock Set-UserEnvironmentPath { throw [InvalidOperationException]::new("PATH write failed") }
+            Mock Write-Host { }
+        }
+
+        It 'should return a failure result instead of throwing an overload error' {
+            $result = $handler.Apply($ctx)
+            $result.Success | Should -Be $false
+            $result.Message | Should -Match "Codex 設定に失敗しました"
+            $result.Error | Should -Match "PATH write failed"
         }
     }
 }

--- a/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
@@ -1219,6 +1219,61 @@ Describe 'WingetHandler' {
             $script:installerArguments | Should -Contain "/VERYSILENT"
             $script:installerTimeoutSeconds | Should -Be 900
         }
+
+        It 'should treat a failed Warp direct installer as success when the latest version is already installed' {
+            Mock Invoke-Winget {
+                param($Arguments, $TimeoutSeconds)
+                if ($Arguments -contains "install") {
+                    $script:wingetInstallCalls++
+                    throw "winget install should not be used for Warp direct installer"
+                }
+                if ($Arguments -contains "show" -and $Arguments -contains "--versions") {
+                    $TimeoutSeconds | Should -Be 60
+                    $global:LASTEXITCODE = 0
+                    return @(
+                        "見つかりました Warp [Warp.Warp]",
+                        "バージョン",
+                        "-----------------------------",
+                        "v0.2026.06.03.09.49.stable_02",
+                        "v0.2026.06.03.09.49.stable_01"
+                    )
+                }
+                if ($Arguments -contains "list" -and $Arguments -contains "--id") {
+                    $global:LASTEXITCODE = 0
+                    return @(
+                        "名前 ID        バージョン                    ソース",
+                        "----------------------------------------------------",
+                        "Warp Warp.Warp v0.2026.06.03.09.49.stable_02 winget"
+                    )
+                }
+                if ($Arguments -contains "list") {
+                    $global:LASTEXITCODE = 0
+                    return @(
+                        "Name Id Version Source",
+                        "Warp Warp.Warp v0.2026.06.03.09.49.stable_02 winget"
+                    )
+                }
+
+                $global:LASTEXITCODE = 1
+                return @()
+            }
+            Mock Invoke-ExternalCommandWithTimeout {
+                param($Command, $Arguments, $TimeoutSeconds)
+                $script:installerCommand = $Command
+                $script:installerArguments = @($Arguments)
+                $script:installerTimeoutSeconds = $TimeoutSeconds
+                $global:LASTEXITCODE = 1
+                return "installer exited with code 1"
+            }
+
+            $ctx.Options["WingetMode"] = "import"
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $result.Message | Should -Match "1 個インストール"
+            $script:wingetInstallCalls | Should -Be 0
+            $script:installerCommand | Should -Be $script:downloadOutFile
+        }
     }
 
     Context 'Apply - import mode: package portableLink' {

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -331,6 +331,10 @@
         },
         {
           "PackageIdentifier": "OpenAI.Codex",
+          "portableLink": {
+            "linkName": "codex.exe",
+            "targetPattern": "codex-x86_64-pc-windows-msvc.exe"
+          },
           "verifyCommand": {
             "args": ["--version"],
             "command": "codex"


### PR DESCRIPTION
## Summary
- Allow Codex CLI shim creation to fall back from symlink to hardlink/copy in non-admin Windows user phase
- Generate the OpenAI.Codex portableLink metadata before winget verification
- Treat a failed Warp direct installer as success when winget confirms the latest version is already installed

## Verification
- pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\powershell\tests\Invoke-Tests.ps1 -Path .\scripts\powershell\tests\handlers\Handler.Codex.Tests.ps1 -MinimumCoverage 0
- pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\powershell\tests\Invoke-Tests.ps1 -Path .\scripts\powershell\tests\handlers\Handler.Winget.Tests.ps1 -MinimumCoverage 0
- pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\powershell\tests\Invoke-Tests.ps1 -Path .\scripts\powershell\tests\PackageCatalog.Tests.ps1 -MinimumCoverage 0
- git diff --check
- nix fmt -- --fail-on-change nix/packages/sets.nix