### PR TITLE
[codex] fix hermes agent mcp config

### DIFF
--- a/chezmoi/ssh/config.tmpl
+++ b/chezmoi/ssh/config.tmpl
@@ -15,6 +15,8 @@ Host *
     IdentityAgent ~/.1password/agent.sock
 {{- end }}
 
+Include ~/.ssh/orca-docker-*.config
+
 # GitHub (personal account: rurusasu)
 Host github.com
     HostName github.com

--- a/docker/hermes-agent/Dockerfile
+++ b/docker/hermes-agent/Dockerfile
@@ -7,6 +7,18 @@ ARG ARTICLE_COLLECTOR_VERSION=v0.6.17
 COPY xapi-mcp.sh /usr/local/bin/hermes-xapi-mcp
 COPY gh-wrapper.sh /usr/local/bin/gh
 
+RUN python3 - <<'PY'
+from pathlib import Path
+
+path = Path("/opt/hermes/gateway/channel_directory.py")
+text = path.read_text(encoding="utf-8")
+old = 'types="public_channel,private_channel",'
+new = 'types="public_channel",'
+if old not in text:
+    raise SystemExit(f"expected Slack channel directory call not found in {path}")
+path.write_text(text.replace(old, new), encoding="utf-8")
+PY
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl gh \
   && arch="$(dpkg --print-architecture)" \

--- a/docker/hermes-agent/compose.yml
+++ b/docker/hermes-agent/compose.yml
@@ -20,10 +20,6 @@ services:
       - type: bind
         source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.xurl
         target: /root/.xurl
-    env_file:
-      - path: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.env
-        format: raw
-        required: false
     environment:
       HERMES_DASHBOARD: "1"
       HERMES_DASHBOARD_HOST: "0.0.0.0"

--- a/scripts/powershell/handlers/Handler.HermesAgent.ps1
+++ b/scripts/powershell/handlers/Handler.HermesAgent.ps1
@@ -1234,19 +1234,54 @@ class HermesAgentHandler : SetupHandlerBase {
             return [PSCustomObject]@{ Changed = $false; Source = "Disabled" }
         }
 
