### PR TITLE
[codex] Isolate Hermes researcher gateway home

### DIFF
--- a/docker/hermes-agent/compose.yml
+++ b/docker/hermes-agent/compose.yml
@@ -37,13 +37,13 @@ services:
     container_name: hermes-researcher
     restart: unless-stopped
     shm_size: 1g
-    command: hermes -p researcher gateway run
+    command: gateway run
     ports:
       - "127.0.0.1:${HERMES_RESEARCHER_API_PORT:-8643}:8642"
       - "127.0.0.1:${HERMES_RESEARCHER_DASHBOARD_PORT:-9120}:9119"
     volumes:
       - type: bind
-        source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}
+        source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/profiles/researcher
         target: /opt/data
       - type: bind
         source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.xurl

--- a/docs/chezmoi/secrets.md
+++ b/docs/chezmoi/secrets.md
@@ -103,8 +103,10 @@ Slack メッセージを拒否する。
 
 `researcher` profile 作成直後の `.env` は default profile から clone されるため、`SlackBot-Researcher` に差し替える前に
 researcher gateway を起動しない。default と researcher が同じ Slack token を待ち受けると、同じ Slack event に二重応答する。
+researcher profile は Slack 専用 gateway として使い、clone 由来の `TELEGRAM_BOT_TOKEN` など他 platform token は残さない。
 
 `researcher` gateway は Docker Compose の別 service として起動する。host ports は default と衝突しないように分ける。
