### PR TITLE
[codex] fix sidekick ctrl shift resize

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -19,6 +19,19 @@ local function resize_sidekick_cli(terminal, delta)
     end
 end
 
+local function resize_sidekick_cli_toward(terminal, direction)
+    local layout = terminal.opts and terminal.opts.layout or "right"
+    if layout == "top" or layout == "bottom" then
+        return
+    end
+
+    local delta = direction == "left" and 5 or -5
+    if layout == "left" then
+        delta = -delta
+    end
+    resize_sidekick_cli(terminal, delta)
+end
+
 return {
     -- Colorscheme
     {
@@ -559,6 +572,22 @@ return {
                             end,
                             mode = "nt",
                             desc = "Sidekick shrink window",
+                        },
+                        resize_left = {
+                            "<C-S-h>",
+                            function(terminal)
+                                resize_sidekick_cli_toward(terminal, "left")
+                            end,
+                            mode = "nt",
+                            desc = "Sidekick resize left",
+                        },
+                        resize_right = {
+                            "<C-S-l>",
+                            function(terminal)
+                                resize_sidekick_cli_toward(terminal, "right")
+                            end,
+                            mode = "nt",
+                            desc = "Sidekick resize right",
                         },
                     },
                 },

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -104,6 +104,9 @@ config.send_composed_key_when_right_alt_is_pressed = false
 config.keys = {
     -- Shift+Enter → insert newline (Claude Code, Codex, multi-line prompts)
     { key = "Return", mods = "SHIFT", action = act.SendString("\n") },
+    -- Pass Ctrl+Shift+h/l through to Neovim; WezTerm defaults Ctrl+Shift+l to the debug overlay.
+    { key = "h", mods = "CTRL|SHIFT", action = act.SendKey({ key = "h", mods = "CTRL|SHIFT" }) },
+    { key = "l", mods = "CTRL|SHIFT", action = act.SendKey({ key = "l", mods = "CTRL|SHIFT" }) },
 
     -- Alt+key → send ESC sequence for fzf/zoxide/PSReadLine bindings
     { key = "q", mods = "ALT", action = act.SendString("\x1bq") },


### PR DESCRIPTION
## Summary
- add sidekick window resize bindings for Ctrl+Shift+h/l
- pass Ctrl+Shift+h/l through WezTerm so Ctrl+Shift+l is not captured by the debug overlay

## Root cause
Sidekick split windows were not handled by the existing float terminal resize mappings, and WezTerm captured Ctrl+Shift+l before Neovim could receive it.

## Validation
- stylua --check chezmoi/dot_config/nvim/lua/plugins/init.lua chezmoi/terminals/wezterm/wezterm.lua
- git diff --check -- chezmoi/dot_config/nvim/lua/plugins/init.lua chezmoi/terminals/wezterm/wezterm.lua
- nvim headless sidekick key validation
- wezterm show-keys validation
- task DOTFILES_PATH=/mnt/d/ruru/dotfiles-sidekick-pr commit -- "fix sidekick ctrl shift resize"