### PR TITLE
[codex] Install Orca with uv Python policy

### DIFF
--- a/chezmoi/dot_codex/config.toml.tmpl
+++ b/chezmoi/dot_codex/config.toml.tmpl
@@ -167,14 +167,14 @@ matcher = "^Bash$"
 [[hooks.PreToolUse.hooks]]
 type = "command"
 command = 'python3 "{{ .chezmoi.homeDir | replace "\\" "/" }}/.codex/hooks/claude_permission_policy.py"'
-command_windows = 'python "{{ .chezmoi.homeDir | replace "\\" "/" }}/.codex/hooks/claude_permission_policy.py"'
+command_windows = 'uv run --isolated --managed-python python "{{ .chezmoi.homeDir | replace "\\" "/" }}/.codex/hooks/claude_permission_policy.py"'
 timeout = 30
 statusMessage = "Checking Claude-aligned Bash policy"
 
 [[hooks.PreToolUse.hooks]]
 type = "command"
 command = 'python3 "{{ .chezmoi.homeDir | replace "\\" "/" }}/.codex/hooks/deny_protected_branch_commit.py"'
-command_windows = 'python "{{ .chezmoi.homeDir | replace "\\" "/" }}/.codex/hooks/deny_protected_branch_commit.py"'
+command_windows = 'uv run --isolated --managed-python python "{{ .chezmoi.homeDir | replace "\\" "/" }}/.codex/hooks/deny_protected_branch_commit.py"'
 timeout = 30
 statusMessage = "Checking protected branch policy"
 

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -107,7 +107,7 @@ let
     };
     python3 = {
       pkg = pkgs.python3;
-      winget = "Python.Python.3.13";
+      winget = null;
       category = "dev";
     };
     go = {
@@ -680,10 +680,6 @@ lib.mapAttrs (_: names: resolve names) grouped
       command = "oxlint";
       args = [ "--version" ];
     };
-    python3 = {
-      command = "python";
-      args = [ "--version" ];
-    };
     google-cloud-sdk = {
       command = "gcloud";
       args = [ "version" ];
@@ -825,6 +821,7 @@ lib.mapAttrs (_: names: resolve names) grouped
       "Microsoft.WindowsTerminal"
       "Microsoft.WSL"
       "OpenAI.Codex"
+      "StablyAI.Orca"
       "TablePlus.TablePlus"
       "Oven-sh.Bun"
       "zig.zig"

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -725,6 +725,7 @@ lib.mapAttrs (_: names: resolve names) grouped
     wezterm = true;
     warp-terminal = true;
     "9PLM9XGG6VKS" = true;
+    "StablyAI.Orca" = true;
   };
 
   # Extra PATH directories for installers that do not register CLI commands on PATH.

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -286,6 +286,31 @@ Describe 'Package catalog consistency' {
         }
     }
 
