### PR TITLE
[codex] Fix Hermes researcher gateway command

### DIFF
--- a/docker/hermes-agent/compose.yml
+++ b/docker/hermes-agent/compose.yml
@@ -37,7 +37,7 @@ services:
     container_name: hermes-researcher
     restart: unless-stopped
     shm_size: 1g
-    command: -p researcher gateway run
+    command: hermes -p researcher gateway run
     ports:
       - "127.0.0.1:${HERMES_RESEARCHER_API_PORT:-8643}:8642"
       - "127.0.0.1:${HERMES_RESEARCHER_DASHBOARD_PORT:-9120}:9119"

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -140,7 +140,7 @@ Describe 'HermesAgentHandler' {
             $composeContent | Should -Match "(?m)^\s{2}researcher:"
             $composeContent | Should -Match "(?m)^\s{4}container_name:\s*hermes-researcher"
             $composeContent | Should -Match "(?m)^\s{4}restart:\s*unless-stopped"
-            $composeContent | Should -Match "(?m)^\s{4}command:\s*-p researcher gateway run"
+            $composeContent | Should -Match "(?m)^\s{4}command:\s*hermes -p researcher gateway run"
             $composeContent | Should -Match ([regex]::Escape('127.0.0.1:${HERMES_RESEARCHER_API_PORT:-8643}:8642'))
             $composeContent | Should -Match ([regex]::Escape('127.0.0.1:${HERMES_RESEARCHER_DASHBOARD_PORT:-9120}:9119'))
             $composeContent | Should -Match ([regex]::Escape('path: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/profiles/researcher/.env'))


### PR DESCRIPTION
## Summary

- Run the researcher gateway through the Hermes executable instead of starting the container command with `-p`.
- Update the Hermes handler test expectation to cover the executable prefix.

## Validation

- `Invoke-Pester -Path scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1 -Output Detailed`
- `task commit` ran repo formatting, pre-commit, PowerShell tests, and chezmoi template lint before committing.
- Verified `hermes-researcher` starts with CMD `hermes -p researcher gateway run` and reaches `HERMES_DASHBOARD_READY`.