### PR TITLE
[codex] Add Hermes lifelog core sync

### DIFF
--- a/docker/hermes-agent/compose.yml
+++ b/docker/hermes-agent/compose.yml
@@ -27,6 +27,7 @@ services:
     environment:
       HERMES_DASHBOARD: "1"
       HERMES_DASHBOARD_HOST: "0.0.0.0"
+      LIFELOG_ROOT: /opt/data/core/lifelog
 
   researcher:
     profiles: ["researcher"]
@@ -50,6 +51,9 @@ services:
         target: /opt/data/docs
         read_only: true
       - type: bind
+        source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/core
+        target: /opt/data/core
+      - type: bind
         source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.xurl
         target: /root/.xurl
     env_file:
@@ -59,6 +63,7 @@ services:
     environment:
       HERMES_DASHBOARD: "1"
       HERMES_DASHBOARD_HOST: "0.0.0.0"
+      LIFELOG_ROOT: /opt/data/core/lifelog
 
   rick:
     profiles: ["rick"]
@@ -82,6 +87,9 @@ services:
         target: /opt/data/docs
         read_only: true
       - type: bind
+        source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/core
+        target: /opt/data/core
+      - type: bind
         source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.xurl
         target: /root/.xurl
     env_file:
@@ -91,6 +99,7 @@ services:
     environment:
       HERMES_DASHBOARD: "1"
       HERMES_DASHBOARD_HOST: "0.0.0.0"
+      LIFELOG_ROOT: /opt/data/core/lifelog
 
   hoffman:
     profiles: ["hoffman"]
@@ -114,6 +123,9 @@ services:
         target: /opt/data/docs
         read_only: true
       - type: bind
+        source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/core
+        target: /opt/data/core
+      - type: bind
         source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.xurl
         target: /root/.xurl
     env_file:
@@ -123,6 +135,7 @@ services:
     environment:
       HERMES_DASHBOARD: "1"
       HERMES_DASHBOARD_HOST: "0.0.0.0"
+      LIFELOG_ROOT: /opt/data/core/lifelog
 
   risarisa:
     profiles: ["risarisa"]
@@ -146,6 +159,9 @@ services:
         target: /opt/data/docs
         read_only: true
       - type: bind
+        source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/core
+        target: /opt/data/core
+      - type: bind
         source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.xurl
         target: /root/.xurl
     env_file:
@@ -155,3 +171,4 @@ services:
     environment:
       HERMES_DASHBOARD: "1"
       HERMES_DASHBOARD_HOST: "0.0.0.0"
+      LIFELOG_ROOT: /opt/data/core/lifelog

--- a/docs/chezmoi/secrets.md
+++ b/docs/chezmoi/secrets.md
@@ -68,6 +68,9 @@ Hermes home は Git-managed profile distribution として扱う。root home と
 `/opt/data/docs/profile-home-layout.md` を配置し、managed profile gateway は root `docs` directory を
 `/opt/data/docs` に read-only mount する。
 root home repository では nested profile repository を混ぜないため `profiles/` を `.gitignore` に追加する。
+`HERMES_DATA_DIR` は Hermes home のままにし、lifelog repo には向けない。共有 lifelog core は
+`~/.hermes/core/lifelog` に clone / sync し、container 内では `/opt/data/core/lifelog` として全 gateway から
+read/write する。root home repository では `core/` を `.gitignore` に追加する。
 
 - account: `my.1password.com`
 - vault: `openclaw`
