### PR TITLE
[codex] fix nvim undo redo keymaps

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/keymaps.lua
+++ b/chezmoi/dot_config/nvim/lua/config/keymaps.lua
@@ -28,6 +28,10 @@ map("n", "<leader>bd", "<cmd>bdelete<cr>", { desc = "Delete buffer" })
 -- Clear search highlight
 map("n", "<Esc>", "<cmd>nohlsearch<cr>", { desc = "Clear search highlight" })
 
+-- Editor-style undo / redo
+map({ "n", "i", "x" }, "<C-z>", "<cmd>undo<cr>", { desc = "Undo" })
+map({ "n", "i", "x" }, "<C-y>", "<cmd>redo<cr>", { desc = "Redo" })
+
 -- Better indenting
 map("v", "<", "<gv", { desc = "Indent left" })
 map("v", ">", ">gv", { desc = "Indent right" })

--- a/docs/chezmoi/keybindings.md
+++ b/docs/chezmoi/keybindings.md
@@ -44,6 +44,8 @@
 
 - Neovim
   - `Leader` は `Space`
+  - `Ctrl+Z`: undo
+  - `Ctrl+Y`: redo
   - `Space+e`: エクスプローラ
   - `Space+ff/fg/fb`: ファイル検索/grep/buffers
   - `Space+aa`: AI チャット toggle (codecompanion)


### PR DESCRIPTION
## Summary
- Add Neovim keymaps for editor-style undo/redo: Ctrl+Z for undo and Ctrl+Y for redo.
- Document the Neovim keybindings in the chezmoi keybinding guide.

## Validation
- Ran headless Neovim with the repo keymap file loaded and verified Ctrl+Z undo followed by Ctrl+Y redo restores inserted text.
- Parsed Windows Terminal settings JSON.
- Ran `git diff --cached --check` before commit.

## Notes
- The working tree also has unrelated Plane files/architecture edits that are intentionally not included in this PR.