+Docker service は `profiles/researcher` を `/opt/data` として mount し、default home の gateway state や supervised process を拾わない。
 
 ```powershell
 task hermes:researcher:up

--- a/scripts/powershell/handlers/Handler.HermesAgent.ps1
+++ b/scripts/powershell/handlers/Handler.HermesAgent.ps1
@@ -814,7 +814,7 @@ class HermesAgentHandler : SetupHandlerBase {
             "SlackBot-Researcher"
         )
         if ($null -ne $slackEnvironment) {
-            $this.WriteSlackEnvironment($envPath, $lines, $slackEnvironment)
+            $this.WriteSlackEnvironment($envPath, $lines, $slackEnvironment, $true)
             return [PSCustomObject]@{ Changed = $true; Source = "1Password" }
         }
 
@@ -863,9 +863,14 @@ class HermesAgentHandler : SetupHandlerBase {
     }
 
     hidden [void] WriteSlackEnvironment([string]$envPath, [string[]]$lines, [pscustomobject]$environment) {
+        $this.WriteSlackEnvironment($envPath, $lines, $environment, $false)
+    }
+
+    hidden [void] WriteSlackEnvironment([string]$envPath, [string[]]$lines, [pscustomobject]$environment, [bool]$removeSharedPlatformSecrets) {
         $filteredLines = @(
             $lines | Where-Object {
-                $_ -notmatch '^\s*SLACK_(BOT_TOKEN|APP_TOKEN|ALLOWED_USERS)\s*='
+                $_ -notmatch '^\s*SLACK_(BOT_TOKEN|APP_TOKEN|ALLOWED_USERS)\s*=' -and
+                (-not $removeSharedPlatformSecrets -or -not $this.IsSharedPlatformSecretLine($_))
             }
         )
 
@@ -878,6 +883,10 @@ class HermesAgentHandler : SetupHandlerBase {
         $filteredLines += "SLACK_ALLOWED_USERS=$($environment.AllowedUsers)"
 
         Set-Content -LiteralPath $envPath -Value $filteredLines -Encoding UTF8
+    }
+
+    hidden [bool] IsSharedPlatformSecretLine([string]$line) {
+        return $line -match '^\s*(TELEGRAM_BOT_TOKEN|DISCORD_BOT_TOKEN|DISCORD_TOKEN|WHATSAPP_[A-Z0-9_]+|SIGNAL_[A-Z0-9_]+|TEAMS_[A-Z0-9_]+|QQBOT_[A-Z0-9_]+|YUANBAO_[A-Z0-9_]+|HOMEASSISTANT_[A-Z0-9_]+)\s*='
     }
 
     hidden [void] WriteNamedEnvironment([string]$envPath, [string[]]$lines, [hashtable]$environment) {

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -140,9 +140,11 @@ Describe 'HermesAgentHandler' {
             $composeContent | Should -Match "(?m)^\s{2}researcher:"
             $composeContent | Should -Match "(?m)^\s{4}container_name:\s*hermes-researcher"
             $composeContent | Should -Match "(?m)^\s{4}restart:\s*unless-stopped"
-            $composeContent | Should -Match "(?m)^\s{4}command:\s*hermes -p researcher gateway run"
+            $composeContent | Should -Match "(?m)^\s{4}command:\s*gateway run"
             $composeContent | Should -Match ([regex]::Escape('127.0.0.1:${HERMES_RESEARCHER_API_PORT:-8643}:8642'))
             $composeContent | Should -Match ([regex]::Escape('127.0.0.1:${HERMES_RESEARCHER_DASHBOARD_PORT:-9120}:9119'))
+            $composeContent | Should -Match ([regex]::Escape('source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/profiles/researcher'))
+            $composeContent | Should -Match "(?m)^\s*target:\s*/opt/data\s*$"
             $composeContent | Should -Match ([regex]::Escape('path: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/profiles/researcher/.env'))
         }
 
@@ -576,6 +578,8 @@ Describe 'HermesAgentHandler' {
             New-Item -ItemType Directory -Path $researcherDir -Force | Out-Null
             Set-Content -LiteralPath $researcherEnvPath -Encoding UTF8 -Value @(
                 "OTHER=value",
+                "GEMINI_API_KEY=shared-api-key",
+                "TELEGRAM_BOT_TOKEN=cloned-telegram-token",
                 "SLACK_BOT_TOKEN=xoxb-cloned-default",
                 "SLACK_APP_TOKEN=xapp-cloned-default",
                 "SLACK_ALLOWED_USERS=UDEFAULT"
@@ -625,10 +629,13 @@ Describe 'HermesAgentHandler' {
             $result.Success | Should -Be $true
             $envContent = Get-Content -LiteralPath $researcherEnvPath -Raw
             $envContent | Should -Match "OTHER=value"
+            $envContent | Should -Match "GEMINI_API_KEY=shared-api-key"
             $envContent | Should -Match "SLACK_BOT_TOKEN=xoxb-researcher-bot-token"
             $envContent | Should -Match "SLACK_APP_TOKEN=xapp-researcher-app-token"
             $envContent | Should -Match "SLACK_ALLOWED_USERS=URESEARCHER"
             $envContent | Should -Not -Match "xoxb-cloned-default"
+            $envContent | Should -Not -Match "TELEGRAM_BOT_TOKEN"
+            $envContent | Should -Not -Match "cloned-telegram-token"
             Should -Invoke Invoke-OpCommand -Times 1 -ParameterFilter {
                 $OpExe -eq "C:\op.exe" -and
                 $Arguments[0] -eq "item" -and


### PR DESCRIPTION
## Summary
- mount the researcher profile home as `/opt/data` for the dedicated Docker service
- keep the researcher gateway Slack-only by removing cloned shared platform tokens when writing its Slack environment
- document the profile-home isolation rule and cover it with Pester tests

## Root Cause
The researcher Docker service previously mounted the root Hermes home and then selected `-p researcher`. That allowed root/default gateway state and supervised profile reconciliation to leak into the dedicated service.

## Validation
- `Invoke-Pester -Path scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1 -Output Detailed` (37 passed)
- `task commit -- "Isolate Hermes researcher gateway home"` (ran nix fmt and pre-commit hooks)
- `task hermes:researcher:up`
- verified `hermes-researcher` mounts `C:\Users\KoheiMiki\.hermes\profiles\researcher -> /opt/data`
- verified Slack `auth.test` returns `ok: true` for the Researcher bot