### PR TITLE
[codex] unify GitHub PAT environment variable

### DIFF
--- a/chezmoi/.chezmoidata/mcp_servers.yaml
+++ b/chezmoi/.chezmoidata/mcp_servers.yaml
@@ -66,7 +66,7 @@ mcp_servers:
       - "dlx"
       - "@modelcontextprotocol/server-github@2025.4.8"
     env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: "${GH_TOKEN}"
+      GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PAT_TOKEN}"
     supports:
       - cursor
       - gemini

--- a/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy_vscode_mcp.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy_vscode_mcp.ps1.tmpl
@@ -32,7 +32,7 @@ $servers["{{ .name }}"] = [ordered]@{
 {{- if hasKey . "env" }}
 $servers["{{ .name }}"]["env"] = @{
 {{- range $key, $value := .env }}
-    "{{ $key }}" = "{{ $value }}"
+    "{{ $key }}" = '{{ $value }}'
 {{- end }}
 }
 {{- end }}

--- a/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy_zed_mcp.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy_zed_mcp.ps1.tmpl
@@ -43,7 +43,7 @@ $servers["{{ .name }}"] = [ordered]@{
 {{- if hasKey . "env" }}
 $servers["{{ .name }}"]["env"] = @{
 {{- range $key, $value := .env }}
-    "{{ $key }}" = "{{ $value }}"
+    "{{ $key }}" = '{{ $value }}'
 {{- end }}
 }
 {{- end }}

--- a/chezmoi/secret/env.ps1
+++ b/chezmoi/secret/env.ps1
@@ -2,12 +2,15 @@
 # Sourced by PowerShell profile at shell startup.
 #
 # Preferred usage: launch WezTerm via ~/.local/bin/wezterm-launch.cmd
-#   op run --env-file injects GH_TOKEN/TAVILY_API_KEY/GITHUB_WORK_TOKEN once at WezTerm startup;
+#   op run --env-file injects GITHUB_PAT_TOKEN/TAVILY_API_KEY/GITHUB_WORK_TOKEN once at WezTerm startup;
 #   all tabs inherit them and this guard exits immediately.
 #
 # Fallback: standalone pwsh attempts bounded op inject calls when values are missing.
 
-if ($env:GH_TOKEN -and $env:TAVILY_API_KEY -and $env:GITHUB_WORK_TOKEN) { return }
+if (-not $env:GITHUB_PAT_TOKEN -and $env:GH_TOKEN) { $env:GITHUB_PAT_TOKEN = $env:GH_TOKEN }
+if (-not $env:GH_TOKEN -and $env:GITHUB_PAT_TOKEN) { $env:GH_TOKEN = $env:GITHUB_PAT_TOKEN }
+
+if ($env:GITHUB_PAT_TOKEN -and $env:GH_TOKEN -and $env:TAVILY_API_KEY -and $env:GITHUB_WORK_TOKEN) { return }
 if (-not $env:DOTFILES_FORCE_SECRET_LOAD) {
     $dotfilesPowerShellArgs = [Environment]::GetCommandLineArgs()
     $dotfilesSecretLoadIsCommandMode = $false
@@ -133,7 +136,7 @@ function Set-DotfilesSecretEnvironment {
         return
     }
 
-    $allowedNames = @('GH_TOKEN', 'TAVILY_API_KEY', 'GITHUB_WORK_TOKEN')
+    $allowedNames = @('GITHUB_PAT_TOKEN', 'GH_TOKEN', 'TAVILY_API_KEY', 'GITHUB_WORK_TOKEN')
     foreach ($line in ($Content -split '\r?\n')) {
         if ($line -notmatch '^([A-Za-z_][A-Za-z0-9_]*)=(.*)$') {
             continue
@@ -153,13 +156,16 @@ try {
     $personalAccount = if ($env:OP_ACCOUNT) { $env:OP_ACCOUNT } else { 'EJLA3HRAVZBCXIQ7SRSFGQBTNU' }
     $workAccount = 'aimatecoltd.1password.com'
 
-    if (-not ($env:GH_TOKEN -and $env:TAVILY_API_KEY)) {
+    if (-not ($env:GITHUB_PAT_TOKEN -and $env:TAVILY_API_KEY)) {
         $personalTemplate = @'
-GH_TOKEN={{ op://Private/GitHubUsedUserPAT/credential }}
+GITHUB_PAT_TOKEN={{ op://Private/GitHubUsedUserPAT/credential }}
 TAVILY_API_KEY={{ op://Private/TavilyUsedUserPAT/credential }}
 '@
         Set-DotfilesSecretEnvironment -Content (Invoke-DotfilesOpInject -Template $personalTemplate -Account $personalAccount -TimeoutSeconds $timeoutSeconds)
     }
+
+    if (-not $env:GITHUB_PAT_TOKEN -and $env:GH_TOKEN) { $env:GITHUB_PAT_TOKEN = $env:GH_TOKEN }
+    if (-not $env:GH_TOKEN -and $env:GITHUB_PAT_TOKEN) { $env:GH_TOKEN = $env:GITHUB_PAT_TOKEN }
 
     if (-not $env:GITHUB_WORK_TOKEN) {
         $workTemplate = @'

--- a/chezmoi/secret/env.sh
+++ b/chezmoi/secret/env.sh
@@ -2,12 +2,19 @@
 # Sourced by .bashrc and .zshrc at shell startup.
 #
 # Preferred usage (WSL in WezTerm): launch WezTerm via wezterm-launch.cmd
-#   wezterm-launch.cmd sets WSLENV=GH_TOKEN:TAVILY_API_KEY before op run,
+#   wezterm-launch.cmd sets WSLENV=GITHUB_PAT_TOKEN:TAVILY_API_KEY:GITHUB_WORK_TOKEN before op run,
 #   so WSL child processes inherit the vars and this guard exits immediately.
 #
 # Fallback (standalone WSL / native Linux): op.exe inject runs once per session.
 
-[ -n "$GH_TOKEN" ] && [ -n "$TAVILY_API_KEY" ] && [ -n "$GITHUB_WORK_TOKEN" ] && return 0
+if [ -z "${GITHUB_PAT_TOKEN:-}" ] && [ -n "${GH_TOKEN:-}" ]; then
+  export GITHUB_PAT_TOKEN="$GH_TOKEN"
+fi
+if [ -z "${GH_TOKEN:-}" ] && [ -n "${GITHUB_PAT_TOKEN:-}" ]; then
+  export GH_TOKEN="$GITHUB_PAT_TOKEN"
+fi
+
+[ -n "$GITHUB_PAT_TOKEN" ] && [ -n "$GH_TOKEN" ] && [ -n "$TAVILY_API_KEY" ] && [ -n "$GITHUB_WORK_TOKEN" ] && return 0
 
 # Under WSL the Linux `op` CLI cannot bridge to the Windows 1Password app.
 # Use op.exe so secrets resolve without a separate Linux signin.
@@ -24,11 +31,11 @@ command -v "$_op_cmd" >/dev/null 2>&1 || {
 _personal_acct="${OP_ACCOUNT:-EJLA3HRAVZBCXIQ7SRSFGQBTNU}"
 _work_acct="aimatecoltd.1password.com"
 
-_secret_tmpl='GH_TOKEN={{ op://Private/GitHubUsedUserPAT/credential }}
+_secret_tmpl='GITHUB_PAT_TOKEN={{ op://Private/GitHubUsedUserPAT/credential }}
 TAVILY_API_KEY={{ op://Private/TavilyUsedUserPAT/credential }}'
 
 _resolved=$(printf '%s\n' "$_secret_tmpl" | "$_op_cmd" inject --account "$_personal_acct" 2>/dev/null) || {
-  printf '[secret/env.sh] warning: %s inject failed; GH_TOKEN/TAVILY_API_KEY not set\n' "$_op_cmd" >&2
+  printf '[secret/env.sh] warning: %s inject failed; GITHUB_PAT_TOKEN/TAVILY_API_KEY not set\n' "$_op_cmd" >&2
   _resolved=''
 }
 _resolved=$(printf '%s' "$_resolved" | tr -d '\r')
@@ -36,6 +43,13 @@ if [ -n "$_resolved" ]; then
   set -a
   eval "$_resolved"
   set +a
+fi
+
+if [ -z "${GITHUB_PAT_TOKEN:-}" ] && [ -n "${GH_TOKEN:-}" ]; then
+  export GITHUB_PAT_TOKEN="$GH_TOKEN"
+fi
+if [ -z "${GH_TOKEN:-}" ] && [ -n "${GITHUB_PAT_TOKEN:-}" ]; then
+  export GH_TOKEN="$GITHUB_PAT_TOKEN"
 fi
 
 _work_tmpl='GITHUB_WORK_TOKEN={{ op://devcontainer/GITHUB_PERSONAL_ACCESS_TOKEN_KOHEI-MIKI-IM8/credential }}'

--- a/chezmoi/secret/secrets.env
+++ b/chezmoi/secret/secrets.env
@@ -1,3 +1,3 @@
-GH_TOKEN=op://Private/GitHubUsedUserPAT/credential
+GITHUB_PAT_TOKEN=op://Private/GitHubUsedUserPAT/credential
 TAVILY_API_KEY=op://Private/TavilyUsedUserPAT/credential
 GITHUB_WORK_TOKEN=op://devcontainer/GITHUB_PERSONAL_ACCESS_TOKEN_KOHEI-MIKI-IM8/credential

--- a/chezmoi/secret/wezterm-launch.cmd
+++ b/chezmoi/secret/wezterm-launch.cmd
@@ -2,11 +2,11 @@
 rem Launch WezTerm with 1Password-injected secrets (op run official pattern).
 rem
 rem  - One biometric prompt on WezTerm startup; no further prompts per tab.
-rem  - WSLENV bridges GH_TOKEN / TAVILY_API_KEY / GITHUB_WORK_TOKEN into WSL child processes
+rem  - WSLENV bridges GITHUB_PAT_TOKEN / TAVILY_API_KEY / GITHUB_WORK_TOKEN into WSL child processes
 rem    so env.sh guard triggers and op.exe inject is skipped there too.
 rem
 rem Usage: pin this file to taskbar or create a Start-menu shortcut.
 rem        Replace any existing "WezTerm" shortcut with this launcher.
 
-set WSLENV=GH_TOKEN:TAVILY_API_KEY:GITHUB_WORK_TOKEN
+set WSLENV=GITHUB_PAT_TOKEN:TAVILY_API_KEY:GITHUB_WORK_TOKEN
 op run --env-file="%USERPROFILE%\.config\shell\secrets.env" -- wezterm

--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -560,7 +560,7 @@ function dotf {
     try { task @args } finally { Pop-Location }
 }
 
-# 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)
+# 1Password-managed secrets (GITHUB_PAT_TOKEN, TAVILY_API_KEY, etc.)
 # Codex 等の最小環境では $HOME が空文字列のため Join-Path がエラーになる。
 if ($HOME) {
     $_secretPs1 = Join-Path $HOME ".config\shell\secret.ps1"

--- a/chezmoi/shells/bashrc
+++ b/chezmoi/shells/bashrc
@@ -156,7 +156,7 @@ bind -x '"\er": __fzf_history_widget'
 # dotf: run task from dotfiles root without changing cwd
 dotf() { (cd ~/.dotfiles && task "$@"); }
 
-# 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)
+# 1Password-managed secrets (GITHUB_PAT_TOKEN, TAVILY_API_KEY, etc.)
 [[ -f "$HOME/.config/shell/secret.sh" ]] && source "$HOME/.config/shell/secret.sh"
 
 # GitHub CLI token switching for personal/work repositories.

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -154,7 +154,7 @@ in
       # dotf: run task from dotfiles root without changing cwd
       dotf() { (cd ~/.dotfiles && task "$@") }
 
-      # 1Password-managed secrets (GH_TOKEN, TAVILY_API_KEY, etc.)
+      # 1Password-managed secrets (GITHUB_PAT_TOKEN, TAVILY_API_KEY, etc.)
       [[ -f "$HOME/.config/shell/secret.sh" ]] && source "$HOME/.config/shell/secret.sh"
 
       # GitHub CLI token switching for personal/work repositories.

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -140,6 +140,22 @@ Describe 'chezmoi テンプレート バリデーション' {
         }
     }
 
+    Context 'Windows MCP deploy scripts の env fallback' {
+        It 'PowerShell 展開時に ${VAR} fallback を空文字にしないこと' {
+            $templates = @(
+                ".chezmoiscripts/deploy/editors/run_onchange_deploy_vscode_mcp.ps1.tmpl",
+                ".chezmoiscripts/deploy/editors/run_onchange_deploy_zed_mcp.ps1.tmpl"
+            ) | ForEach-Object { Join-Path $script:chezmoiRoot $_ }
+
+            foreach ($path in $templates) {
+                $content = Get-Content -LiteralPath $path -Raw
+
+                $content | Should -Match '"\{\{ \$key \}\}" = ''\{\{ \$value \}\}''' -Because "$path should write mcp_servers.yaml env fallback values literally"
+                $content | Should -Not -Match '"\{\{ \$key \}\}" = "\{\{ \$value \}\}"' -Because "$path must not let PowerShell expand `${VAR} fallback values"
+            }
+        }
+    }
+
     Context 'Plane MCP server configuration' {
         BeforeAll {
             $script:mcpServersPath = Join-Path $script:chezmoiRoot ".chezmoidata/mcp_servers.yaml"

--- a/scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1
@@ -18,6 +18,7 @@ AfterAll {
 Describe 'PowerShell secret loader' {
     BeforeEach {
         $script:previousGhToken = [Environment]::GetEnvironmentVariable('GH_TOKEN', 'Process')
+        $script:previousGitHubPatToken = [Environment]::GetEnvironmentVariable('GITHUB_PAT_TOKEN', 'Process')
         $script:previousTavilyApiKey = [Environment]::GetEnvironmentVariable('TAVILY_API_KEY', 'Process')
         $script:previousWorkToken = [Environment]::GetEnvironmentVariable('GITHUB_WORK_TOKEN', 'Process')
         $script:previousOpBin = [Environment]::GetEnvironmentVariable('DOTFILES_OP_BIN', 'Process')
@@ -25,6 +26,7 @@ Describe 'PowerShell secret loader' {
         $script:previousForceSecretLoad = [Environment]::GetEnvironmentVariable('DOTFILES_FORCE_SECRET_LOAD', 'Process')
 
         Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
+        Remove-Item Env:GITHUB_PAT_TOKEN -ErrorAction SilentlyContinue
         Remove-Item Env:TAVILY_API_KEY -ErrorAction SilentlyContinue
         Remove-Item Env:GITHUB_WORK_TOKEN -ErrorAction SilentlyContinue
         $env:DOTFILES_SECRET_LOAD_TIMEOUT_SECONDS = '3'
@@ -37,6 +39,13 @@ Describe 'PowerShell secret loader' {
         }
         else {
             $env:GH_TOKEN = $script:previousGhToken
+        }
+
+        if ($null -eq $script:previousGitHubPatToken) {
+            Remove-Item Env:GITHUB_PAT_TOKEN -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:GITHUB_PAT_TOKEN = $script:previousGitHubPatToken
         }
 
         if ($null -eq $script:previousTavilyApiKey) {
@@ -80,7 +89,7 @@ Describe 'PowerShell secret loader' {
         Set-Content -LiteralPath $fakeOp -Encoding ascii -Value @'
 @echo off
 if "%1"=="inject" if "%2"=="--in-file" if exist "%3" if "%4"=="--account" if "%5"=="EJLA3HRAVZBCXIQ7SRSFGQBTNU" (
-  echo GH_TOKEN=personal-token
+  echo GITHUB_PAT_TOKEN=personal-token
   echo TAVILY_API_KEY=tavily-token
   exit /b 0
 )
@@ -94,6 +103,7 @@ exit /b 1
 
         . $script:secretLoaderPath
 
+        $env:GITHUB_PAT_TOKEN | Should -Be 'personal-token'
         $env:GH_TOKEN | Should -Be 'personal-token'
         $env:TAVILY_API_KEY | Should -Be 'tavily-token'
         $env:GITHUB_WORK_TOKEN | Should -Be 'work-token'
@@ -140,15 +150,18 @@ exit /b 0
 `$env:DOTFILES_SECRET_LOAD_TIMEOUT_SECONDS = '3'
 Remove-Item Env:DOTFILES_FORCE_SECRET_LOAD -ErrorAction SilentlyContinue
 Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
+Remove-Item Env:GITHUB_PAT_TOKEN -ErrorAction SilentlyContinue
 Remove-Item Env:TAVILY_API_KEY -ErrorAction SilentlyContinue
 Remove-Item Env:GITHUB_WORK_TOKEN -ErrorAction SilentlyContinue
 . '$loader'
 [Console]::WriteLine('gh=' + [bool]`$env:GH_TOKEN)
+[Console]::WriteLine('githubPat=' + [bool]`$env:GITHUB_PAT_TOKEN)
 "@
 
         $output = & pwsh -NoLogo -NoProfile -Command $command
 
         $output | Should -Contain 'gh=False'
+        $output | Should -Contain 'githubPat=False'
         Test-Path -LiteralPath $marker | Should -BeFalse
     }
 }
@@ -287,6 +300,8 @@ Describe 'GitHub token switching templates' {
     It 'WezTerm launcher が GITHUB_WORK_TOKEN を WSL に渡すこと' {
         $content = Get-Content -LiteralPath $script:weztermLaunch -Raw
 
+        $content | Should -Match 'WSLENV=GITHUB_PAT_TOKEN:TAVILY_API_KEY:GITHUB_WORK_TOKEN'
+        $content | Should -Not -Match 'WSLENV=GH_TOKEN'
         $content | Should -Match 'WSLENV=.*GITHUB_WORK_TOKEN'
     }
 
@@ -294,6 +309,8 @@ Describe 'GitHub token switching templates' {
         $secretsEnvPath = Join-Path $script:chezmoiRoot "secret/secrets.env"
         $content = Get-Content -LiteralPath $secretsEnvPath -Raw
 
+        $content | Should -Match 'GITHUB_PAT_TOKEN=op://Private/GitHubUsedUserPAT/credential'
+        $content | Should -Not -Match '^GH_TOKEN=op://Private/GitHubUsedUserPAT/credential'
         $content | Should -Match 'GITHUB_WORK_TOKEN=op://devcontainer/GITHUB_PERSONAL_ACCESS_TOKEN_KOHEI-MIKI-IM8/credential'
     }
 
@@ -301,6 +318,7 @@ Describe 'GitHub token switching templates' {
         $secretPs1Path = Join-Path $script:chezmoiRoot "secret/env.ps1"
         $content = Get-Content -LiteralPath $secretPs1Path -Raw
 
+        $content | Should -Match 'GITHUB_PAT_TOKEN'
         $content | Should -Match 'GITHUB_WORK_TOKEN'
     }
 }


### PR DESCRIPTION
## Summary
- Canonicalize GitHub PAT environment wiring on `GITHUB_PAT_TOKEN`.
- Keep `GH_TOKEN` as a compatibility alias for existing shell and PowerShell sessions.
- Update MCP/VSCode/Zed/WezTerm/WSL secret wiring so GitHub auth uses the same canonical variable.
- Add template tests covering the GitHub PAT variable behavior.

## Why
Codex GitHub MCP startup expects `GITHUB_PAT_TOKEN`, while parts of the dotfiles were still centered on `GH_TOKEN`. The editor MCP deploy templates also expanded `${VAR}`-style fallback strings too early in PowerShell, which could turn fallback placeholders into empty values.

## Validation
- `Invoke-Pester -Path .worktrees/codex-unify-github-pat-token/scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1,.worktrees/codex-unify-github-pat-token/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1 -Output Detailed` (48 passed)
- `task commit DOTFILES_PATH=/mnt/d/ruru/dotfiles/.worktrees/codex-unify-github-pat-token -- "fix github pat token env"` (ran nix fmt and pre-commit hooks successfully)
- `task test:bash` (19 passed)
- `task fmt:check`
- `git diff --check`
- Earlier full `task test` run passed with 991 passed, 5 skipped, 0 failed

## Notes
`task chezmoi` applied the relevant shell and MCP deploy pieces, then stopped later on an unrelated `LIFELOG_ROOT is required` check. VSCode and Zed MCP deploy templates were also executed directly and verified to preserve `${GITHUB_PAT_TOKEN}` fallback references.