+    Context 'Windows Orca and Python installation policy' {
+        It 'should manage Orca as a Windows-only winget package and avoid native Python winget installs in the SSOT' {
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+
+            $sets | Should -Match '(?s)windowsOnly\s*=\s*\{.*?winget\s*=\s*\[.*?"StablyAI\.Orca".*?\]'
+            $sets | Should -Match '(?s)python3\s*=\s*\{.*?pkg\s*=\s*pkgs\.python3;.*?winget\s*=\s*null;'
+            $sets | Should -Not -Match 'winget\s*=\s*"Python\.Python\.3\.13"'
+            $sets | Should -Match '(?s)uv\s*=\s*\{.*?pkg\s*=\s*pkgs\.uv;.*?winget\s*=\s*"astral-sh\.uv"'
+        }
+
+        It 'should generate Orca and uv without the native Python winget package' {
+            $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
+            $wingetSource = @($json.Sources | Where-Object { $_.SourceDetails.Name -eq 'winget' }) | Select-Object -First 1
+            $orca = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'StablyAI.Orca' }) | Select-Object -First 1
+            $python = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'Python.Python.3.13' }) | Select-Object -First 1
+            $uv = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'astral-sh.uv' }) | Select-Object -First 1
+
+            $orca | Should -Not -BeNullOrEmpty
+            $python | Should -BeNullOrEmpty -Because "Windows Python should be provisioned through uv, not the native winget package"
+            $uv | Should -Not -BeNullOrEmpty
+            $uv.verifyCommand.command | Should -Be 'uv'
+            @($uv.verifyCommand.args) | Should -Contain '--version'
+        }
+    }
+
     Context 'Windows native Rust browser automation tools' {
         It 'should manage agent-browser as a Windows npm global package with verification' {
             $sets = Get-Content -LiteralPath $script:setsPath -Raw

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -291,6 +291,7 @@ Describe 'Package catalog consistency' {
             $sets = Get-Content -LiteralPath $script:setsPath -Raw
 
             $sets | Should -Match '(?s)windowsOnly\s*=\s*\{.*?winget\s*=\s*\[.*?"StablyAI\.Orca".*?\]'
+            $sets | Should -Match '(?s)wingetCiSkipInstall\s*=\s*\{.*?"StablyAI\.Orca"\s*=\s*true;'
             $sets | Should -Match '(?s)python3\s*=\s*\{.*?pkg\s*=\s*pkgs\.python3;.*?winget\s*=\s*null;'
             $sets | Should -Not -Match 'winget\s*=\s*"Python\.Python\.3\.13"'
             $sets | Should -Match '(?s)uv\s*=\s*\{.*?pkg\s*=\s*pkgs\.uv;.*?winget\s*=\s*"astral-sh\.uv"'
@@ -304,6 +305,7 @@ Describe 'Package catalog consistency' {
             $uv = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'astral-sh.uv' }) | Select-Object -First 1
 
             $orca | Should -Not -BeNullOrEmpty
+            $orca.ciSkipInstall | Should -BeTrue
             $python | Should -BeNullOrEmpty -Because "Windows Python should be provisioned through uv, not the native winget package"
             $uv | Should -Not -BeNullOrEmpty
             $uv.verifyCommand.command | Should -Be 'uv'

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -397,6 +397,17 @@ Describe 'chezmoi テンプレート バリデーション' {
         }
     }
 
+    Context 'Codex hook Python runtime policy' {
+        It 'should run Windows Python hooks through uv managed Python' {
+            $templatePath = Join-Path $script:chezmoiRoot "dot_codex/config.toml.tmpl"
+            $content = Get-Content -LiteralPath $templatePath -Raw
+
+            $content | Should -Not -Match "(?m)^command_windows\s*=\s*'python\s+" -Because "Windows must not depend on native Python installs"
+            $content | Should -Match "(?m)^command_windows\s*=\s*'uv run --isolated --managed-python python .+claude_permission_policy\.py`"'" -Because "Codex hooks should use uv-managed Python on Windows"
+            $content | Should -Match "(?m)^command_windows\s*=\s*'uv run --isolated --managed-python python .+deny_protected_branch_commit\.py`"'" -Because "Codex hooks should use uv-managed Python on Windows"
+        }
+    }
+
     Context 'Codex MCP startup defaults' {
         BeforeAll {
             $script:mcpServersPath = Join-Path $script:chezmoiRoot ".chezmoidata/mcp_servers.yaml"

--- a/scripts/powershell/tests/chezmoi/MempalaceRemoval.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/MempalaceRemoval.Tests.ps1
@@ -44,3 +44,38 @@ Describe 'mempalace is not installed by chezmoi' {
         $violations | Should -BeNullOrEmpty -Because "chezmoi apply must not invoke interactive mempalace setup"
     }
 }
+
+Describe 'serena is not installed by chezmoi' {
+    It 'does not configure the serena MCP server' {
+        $paths = @(
+            (Join-Path $script:chezmoiRoot ".chezmoidata/mcp_servers.yaml"),
+            (Join-Path $script:repoRoot ".codex/config.toml"),
+            (Join-Path $script:repoRoot ".mcp.json")
+        )
+
+        foreach ($path in $paths) {
+            if (-not (Test-Path -LiteralPath $path)) { continue }
+
+            $content = Get-Content -LiteralPath $path -Raw
+            $content | Should -Not -Match '(?i)serena-mcp-server|oraios/serena'
+            $content | Should -Not -Match '(?im)^\s*(\[mcp_servers\.serena\]|"serena"\s*:|- name:\s*serena)\s*$'
+        }
+    }
+
+    It 'does not run serena installation or initialization commands' {
+        $files = Get-ChildItem -Path $script:chezmoiRoot -Recurse -File |
+            Where-Object { $_.FullName -notmatch '\\.git\\' }
+
+        $violations = @()
+        foreach ($file in $files) {
+            $content = Get-Content -LiteralPath $file.FullName -Raw -ErrorAction SilentlyContinue
+            if (-not $content) { continue }
+
+            if ($content -match '(?i)(uvx|uv\s+tool\s+install|pipx|pip\s+install).*serena|serena-mcp-server|oraios/serena') {
+                $violations += $file.FullName
+            }
+        }
+
+        $violations | Should -BeNullOrEmpty -Because "chezmoi apply must not install or configure Serena"
+    }
+}

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -337,7 +337,8 @@
           }
         },
         {
-          "PackageIdentifier": "StablyAI.Orca"
+          "PackageIdentifier": "StablyAI.Orca",
+          "ciSkipInstall": true
         },
         {
           "PackageIdentifier": "TablePlus.TablePlus"

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -169,13 +169,6 @@
           }
         },
         {
-          "PackageIdentifier": "Python.Python.3.13",
-          "verifyCommand": {
-            "args": ["--version"],
-            "command": "python"
-          }
-        },
-        {
           "PackageIdentifier": "BurntSushi.ripgrep.MSVC",
           "verifyCommand": {
             "args": ["--version"],
@@ -342,6 +335,9 @@
             "args": ["--version"],
             "command": "codex"
           }
+        },
+        {
+          "PackageIdentifier": "StablyAI.Orca"
         },
         {
           "PackageIdentifier": "TablePlus.TablePlus"


### PR DESCRIPTION
## Summary
- Add `StablyAI.Orca` to the Windows winget package catalog.
- Remove the native `Python.Python.3.13` winget install path and keep Windows Python usage on uv-managed runtimes.
- Run Codex Windows hooks via `uv run --isolated --managed-python python`.
- Add regression coverage to keep Serena out of chezmoi/MCP configuration.

## Validation
- `pwsh -NoLogo -NoProfile -Command "& '.\\scripts\\powershell\\tests\\Invoke-Tests.ps1' -Path @('.\\scripts\\powershell\\tests\\PackageCatalog.Tests.ps1', '.\\scripts\\powershell\\tests\\chezmoi\\ChezmoiTemplate.Tests.ps1', '.\\scripts\\powershell\\tests\\chezmoi\\MempalaceRemoval.Tests.ps1')"`
- `git diff --check`
- `winget list --id StablyAI.Orca --exact`
- `winget list Python`
- `uv run --isolated --managed-python python --version`