@@ -170,6 +173,12 @@ Hermes Agent の API / MCP 用 token も同じ `openclaw` vault から `~/.herme
 GitHub 操作用には Hermes container 内の `gh` CLI を使う。`gh` は `GH_TOKEN` / `GITHUB_TOKEN` を
 参照するため、token を rotate した場合は 1Password 側を更新して Hermes setup を再実行する。
 `mcp_servers.github` は重複するため Hermes setup で削除する。
+
+Hermes setup は `scripts/lifelog_sync.sh` と daily cron job を `~/.hermes` に作成する。
+初回 install では compose 起動後に `sh /opt/data/scripts/lifelog_sync.sh --bootstrap` を default gateway で実行し、
+`~/.hermes/core/lifelog` を GitHub から復元する。以後は Hermes cron が毎日 `04:20 UTC` に lifelog repo を
+`commit -> pull --rebase -> push` で同期する。`.env`、`auth.json`、token、secret、DB、logs、sessions、cache などが
+staged された場合は commit / push せず失敗させる。
 
 X API MCP は `xurl` bridge を使う。Hermes setup は `mcp_servers.xapi` と `mcp_servers.x-docs` を
 `~/.hermes/config.yaml` に生成し、`xurl` の OAuth cache は `~/.hermes/.xurl` に永続化する。

--- a/docs/hermes-agent/profile-home-layout.md
+++ b/docs/hermes-agent/profile-home-layout.md
@@ -7,7 +7,9 @@ Hermes profile homes should keep the filesystem layout that Hermes expects, whil
 - The default gateway mounts `~/.hermes` as `/opt/data`.
 - A dedicated profile gateway mounts `~/.hermes/profiles/<profile>` as `/opt/data`.
 - A dedicated profile gateway mounts the root shared docs directory `~/.hermes/docs` onto `/opt/data/docs` read-only.
+- A dedicated profile gateway mounts the root shared core directory `~/.hermes/core` onto `/opt/data/core` read/write.
 - From the default gateway, profile homes are visible under `/opt/data/profiles/<profile>`.
+- `HERMES_DATA_DIR` remains the Hermes home. Do not point it at lifelog; lifelog is restored under `~/.hermes/core/lifelog`.
 
 ## Standard Profile Filesystem
 
@@ -75,3 +77,19 @@ Ignore secrets and live state:
 ## Sharing Knowledge
 
 Do not share profile `memories/` through Git. Put durable shared guidance in `docs/` or repository `AGENTS.md` files, and use Slack, Hermes Kanban, GitHub issues, or Linear for cross-agent work state. If a shared memory backend is introduced later, namespace it by user, app, and profile.
+
+## Lifelog Core
+
+`install.cmd` restores the shared lifelog core at:
+
+```text
+~/.hermes/core/lifelog
+```
+
+Hermes gateways see it at:
+
+```text
+/opt/data/core/lifelog
+```
+
+Every managed profile should treat `/opt/data/core/lifelog/AGENTS.md` and relevant lifelog notes as the shared source of truth before making user-context decisions. The Hermes home repository ignores `core/`; lifelog is its own Git repository and is synced by the `lifelog_sync.sh` cron job.

--- a/scripts/powershell/handlers/Handler.HermesAgent.ps1
+++ b/scripts/powershell/handlers/Handler.HermesAgent.ps1
@@ -77,6 +77,7 @@ class HermesAgentHandler : SetupHandlerBase {
             $this.EnsureDirectory($dataDir)
             $this.EnsureDirectory((Join-Path $dataDir ".xurl"))
             $homeRepositoryResult = $this.EnsureHomeRepositoryLayout($ctx, $dataDir)
+            $lifelogCoreResult = $this.EnsureLifelogCore($ctx, $dataDir)
             $modelResult = $this.EnsureModelConfiguration($ctx, $dataDir)
 
             $envPath = Join-Path $dataDir ".env"
@@ -89,7 +90,11 @@ class HermesAgentHandler : SetupHandlerBase {
             $mcpResult = $this.EnsureMcpConfiguration($ctx, $dataDir)
             $slackMentionResult = $this.EnsureSlackMentionConfiguration($ctx, $dataDir)
 
-            $composeArgs = @("compose", "-f", $composeFile, "up", "-d", "--build")
+            $composeArgs = @("compose", "-f", $composeFile)
+            foreach ($profileName in $this.GetManagedProfileNames($ctx)) {
+                $composeArgs += @("--profile", $profileName)
+            }
+            $composeArgs += @("up", "-d", "--build")
             $output = @(Invoke-Docker -Arguments $composeArgs -TimeoutSeconds $this.DockerComposeTimeoutSeconds)
             $exitCode = $LASTEXITCODE
             if ($exitCode -ne 0) {
@@ -98,6 +103,11 @@ class HermesAgentHandler : SetupHandlerBase {
                     $message = "exit code $exitCode"
                 }
                 return $this.CreateFailureResult("Hermes Agent コンテナの起動に失敗しました: $message")
+            }
+
+            $lifelogBootstrapResult = $this.InvokeLifelogCoreBootstrap($ctx)
+            if (-not $lifelogBootstrapResult.Success) {
+                return $this.CreateFailureResult($lifelogBootstrapResult.Message)
             }
 
             if ($authResult.Changed -and $authResult.Source -eq "1Password") {
@@ -134,6 +144,13 @@ class HermesAgentHandler : SetupHandlerBase {
 
             if ($homeRepositoryResult.Changed) {
                 $this.Log("Hermes home/profile Git 管理ポリシーを更新しました", "Green")
+            }
+
+            if ($lifelogCoreResult.Changed) {
+                $this.Log("Hermes lifelog core 設定を更新しました", "Green")
+            }
+            if ($lifelogBootstrapResult.Changed) {
+                $this.Log("Hermes lifelog core を同期しました", "Green")
             }
 
             if ($openClawApiResult.Changed -and $openClawApiResult.Count -gt 0) {
@@ -271,6 +288,342 @@ class HermesAgentHandler : SetupHandlerBase {
         }
 
         return [PSCustomObject]@{ Changed = $changed; Source = "Config" }
+    }
+
+    hidden [pscustomobject] EnsureLifelogCore([SetupContext]$ctx, [string]$dataDir) {
+        if (-not $this.IsTruthy($ctx.GetOption("HermesAgentLifelogCoreEnabled", $true))) {
+            return [PSCustomObject]@{ Changed = $false; Source = "Disabled" }
+        }
+
+        $changed = $false
+        $coreDir = Join-Path $dataDir "core"
+        $this.EnsureDirectory($coreDir)
+
+        $changed = $this.EnsureGitignoreEntry(
+            (Join-Path $dataDir ".gitignore"),
+            "core/",
+            "Shared lifelog core is a separate Git repository cloned at runtime."
+        ) -or $changed
+
+        $scriptsDir = Join-Path $dataDir "scripts"
+        $this.EnsureDirectory($scriptsDir)
+        $changed = $this.EnsureFileLinesLf(
+            (Join-Path $scriptsDir "lifelog_sync.sh"),
+            $this.GetLifelogCoreSyncScriptLines()
+        ) -or $changed
+
+        $changed = $this.EnsureLifelogCronJob($dataDir) -or $changed
+
+        $changed = $this.EnsureManagedBlock(
+            (Join-Path $dataDir "SOUL.md"),
+            "HERMES_LIFELOG_CORE_POLICY",
+            $this.GetLifelogCorePolicyBlockLines()
+        ) -or $changed
+
+        foreach ($profileName in $this.GetManagedProfileNames($ctx)) {
+            $profileDir = Join-Path (Join-Path $dataDir "profiles") $profileName
+            if (-not (Test-Path -LiteralPath $profileDir -PathType Container)) {
+                continue
+            }
+            $changed = $this.EnsureManagedBlock(
+                (Join-Path $profileDir "SOUL.md"),
+                "HERMES_LIFELOG_CORE_POLICY",
+                $this.GetLifelogCorePolicyBlockLines()
+            ) -or $changed
+        }
+
+        return [PSCustomObject]@{ Changed = $changed; Source = "Config" }
+    }
+
+    hidden [bool] EnsureFileLinesLf([string]$path, [string[]]$desiredLines) {
+        $desiredContent = ($desiredLines -join "`n") + "`n"
+        $existingContent = ""
+        if (Test-Path -LiteralPath $path -PathType Leaf) {
+            $existingContent = Get-Content -LiteralPath $path -Raw -ErrorAction Stop
+        }
+
+        if ($existingContent -eq $desiredContent) {
+            return $false
+        }
+
+        $this.EnsureDirectory((Split-Path -Parent $path))
+        Set-Content -LiteralPath $path -Encoding UTF8 -NoNewline -Value $desiredContent
+        return $true
+    }
+
+    hidden [pscustomobject] InvokeLifelogCoreBootstrap([SetupContext]$ctx) {
+        if (-not $this.IsTruthy($ctx.GetOption("HermesAgentLifelogCoreEnabled", $true))) {
+            return [PSCustomObject]@{ Success = $true; Changed = $false; Source = "Disabled"; Message = "" }
+        }
+        if (-not $this.IsTruthy($ctx.GetOption("HermesAgentLifelogCoreBootstrapEnabled", $true))) {
+            return [PSCustomObject]@{ Success = $true; Changed = $false; Source = "Disabled"; Message = "" }
+        }
+
+        $output = @(Invoke-Docker -Arguments @(
+                "exec",
+                "hermes",
+                "bash",
+                "-lc",
+                "bash /opt/data/scripts/lifelog_sync.sh --bootstrap"
+            ) -TimeoutSeconds $this.DockerRunTimeoutSeconds)
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
+            $message = ($output -join "`n").Trim()
+            if ([string]::IsNullOrWhiteSpace($message)) {
+                $message = "exit code $exitCode"
+            }
+            return [PSCustomObject]@{
+                Success = $false
+                Changed = $false
+                Source  = "Docker"
+                Message = "Hermes lifelog core の初回同期に失敗しました: $message"
+            }
+        }
+
+        return [PSCustomObject]@{
+            Success = $true
+            Changed = $true
+            Source  = "Docker"
+            Message = ""
+        }
+    }
+
+    hidden [string[]] GetLifelogCorePolicyBlockLines() {
+        return @(
+            "## Lifelog Core Policy",
+            "",
+            "Before making user-context decisions, read /opt/data/core/lifelog/AGENTS.md and the relevant notes under /opt/data/core/lifelog.",
+            "Treat /opt/data/core/lifelog as the shared source of truth for durable cross-agent user context.",
+            "Write durable shared context to /opt/data/core/lifelog according to its AGENTS.md; do not use profile memories/ as the shared source of truth."
+        )
+    }
+
+    hidden [bool] EnsureLifelogCronJob([string]$dataDir) {
+        $cronDir = Join-Path $dataDir "cron"
+        $this.EnsureDirectory($cronDir)
+        $cronPath = Join-Path $cronDir "jobs.json"
+
+        $cron = $null
+        if (Test-Path -LiteralPath $cronPath -PathType Leaf) {
+            try {
+                $cron = Get-Content -LiteralPath $cronPath -Raw -ErrorAction Stop | ConvertFrom-Json
+            }
+            catch {
+                $cron = $null
+            }
+        }
+        if ($null -eq $cron) {
+            $cron = [PSCustomObject]@{
+                jobs       = @()
+                updated_at = $null
+            }
+        }
+
+        $jobs = @()
+        if ($null -ne $cron.jobs) {
+            $jobs = @($cron.jobs)
+        }
+
+        $desiredJob = $this.GetLifelogCronJob()
+        $changed = $false
+        $updatedJobs = @()
+        $found = $false
+        foreach ($job in $jobs) {
+            if ($job.id -eq $desiredJob.id) {
+                $found = $true
+                $mergedJob = $this.MergeLifelogCronJob($job, $desiredJob)
+                if ((ConvertTo-Json -InputObject $job -Depth 10 -Compress) -ne (ConvertTo-Json -InputObject $mergedJob -Depth 10 -Compress)) {
+                    $changed = $true
+                }
+                $updatedJobs += $mergedJob
+                continue
+            }
+            $updatedJobs += $job
+        }
+
+        if (-not $found) {
+            $updatedJobs += $desiredJob
+            $changed = $true
+        }
+
+        if (-not $changed) {
+            return $false
+        }
+
+        $cron.jobs = @($updatedJobs)
+        $cron.updated_at = (Get-Date).ToUniversalTime().ToString("o")
+        $json = ConvertTo-Json -InputObject $cron -Depth 10
+        Set-Content -LiteralPath $cronPath -Encoding UTF8 -Value $json
+        return $true
+    }
+
+    hidden [pscustomobject] MergeLifelogCronJob([object]$existingJob, [pscustomobject]$desiredJob) {
+        $mergedJob = ConvertFrom-Json -InputObject (ConvertTo-Json -InputObject $existingJob -Depth 10)
+        foreach ($propertyName in @(
+                "name",
+                "prompt",
+                "skills",
+                "skill",
+                "model",
+                "provider",
+                "provider_snapshot",
+                "model_snapshot",
+                "base_url",
+                "script",
+                "no_agent",
+                "context_from",
+                "schedule",
+                "schedule_display",
+                "enabled",
+                "workdir"
+            )) {
+            $mergedJob | Add-Member -MemberType NoteProperty -Name $propertyName -Value $desiredJob.$propertyName -Force
+        }
+
+        return $mergedJob
+    }
+
+    hidden [pscustomobject] GetLifelogCronJob() {
+        return [PSCustomObject]@{
+            id                  = "lifelog-core-sync"
+            name                = "Daily Lifelog core GitHub sync"
+            prompt              = "Run the Hermes lifelog core GitHub sync script. It clones or updates /opt/data/core/lifelog, commits non-secret lifelog changes, rebases from origin/main, and pushes back to GitHub."
+            skills              = @()
+            skill               = $null
+            model               = $null
+            provider            = $null
+            provider_snapshot   = $null
+            model_snapshot      = $null
+            base_url            = $null
+            script              = "lifelog_sync.sh"
+            no_agent            = $true
+            context_from        = $null
+            schedule            = [PSCustomObject]@{
+                kind    = "cron"
+                expr    = "20 4 * * *"
+                display = "20 4 * * *"
+            }
+            schedule_display    = "20 4 * * *"
+            repeat              = [PSCustomObject]@{
+                times     = $null
+                completed = 0
+            }
+            enabled             = $true
+            state               = "scheduled"
+            paused_at           = $null
+            paused_reason       = $null
+            last_run_at         = $null
+            last_status         = $null
+            last_error          = $null
+            last_delivery_error = $null
+            enabled_toolsets    = $null
+            workdir             = $null
+        }
+    }
+
+    hidden [string[]] GetLifelogCoreSyncScriptLines() {
+        return @(
+            "#!/usr/bin/env bash",
+            "set -euo pipefail",
+            "",
+            'LIFELOG_DIR="${LIFELOG_ROOT:-/opt/data/core/lifelog}"',
+            'LIFELOG_REMOTE_URL="${LIFELOG_REMOTE_URL:-https://github.com/rurusasu/lifelog.git}"',
+            'LIFELOG_BRANCH="${LIFELOG_BRANCH:-main}"',
+            'HERMES_HOME_DIR="/opt/data"',
+            "",
+            'load_github_token() {',
+            '  if [ -f "$HERMES_HOME_DIR/.env" ]; then',
+            '    while IFS="=" read -r key value || [ -n "$key" ]; do',
+            '      key="${key#export }"',
+            '      key="${key%$''\r''}"',
+            '      value="${value%$''\r''}"',
+            '      value="${value%\"}"; value="${value#\"}"',
+            '      case "$key" in',
+            '        GH_TOKEN|GITHUB_TOKEN) [ -z "${GH_TOKEN:-}" ] && export GH_TOKEN="$value" ;;',
+            '        GITHUB_PERSONAL_ACCESS_TOKEN) [ -z "${GH_TOKEN:-}" ] && export GH_TOKEN="$value" ;;',
+            '      esac',
+            '    done < "$HERMES_HOME_DIR/.env"',
+            '  fi',
+            '}',
+            "",
+            'setup_git_auth() {',
+            '  export GIT_TERMINAL_PROMPT=0',
+            '  if [ -z "${GH_TOKEN:-}" ]; then',
+            '    return',
+            '  fi',
+            '  GIT_ASKPASS_FILE="$(mktemp)"',
+            '  export GIT_ASKPASS_FILE',
+            '  cat > "$GIT_ASKPASS_FILE" <<''ASKPASS''',
+            "#!/bin/sh",
+            'case "$1" in',
+            '  *Username*) printf "%s\n" "x-access-token" ;;',
+            '  *Password*) printf "%s\n" "$GH_TOKEN" ;;',
+            '  *) printf "\n" ;;',
+            'esac',
+            "ASKPASS",
+            '  chmod 700 "$GIT_ASKPASS_FILE"',
+            '  export GIT_ASKPASS="$GIT_ASKPASS_FILE"',
+            '}',
+            "",
+            'cleanup() {',
+            '  if [ -n "${GIT_ASKPASS_FILE:-}" ] && [ -f "$GIT_ASKPASS_FILE" ]; then',
+            '    rm -f "$GIT_ASKPASS_FILE"',
+            '  fi',
+            '}',
+            'trap cleanup EXIT',
+            "",
+            'refuse_secret_changes() {',
+            '  if git -c safe.directory="$LIFELOG_DIR" diff --cached --name-only | grep -E ''(^|/)(\.direnv/|\.env|\.env\..*|auth\.json|.*token.*|.*secret.*|.*password.*|state\.db|.*\.sqlite3?|.*\.db|.*-shm|.*-wal|logs/|sessions/|cache/)'' >/dev/null 2>&1; then',
+            '    echo "Hermes lifelog sync refused: secret/state/runtime file would be committed"',
+            '    git -c safe.directory="$LIFELOG_DIR" reset --mixed >/dev/null',
+            '    exit 1',
+            '  fi',
+            '}',
+            "",
+            'restore_runtime_paths() {',
+            '  git -c safe.directory="$LIFELOG_DIR" restore --staged --worktree -- .direnv >/dev/null 2>&1 || true',
+            '}',
+            "",
+            'load_github_token',
+            'setup_git_auth',
+            'mkdir -p "$(dirname "$LIFELOG_DIR")"',
+            "",
+            'if [ ! -d "$LIFELOG_DIR/.git" ]; then',
+            '  if [ -e "$LIFELOG_DIR" ] && [ "$(find "$LIFELOG_DIR" -mindepth 1 -maxdepth 1 2>/dev/null | head -n 1)" != "" ]; then',
+            '    echo "Hermes lifelog sync failed: $LIFELOG_DIR exists but is not an empty git repository"',
+            '    exit 1',
+            '  fi',
+            '  rm -rf "$LIFELOG_DIR"',
+            '  git clone --branch "$LIFELOG_BRANCH" "$LIFELOG_REMOTE_URL" "$LIFELOG_DIR"',
+            'fi',
+            "",
+            'cd "$LIFELOG_DIR"',
+            'if ! git -c safe.directory="$LIFELOG_DIR" config user.name >/dev/null; then',
+            '  git -c safe.directory="$LIFELOG_DIR" config user.name "Hermes Lifelog Sync"',
+            'fi',
+            'if ! git -c safe.directory="$LIFELOG_DIR" config user.email >/dev/null; then',
+            '  git -c safe.directory="$LIFELOG_DIR" config user.email "hermes-lifelog-sync@users.noreply.github.com"',
+            'fi',
+            'current_branch="$(git -c safe.directory="$LIFELOG_DIR" branch --show-current)"',
+            'if [ "$current_branch" != "$LIFELOG_BRANCH" ]; then',
+            '  echo "Hermes lifelog sync failed: expected branch $LIFELOG_BRANCH but found $current_branch"',
+            '  exit 1',
+            'fi',
+            "",
+            'restore_runtime_paths',
+            'git -c safe.directory="$LIFELOG_DIR" add -A -- .',
+            'refuse_secret_changes',
+            'if ! git -c safe.directory="$LIFELOG_DIR" diff --cached --quiet; then',
+            '  git -c safe.directory="$LIFELOG_DIR" commit -m "chore: sync lifelog $(date -u +%Y-%m-%d)" >/dev/null',
+            '  echo "Hermes lifelog committed local changes."',
+            'fi',
+            "",
+            'git -c safe.directory="$LIFELOG_DIR" pull --rebase origin "$LIFELOG_BRANCH"',
+            'git -c safe.directory="$LIFELOG_DIR" push origin "$LIFELOG_BRANCH"',
+            'if [ "${1:-}" = "--bootstrap" ]; then',
+            '  echo "Hermes lifelog bootstrap completed."',
+            'fi'
+        )
     }
 
     hidden [bool] EnsureProfileRepositoryLayout([string]$dataDir, [string]$profileName) {
@@ -494,7 +847,9 @@ class HermesAgentHandler : SetupHandlerBase {
             '- The default gateway mounts `~/.hermes` as `/opt/data`.',
             '- A dedicated profile gateway mounts `~/.hermes/profiles/<profile>` as `/opt/data`.',
             '- A dedicated profile gateway mounts the root shared docs directory `~/.hermes/docs` onto `/opt/data/docs` read-only.',
+            '- A dedicated profile gateway mounts the root shared core directory `~/.hermes/core` onto `/opt/data/core` read/write.',
             '- From the default gateway, profile homes are visible under `/opt/data/profiles/<profile>`.',
+            '- `HERMES_DATA_DIR` remains the Hermes home. Do not point it at lifelog; lifelog is restored under `~/.hermes/core/lifelog`.',
             '',
             '## Standard Profile Filesystem',
             '',
@@ -561,7 +916,23 @@ class HermesAgentHandler : SetupHandlerBase {
             '',
             '## Shared Knowledge',
             '',
-            'Do not share profile `memories/` through Git. Put durable shared guidance in `docs/` or repository `AGENTS.md` files, and use Slack, Hermes Kanban, GitHub issues, or Linear for cross-agent work state. If a shared memory backend is introduced later, namespace it by user, app, and profile.'
+            'Do not share profile `memories/` through Git. Put durable shared guidance in `docs/` or repository `AGENTS.md` files, and use Slack, Hermes Kanban, GitHub issues, or Linear for cross-agent work state. If a shared memory backend is introduced later, namespace it by user, app, and profile.',
+            '',
+            '## Lifelog Core',
+            '',
+            '`install.cmd` restores the shared lifelog core at:',
+            '',
+            '```text',
+            '~/.hermes/core/lifelog',
+            '```',
+            '',
+            'Hermes gateways see it at:',
+            '',
+            '```text',
+            '/opt/data/core/lifelog',
+            '```',
+            '',
+            'Every managed profile should treat `/opt/data/core/lifelog/AGENTS.md` and relevant lifelog notes as the shared source of truth before making user-context decisions. The Hermes home repository ignores `core/`; lifelog is its own Git repository and is synced by the `lifelog_sync.sh` cron job.'
         )
     }
 

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -161,6 +161,18 @@ Describe 'HermesAgentHandler' {
             $composeContent | Should -Match "(?m)^\s*read_only:\s*true\s*$"
         }
 
+        It 'should expose the shared lifelog core to every Hermes gateway' {
+            $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..\..\..")
+            $composePath = Join-Path $repoRoot "docker\hermes-agent\compose.yml"
+            $composeContent = Get-Content -LiteralPath $composePath -Raw
+
+            $composeContent | Should -Match "(?m)^\s*LIFELOG_ROOT:\s*/opt/data/core/lifelog\s*$"
+            foreach ($profile in @("researcher", "rick", "hoffman", "risarisa")) {
+                $composeContent | Should -Match ([regex]::Escape("source: `${HERMES_DATA_DIR:-`${USERPROFILE:-`${HOME}}/.hermes}/core"))
+                $composeContent | Should -Match "(?m)^\s*target:\s*/opt/data/core\s*$"
+            }
+        }
+
         It 'should rebuild the local Hermes image instead of pulling it from a registry' {
             $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..\..\..")
             $taskfilePath = Join-Path $repoRoot "Taskfile.yml"
@@ -275,6 +287,11 @@ Describe 'HermesAgentHandler' {
                     return @("started")
                 }
 
+                if ($Arguments[0] -eq "exec") {
+                    $global:LASTEXITCODE = 0
+                    return @("lifelog synced")
+                }
+
                 $global:LASTEXITCODE = 1
                 return @("unexpected docker call")
             }
@@ -297,6 +314,11 @@ Describe 'HermesAgentHandler' {
             $composeCall = @($script:dockerCalls | Where-Object { $_[0] -eq "compose" })[0]
             $composeCall | Should -Contain "-f"
             $composeCall | Should -Contain $script:composeFile
+            $composeCall | Should -Contain "--profile"
+            $composeCall | Should -Contain "researcher"
+            $composeCall | Should -Contain "rick"
+            $composeCall | Should -Contain "hoffman"
+            $composeCall | Should -Contain "risarisa"
             $composeCall | Should -Contain "up"
             $composeCall | Should -Contain "-d"
             $composeCall | Should -Contain "--build"
@@ -873,6 +895,105 @@ Describe 'HermesAgentHandler' {
             $profileSoul = Get-Content -LiteralPath (Join-Path $researcherDir "SOUL.md") -Raw
             $profileSoul | Should -Match "/opt/data/docs/profile-home-layout.md"
             $profileSoul | Should -Match "standard filesystem layout"
+        }
+
+        It 'should bootstrap shared lifelog core files, policy, cron, and first sync' {
+            $dataDir = Join-Path $script:userProfile ".hermes"
+            $researcherDir = Join-Path $dataDir "profiles\researcher"
+            New-Item -ItemType Directory -Path $researcherDir -Force | Out-Null
+            Set-Content -LiteralPath (Join-Path $dataDir ".gitignore") -Encoding UTF8 -Value @(
+                ".env",
+                "profiles/"
+            )
+            Set-Content -LiteralPath (Join-Path $dataDir "SOUL.md") -Encoding UTF8 -Value "Default profile soul."
+            Set-Content -LiteralPath (Join-Path $researcherDir "SOUL.md") -Encoding UTF8 -Value "Researcher profile soul."
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            Test-Path -LiteralPath (Join-Path $dataDir "core") -PathType Container | Should -Be $true
+
+            $rootGitignore = Get-Content -LiteralPath (Join-Path $dataDir ".gitignore") -Raw
+            $rootGitignore | Should -Match "(?m)^core/\r?$"
+
+            $syncScriptPath = Join-Path $dataDir "scripts\lifelog_sync.sh"
+            $syncScriptPath | Should -Exist
+            $syncScript = Get-Content -LiteralPath $syncScriptPath -Raw
+            $syncScript | Should -Match "/opt/data/core/lifelog"
+            $syncScript | Should -Match "github\.com/rurusasu/lifelog\.git"
+            $syncScript | Should -Match 'safe\.directory="\$LIFELOG_DIR"'
+            $syncScript | Should -Match "restore_runtime_paths"
+            $syncScript | Should -Match "\.direnv"
+            $syncScript | Should -Match "Hermes Lifelog Sync"
+            $syncScript | Should -Match "Hermes lifelog sync refused"
+            $syncScript | Should -Not -Match "`r"
+            $syncScript | Should -Not -Match ([string][char]7)
+
+            $cronPath = Join-Path $dataDir "cron\jobs.json"
+            $cronPath | Should -Exist
+            $cron = Get-Content -LiteralPath $cronPath -Raw | ConvertFrom-Json
+            $lifelogJob = @($cron.jobs | Where-Object { $_.id -eq "lifelog-core-sync" })[0]
+            $lifelogJob.name | Should -Be "Daily Lifelog core GitHub sync"
+            $lifelogJob.script | Should -Be "lifelog_sync.sh"
+            $lifelogJob.no_agent | Should -Be $true
+            $lifelogJob.schedule.expr | Should -Be "20 4 * * *"
+
+            $rootSoul = Get-Content -LiteralPath (Join-Path $dataDir "SOUL.md") -Raw
+            $rootSoul | Should -Match "/opt/data/core/lifelog/AGENTS.md"
+            $rootSoul | Should -Match "shared source of truth"
+
+            $profileSoul = Get-Content -LiteralPath (Join-Path $researcherDir "SOUL.md") -Raw
+            $profileSoul | Should -Match "/opt/data/core/lifelog/AGENTS.md"
+            $profileSoul | Should -Match "shared source of truth"
+
+            Should -Invoke Invoke-Docker -Times 1 -ParameterFilter {
+                $Arguments[0] -eq "exec" -and
+                $Arguments[1] -eq "hermes" -and
+                ($Arguments -join " ") -match "bash /opt/data/scripts/lifelog_sync.sh --bootstrap"
+            }
+        }
+
+        It 'should update an existing lifelog cron job without removing runtime fields' {
+            $dataDir = Join-Path $script:userProfile ".hermes"
+            $cronDir = Join-Path $dataDir "cron"
+            New-Item -ItemType Directory -Path $cronDir -Force | Out-Null
+            Set-Content -LiteralPath (Join-Path $cronDir "jobs.json") -Encoding UTF8 -Value (@{
+                    jobs       = @(
+                        @{
+                            id         = "lifelog-core-sync"
+                            name       = "stale lifelog sync"
+                            script     = "old.sh"
+                            no_agent   = $false
+                            schedule   = @{
+                                kind    = "cron"
+                                expr    = "0 0 * * *"
+                                display = "0 0 * * *"
+                            }
+                            fire_claim = "runtime-claim"
+                        },
+                        @{
+                            id     = "other-job"
+                            name   = "Other job"
+                            script = "other.sh"
+                        }
+                    )
+                    updated_at = "2026-01-01T00:00:00Z"
+                } | ConvertTo-Json -Depth 10)
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $cron = Get-Content -LiteralPath (Join-Path $cronDir "jobs.json") -Raw | ConvertFrom-Json
+            $lifelogJob = @($cron.jobs | Where-Object { $_.id -eq "lifelog-core-sync" })[0]
+            $lifelogJob.name | Should -Be "Daily Lifelog core GitHub sync"
+            $lifelogJob.script | Should -Be "lifelog_sync.sh"
+            $lifelogJob.no_agent | Should -Be $true
+            $lifelogJob.schedule.expr | Should -Be "20 4 * * *"
+            $lifelogJob.fire_claim | Should -Be "runtime-claim"
+
+            $otherJob = @($cron.jobs | Where-Object { $_.id -eq "other-job" })[0]
+            $otherJob.name | Should -Be "Other job"
+            $otherJob.script | Should -Be "other.sh"
         }
 
         It 'should configure OpenClaw API environment from 1Password items' {


### PR DESCRIPTION
## Summary

- Add a shared Hermes lifelog core under `~/.hermes/core/lifelog` while keeping `HERMES_DATA_DIR` pointed at the Hermes home.
- Mount the shared core into every Hermes gateway as `/opt/data/core` and set `LIFELOG_ROOT=/opt/data/core/lifelog`.
- Extend the Hermes install handler to create the lifelog sync script, daily cron job, and bootstrap sync through the running gateway.
- Document the layout and sync behavior for Hermes home/profile operations.

## Validation

- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1` passed: 43/43.
- `git diff --check` passed with no whitespace errors.
- Runtime verification confirmed all Hermes containers see `LIFELOG_ROOT=/opt/data/core/lifelog` and the sync script completed with `Everything up-to-date`.