-        $configPath = Join-Path $dataDir "config.yaml"
-        $existingLines = @()
-        if (Test-Path -LiteralPath $configPath) {
-            $existingLines = @(Get-Content -LiteralPath $configPath -ErrorAction Stop)
+        $configTargets = @(
+            [PSCustomObject]@{
+                ConfigPath = Join-Path $dataDir "config.yaml"
+                DataDir    = $dataDir
+            }
+        )
+
+        $profilesDir = Join-Path $dataDir "profiles"
+        foreach ($profileName in $this.GetManagedProfileNames($ctx)) {
+            $profileDir = Join-Path $profilesDir $profileName
+            if (Test-Path -LiteralPath $profileDir -PathType Container) {
+                $configTargets += [PSCustomObject]@{
+                    ConfigPath = Join-Path $profileDir "config.yaml"
+                    DataDir    = $profileDir
+                }
+            }
         }
 
-        $updatedLines = $this.SetMcpConfigLines($existingLines)
-        $changed = -not $this.LinesEqual($existingLines, $updatedLines)
-        if ($changed) {
-            Set-Content -LiteralPath $configPath -Encoding UTF8 -Value $updatedLines
+        $changedPaths = @()
+        foreach ($target in $configTargets) {
+            $configPath = $target.ConfigPath
+            $targetDataDir = $target.DataDir
+            $existingLines = @()
+            if (Test-Path -LiteralPath $configPath) {
+                $existingLines = @(Get-Content -LiteralPath $configPath -ErrorAction Stop)
+            }
+
+            $envPath = Join-Path $targetDataDir ".env"
+            $envLines = @()
+            if (Test-Path -LiteralPath $envPath) {
+                $envLines = @(Get-Content -LiteralPath $envPath -ErrorAction Stop)
+            }
+
+            $includeXApi = $this.HasXApiMcpAuthentication($targetDataDir, $envLines)
+            $updatedLines = $this.SetMcpConfigLines($existingLines, $includeXApi)
+            if (-not $this.LinesEqual($existingLines, $updatedLines)) {
+                $this.EnsureDirectory((Split-Path -Parent $configPath))
+                Set-Content -LiteralPath $configPath -Encoding UTF8 -Value $updatedLines
+                $changedPaths += $configPath
+            }
         }
 
-        return [PSCustomObject]@{ Changed = $changed; Source = "Config" }
+        return [PSCustomObject]@{
+            Changed = $changedPaths.Count -gt 0
+            Source  = "Config"
+            Count   = $changedPaths.Count
+            Paths   = $changedPaths
+        }
     }
 
     hidden [pscustomobject] EnsureTerminalEnvironmentPassthroughConfiguration([SetupContext]$ctx, [string]$dataDir) {
@@ -1469,15 +1504,21 @@ class HermesAgentHandler : SetupHandlerBase {
         return $result
     }
 
-    hidden [string[]] SetMcpConfigLines([string[]]$lines) {
+    hidden [string[]] SetMcpConfigLines([string[]]$lines, [bool]$includeXApi) {
         $managedServerNames = @("github", "xapi", "x-docs")
-        $desiredLines = @(
-            "  xapi:",
-            "    command: /usr/local/bin/hermes-xapi-mcp",
-            "    connect_timeout: 300",
-            "    env:",
-            '      X_API_CLIENT_ID: ${X_API_CLIENT_ID}',
-            '      X_API_CLIENT_SECRET: ${X_API_CLIENT_SECRET}',
+        $desiredLines = @()
+        if ($includeXApi) {
+            $desiredLines += @(
+                "  xapi:",
+                "    command: /usr/local/bin/hermes-xapi-mcp",
+                "    connect_timeout: 300",
+                "    env:",
+                '      X_API_CLIENT_ID: ${X_API_CLIENT_ID}',
+                '      X_API_CLIENT_SECRET: ${X_API_CLIENT_SECRET}'
+            )
+        }
+
+        $desiredLines += @(
             "  x-docs:",
             "    url: https://docs.x.com/mcp",
             "    connect_timeout: 60"
@@ -1531,6 +1572,51 @@ class HermesAgentHandler : SetupHandlerBase {
         }
 
         return $result
+    }
+
+    hidden [bool] HasXApiMcpAuthentication([string]$dataDir, [string[]]$envLines) {
+        $clientId = $this.GetEnvLineValue($envLines, "X_API_CLIENT_ID")
+        $clientSecret = $this.GetEnvLineValue($envLines, "X_API_CLIENT_SECRET")
+        if ($this.HasRealEnvValue($clientId) -and $this.HasRealEnvValue($clientSecret)) {
+            return $true
+        }
+
+        $xurlDir = Join-Path $dataDir ".xurl"
+        if (-not (Test-Path -LiteralPath $xurlDir -PathType Container)) {
+            return $false
+        }
+
+        $cacheFile = Get-ChildItem -LiteralPath $xurlDir -Force -File -Recurse -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        return $null -ne $cacheFile
+    }
+
+    hidden [string] GetEnvLineValue([string[]]$lines, [string]$name) {
+        $escapedName = [regex]::Escape($name)
+        foreach ($line in $lines) {
+            if ($line -match "^\s*(?:export\s+)?$escapedName\s*=\s*(?<value>.*)\s*$") {
+                return $Matches["value"]
+            }
+        }
+
+        return $null
+    }
+
+    hidden [bool] HasRealEnvValue([string]$value) {
+        if ([string]::IsNullOrWhiteSpace($value)) {
+            return $false
+        }
+
+        $trimmed = $value.Trim()
+        if ($trimmed.Length -ge 2) {
+            $first = $trimmed.Substring(0, 1)
+            $last = $trimmed.Substring($trimmed.Length - 1, 1)
+            if (($first -eq '"' -and $last -eq '"') -or ($first -eq "'" -and $last -eq "'")) {
+                $trimmed = $trimmed.Substring(1, $trimmed.Length - 2).Trim()
+            }
+        }
+
+        return -not [string]::IsNullOrWhiteSpace($trimmed) -and $trimmed -notmatch '^\$\{[^}]+\}$'
     }
 
     hidden [string[]] RemoveGithubMcpConfigLines([string[]]$lines) {
@@ -1768,6 +1854,14 @@ class HermesAgentHandler : SetupHandlerBase {
             return [PSCustomObject]@{ Changed = $false; Source = "Missing"; Count = 0; Profiles = @() }
         }
 
+        $profileEnvironment = @{}
+        foreach ($key in $environment.Keys) {
+            $envName = [string]$key
+            if (-not $this.IsSharedPlatformSecretName($envName)) {
+                $profileEnvironment[$envName] = $environment[$key]
+            }
+        }
+
         $profilesDir = Join-Path $dataDir "profiles"
         $changedProfiles = @()
         foreach ($profileName in $this.GetManagedProfileNames($ctx)) {
@@ -1782,7 +1876,10 @@ class HermesAgentHandler : SetupHandlerBase {
                 $profileLines = @(Get-Content -LiteralPath $profileEnvPath -ErrorAction Stop)
             }
 
-            $updatedLines = $this.SetNamedEnvironmentLines($profileLines, $environment)
+            $managedProfileLines = @(
+                $profileLines | Where-Object { -not $this.IsSharedPlatformSecretLine($_) }
+            )
+            $updatedLines = $this.SetNamedEnvironmentLines($managedProfileLines, $profileEnvironment)
             if (-not $this.LinesEqual($profileLines, $updatedLines)) {
                 Set-Content -LiteralPath $profileEnvPath -Encoding UTF8 -Value $updatedLines
                 $changedProfiles += $profileName
@@ -1865,7 +1962,19 @@ class HermesAgentHandler : SetupHandlerBase {
     }
 
     hidden [bool] IsSharedPlatformSecretLine([string]$line) {
-        return $line -match '^\s*(TELEGRAM_BOT_TOKEN|DISCORD_BOT_TOKEN|DISCORD_TOKEN|WHATSAPP_[A-Z0-9_]+|SIGNAL_[A-Z0-9_]+|TEAMS_[A-Z0-9_]+|QQBOT_[A-Z0-9_]+|YUANBAO_[A-Z0-9_]+|HOMEASSISTANT_[A-Z0-9_]+)\s*='
+        if ($line -notmatch '^\s*(?:export\s+)?(?<name>[A-Z0-9_]+)\s*=') {
+            return $false
+        }
+
+        return $this.IsSharedPlatformSecretName($Matches["name"])
+    }
+
+    hidden [bool] IsSharedPlatformSecretName([string]$name) {
+        if ([string]::IsNullOrWhiteSpace($name)) {
+            return $false
+        }
+
+        return $name.Trim() -match '^(TELEGRAM_BOT_TOKEN|DISCORD_BOT_TOKEN|DISCORD_TOKEN|WHATSAPP_[A-Z0-9_]+|SIGNAL_[A-Z0-9_]+|TEAMS_[A-Z0-9_]+|QQBOT_[A-Z0-9_]+|YUANBAO_[A-Z0-9_]+|HOMEASSISTANT_[A-Z0-9_]+)$'
     }
 
     hidden [void] WriteNamedEnvironment([string]$envPath, [string[]]$lines, [hashtable]$environment) {

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -101,6 +101,9 @@ Describe 'HermesAgentHandler' {
             $dockerfileContent | Should -Match "npx --version"
             $dockerfileContent | Should -Match "xapi-mcp\.sh"
             $dockerfileContent | Should -Match "/usr/local/bin/hermes-xapi-mcp"
+            $dockerfileContent | Should -Match "channel_directory\.py"
+            $dockerfileContent | Should -Match 'types="public_channel,private_channel"'
+            $dockerfileContent | Should -Match 'types="public_channel"'
             $dockerfileContent | Should -Match "ARTICLE_COLLECTOR_VERSION"
             $dockerfileContent | Should -Match "article-collector-linux-amd64"
             $dockerfileContent | Should -Match "article-collector-linux-arm64"
@@ -125,15 +128,13 @@ Describe 'HermesAgentHandler' {
             $wrapperContent | Should -Match ([regex]::Escape('exec npx -y @xdevplatform/xurl mcp https://api.x.com/mcp'))
         }
 
-        It 'should pass the Hermes env file into the container without Compose interpolation' {
+        It 'should not inject the Hermes env file into every supervised gateway process' {
             $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..\..\..")
             $composePath = Join-Path $repoRoot "docker\hermes-agent\compose.yml"
             $composeContent = Get-Content -LiteralPath $composePath -Raw
 
-            $composeContent | Should -Match "(?m)^\s*env_file:"
-            $composeContent | Should -Match ([regex]::Escape('path: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.env'))
-            $composeContent | Should -Match "(?m)^\s*format:\s*raw\s*$"
-            $composeContent | Should -Match "(?m)^\s*required:\s*false\s*$"
+            $composeContent | Should -Not -Match "(?m)^\s*env_file:"
+            $composeContent | Should -Not -Match ([regex]::Escape('path: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.env'))
         }
 
         It 'should persist xurl OAuth cache for the X API MCP bridge' {
@@ -1201,10 +1202,12 @@ Describe 'HermesAgentHandler' {
             $rickDir = Join-Path $profilesDir "rick"
             $risarisaDir = Join-Path $profilesDir "risarisa"
             Set-Content -LiteralPath (Join-Path $rickDir ".env") -Encoding UTF8 -Value @(
-                "SLACK_BOT_TOKEN=xoxb-rick-token"
+                "SLACK_BOT_TOKEN=xoxb-rick-token",
+                "TELEGRAM_BOT_TOKEN=stale-rick-telegram-token"
             )
             Set-Content -LiteralPath (Join-Path $risarisaDir ".env") -Encoding UTF8 -Value @(
-                "GITHUB_TOKEN=stale-token"
+                "GITHUB_TOKEN=stale-token",
+                "TELEGRAM_BOT_TOKEN=stale-risarisa-telegram-token"
             )
 
             Mock Get-Command {
@@ -1271,11 +1274,14 @@ Describe 'HermesAgentHandler' {
                 $profileEnvContent | Should -Match "GH_TOKEN=github-token"
                 $profileEnvContent | Should -Match "GITHUB_PERSONAL_ACCESS_TOKEN=github-token"
                 $profileEnvContent | Should -Match "OPENCLAW_GATEWAY_TOKEN=gateway-token"
+                $profileEnvContent | Should -Not -Match "TELEGRAM_BOT_TOKEN"
             }
             $rickEnvContent = Get-Content -LiteralPath (Join-Path $rickDir ".env") -Raw
             $rickEnvContent | Should -Match "SLACK_BOT_TOKEN=xoxb-rick-token"
+            $rickEnvContent | Should -Not -Match "stale-rick-telegram-token"
             $risarisaEnvContent = Get-Content -LiteralPath (Join-Path $risarisaDir ".env") -Raw
             $risarisaEnvContent | Should -Not -Match "GITHUB_TOKEN=stale-token"
+            $risarisaEnvContent | Should -Not -Match "stale-risarisa-telegram-token"
         }
 
         It 'should fail before compose when any required OpenClaw API token cannot be configured' {
@@ -1294,7 +1300,7 @@ Describe 'HermesAgentHandler' {
             @($script:dockerCalls | Where-Object { $_[0] -eq "compose" }).Count | Should -Be 0
         }
 
-        It 'should configure X MCP servers and remove the GitHub MCP server from config.yaml' {
+        It 'should skip the X API MCP server without authentication and remove the GitHub MCP server from config.yaml' {
             $configDir = Join-Path $script:userProfile ".hermes"
             $configPath = Join-Path $configDir "config.yaml"
             New-Item -ItemType Directory -Path $configDir -Force | Out-Null
@@ -1317,16 +1323,13 @@ Describe 'HermesAgentHandler' {
             $configContent | Should -Not -Match "(?m)^\s{2}github:"
             $configContent | Should -Not -Match "@modelcontextprotocol/server-github"
             $configContent | Should -Match "(?m)^\s{2}local:"
-            $configContent | Should -Match "(?m)^\s{2}xapi:"
-            $configContent | Should -Match "(?m)^\s{4}command:\s*/usr/local/bin/hermes-xapi-mcp"
-            $configContent | Should -Match "(?m)^\s{4}connect_timeout:\s*300"
-            $configContent | Should -Match "(?m)^\s{6}X_API_CLIENT_ID:\s*`\$`\{X_API_CLIENT_ID`\}"
-            $configContent | Should -Match "(?m)^\s{6}X_API_CLIENT_SECRET:\s*`\$`\{X_API_CLIENT_SECRET`\}"
+            $configContent | Should -Not -Match "(?m)^\s{2}xapi:"
+            $configContent | Should -Not -Match "/usr/local/bin/hermes-xapi-mcp"
             $configContent | Should -Match "(?m)^\s{2}x-docs:"
             $configContent | Should -Match "https://docs\.x\.com/mcp"
         }
 
-        It 'should preserve X MCP servers when mcp_servers is absent' {
+        It 'should add X docs only when mcp_servers is absent and X API authentication is unavailable' {
             $configDir = Join-Path $script:userProfile ".hermes"
             $configPath = Join-Path $configDir "config.yaml"
             New-Item -ItemType Directory -Path $configDir -Force | Out-Null
@@ -1340,7 +1343,58 @@ Describe 'HermesAgentHandler' {
             $result.Success | Should -Be $true
             $configContent = Get-Content -LiteralPath $configPath -Raw
             $configContent | Should -Match "(?m)^mcp_servers:"
+            $configContent | Should -Not -Match "(?m)^\s{2}xapi:"
+            $configContent | Should -Match "(?m)^\s{2}x-docs:"
+        }
+
+        It 'should remove stale X API MCP servers from managed profile configs without authentication' {
+            $ctx.Options["HermesAgentManagedProfiles"] = "rick,hoffman"
+            $dataDir = Join-Path $script:userProfile ".hermes"
+            $profilesDir = Join-Path $dataDir "profiles"
+            foreach ($profileName in @("rick", "hoffman")) {
+                $profileDir = Join-Path $profilesDir $profileName
+                New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
+                Set-Content -LiteralPath (Join-Path $profileDir "config.yaml") -Encoding UTF8 -Value @(
+                    "model:",
+                    "  provider: openai-codex",
+                    "mcp_servers:",
+                    "  xapi:",
+                    "    command: /usr/local/bin/hermes-xapi-mcp",
+                    "    connect_timeout: 300",
+                    "  local:",
+                    "    command: local-tool"
+                )
+            }
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            foreach ($profileName in @("rick", "hoffman")) {
+                $configContent = Get-Content -LiteralPath (Join-Path $profilesDir "$profileName\config.yaml") -Raw
+                $configContent | Should -Not -Match "(?m)^\s{2}xapi:"
+                $configContent | Should -Not -Match "/usr/local/bin/hermes-xapi-mcp"
+                $configContent | Should -Match "(?m)^\s{2}local:"
+                $configContent | Should -Match "(?m)^\s{2}x-docs:"
+            }
+        }
+
+        It 'should configure the X API MCP server when an xurl OAuth cache exists' {
+            $configDir = Join-Path $script:userProfile ".hermes"
+            $cacheDir = Join-Path $configDir ".xurl"
+            $configPath = Join-Path $configDir "config.yaml"
+            New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
+            Set-Content -LiteralPath (Join-Path $cacheDir "oauth.json") -Encoding UTF8 -Value "{}"
+            Set-Content -LiteralPath $configPath -Encoding UTF8 -Value @(
+                "model:",
+                "  provider: openai-codex"
+            )
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $configContent = Get-Content -LiteralPath $configPath -Raw
             $configContent | Should -Match "(?m)^\s{2}xapi:"
+            $configContent | Should -Match "(?m)^\s{4}command:\s*/usr/local/bin/hermes-xapi-mcp"
             $configContent | Should -Match "(?m)^\s{2}x-docs:"
         }
 
@@ -1429,6 +1483,15 @@ Describe 'HermesAgentHandler' {
             $envContent = Get-Content -LiteralPath $envPath -Raw
             $envContent | Should -Match "X_API_CLIENT_ID=x-client-id"
             $envContent | Should -Match "X_API_CLIENT_SECRET=x-client-secret"
+
+            $configPath = Join-Path $script:userProfile ".hermes\config.yaml"
+            $configContent = Get-Content -LiteralPath $configPath -Raw
+            $configContent | Should -Match "(?m)^\s{2}xapi:"
+            $configContent | Should -Match "(?m)^\s{4}command:\s*/usr/local/bin/hermes-xapi-mcp"
+            $configContent | Should -Match "(?m)^\s{4}connect_timeout:\s*300"
+            $configContent | Should -Match "(?m)^\s{6}X_API_CLIENT_ID:\s*`\$`\{X_API_CLIENT_ID`\}"
+            $configContent | Should -Match "(?m)^\s{6}X_API_CLIENT_SECRET:\s*`\$`\{X_API_CLIENT_SECRET`\}"
+            $configContent | Should -Match "(?m)^\s{2}x-docs:"
         }
 
         It 'should fail before compose when Slack integration is required but unavailable' {


### PR DESCRIPTION
## Summary
- Manage Hermes MCP config across the root config and managed profile configs.
- Enable the X API MCP server only when OAuth/env authentication exists, while always keeping X docs configured.
- Remove the Hermes compose env_file injection so gateway processes do not inherit every secret by default.
- Add the Orca Docker SSH config include and patch Hermes Slack channel lookup to public channels only.
- Extend HermesAgentHandler tests for the new MCP/auth/profile behavior.

## Validation
- `Invoke-Pester -Path .worktrees/codex-hermes-agent-mcp-config/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1 -Output Detailed` (50 passed)
- `task commit DOTFILES_PATH=/mnt/d/ruru/dotfiles/.worktrees/codex-hermes-agent-mcp-config -- fix hermes agent mcp config` (ran `nix fmt` and pre-commit hooks successfully)
- `git diff --check --cached`