### PR TITLE
[codex] fix winget CLI command resolution

### DIFF
--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -730,8 +730,10 @@ lib.mapAttrs (_: names: resolve names) grouped
   # Extra PATH directories for installers that do not register CLI commands on PATH.
   # Entries may contain Windows environment variables and glob wildcards.
   wingetPathEntries = {
-    _1password-cli = [ "%LOCALAPPDATA%\\Microsoft\\WinGet\\Links" ];
-    "AgileBits.1Password.CLI" = [ "%LOCALAPPDATA%\\Microsoft\\WinGet\\Links" ];
+    _1password-cli = [ "%LOCALAPPDATA%\\Microsoft\\WinGet\\Packages\\AgileBits.1Password.CLI*" ];
+    "AgileBits.1Password.CLI" = [
+      "%LOCALAPPDATA%\\Microsoft\\WinGet\\Packages\\AgileBits.1Password.CLI*"
+    ];
     google-cloud-sdk = [
       "%ProgramFiles%\\Google\\Cloud SDK\\google-cloud-sdk\\bin"
       "%ProgramFiles(x86)%\\Google\\Cloud SDK\\google-cloud-sdk\\bin"
@@ -746,14 +748,6 @@ lib.mapAttrs (_: names: resolve names) grouped
 
   # Portable winget packages whose package exe name does not match the command name.
   wingetPortableLinksById = {
-    _1password-cli = {
-      linkName = "op.exe";
-      targetPattern = "op.exe";
-    };
-    "AgileBits.1Password.CLI" = {
-      linkName = "op.exe";
-      targetPattern = "op.exe";
-    };
     "OpenAI.Codex" = {
       linkName = "codex.exe";
       targetPattern = "codex-x86_64-pc-windows-msvc.exe";

--- a/scripts/powershell/handlers/Handler.Bun.ps1
+++ b/scripts/powershell/handlers/Handler.Bun.ps1
@@ -5,8 +5,8 @@
 .DESCRIPTION
     winget の Oven-sh.Bun パッケージは portable archive 形式で、
     実行ファイルが bun-windows-x64\bun.exe というサブディレクトリに配置される。
-    winget は自動で PATH も Links shim も作らないため、このハンドラーで
-    WinGet\Links に bun.exe シンボリックリンクを作成し、Links を USER PATH に追加する。
+    実行ファイル名は bun.exe のままなので、shim は作らず実体ディレクトリを
+    USER PATH に追加する。
 
 .NOTES
     Order = 8 (Codex の後、Docker の前)
@@ -18,7 +18,7 @@ $libPath = Split-Path -Parent $PSScriptRoot
 class BunHandler : SetupHandlerBase {
     BunHandler() {
         $this.Name = "Bun"
-        $this.Description = "Bun シンボリックリンク作成"
+        $this.Description = "Bun PATH 設定"
         $this.Order = 8
         $this.RequiresAdmin = $false
         $this.Phase = 1
@@ -31,13 +31,11 @@ class BunHandler : SetupHandlerBase {
             return $false
         }
 
-        $linksPath = $this.GetLinksPath()
-        $linkPath = Join-Path $linksPath "bun.exe"
+        $bunBinDir = Split-Path -Parent $bunExe
+        $linkPath = Join-Path $this.GetLinksPath() "bun.exe"
 
-        # リンクが最新でも Links パスが USER PATH に無い場合は適用する。
-        # (winget upgrade 後の陳腐化, 手動 shim, 過去の部分実行, copy フォールバック後を想定。)
-        if ($this.IsPortableLinkCurrent($linkPath, $bunExe) -and $this.IsLinksInUserPath($linksPath)) {
-            $this.Log("bun.exe リンクと PATH 設定は既に完了しています", "Gray")
+        if ($this.IsPathInUserPath($bunBinDir) -and -not (Test-Path -LiteralPath $linkPath)) {
+            $this.Log("Bun 実体 PATH は既に設定されています", "Gray")
             return $false
         }
 
@@ -51,36 +49,13 @@ class BunHandler : SetupHandlerBase {
                 return $this.CreateFailureResult("Bun 実行ファイルが見つかりません")
             }
 
-            $linksPath = $this.GetLinksPath()
-            if (-not (Test-Path $linksPath)) {
-                New-Item -ItemType Directory -Path $linksPath -Force | Out-Null
-            }
+            $this.RemoveLegacyShim((Join-Path $this.GetLinksPath() "bun.exe"))
+            $this.EnsureUserPathEntry((Split-Path -Parent $bunExe), "Bun executable directory")
 
-            $linkPath = Join-Path $linksPath "bun.exe"
-
-            # リンクが陳腐化している（旧バージョンを指すコピー等）場合のみ貼り直す。
-            # winget upgrade 後に Links\bun.exe が旧バージョンを指す問題への対処。
-            if (-not $this.IsPortableLinkCurrent($linkPath, $bunExe)) {
-                $this.CreatePortableLink($linkPath, $bunExe)
-            }
-            else {
-                $this.Log("bun.exe リンクは最新です", "Gray")
-            }
-
-            # PATH は常に冪等チェック。リンクが既存でも PATH 未設定なら追加する。
-            if (-not $this.IsLinksInUserPath($linksPath)) {
-                $this.Log("PATH に Links フォルダを追加しています...")
-                $userPath = Get-UserEnvironmentPath
-                $newPath = if ($userPath) { "$userPath;$linksPath" } else { $linksPath }
-                Set-UserEnvironmentPath -Path $newPath
-                $env:Path = "$env:Path;$linksPath"
-                $this.Log("PATH を更新しました", "Green")
-            }
-
-            return $this.CreateSuccessResult("bun.exe リンクと PATH を設定しました")
+            return $this.CreateSuccessResult("Bun PATH を設定しました")
         }
         catch {
-            return $this.CreateFailureResult("Bun 設定に失敗しました", $_)
+            return $this.CreateFailureResult("Bun 設定に失敗しました", $_.Exception)
         }
     }
 
@@ -105,9 +80,48 @@ class BunHandler : SetupHandlerBase {
         return Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
     }
 
-    hidden [bool] IsLinksInUserPath([string]$linksPath) {
+    hidden [void] RemoveLegacyShim([string]$linkPath) {
+        if (Test-Path -LiteralPath $linkPath) {
+            Remove-Item -LiteralPath $linkPath -Force
+            $this.Log("旧 bun.exe shim を削除しました: $linkPath", "Green")
+        }
+    }
+
+    hidden [bool] IsPathInUserPath([string]$targetPath) {
         $userPath = Get-UserEnvironmentPath
         if (-not $userPath) { return $false }
-        return $userPath -like "*$linksPath*"
+        $normalizedTarget = $this.NormalizePathForComparison($targetPath)
+        foreach ($item in @($userPath -split ";" | Where-Object { $_ })) {
+            if ($this.NormalizePathForComparison($item) -eq $normalizedTarget) {
+                return $true
+            }
+        }
+        return $false
+    }
+
+    hidden [void] EnsureUserPathEntry([string]$targetPath, [string]$label) {
+        if ($this.IsPathInUserPath($targetPath)) {
+            $this.Log("$label は既に USER PATH に含まれています", "Gray")
+        }
+        else {
+            $userPath = Get-UserEnvironmentPath
+            $userItems = if ($userPath) { @($userPath -split ";" | Where-Object { $_ }) } else { @() }
+            Set-UserEnvironmentPath -Path (($userItems + @($targetPath)) -join ";")
+            $this.Log("USER PATH に $label を追加しました: $targetPath", "Green")
+        }
+
+        $processItems = if ($env:PATH) { @($env:PATH -split ";" | Where-Object { $_ }) } else { @() }
+        foreach ($item in $processItems) {
+            if ($this.NormalizePathForComparison($item) -eq $this.NormalizePathForComparison($targetPath)) {
+                return
+            }
+        }
+        $env:PATH = if ($env:PATH) { "$env:PATH;$targetPath" } else { $targetPath }
+    }
+
+    hidden [string] NormalizePathForComparison([string]$path) {
+        if (-not $path) { return "" }
+        $trimChars = [char[]]@([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+        return $path.Trim('"').TrimEnd($trimChars).ToLowerInvariant()
     }
 }

--- a/scripts/powershell/handlers/Handler.Codex.ps1
+++ b/scripts/powershell/handlers/Handler.Codex.ps1
@@ -77,7 +77,7 @@ class CodexHandler : SetupHandlerBase {
             $linkPath = Join-Path $linksPath "codex.exe"
 
             # リンクが陳腐化している（旧バージョンを指すコピー等）場合のみ貼り直す。
-            # 非昇格環境では symlink が失敗するため、共通 portable shim fallback を使う。
+            # 既存リンクは、現行 exe への symlink 作成に成功してから置き換える。
             if (-not $this.IsPortableLinkCurrent($linkPath, $codexExe)) {
                 $this.CreatePortableLink($linkPath, $codexExe)
             }

--- a/scripts/powershell/handlers/Handler.OnePasswordCli.ps1
+++ b/scripts/powershell/handlers/Handler.OnePasswordCli.ps1
@@ -1,11 +1,11 @@
 <#
 .SYNOPSIS
-    1Password CLI の host-side shim 設定ハンドラー
+    1Password CLI の host-side PATH 設定ハンドラー
 
 .DESCRIPTION
     VS Code Dev Containers の initializeCommand は Windows 側の cmd.exe から
-    `op` を解決する。起動済み Code.exe は PATH 更新を拾わないため、既定で
-    PATH に入りやすい WindowsApps と WinGet Links に op.exe shim を作成する。
+    `op` を解決する。op.exe は winget パッケージ内の実体名とコマンド名が
+    一致しているため、shim は作らず実体ディレクトリを USER PATH に追加する。
 
 .NOTES
     Order = 9 (Winget/Codex/Bun の後、Chezmoi の前)
@@ -17,7 +17,7 @@ $libPath = Split-Path -Parent $PSScriptRoot
 class OnePasswordCliHandler : SetupHandlerBase {
     OnePasswordCliHandler() {
         $this.Name = "OnePasswordCli"
-        $this.Description = "1Password CLI op.exe shim 作成"
+        $this.Description = "1Password CLI PATH 設定"
         $this.Order = 9
         $this.RequiresAdmin = $false
         $this.Phase = 1
@@ -30,18 +30,16 @@ class OnePasswordCliHandler : SetupHandlerBase {
             return $false
         }
 
-        $windowsApps = $this.GetWindowsAppsPath()
-        $linksPath = $this.GetLinksPath()
-        $windowsAppsShim = Join-Path $windowsApps "op.exe"
-        $linksShim = Join-Path $linksPath "op.exe"
+        $packageDir = Split-Path -Parent $opExe
+        $windowsAppsShim = Join-Path $this.GetWindowsAppsPath() "op.exe"
+        $linksShim = Join-Path $this.GetLinksPath() "op.exe"
 
         if (
-            $this.IsPortableLinkCurrent($windowsAppsShim, $opExe) -and
-            $this.IsPortableLinkCurrent($linksShim, $opExe) -and
-            $this.IsPathInUserPath($windowsApps) -and
-            $this.IsPathInUserPath($linksPath)
+            $this.IsPathInUserPath($packageDir) -and
+            -not (Test-Path -LiteralPath $windowsAppsShim) -and
+            -not (Test-Path -LiteralPath $linksShim)
         ) {
-            $this.Log("op.exe shim と PATH 設定は既に完了しています", "Gray")
+            $this.Log("1Password CLI 実体 PATH は既に設定されています", "Gray")
             return $false
         }
 
@@ -55,36 +53,21 @@ class OnePasswordCliHandler : SetupHandlerBase {
                 return $this.CreateFailureResult("1Password CLI 実行ファイルが見つかりません")
             }
 
-            $windowsApps = $this.GetWindowsAppsPath()
-            $linksPath = $this.GetLinksPath()
-            $this.EnsureDirectory($windowsApps)
-            $this.EnsureDirectory($linksPath)
+            $this.RemoveLegacyShim((Join-Path $this.GetWindowsAppsPath() "op.exe"))
+            $this.RemoveLegacyShim((Join-Path $this.GetLinksPath() "op.exe"))
+            $this.EnsureUserPathEntry((Split-Path -Parent $opExe), "1Password CLI package directory")
 
-            $this.EnsureShimCurrent((Join-Path $windowsApps "op.exe"), $opExe)
-            $this.EnsureShimCurrent((Join-Path $linksPath "op.exe"), $opExe)
-
-            $this.EnsureUserPathEntry($windowsApps, "WindowsApps")
-            $this.EnsureUserPathEntry($linksPath, "WinGet Links")
-
-            return $this.CreateSuccessResult("op.exe shim と PATH を設定しました")
+            return $this.CreateSuccessResult("1Password CLI PATH を設定しました")
         }
         catch {
-            return $this.CreateFailureResult("1Password CLI shim 設定に失敗しました", $_)
+            return $this.CreateFailureResult("1Password CLI PATH 設定に失敗しました", $_.Exception)
         }
     }
 
-    hidden [void] EnsureShimCurrent([string]$linkPath, [string]$targetExe) {
-        if (-not $this.IsPortableLinkCurrent($linkPath, $targetExe)) {
-            $this.CreatePortableLink($linkPath, $targetExe)
-        }
-        else {
-            $this.Log("op.exe shim は最新です: $linkPath", "Gray")
-        }
-    }
-
-    hidden [void] EnsureDirectory([string]$path) {
-        if (-not (Test-Path -LiteralPath $path -PathType Container)) {
-            New-Item -ItemType Directory -Path $path -Force | Out-Null
+    hidden [void] RemoveLegacyShim([string]$linkPath) {
+        if (Test-Path -LiteralPath $linkPath) {
+            Remove-Item -LiteralPath $linkPath -Force
+            $this.Log("旧 op.exe shim を削除しました: $linkPath", "Green")
         }
     }
 

--- a/scripts/powershell/handlers/Handler.OnePasswordCli.ps1
+++ b/scripts/powershell/handlers/Handler.OnePasswordCli.ps1
@@ -5,7 +5,9 @@
 .DESCRIPTION
     VS Code Dev Containers の initializeCommand は Windows 側の cmd.exe から
     `op` を解決する。op.exe は winget パッケージ内の実体名とコマンド名が
-    一致しているため、shim は作らず実体ディレクトリを USER PATH に追加する。
+    一致しているため、実体ディレクトリを USER PATH に追加する。
+    既に起動している VS Code が古い PATH を保持している場合に備えて、
+    既存 PATH 上の shim は現行 exe へのシンボリックリンクとして維持する。
 
 .NOTES
     Order = 9 (Winget/Codex/Bun の後、Chezmoi の前)
@@ -31,19 +33,33 @@ class OnePasswordCliHandler : SetupHandlerBase {
         }
 
         $packageDir = Split-Path -Parent $opExe
-        $windowsAppsShim = Join-Path $this.GetWindowsAppsPath() "op.exe"
-        $linksShim = Join-Path $this.GetLinksPath() "op.exe"
-
-        if (
-            $this.IsPathInUserPath($packageDir) -and
-            -not (Test-Path -LiteralPath $windowsAppsShim) -and
-            -not (Test-Path -LiteralPath $linksShim)
-        ) {
-            $this.Log("1Password CLI 実体 PATH は既に設定されています", "Gray")
-            return $false
+        if (-not $this.IsPathFirstInUserPath($packageDir)) {
+            return $true
         }
 
-        return $true
+        $compatibilityShims = @(
+            @{
+                Directory = $this.GetWindowsAppsPath()
+                LinkPath  = Join-Path $this.GetWindowsAppsPath() "op.exe"
+            },
+            @{
+                Directory = $this.GetLinksPath()
+                LinkPath  = Join-Path $this.GetLinksPath() "op.exe"
+            }
+        )
+
+        foreach ($shim in $compatibilityShims) {
+            if (
+                $this.NeedsCompatibilityShim($shim.Directory, $shim.LinkPath) -and
+                -not $this.IsPortableLinkCurrent($shim.LinkPath, $opExe)
+            ) {
+                return $true
+            }
+        }
+
+        $this.Log("1Password CLI PATH と互換 shim は既に設定されています", "Gray")
+
+        return $false
     }
 
     [SetupResult] Apply([SetupContext]$ctx) {
@@ -53,9 +69,10 @@ class OnePasswordCliHandler : SetupHandlerBase {
                 return $this.CreateFailureResult("1Password CLI 実行ファイルが見つかりません")
             }
 
-            $this.RemoveLegacyShim((Join-Path $this.GetWindowsAppsPath() "op.exe"))
-            $this.RemoveLegacyShim((Join-Path $this.GetLinksPath() "op.exe"))
-            $this.EnsureUserPathEntry((Split-Path -Parent $opExe), "1Password CLI package directory")
+            $packageDir = Split-Path -Parent $opExe
+            $this.EnsureUserPathEntry($packageDir, "1Password CLI package directory")
+            $this.EnsureCompatibilityShim($this.GetWindowsAppsPath(), "op.exe", $opExe, "WindowsApps")
+            $this.EnsureCompatibilityShim($this.GetLinksPath(), "op.exe", $opExe, "WinGet Links")
 
             return $this.CreateSuccessResult("1Password CLI PATH を設定しました")
         }
@@ -64,11 +81,32 @@ class OnePasswordCliHandler : SetupHandlerBase {
         }
     }
 
-    hidden [void] RemoveLegacyShim([string]$linkPath) {
-        if (Test-Path -LiteralPath $linkPath) {
-            Remove-Item -LiteralPath $linkPath -Force
-            $this.Log("旧 op.exe shim を削除しました: $linkPath", "Green")
+    hidden [void] EnsureCompatibilityShim([string]$directory, [string]$linkName, [string]$targetExe, [string]$label) {
+        $linkPath = Join-Path $directory $linkName
+        if (-not $this.NeedsCompatibilityShim($directory, $linkPath)) {
+            $this.Log("$label は現在の PATH に無いため互換 shim を作成しません", "Gray")
+            return
         }
+
+        if (-not (Test-Path -LiteralPath $directory)) {
+            New-Item -ItemType Directory -Path $directory -Force | Out-Null
+        }
+
+        if ($this.IsPortableLinkCurrent($linkPath, $targetExe)) {
+            $this.Log("$label の op.exe shim は最新です", "Gray")
+            return
+        }
+
+        $this.CreatePortableLink($linkPath, $targetExe)
+        $this.Log("$label の op.exe shim を現行 exe への symlink に更新しました", "Green")
+    }
+
+    hidden [bool] NeedsCompatibilityShim([string]$directory, [string]$linkPath) {
+        return (
+            $this.IsPathInUserPath($directory) -or
+            $this.IsPathInProcessPath($directory) -or
+            (Test-Path -LiteralPath $linkPath)
+        )
     }
 
     hidden [string] GetOnePasswordCliExecutablePath() {
@@ -113,39 +151,59 @@ class OnePasswordCliHandler : SetupHandlerBase {
         return [Environment]::GetFolderPath("UserProfile")
     }
 
-    hidden [bool] IsPathInUserPath([string]$targetPath) {
+    hidden [bool] IsPathFirstInUserPath([string]$targetPath) {
         $userPath = Get-UserEnvironmentPath
-        if (-not $userPath) { return $false }
+        $userItems = if ($userPath) { @($userPath -split ";" | Where-Object { $_ }) } else { @() }
+        if ($userItems.Count -eq 0) { return $false }
+
+        return $this.NormalizePathForComparison($userItems[0]) -eq $this.NormalizePathForComparison($targetPath)
+    }
+
+    hidden [bool] IsPathInUserPath([string]$targetPath) {
+        return $this.IsPathInPathList((Get-UserEnvironmentPath), $targetPath)
+    }
+
+    hidden [bool] IsPathInProcessPath([string]$targetPath) {
+        return $this.IsPathInPathList($env:PATH, $targetPath)
+    }
+
+    hidden [void] EnsureUserPathEntry([string]$targetPath, [string]$label) {
+        $normalizedTarget = $this.NormalizePathForComparison($targetPath)
+        $userPath = Get-UserEnvironmentPath
+        $userItems = if ($userPath) { @($userPath -split ";" | Where-Object { $_ }) } else { @() }
+        $filteredUserItems = @($userItems | Where-Object {
+                $this.NormalizePathForComparison($_) -ne $normalizedTarget
+            })
+
+        if ($userItems.Count -gt 0 -and $this.NormalizePathForComparison($userItems[0]) -eq $normalizedTarget) {
+            $this.Log("$label は既に USER PATH の先頭にあります", "Gray")
+        }
+        else {
+            Set-UserEnvironmentPath -Path ((@($targetPath) + $filteredUserItems) -join ";")
+            $this.Log("USER PATH の先頭に $label を設定しました: $targetPath", "Green")
+        }
+
+        $processItems = if ($env:PATH) { @($env:PATH -split ";" | Where-Object { $_ }) } else { @() }
+        if ($processItems.Count -gt 0 -and $this.NormalizePathForComparison($processItems[0]) -eq $normalizedTarget) {
+            return
+        }
+
+        $filteredProcessItems = @($processItems | Where-Object {
+                $this.NormalizePathForComparison($_) -ne $normalizedTarget
+            })
+        $env:PATH = ((@($targetPath) + $filteredProcessItems) -join ";")
+    }
+
+    hidden [bool] IsPathInPathList([string]$pathList, [string]$targetPath) {
+        if (-not $pathList) { return $false }
 
         $normalizedTarget = $this.NormalizePathForComparison($targetPath)
-        foreach ($item in @($userPath -split ";" | Where-Object { $_ })) {
+        foreach ($item in @($pathList -split ";" | Where-Object { $_ })) {
             if ($this.NormalizePathForComparison($item) -eq $normalizedTarget) {
                 return $true
             }
         }
         return $false
-    }
-
-    hidden [void] EnsureUserPathEntry([string]$targetPath, [string]$label) {
-        if ($this.IsPathInUserPath($targetPath)) {
-            $this.Log("$label は既に USER PATH に含まれています", "Gray")
-        }
-        else {
-            $userPath = Get-UserEnvironmentPath
-            $userItems = if ($userPath) { @($userPath -split ";" | Where-Object { $_ }) } else { @() }
-            Set-UserEnvironmentPath -Path (($userItems + @($targetPath)) -join ";")
-            $this.Log("USER PATH に $label を追加しました: $targetPath", "Green")
-        }
-
-        $normalizedTarget = $this.NormalizePathForComparison($targetPath)
-        $processItems = if ($env:PATH) { @($env:PATH -split ";" | Where-Object { $_ }) } else { @() }
-        foreach ($item in $processItems) {
-            if ($this.NormalizePathForComparison($item) -eq $normalizedTarget) {
-                return
-            }
-        }
-
-        $env:PATH = if ($env:PATH) { "$env:PATH;$targetPath" } else { $targetPath }
     }
 
     hidden [string] NormalizePathForComparison([string]$path) {

--- a/scripts/powershell/lib/SetupHandler.ps1
+++ b/scripts/powershell/lib/SetupHandler.ps1
@@ -271,13 +271,10 @@ class SetupHandlerBase {
     .SYNOPSIS
         WinGet\Links 配下の shim が現行 exe を指しているか判定する
     .DESCRIPTION
-        winget portable パッケージは安定したパッケージディレクトリ内で in-place 更新される。
-        Links\<name>.exe がシンボリックリンクなら更新を自動追従するが、
-        シンボリックリンク作成に失敗してハードリンク/コピーへフォールバックしていると、
-        winget upgrade 後も旧バージョンの実体を指したまま陳腐化する。
-        - シンボリックリンク: ターゲットが現行 exe と一致すれば最新
-        - ハードリンク/コピー: サイズと更新日時を現行 exe と比較して同一性を判定
-        ダングリング（ターゲット消失）や未作成は最新ではないとみなす。
+        Links\<name>.exe はシンボリックリンクだけを有効な portable link とみなす。
+        ハードリンク/コピーは winget upgrade 後に旧バージョンの実体を保持し得るため、
+        常に陳腐化として扱い、次回 Apply でシンボリックリンクへ置き換える。
+        ダングリング（ターゲット消失）や未作成も最新ではないとみなす。
     .PARAMETER linkPath
         Links 配下の shim パス
     .PARAMETER targetExe
@@ -293,19 +290,15 @@ class SetupHandlerBase {
             return (@($link.Target)[0]) -eq $targetExe
         }
 
-        # ハードリンク/コピーは内容で比較する。
-        # winget の更新でサイズと更新日時の双方が変わるため陳腐化を検出できる。
-        $src = Get-Item -LiteralPath $targetExe -Force
-        return ($link.Length -eq $src.Length) -and ($link.LastWriteTimeUtc -eq $src.LastWriteTimeUtc)
+        return $false
     }
 
     <#
     .SYNOPSIS
-        WinGet\Links 配下に shim を作成する（symlink→hardlink→copy フォールバック）
+        WinGet\Links 配下にシンボリックリンク shim を作成する
     .DESCRIPTION
-        Windows ではシンボリックリンク作成に管理者権限または開発者モードが必要なため、
-        失敗時はハードリンク、それも失敗ならコピーへフォールバックする。
-        既存 shim は事前に削除し、確実に現行 exe へ貼り直す。
+        既存 shim は事前に削除し、現行 exe へのシンボリックリンクへ貼り直す。
+        ハードリンク/コピーは winget upgrade に追従しないため使用しない。
     .PARAMETER linkPath
         作成する shim パス
     .PARAMETER targetExe
@@ -317,27 +310,8 @@ class SetupHandlerBase {
         }
 
         $this.Log("シンボリックリンクを作成しています: $linkPath -> $targetExe")
-
-        try {
-            New-Item -ItemType SymbolicLink -Path $linkPath -Target $targetExe -Force -ErrorAction Stop | Out-Null
-            $this.Log("シンボリックリンクを作成しました", "Green")
-            return
-        }
-        catch {
-            $this.LogWarning("シンボリックリンク作成失敗: $($_.Exception.Message)")
-        }
-
-        try {
-            New-Item -ItemType HardLink -Path $linkPath -Target $targetExe -Force -ErrorAction Stop | Out-Null
-            $this.Log("ハードリンクを作成しました", "Green")
-            return
-        }
-        catch {
-            $this.LogWarning("ハードリンク作成失敗: $($_.Exception.Message)")
-        }
-
-        Copy-Item -Path $targetExe -Destination $linkPath -Force
-        $this.Log("ファイルをコピーしました", "Green")
+        New-Item -ItemType SymbolicLink -Path $linkPath -Target $targetExe -Force -ErrorAction Stop | Out-Null
+        $this.Log("シンボリックリンクを作成しました", "Green")
     }
 
     <#

--- a/scripts/powershell/lib/SetupHandler.ps1
+++ b/scripts/powershell/lib/SetupHandler.ps1
@@ -297,7 +297,7 @@ class SetupHandlerBase {
     .SYNOPSIS
         WinGet\Links 配下にシンボリックリンク shim を作成する
     .DESCRIPTION
-        既存 shim は事前に削除し、現行 exe へのシンボリックリンクへ貼り直す。
+        既存 shim は一時シンボリックリンクの作成成功後に置き換える。
         ハードリンク/コピーは winget upgrade に追従しないため使用しない。
     .PARAMETER linkPath
         作成する shim パス
@@ -305,13 +305,38 @@ class SetupHandlerBase {
         リンク先の実行ファイル
     #>
     [void] CreatePortableLink([string]$linkPath, [string]$targetExe) {
-        if (Test-Path -LiteralPath $linkPath) {
-            Remove-Item -LiteralPath $linkPath -Force
+        if (-not (Test-Path -LiteralPath $linkPath)) {
+            $this.Log("シンボリックリンクを作成しています: $linkPath -> $targetExe")
+            New-Item -ItemType SymbolicLink -Path $linkPath -Target $targetExe -Force -ErrorAction Stop | Out-Null
+            $this.Log("シンボリックリンクを作成しました", "Green")
+            return
         }
 
-        $this.Log("シンボリックリンクを作成しています: $linkPath -> $targetExe")
-        New-Item -ItemType SymbolicLink -Path $linkPath -Target $targetExe -Force -ErrorAction Stop | Out-Null
-        $this.Log("シンボリックリンクを作成しました", "Green")
+        $parentDir = Split-Path -Parent $linkPath
+        $linkName = Split-Path -Leaf $linkPath
+        $suffix = [System.Guid]::NewGuid().ToString("N")
+        $tempLinkPath = Join-Path $parentDir ".$linkName.$suffix.tmp"
+        $backupPath = Join-Path $parentDir ".$linkName.$suffix.backup"
+        $oldMoved = $false
+
+        try {
+            $this.Log("シンボリックリンクを作成しています: $linkPath -> $targetExe")
+            New-Item -ItemType SymbolicLink -Path $tempLinkPath -Target $targetExe -Force -ErrorAction Stop | Out-Null
+            Move-Item -LiteralPath $linkPath -Destination $backupPath -Force -ErrorAction Stop
+            $oldMoved = $true
+            Move-Item -LiteralPath $tempLinkPath -Destination $linkPath -Force -ErrorAction Stop
+            Remove-Item -LiteralPath $backupPath -Force -ErrorAction SilentlyContinue
+            $this.Log("シンボリックリンクを作成しました", "Green")
+        }
+        catch {
+            if ($oldMoved -and -not (Test-Path -LiteralPath $linkPath) -and (Test-Path -LiteralPath $backupPath)) {
+                Move-Item -LiteralPath $backupPath -Destination $linkPath -Force -ErrorAction SilentlyContinue
+            }
+            if (Test-Path -LiteralPath $tempLinkPath) {
+                Remove-Item -LiteralPath $tempLinkPath -Force -ErrorAction SilentlyContinue
+            }
+            throw
+        }
     }
 
     <#

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -176,22 +176,21 @@ Describe 'Package catalog consistency' {
     }
 
     Context '1Password CLI package' {
-        It 'should define op shim metadata in the SSOT before winget verification' {
+        It 'should define the real op package directory in the SSOT before winget verification' {
             $sets = Get-Content -LiteralPath $script:setsPath -Raw
 
-            $sets | Should -Match '(?s)wingetPathEntries\s*=\s*\{.*?_1password-cli\s*=\s*\[.*?%LOCALAPPDATA%\\\\Microsoft\\\\WinGet\\\\Links'
-            $sets | Should -Match '(?s)wingetPortableLinksById\s*=\s*\{.*?_1password-cli\s*=\s*\{.*?linkName\s*=\s*"op\.exe".*?targetPattern\s*=\s*"op\.exe"'
+            $sets | Should -Match '(?s)wingetPathEntries\s*=\s*\{.*?_1password-cli\s*=\s*\[.*?%LOCALAPPDATA%\\\\Microsoft\\\\WinGet\\\\Packages\\\\AgileBits\.1Password\.CLI\*'
+            $sets | Should -Not -Match '(?s)wingetPortableLinksById\s*=\s*\{.*?_1password-cli\s*=\s*\{.*?linkName\s*=\s*"op\.exe"'
         }
 
-        It 'should generate op portable link metadata into winget packages.json' {
+        It 'should generate op package path metadata into winget packages.json' {
             $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
             $wingetSource = @($json.Sources | Where-Object { $_.SourceDetails.Name -eq 'winget' }) | Select-Object -First 1
             $package = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'AgileBits.1Password.CLI' }) | Select-Object -First 1
 
             $package | Should -Not -BeNullOrEmpty
-            @($package.pathEntries) | Should -Contain '%LOCALAPPDATA%\Microsoft\WinGet\Links'
-            $package.portableLink.linkName | Should -Be 'op.exe'
-            $package.portableLink.targetPattern | Should -Be 'op.exe'
+            @($package.pathEntries) | Should -Contain '%LOCALAPPDATA%\Microsoft\WinGet\Packages\AgileBits.1Password.CLI*'
+            $package.PSObject.Properties.Name | Should -Not -Contain 'portableLink'
             $package.verifyCommand.command | Should -Be 'op'
             @($package.verifyCommand.args) | Should -Contain '--version'
         }

--- a/scripts/powershell/tests/handlers/Handler.Bun.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Bun.Tests.ps1
@@ -63,29 +63,26 @@ Describe 'BunHandler' {
         }
     }
 
-    Context 'CanApply - link is current AND PATH already configured' {
+    Context 'CanApply - executable directory PATH already configured' {
         BeforeEach {
             Set-BunPackageInstalled
             Mock Test-Path {
                 if ($Path -like "*bun-windows-x64\bun.exe") { return $true }
-                if ($LiteralPath -like "*Links\bun.exe") { return $true }
+                if ($LiteralPath -like "*Links\bun.exe") { return $false }
                 return $false
             }
-            Mock Get-Item {
-                return [PSCustomObject]@{ LinkType = "SymbolicLink"; Target = $script:bunExe }
-            } -ParameterFilter { $LiteralPath -like "*Links\bun.exe" }
-            $script:expectedLinks = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
-            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedLinks" }
+            $script:bunBinDir = Split-Path -Parent $script:bunExe
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:bunBinDir" }
             Mock Write-Host { }
         }
 
-        It 'should return false when both link and PATH are set' {
+        It 'should return false without requiring a WinGet Links shim' {
             $result = $handler.CanApply($ctx)
             $result | Should -Be $false
         }
     }
 
-    Context 'CanApply - link is stale copy from old version (winget upgrade)' {
+    Context 'CanApply - legacy shim is stale copy from old version (winget upgrade)' {
         BeforeEach {
             Set-BunPackageInstalled
             Mock Test-Path {
@@ -104,13 +101,13 @@ Describe 'BunHandler' {
             Mock Write-Host { }
         }
 
-        It 'should return true so the stale link is refreshed' {
+        It 'should return true so the stale shim is removed' {
             $result = $handler.CanApply($ctx)
             $result | Should -Be $true
         }
     }
 
-    Context 'CanApply - link is current but PATH not configured' {
+    Context 'CanApply - legacy shim exists but PATH not configured' {
         BeforeEach {
             Set-BunPackageInstalled
             Mock Test-Path {
@@ -125,7 +122,7 @@ Describe 'BunHandler' {
             Mock Write-Host { }
         }
 
-        It 'should return true so Apply can add PATH' {
+        It 'should return true so Apply can remove the shim and add PATH' {
             $result = $handler.CanApply($ctx)
             $result | Should -Be $true
         }
@@ -149,6 +146,25 @@ Describe 'BunHandler' {
         }
     }
 
+    Context 'CanApply - Bun executable directory is already on PATH' {
+        BeforeEach {
+            Set-BunPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*bun-windows-x64\bun.exe") { return $true }
+                if ($LiteralPath -like "*Links\bun.exe") { return $false }
+                return $false
+            }
+            $script:bunBinDir = Split-Path -Parent $script:bunExe
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:bunBinDir" }
+            Mock Write-Host { }
+        }
+
+        It 'should return false without requiring a WinGet Links shim' {
+            $result = $handler.CanApply($ctx)
+            $result | Should -Be $false
+        }
+    }
+
     Context 'Apply - executable not found' {
         BeforeEach {
             Mock Get-ChildItem { return $null } -ParameterFilter {
@@ -165,35 +181,40 @@ Describe 'BunHandler' {
         }
     }
 
-    Context 'Apply - creates link when missing' {
+    Context 'Apply - adds executable directory when PATH is missing' {
         BeforeEach {
             Set-BunPackageInstalled
+            $script:bunBinDir = Split-Path -Parent $script:bunExe
             Mock Test-Path {
                 if ($Path -like "*bun-windows-x64\bun.exe") { return $true }
                 if ($Path -like "*Links") { return $true }
                 if ($LiteralPath -like "*Links\bun.exe") { return $false }
                 return $false
             }
-            Mock New-Item { } -ParameterFilter { $ItemType -eq "SymbolicLink" }
-            Mock New-Item { } -ParameterFilter { $ItemType -eq "HardLink" }
+            Mock New-Item { throw "Bun should not create shims" } -ParameterFilter {
+                $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
+            }
             Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
             Mock Remove-Item { }
-            Mock Copy-Item { }
+            Mock Copy-Item { throw "Bun should not copy shims" }
             Mock Get-UserEnvironmentPath { return "C:\Windows" }
             Mock Set-UserEnvironmentPath { }
             Mock Write-Host { }
         }
 
-        It 'should create symlink and return success' {
+        It 'should add bun-windows-x64 to PATH without creating a shim' {
             $result = $handler.Apply($ctx)
             $result.Success | Should -Be $true
-            Should -Invoke New-Item -Times 1 -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Should -Invoke Set-UserEnvironmentPath -Times 1 -ParameterFilter { $Path -like "*$script:bunBinDir*" }
+            Should -Invoke New-Item -Times 0 -ParameterFilter { $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink" }
+            Should -Invoke Copy-Item -Times 0
         }
     }
 
-    Context 'Apply - fallback to copy when symlink fails' {
+    Context 'Apply - no copy fallback when PATH is missing' {
         BeforeEach {
             Set-BunPackageInstalled
+            $script:bunBinDir = Split-Path -Parent $script:bunExe
             Mock Test-Path {
                 if ($Path -like "*bun-windows-x64\bun.exe") { return $true }
                 if ($Path -like "*Links") { return $true }
@@ -211,10 +232,45 @@ Describe 'BunHandler' {
             Mock Write-Host { }
         }
 
-        It 'should fallback to copy and return success' {
+        It 'should add PATH directly and never copy a command shim' {
             $result = $handler.Apply($ctx)
             $result.Success | Should -Be $true
-            Should -Invoke Copy-Item -Times 1
+            Should -Invoke Set-UserEnvironmentPath -Times 1 -ParameterFilter { $Path -like "*$script:bunBinDir*" }
+            Should -Invoke Copy-Item -Times 0
+        }
+    }
+
+    Context 'Apply - direct executable directory PATH' {
+        BeforeEach {
+            Set-BunPackageInstalled
+            $script:bunBinDir = Split-Path -Parent $script:bunExe
+            Mock Test-Path {
+                if ($Path -like "*bun-windows-x64\bun.exe") { return $true }
+                if ($Path -like "*Links") { return $true }
+                if ($LiteralPath -like "*Links\bun.exe") { return $true }
+                return $false
+            }
+            Mock Get-Item {
+                return [PSCustomObject]@{ LinkType = ""; Length = 100; LastWriteTimeUtc = [datetime]'2024-01-01' }
+            } -ParameterFilter { $LiteralPath -like "*Links\bun.exe" }
+            Mock New-Item { throw "Bun should not create command shims" } -ParameterFilter {
+                $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
+            }
+            Mock Remove-Item { }
+            Mock Copy-Item { throw "Bun should not copy command shims" }
+            Mock Get-UserEnvironmentPath { return "C:\Windows" }
+            Mock Set-UserEnvironmentPath { }
+            Mock Write-Host { }
+        }
+
+        It 'should add the real bun directory and remove old shims without recreating them' {
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            Should -Invoke Remove-Item -Times 1 -ParameterFilter { $LiteralPath -like "*Links\bun.exe" }
+            Should -Invoke Set-UserEnvironmentPath -Times 1 -ParameterFilter { $Path -like "*$script:bunBinDir*" }
+            Should -Invoke New-Item -Times 0 -ParameterFilter { $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink" }
+            Should -Invoke Copy-Item -Times 0
         }
     }
 
@@ -243,11 +299,11 @@ Describe 'BunHandler' {
             Mock Write-Host { }
         }
 
-        It 'should remove the stale link and recreate it' {
+        It 'should remove the stale link without recreating it' {
             $result = $handler.Apply($ctx)
             $result.Success | Should -Be $true
             Should -Invoke Remove-Item -Times 1 -ParameterFilter { $LiteralPath -like "*Links\bun.exe" }
-            Should -Invoke New-Item -Times 1 -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Should -Invoke New-Item -Times 0 -ParameterFilter { $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink" }
         }
     }
 
@@ -275,10 +331,11 @@ Describe 'BunHandler' {
             Mock Write-Host { }
         }
 
-        It 'should add Links to PATH without recreating the link' {
+        It 'should remove the old shim and add the executable directory to PATH' {
             $result = $handler.Apply($ctx)
             $result.Success | Should -Be $true
             Should -Invoke Set-UserEnvironmentPath -Times 1
+            Should -Invoke Remove-Item -Times 1 -ParameterFilter { $LiteralPath -like "*Links\bun.exe" }
             Should -Invoke Copy-Item -Times 0
             Should -Invoke New-Item -Times 0 -ParameterFilter { $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink" }
         }

--- a/scripts/powershell/tests/handlers/Handler.Codex.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Codex.Tests.ps1
@@ -327,17 +327,54 @@ Describe 'CodexHandler' {
             Mock New-Item { } -ParameterFilter { $ItemType -eq "SymbolicLink" }
             Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
             Mock Remove-Item { }
+            Mock Move-Item { }
             Mock Copy-Item { }
             Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedLinks" }
             Mock Set-UserEnvironmentPath { }
             Mock Write-Host { }
         }
 
-        It 'should remove the stale link and recreate it' {
+        It 'should replace the stale link after creating the new symlink' {
             $result = $handler.Apply($ctx)
             $result.Success | Should -Be $true
-            Should -Invoke Remove-Item -Times 1 -ParameterFilter { $LiteralPath -like "*Links\codex.exe" }
             Should -Invoke New-Item -Times 1 -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Should -Invoke Move-Item -Times 2
+            Should -Invoke Remove-Item -Times 0 -ParameterFilter { $LiteralPath -like "*Links\codex.exe" }
+        }
+    }
+
+    Context 'Apply - symlink creation fails with existing stale link' {
+        BeforeEach {
+            Set-CodexPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*codex-x86_64-pc-windows-msvc.exe") { return $true }
+                if ($Path -like "*Links") { return $true }
+                if ($LiteralPath -like "*Links\codex.exe") { return $true }
+                return $false
+            }
+            Mock Get-Item {
+                return [PSCustomObject]@{ LinkType = ""; Length = 174106600; LastWriteTimeUtc = [datetime]'2024-01-01' }
+            } -ParameterFilter { $LiteralPath -like "*Links\codex.exe" }
+            Mock New-Item { throw "Developer Mode is required" } -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Mock New-Item { throw "hardlink fallback must not be used" } -ParameterFilter { $ItemType -eq "HardLink" }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
+            Mock Remove-Item { }
+            Mock Move-Item { throw "old link should not be moved before symlink creation succeeds" }
+            Mock Copy-Item { throw "copy fallback must not be used" }
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedLinks" }
+            Mock Set-UserEnvironmentPath { }
+            Mock Write-Host { }
+        }
+
+        It 'should fail without removing or moving the existing link' {
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $false
+            Should -Invoke New-Item -Times 1 -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Should -Invoke Move-Item -Times 0
+            Should -Invoke Remove-Item -Times 0 -ParameterFilter { $LiteralPath -like "*Links\codex.exe" }
+            Should -Invoke New-Item -Times 0 -ParameterFilter { $ItemType -eq "HardLink" }
+            Should -Invoke Copy-Item -Times 0
         }
     }
 

--- a/scripts/powershell/tests/handlers/Handler.Codex.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Codex.Tests.ps1
@@ -116,7 +116,7 @@ Describe 'CodexHandler' {
         }
     }
 
-    Context 'CanApply - link is matching portable link instead of symlink' {
+    Context 'CanApply - link is matching non-symlink portable link' {
         BeforeEach {
             Set-CodexPackageInstalled
             Mock Test-Path {
@@ -124,7 +124,7 @@ Describe 'CodexHandler' {
                 if ($LiteralPath -like "*Links\codex.exe") { return $true }
                 return $false
             }
-            # 現行 exe と一致する hardlink/copy は、非昇格環境での fallback 結果として許可する。
+            # hardlink/copy は winget upgrade に追従しないため、現時点で一致していても置き換える。
             Mock Get-Item {
                 return [PSCustomObject]@{ LinkType = ""; Length = 246156592; LastWriteTimeUtc = [datetime]'2024-06-01' }
             }
@@ -132,9 +132,9 @@ Describe 'CodexHandler' {
             Mock Write-Host { }
         }
 
-        It 'should return false when the portable link and PATH are current' {
+        It 'should return true so the non-symlink link is replaced with a symlink' {
             $result = $handler.CanApply($ctx)
-            $result | Should -Be $false
+            $result | Should -Be $true
         }
     }
 
@@ -240,7 +240,7 @@ Describe 'CodexHandler' {
         }
     }
 
-    Context 'Apply - fallback to hardlink when symlink cannot be created' {
+    Context 'Apply - no hardlink fallback when symlink cannot be created' {
         BeforeEach {
             Set-CodexPackageInstalled
             $script:newItemTypes = @()
@@ -269,11 +269,41 @@ Describe 'CodexHandler' {
             Mock Write-Host { }
         }
 
-        It 'should fallback to hardlink and return success' {
+        It 'should fail without creating hardlink or copy fallbacks' {
             $result = $handler.Apply($ctx)
-            $result.Success | Should -Be $true
+            $result.Success | Should -Be $false
             $script:newItemTypes | Should -Contain "SymbolicLink"
-            $script:newItemTypes | Should -Contain "HardLink"
+            $script:newItemTypes | Should -Not -Contain "HardLink"
+            Should -Invoke Copy-Item -Times 0
+        }
+    }
+
+    Context 'Apply - symlink creation fails' {
+        BeforeEach {
+            Set-CodexPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*codex-x86_64-pc-windows-msvc.exe") { return $true }
+                if ($Path -like "*Links") { return $true }
+                if ($LiteralPath -like "*Links\codex.exe") { return $false }
+                return $false
+            }
+            Mock New-Item { throw "Developer Mode is required" } -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Mock New-Item { throw "hardlink fallback must not be used" } -ParameterFilter { $ItemType -eq "HardLink" }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
+            Mock Remove-Item { }
+            Mock Copy-Item { throw "copy fallback must not be used" }
+            Mock Get-UserEnvironmentPath { return "C:\Windows" }
+            Mock Set-UserEnvironmentPath { }
+            Mock Write-Host { }
+        }
+
+        It 'should fail instead of creating a hardlink or copy fallback' {
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $false
+            $result.Message | Should -Match "Codex 設定に失敗しました"
+            Should -Invoke New-Item -Times 1 -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Should -Invoke New-Item -Times 0 -ParameterFilter { $ItemType -eq "HardLink" }
             Should -Invoke Copy-Item -Times 0
         }
     }

--- a/scripts/powershell/tests/handlers/Handler.OnePasswordCli.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.OnePasswordCli.Tests.ps1
@@ -58,27 +58,24 @@ Describe 'OnePasswordCliHandler' {
         }
     }
 
-    Context 'CanApply - shims are current and PATH configured' {
+    Context 'CanApply - package directory PATH configured' {
         BeforeEach {
             Set-OnePasswordCliPackageInstalled
             Mock Test-Path {
-                if ($Path -like "*op.exe") { return $true }
-                if ($LiteralPath -like "*op.exe") { return $true }
+                if ($Path -like "*AgileBits.1Password.CLI*op.exe") { return $true }
+                if ($LiteralPath -like "*op.exe") { return $false }
                 return $false
             }
-            Mock Get-Item {
-                return [PSCustomObject]@{ LinkType = "SymbolicLink"; Target = $script:opExe }
-            } -ParameterFilter { $LiteralPath -like "*op.exe" }
-            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedWindowsApps;$script:expectedLinks" }
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:opPkgDir" }
             Mock Write-Host { }
         }
 
-        It 'should return false when both shims and PATH are already set' {
+        It 'should return false without requiring command shims' {
             $handler.CanApply($ctx) | Should -Be $false
         }
     }
 
-    Context 'CanApply - WindowsApps shim missing' {
+    Context 'CanApply - package directory PATH missing' {
         BeforeEach {
             Set-OnePasswordCliPackageInstalled
             Mock Test-Path {
@@ -94,12 +91,29 @@ Describe 'OnePasswordCliHandler' {
             Mock Write-Host { }
         }
 
-        It 'should return true so old VS Code processes can resolve op through WindowsApps' {
+        It 'should return true so Apply can switch to package directory PATH' {
             $handler.CanApply($ctx) | Should -Be $true
         }
     }
 
-    Context 'CanApply - link is stale copy from old version' {
+    Context 'CanApply - package directory is already on PATH' {
+        BeforeEach {
+            Set-OnePasswordCliPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*AgileBits.1Password.CLI*op.exe") { return $true }
+                if ($LiteralPath -like "*op.exe") { return $false }
+                return $false
+            }
+            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:opPkgDir" }
+            Mock Write-Host { }
+        }
+
+        It 'should return false without requiring WindowsApps or WinGet Links shims' {
+            $handler.CanApply($ctx) | Should -Be $false
+        }
+    }
+
+    Context 'CanApply - legacy shim is stale copy from old version' {
         BeforeEach {
             Set-OnePasswordCliPackageInstalled
             Mock Test-Path {
@@ -117,12 +131,12 @@ Describe 'OnePasswordCliHandler' {
             Mock Write-Host { }
         }
 
-        It 'should return true so stale shims are refreshed after winget upgrade' {
+        It 'should return true so stale shims are removed after winget upgrade' {
             $handler.CanApply($ctx) | Should -Be $true
         }
     }
 
-    Context 'Apply - creates WindowsApps and WinGet Links shims' {
+    Context 'Apply - adds package directory PATH' {
         BeforeEach {
             Set-OnePasswordCliPackageInstalled
             Mock Test-Path {
@@ -132,22 +146,58 @@ Describe 'OnePasswordCliHandler' {
                 if ($LiteralPath -like "*op.exe") { return $false }
                 return $false
             }
-            Mock New-Item { } -ParameterFilter { $ItemType -eq "SymbolicLink" }
-            Mock New-Item { } -ParameterFilter { $ItemType -eq "HardLink" }
+            Mock New-Item { throw "op should not create command shims" } -ParameterFilter {
+                $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
+            }
             Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
             Mock Remove-Item { }
-            Mock Copy-Item { }
+            Mock Copy-Item { throw "op should not copy command shims" }
             Mock Get-UserEnvironmentPath { return "C:\Windows" }
             Mock Set-UserEnvironmentPath { }
             Mock Write-Host { }
         }
 
-        It 'should create both shims and add stable PATH entries' {
+        It 'should add the package directory without creating shims' {
             $result = $handler.Apply($ctx)
 
             $result.Success | Should -Be $true
-            Should -Invoke New-Item -Times 2 -ParameterFilter { $ItemType -eq "SymbolicLink" }
-            Should -Invoke Set-UserEnvironmentPath -Times 2
+            Should -Invoke New-Item -Times 0 -ParameterFilter { $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink" }
+            Should -Invoke Copy-Item -Times 0
+            Should -Invoke Set-UserEnvironmentPath -Times 1 -ParameterFilter { $Path -like "*$script:opPkgDir*" }
+        }
+    }
+
+    Context 'Apply - direct package directory PATH' {
+        BeforeEach {
+            Set-OnePasswordCliPackageInstalled
+            Mock Test-Path {
+                if ($Path -like "*AgileBits.1Password.CLI*op.exe") { return $true }
+                if ($Path -like "*WindowsApps") { return $true }
+                if ($Path -like "*WinGet\Links") { return $true }
+                if ($LiteralPath -like "*op.exe") { return $true }
+                return $false
+            }
+            Mock New-Item { throw "op should not create command shims" } -ParameterFilter {
+                $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
+            }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
+            Mock Remove-Item { }
+            Mock Copy-Item { throw "op should not copy command shims" }
+            Mock Get-UserEnvironmentPath { return "C:\Windows" }
+            Mock Set-UserEnvironmentPath { }
+            Mock Write-Host { }
+        }
+
+        It 'should add the package directory and remove old shims without recreating them' {
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            Should -Invoke Remove-Item -Times 2 -ParameterFilter { $LiteralPath -like "*op.exe" }
+            Should -Invoke Set-UserEnvironmentPath -Times 1 -ParameterFilter { $Path -like "*$script:opPkgDir*" }
+            Should -Invoke New-Item -Times 0 -ParameterFilter {
+                $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
+            }
+            Should -Invoke Copy-Item -Times 0
         }
     }
 
@@ -175,11 +225,12 @@ Describe 'OnePasswordCliHandler' {
             Mock Write-Host { }
         }
 
-        It 'should only add PATH entries without recreating shims' {
+        It 'should remove shims and add only the package directory PATH' {
             $result = $handler.Apply($ctx)
 
             $result.Success | Should -Be $true
-            Should -Invoke Set-UserEnvironmentPath -Times 2
+            Should -Invoke Remove-Item -Times 2 -ParameterFilter { $LiteralPath -like "*op.exe" }
+            Should -Invoke Set-UserEnvironmentPath -Times 1 -ParameterFilter { $Path -like "*$script:opPkgDir*" }
             Should -Invoke New-Item -Times 0 -ParameterFilter {
                 $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
             }

--- a/scripts/powershell/tests/handlers/Handler.OnePasswordCli.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.OnePasswordCli.Tests.ps1
@@ -26,6 +26,12 @@ Describe 'OnePasswordCliHandler' {
     BeforeEach {
         $script:handler = [OnePasswordCliHandler]::new()
         $script:ctx = [SetupContext]::new($script:projectRoot)
+        $script:originalPath = $env:PATH
+        $env:PATH = "C:\Windows"
+    }
+
+    AfterEach {
+        $env:PATH = $script:originalPath
     }
 
     Context 'Constructor' {
@@ -66,11 +72,11 @@ Describe 'OnePasswordCliHandler' {
                 if ($LiteralPath -like "*op.exe") { return $false }
                 return $false
             }
-            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:opPkgDir" }
+            Mock Get-UserEnvironmentPath { return "$script:opPkgDir;C:\Windows" }
             Mock Write-Host { }
         }
 
-        It 'should return false without requiring command shims' {
+        It 'should return false when package directory is first and command shims are not active' {
             $handler.CanApply($ctx) | Should -Be $false
         }
     }
@@ -104,11 +110,11 @@ Describe 'OnePasswordCliHandler' {
                 if ($LiteralPath -like "*op.exe") { return $false }
                 return $false
             }
-            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:opPkgDir" }
+            Mock Get-UserEnvironmentPath { return "$script:opPkgDir;C:\Windows" }
             Mock Write-Host { }
         }
 
-        It 'should return false without requiring WindowsApps or WinGet Links shims' {
+        It 'should return false without requiring inactive WindowsApps or WinGet Links shims' {
             $handler.CanApply($ctx) | Should -Be $false
         }
     }
@@ -127,11 +133,11 @@ Describe 'OnePasswordCliHandler' {
                 }
                 return [PSCustomObject]@{ LinkType = ""; Length = 200; LastWriteTimeUtc = [datetime]'2024-06-01' }
             }
-            Mock Get-UserEnvironmentPath { return "C:\Windows;$script:expectedWindowsApps;$script:expectedLinks" }
+            Mock Get-UserEnvironmentPath { return "$script:opPkgDir;C:\Windows;$script:expectedWindowsApps;$script:expectedLinks" }
             Mock Write-Host { }
         }
 
-        It 'should return true so stale shims are removed after winget upgrade' {
+        It 'should return true so stale shims are replaced after winget upgrade' {
             $handler.CanApply($ctx) | Should -Be $true
         }
     }
@@ -141,8 +147,8 @@ Describe 'OnePasswordCliHandler' {
             Set-OnePasswordCliPackageInstalled
             Mock Test-Path {
                 if ($Path -like "*AgileBits.1Password.CLI*op.exe") { return $true }
-                if ($Path -like "*WindowsApps") { return $true }
-                if ($Path -like "*WinGet\Links") { return $true }
+                if ($Path -like "*WindowsApps" -or $LiteralPath -like "*WindowsApps") { return $true }
+                if ($Path -like "*WinGet\Links" -or $LiteralPath -like "*WinGet\Links") { return $true }
                 if ($LiteralPath -like "*op.exe") { return $false }
                 return $false
             }
@@ -157,7 +163,7 @@ Describe 'OnePasswordCliHandler' {
             Mock Write-Host { }
         }
 
-        It 'should add the package directory without creating shims' {
+        It 'should add the package directory without creating inactive compatibility shims' {
             $result = $handler.Apply($ctx)
 
             $result.Success | Should -Be $true
@@ -172,31 +178,33 @@ Describe 'OnePasswordCliHandler' {
             Set-OnePasswordCliPackageInstalled
             Mock Test-Path {
                 if ($Path -like "*AgileBits.1Password.CLI*op.exe") { return $true }
-                if ($Path -like "*WindowsApps") { return $true }
-                if ($Path -like "*WinGet\Links") { return $true }
+                if ($Path -like "*WindowsApps" -or $LiteralPath -like "*WindowsApps") { return $true }
+                if ($Path -like "*WinGet\Links" -or $LiteralPath -like "*WinGet\Links") { return $true }
                 if ($LiteralPath -like "*op.exe") { return $true }
                 return $false
             }
-            Mock New-Item { throw "op should not create command shims" } -ParameterFilter {
-                $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
-            }
+            Mock Get-Item {
+                return [PSCustomObject]@{ LinkType = ""; Length = 100; LastWriteTimeUtc = [datetime]'2024-01-01' }
+            } -ParameterFilter { $LiteralPath -like "*op.exe" }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Mock New-Item { throw "hardlink fallback must not be used" } -ParameterFilter { $ItemType -eq "HardLink" }
             Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
             Mock Remove-Item { }
+            Mock Move-Item { }
             Mock Copy-Item { throw "op should not copy command shims" }
             Mock Get-UserEnvironmentPath { return "C:\Windows" }
             Mock Set-UserEnvironmentPath { }
             Mock Write-Host { }
         }
 
-        It 'should add the package directory and remove old shims without recreating them' {
+        It 'should add the package directory and replace old shims with symlinks' {
             $result = $handler.Apply($ctx)
 
             $result.Success | Should -Be $true
-            Should -Invoke Remove-Item -Times 2 -ParameterFilter { $LiteralPath -like "*op.exe" }
             Should -Invoke Set-UserEnvironmentPath -Times 1 -ParameterFilter { $Path -like "*$script:opPkgDir*" }
-            Should -Invoke New-Item -Times 0 -ParameterFilter {
-                $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"
-            }
+            Should -Invoke New-Item -Times 2 -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Should -Invoke New-Item -Times 0 -ParameterFilter { $ItemType -eq "HardLink" }
+            Should -Invoke Move-Item -Times 4
             Should -Invoke Copy-Item -Times 0
         }
     }
@@ -206,8 +214,8 @@ Describe 'OnePasswordCliHandler' {
             Set-OnePasswordCliPackageInstalled
             Mock Test-Path {
                 if ($Path -like "*op.exe") { return $true }
-                if ($Path -like "*WindowsApps") { return $true }
-                if ($Path -like "*WinGet\Links") { return $true }
+                if ($Path -like "*WindowsApps" -or $LiteralPath -like "*WindowsApps") { return $true }
+                if ($Path -like "*WinGet\Links" -or $LiteralPath -like "*WinGet\Links") { return $true }
                 if ($LiteralPath -like "*op.exe") { return $true }
                 return $false
             }
@@ -219,17 +227,19 @@ Describe 'OnePasswordCliHandler' {
             }
             Mock New-Item { } -ParameterFilter { $ItemType -eq "Directory" }
             Mock Remove-Item { }
+            Mock Move-Item { throw "should not replace current shim" }
             Mock Copy-Item { }
             Mock Get-UserEnvironmentPath { return "C:\Windows" }
             Mock Set-UserEnvironmentPath { }
             Mock Write-Host { }
         }
 
-        It 'should remove shims and add only the package directory PATH' {
+        It 'should keep current symlink shims and add the package directory PATH' {
             $result = $handler.Apply($ctx)
 
             $result.Success | Should -Be $true
-            Should -Invoke Remove-Item -Times 2 -ParameterFilter { $LiteralPath -like "*op.exe" }
+            Should -Invoke Remove-Item -Times 0 -ParameterFilter { $LiteralPath -like "*op.exe" }
+            Should -Invoke Move-Item -Times 0
             Should -Invoke Set-UserEnvironmentPath -Times 1 -ParameterFilter { $Path -like "*$script:opPkgDir*" }
             Should -Invoke New-Item -Times 0 -ParameterFilter {
                 $ItemType -eq "SymbolicLink" -or $ItemType -eq "HardLink"

--- a/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
@@ -1314,6 +1314,8 @@ Describe 'WingetHandler' {
             Mock Invoke-VerifyCommand { $global:LASTEXITCODE = 0; return "1.0.0" }
             Mock Get-UserEnvironmentPath { return "C:\Windows\System32" }
             Mock Set-UserEnvironmentPath { }
+            Mock New-Item { } -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Mock Copy-Item { }
         }
         AfterEach {
             $env:LOCALAPPDATA = $script:origLocalAppData
@@ -1325,9 +1327,25 @@ Describe 'WingetHandler' {
             $result = $handler.Apply($ctx)
 
             $result.Success | Should -Be $true
-            Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links\oxlint.exe" | Should -Exist
+            Should -Invoke New-Item -Times 1 -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Should -Invoke New-Item -Times 0 -ParameterFilter { $ItemType -eq "HardLink" }
+            Should -Invoke Copy-Item -Times 0
             Should -Invoke Invoke-VerifyCommand -Times 1
             Should -Invoke Set-UserEnvironmentPath -Times 1
+        }
+
+        It 'should fail instead of falling back to hardlink or copy when symlink creation fails' {
+            Mock New-Item { throw "Developer Mode is required" } -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Mock New-Item { throw "hardlink fallback must not be used" } -ParameterFilter { $ItemType -eq "HardLink" }
+            Mock Copy-Item { throw "copy fallback must not be used" }
+
+            $ctx.Options["WingetMode"] = "import"
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $false
+            Should -Invoke New-Item -Times 1 -ParameterFilter { $ItemType -eq "SymbolicLink" }
+            Should -Invoke New-Item -Times 0 -ParameterFilter { $ItemType -eq "HardLink" }
+            Should -Invoke Copy-Item -Times 0
         }
     }
 

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -5,11 +5,7 @@
       "Packages": [
         {
           "PackageIdentifier": "AgileBits.1Password.CLI",
-          "pathEntries": ["%LOCALAPPDATA%\\Microsoft\\WinGet\\Links"],
-          "portableLink": {
-            "linkName": "op.exe",
-            "targetPattern": "op.exe"
-          },
+          "pathEntries": ["%LOCALAPPDATA%\\Microsoft\\WinGet\\Packages\\AgileBits.1Password.CLI*"],
           "verifyCommand": {
             "args": ["--version"],
             "command": "op"


### PR DESCRIPTION
## Summary
- make Winget portable links symlink-only so stale hardlink/copy shims are replaced instead of preserved
- switch Bun and 1Password CLI to their real package executable directories instead of command shims
- update the Winget package catalog contract and tests for Codex/oxlint symlink-only behavior and op direct PATH resolution

## Validation
- pwsh -NoProfile -Command "Invoke-Pester -Path scripts/powershell/tests/handlers/Handler.Codex.Tests.ps1,scripts/powershell/tests/handlers/Handler.Bun.Tests.ps1,scripts/powershell/tests/handlers/Handler.OnePasswordCli.Tests.ps1,scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1,scripts/powershell/tests/PackageCatalog.Tests.ps1 -PassThru" (140 passed)
- task test (888 passed, 0 failed, 5 skipped)
- git diff --check for the committed files