### PR TITLE
fix: stabilize codex github mcp token load

### DIFF
--- a/chezmoi/.chezmoiscripts/deploy/kaggle/run_always_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/kaggle/run_always_deploy.ps1.tmpl
@@ -5,7 +5,7 @@ $ErrorActionPreference = "Stop"
 $KaggleDir = "$env:USERPROFILE\.kaggle"
 $OpAccount = "{{ .op_account_personal }}"
 $SecretRef = "op://Private/Kaggle/c4patuuzwob2vcwt43qqphoyeu"
-$OpReadTimeoutSeconds = 10
+$OpReadTimeoutSeconds = 20
 
 $opCmd = Get-Command op -ErrorAction SilentlyContinue
 if (-not $opCmd) {

--- a/chezmoi/.chezmoiscripts/deploy/kaggle/run_always_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/kaggle/run_always_deploy.sh.tmpl
@@ -5,7 +5,7 @@ set -euo pipefail
 
 OP_ACCOUNT="{{ .op_account_personal }}"
 SECRET_REF="op://Private/Kaggle/c4patuuzwob2vcwt43qqphoyeu"
-OP_READ_TIMEOUT_SECONDS=10
+OP_READ_TIMEOUT_SECONDS=20
 
 OP_CACHE_ARGS=()
 if [ -n "${WSL_DISTRO_NAME:-}" ] && command -v op.exe >/dev/null 2>&1; then

--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.ps1.tmpl
@@ -8,7 +8,7 @@ $PersonalAccount = "{{ .op_account_personal }}"
 $WorkAccount = "{{ .op_account_work }}"
 $PersonalPubkeyRef = "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key"
 $WorkPubkeyRef = "op://Employee/GitHub Work/public key"
-$OpReadTimeoutSeconds = 10
+$OpReadTimeoutSeconds = 20
 
 function Deploy-Content {
   param(

--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.sh.tmpl
@@ -8,7 +8,7 @@ PERSONAL_ACCOUNT="{{ .op_account_personal }}"
 WORK_ACCOUNT="{{ .op_account_work }}"
 PERSONAL_PUBKEY_REF="op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key"
 WORK_PUBKEY_REF="op://Employee/GitHub Work/public key"
-OP_READ_TIMEOUT_SECONDS=10
+OP_READ_TIMEOUT_SECONDS=20
 
 HOME_DIR="${HOME:-/home/$(whoami)}"
 

--- a/chezmoi/dot_config/shell/secret.ps1
+++ b/chezmoi/dot_config/shell/secret.ps1
@@ -5,7 +5,7 @@
 #   op run --account ... --env-file injects personal/work secrets once at WezTerm startup;
 #   all tabs inherit them and this guard exits immediately.
 #
-# Fallback: standalone pwsh attempts bounded op inject calls when values are missing.
+# Fallback: standalone pwsh attempts bounded op read calls when values are missing.
 
 if (-not $env:GITHUB_PAT_TOKEN -and $env:GH_TOKEN) { $env:GITHUB_PAT_TOKEN = $env:GH_TOKEN }
 if (-not $env:GH_TOKEN -and $env:GITHUB_PAT_TOKEN) { $env:GH_TOKEN = $env:GITHUB_PAT_TOKEN }
@@ -53,7 +53,7 @@ function Get-DotfilesSecretLoadTimeoutSeconds {
     [CmdletBinding()]
     param()
 
-    $timeoutSeconds = 8
+    $timeoutSeconds = 60
     if ($env:DOTFILES_SECRET_LOAD_TIMEOUT_SECONDS) {
         $parsedTimeout = 0
         if ([int]::TryParse($env:DOTFILES_SECRET_LOAD_TIMEOUT_SECONDS, [ref]$parsedTimeout) -and $parsedTimeout -gt 0) {
@@ -64,11 +64,11 @@ function Get-DotfilesSecretLoadTimeoutSeconds {
     return $timeoutSeconds
 }
 
-function Invoke-DotfilesOpInject {
+function Invoke-DotfilesOpRead {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [string]$Template,
+        [string]$Reference,
 
         [Parameter(Mandatory = $true)]
         [string]$Account,
@@ -82,72 +82,74 @@ function Invoke-DotfilesOpInject {
         return $null
     }
 
-    $stdin = [System.IO.Path]::GetTempFileName()
     $stdout = [System.IO.Path]::GetTempFileName()
     $stderr = [System.IO.Path]::GetTempFileName()
 
     try {
-        Set-Content -LiteralPath $stdin -Value $Template -Encoding utf8 -NoNewline
         $process = Start-Process `
             -FilePath $opBin `
-            -ArgumentList @('--cache=false', 'inject', '--in-file', $stdin, '--account', $Account) `
+            -ArgumentList @('--cache=false', 'read', $Reference, '--account', $Account) `
             -PassThru `
             -WindowStyle Hidden `
             -RedirectStandardOutput $stdout `
             -RedirectStandardError $stderr
 
         if ($process.WaitForExit($TimeoutSeconds * 1000) -and $process.ExitCode -eq 0) {
-            return Get-Content -LiteralPath $stdout -Raw -ErrorAction SilentlyContinue
+            $value = Get-Content -LiteralPath $stdout -Raw -ErrorAction SilentlyContinue
+            if ($null -eq $value) {
+                return $null
+            }
+            return ([string]$value).Trim()
         }
 
         if (-not $process.HasExited) {
             Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
-            Write-Warning "1Password secret injection timed out after $TimeoutSeconds seconds; continuing without injected secrets."
+            Write-Warning "1Password secret read timed out after $TimeoutSeconds seconds; continuing without '$Reference'."
         }
         else {
             $errorContent = Get-Content -LiteralPath $stderr -Raw -ErrorAction SilentlyContinue
             $errorText = if ($null -ne $errorContent) { $errorContent.Trim() } else { '' }
             if ($errorText) {
-                Write-Warning "1Password secret injection failed: $errorText"
+                Write-Warning "1Password secret read failed for '$Reference': $errorText"
             }
             else {
-                Write-Warning "1Password secret injection failed with exit code $($process.ExitCode)."
+                Write-Warning "1Password secret read failed for '$Reference' with exit code $($process.ExitCode)."
             }
         }
     }
     catch {
-        Write-Warning "1Password secret injection failed: $($_.Exception.Message)"
+        Write-Warning "1Password secret read failed for '$Reference': $($_.Exception.Message)"
     }
     finally {
-        Remove-Item -LiteralPath $stdin, $stdout, $stderr -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $stdout, $stderr -Force -ErrorAction SilentlyContinue
     }
 
     return $null
 }
 
-function Set-DotfilesSecretEnvironment {
+function Set-DotfilesSecretEnvironmentValue {
     [CmdletBinding()]
     param(
-        [Parameter()]
-        [string]$Content
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Reference,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Account,
+
+        [Parameter(Mandatory = $true)]
+        [int]$TimeoutSeconds
     )
 
-    if (-not $Content) {
+    if ([Environment]::GetEnvironmentVariable($Name, 'Process')) {
         return
     }
 
-    $allowedNames = @('GITHUB_PAT_TOKEN', 'GH_TOKEN', 'TAVILY_API_KEY', 'GITHUB_WORK_TOKEN')
-    foreach ($line in ($Content -split '\r?\n')) {
-        if ($line -notmatch '^([A-Za-z_][A-Za-z0-9_]*)=(.*)$') {
-            continue
-        }
-
-        $name = $Matches[1]
-        if ($name -notin $allowedNames) {
-            continue
-        }
-
-        [Environment]::SetEnvironmentVariable($name, $Matches[2], 'Process')
+    $value = Invoke-DotfilesOpRead -Reference $Reference -Account $Account -TimeoutSeconds $TimeoutSeconds
+    if ($value) {
+        [Environment]::SetEnvironmentVariable($Name, $value, 'Process')
     }
 }
 
@@ -156,29 +158,32 @@ try {
     $personalAccount = if ($env:OP_ACCOUNT) { $env:OP_ACCOUNT } else { 'EJLA3HRAVZBCXIQ7SRSFGQBTNU' }
     $workAccount = 'aimatecoltd.1password.com'
 
-    if (-not ($env:GITHUB_PAT_TOKEN -and $env:TAVILY_API_KEY)) {
-        $personalTemplate = @'
-GITHUB_PAT_TOKEN={{ op://Private/GitHubUsedUserPAT/credential }}
-TAVILY_API_KEY={{ op://Private/TavilyUsedUserPAT/credential }}
-'@
-        Set-DotfilesSecretEnvironment -Content (Invoke-DotfilesOpInject -Template $personalTemplate -Account $personalAccount -TimeoutSeconds $timeoutSeconds)
-    }
+    Set-DotfilesSecretEnvironmentValue `
+        -Name 'GITHUB_PAT_TOKEN' `
+        -Reference 'op://Private/GitHubUsedUserPAT/credential' `
+        -Account $personalAccount `
+        -TimeoutSeconds $timeoutSeconds
+
+    Set-DotfilesSecretEnvironmentValue `
+        -Name 'TAVILY_API_KEY' `
+        -Reference 'op://Private/TavilyUsedUserPAT/credential' `
+        -Account $personalAccount `
+        -TimeoutSeconds $timeoutSeconds
 
     if (-not $env:GITHUB_PAT_TOKEN -and $env:GH_TOKEN) { $env:GITHUB_PAT_TOKEN = $env:GH_TOKEN }
     if (-not $env:GH_TOKEN -and $env:GITHUB_PAT_TOKEN) { $env:GH_TOKEN = $env:GITHUB_PAT_TOKEN }
 
-    if (-not $env:GITHUB_WORK_TOKEN) {
-        $workTemplate = @'
-GITHUB_WORK_TOKEN={{ op://devcontainer/GITHUB_PERSONAL_ACCESS_TOKEN_KOHEI-MIKI-IM8/credential }}
-'@
-        Set-DotfilesSecretEnvironment -Content (Invoke-DotfilesOpInject -Template $workTemplate -Account $workAccount -TimeoutSeconds $timeoutSeconds)
-    }
+    Set-DotfilesSecretEnvironmentValue `
+        -Name 'GITHUB_WORK_TOKEN' `
+        -Reference 'op://devcontainer/GITHUB_PERSONAL_ACCESS_TOKEN_KOHEI-MIKI-IM8/credential' `
+        -Account $workAccount `
+        -TimeoutSeconds $timeoutSeconds
 }
 finally {
     Remove-Item Function:\Resolve-DotfilesOpCli -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-DotfilesSecretLoadTimeoutSeconds -ErrorAction SilentlyContinue
-    Remove-Item Function:\Invoke-DotfilesOpInject -ErrorAction SilentlyContinue
-    Remove-Item Function:\Set-DotfilesSecretEnvironment -ErrorAction SilentlyContinue
+    Remove-Item Function:\Invoke-DotfilesOpRead -ErrorAction SilentlyContinue
+    Remove-Item Function:\Set-DotfilesSecretEnvironmentValue -ErrorAction SilentlyContinue
 
-    Remove-Variable timeoutSeconds, personalAccount, workAccount, personalTemplate, workTemplate -ErrorAction SilentlyContinue
+    Remove-Variable timeoutSeconds, personalAccount, workAccount -ErrorAction SilentlyContinue
 }

--- a/chezmoi/dot_local/bin/executable_op-run-gui-launch.ps1
+++ b/chezmoi/dot_local/bin/executable_op-run-gui-launch.ps1
@@ -16,7 +16,7 @@ param(
     [string]$WorkEnvFile,
 
     [Parameter()]
-    [int]$TimeoutSeconds = 8,
+    [int]$TimeoutSeconds = 60,
 
     [Parameter(Mandatory = $true)]
     [string]$Target,
@@ -28,7 +28,7 @@ param(
 $ErrorActionPreference = 'Stop'
 
 if ($TimeoutSeconds -le 0) {
-    $TimeoutSeconds = 8
+    $TimeoutSeconds = 60
 }
 
 function ConvertTo-DotfilesCmdQuoted {

--- a/chezmoi/dot_local/bin/executable_orca-launch.cmd
+++ b/chezmoi/dot_local/bin/executable_orca-launch.cmd
@@ -26,7 +26,7 @@ set "PERSONAL_SECRETS_ENV=%USERPROFILE%\.config\shell\secrets.env"
 set "WORK_SECRETS_ENV=%USERPROFILE%\.config\shell\secrets-work.env"
 set "OP_RUN_GUI_LAUNCH=%USERPROFILE%\.local\bin\op-run-gui-launch.ps1"
 set "OP_RUN_TIMEOUT_SECONDS=%DOTFILES_OP_RUN_TIMEOUT_SECONDS%"
-if "%OP_RUN_TIMEOUT_SECONDS%"=="" set "OP_RUN_TIMEOUT_SECONDS=8"
+if "%OP_RUN_TIMEOUT_SECONDS%"=="" set "OP_RUN_TIMEOUT_SECONDS=60"
 set "PWSH_EXE=%LOCALAPPDATA%\Microsoft\WinGet\Links\pwsh.exe"
 if not exist "%PWSH_EXE%" (
   for /f "delims=" %%I in ('"%WHERE_EXE%" pwsh.exe 2^>nul') do (

--- a/chezmoi/dot_local/bin/executable_wezterm-launch.cmd
+++ b/chezmoi/dot_local/bin/executable_wezterm-launch.cmd
@@ -25,7 +25,7 @@ if not exist "%OP_EXE%" (
 :found_op
 set "OP_RUN_GUI_LAUNCH=%USERPROFILE%\.local\bin\op-run-gui-launch.ps1"
 set "OP_RUN_TIMEOUT_SECONDS=%DOTFILES_OP_RUN_TIMEOUT_SECONDS%"
-if "%OP_RUN_TIMEOUT_SECONDS%"=="" set "OP_RUN_TIMEOUT_SECONDS=8"
+if "%OP_RUN_TIMEOUT_SECONDS%"=="" set "OP_RUN_TIMEOUT_SECONDS=60"
 set "PWSH_EXE=%LOCALAPPDATA%\Microsoft\WinGet\Links\pwsh.exe"
 if not exist "%PWSH_EXE%" (
   for /f "delims=" %%I in ('"%WHERE_EXE%" pwsh.exe 2^>nul') do (

--- a/docs/chezmoi/secrets.md
+++ b/docs/chezmoi/secrets.md
@@ -22,9 +22,9 @@ SSH Agent / `op-ssh-sign` のパスは [1Password CLI 運用](../1password/READM
 - `chezmoi/dot_config/shell/secrets-work.env`
   - 会社用 1Password account の `op run --env-file` 用。`devcontainer` vault の work token を置く。
 - `chezmoi/dot_config/shell/secret.sh`
-  - WSL / Linux の fallback loader。`op inject --account ...` を実行時に呼ぶ。
+  - WSL / Linux の fallback loader。`op read --account ...` を実行時に呼ぶ。
 - `chezmoi/dot_config/shell/secret.ps1`
-  - PowerShell 用。通常は WezTerm launcher から注入済みの環境変数を受け取り、未設定なら timeout 付きで `op inject --account ...` を呼ぶ。
+  - PowerShell 用。通常は WezTerm launcher から注入済みの環境変数を受け取り、未設定なら timeout 付きで個別に `op read --account ...` を呼ぶ。
 - `chezmoi/dot_local/bin/executable_orca-launch.cmd`
   - Orca 経由で起動される Codex 用。GitHub MCP は shell profile 実行前に `GITHUB_PAT_TOKEN` を読むため、Orca 自体を `op run --env-file` の内側で起動する。
 - `chezmoi/dot_local/bin/executable_op-run-gui-launch.ps1`
@@ -230,10 +230,10 @@ Orca から Codex を起動する場合は、Orca process に先に注入する:
 ~\.local\bin\orca-launch.cmd
 ```
 
-GUI launcher の 1Password 待ち時間は既定 8 秒。必要なら上書きする:
+GUI launcher の 1Password 待ち時間は既定 60 秒。必要なら上書きする:
 
 ```powershell
-$env:DOTFILES_OP_RUN_TIMEOUT_SECONDS = "15"
+$env:DOTFILES_OP_RUN_TIMEOUT_SECONDS = "60"
 ~\.local\bin\orca-launch.cmd
 ```
 

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -655,9 +655,11 @@ Describe 'chezmoi テンプレート バリデーション' {
             $linuxContent = Get-Content -LiteralPath $script:kaggleDeployLinux -Raw
 
             $windowsContent | Should -Match '\$OpReadTimeoutSeconds' -Because "run_always scripts must not hang when 1Password app integration prompts or stalls"
+            $windowsContent | Should -Match '\$OpReadTimeoutSeconds = 20' -Because "1Password reads can exceed 8-10 seconds after app auth"
             $windowsContent | Should -Match 'WaitForExit\(\$timeoutMs\)' -Because "Windows op read should be bounded"
             $windowsContent | Should -Match 'Kill\(' -Because "timed-out Windows op reads should be terminated"
             $linuxContent | Should -Match 'OP_READ_TIMEOUT_SECONDS' -Because "run_always scripts must not hang when 1Password app integration prompts or stalls"
+            $linuxContent | Should -Match 'OP_READ_TIMEOUT_SECONDS=20' -Because "WSL op.exe reads can exceed 8-10 seconds after app auth"
             $linuxContent | Should -Match 'timeout|gtimeout' -Because "Unix op read should be bounded"
             $linuxContent | Should -Match 'timed out after \$OP_READ_TIMEOUT_SECONDS seconds' -Because "timeout failures should be reported as non-fatal skips"
         }

--- a/scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1
@@ -84,18 +84,21 @@ Describe 'PowerShell secret loader' {
         }
     }
 
-    It '環境変数が未設定なら op inject から PowerShell process 環境に読み込むこと' {
+    It '環境変数が未設定なら op read から PowerShell process 環境に読み込むこと' {
         $fakeOp = Join-Path $TestDrive 'op.cmd'
         Set-Content -LiteralPath $fakeOp -Encoding ascii -Value @'
 @echo off
 set "ARGS=%*"
-if not "%ARGS:EJLA3HRAVZBCXIQ7SRSFGQBTNU=%"=="%ARGS%" (
-  echo GITHUB_PAT_TOKEN=personal-token
-  echo TAVILY_API_KEY=tavily-token
+if not "%ARGS:GitHubUsedUserPAT=%"=="%ARGS%" (
+  echo personal-token
   exit /b 0
 )
-if not "%ARGS:aimatecoltd.1password.com=%"=="%ARGS%" (
-  echo GITHUB_WORK_TOKEN=work-token
+if not "%ARGS:TavilyUsedUserPAT=%"=="%ARGS%" (
+  echo tavily-token
+  exit /b 0
+)
+if not "%ARGS:GITHUB_PERSONAL_ACCESS_TOKEN_KOHEI-MIKI-IM8=%"=="%ARGS%" (
+  echo work-token
   exit /b 0
 )
 exit /b 1
@@ -110,7 +113,7 @@ exit /b 1
         $env:GITHUB_WORK_TOKEN | Should -Be 'work-token'
     }
 
-    It 'op inject が失敗しても shell 起動を例外で止めないこと' {
+    It 'op read が失敗しても shell 起動を例外で止めないこと' {
         $fakeOp = Join-Path $TestDrive 'op-fail.cmd'
         Set-Content -LiteralPath $fakeOp -Encoding ascii -Value @'
 @echo off
@@ -316,6 +319,7 @@ Describe 'GitHub token switching templates' {
         $content | Should -Match 'WSLENV=.*GITHUB_WORK_TOKEN'
         $content | Should -Match 'op-run-gui-launch\.ps1'
         $content | Should -Match 'DOTFILES_OP_RUN_TIMEOUT_SECONDS'
+        $content | Should -Match 'OP_RUN_TIMEOUT_SECONDS=60'
         $content | Should -Match 'for /f "delims=" %%I in'
         $content | Should -Not -Match 'set "OP_EXE=op"'
     }
@@ -326,6 +330,7 @@ Describe 'GitHub token switching templates' {
 
         $content | Should -Match 'op-run-gui-launch\.ps1' -Because 'GUI launchers should not hang forever when 1Password is locked'
         $content | Should -Match 'DOTFILES_OP_RUN_TIMEOUT_SECONDS' -Because '1Password startup injection should have a bounded wait'
+        $content | Should -Match 'OP_RUN_TIMEOUT_SECONDS=60' -Because '1Password can take longer than 20 seconds on the first app auth'
         $content | Should -Match 'PERSONAL_ACCOUNT=EJLA3HRAVZBCXIQ7SRSFGQBTNU' -Because 'personal secrets must resolve against the personal account'
         $content | Should -Match 'WORK_ACCOUNT=aimatecoltd\.1password\.com' -Because 'work secrets must resolve against the company account'
         $content | Should -Match 'Orca\.exe'
@@ -370,6 +375,9 @@ Describe 'GitHub token switching templates' {
         $content | Should -Match 'GITHUB_PAT_TOKEN'
         $content | Should -Match 'GITHUB_WORK_TOKEN'
         $content | Should -Match '--cache=false'
+        $content | Should -Match "'read'"
+        $content | Should -Match 'GitHubUsedUserPAT'
+        $content | Should -Match '\$timeoutSeconds = 60'
     }
 
     It 'WSL secret loader uses op.exe with cache disabled' {
@@ -384,6 +392,7 @@ Describe 'GitHub token switching templates' {
     It 'GUI op run launcher attempts target fallback when 1Password injection times out' {
         $helperPath = Join-Path $script:chezmoiRoot "dot_local/bin/executable_op-run-gui-launch.ps1"
         Test-Path -LiteralPath $helperPath | Should -BeTrue
+        (Get-Content -LiteralPath $helperPath -Raw) | Should -Match '\[int\]\$TimeoutSeconds = 60'
 
         $fakeOp = Join-Path $TestDrive 'op.cmd'
         $personalEnv = Join-Path $TestDrive 'personal.env'

--- a/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
@@ -173,6 +173,7 @@ Describe 'SSH deploy スクリプト' {
 
         It '1Password 実行時読み込みに timeout があること' {
             $script:ps1Content | Should -Match '\$OpReadTimeoutSeconds' -Because "run_always deploy should not hang when 1Password prompts or stalls"
+            $script:ps1Content | Should -Match '\$OpReadTimeoutSeconds = 20' -Because "1Password reads can exceed 8-10 seconds after app auth"
             $script:ps1Content | Should -Match 'WaitForExit\(\$timeoutMs\)' -Because "Windows op read should be bounded"
             $script:ps1Content | Should -Match 'Kill\(' -Because "timed-out Windows op reads should be terminated"
             $script:ps1Content | Should -Match 'timed out after \$OpReadTimeoutSeconds seconds' -Because "timeout should take the non-fatal skip path"
@@ -201,6 +202,7 @@ Describe 'SSH deploy スクリプト' {
 
         It '1Password 実行時読み込みに timeout があること' {
             $script:shContent | Should -Match 'OP_READ_TIMEOUT_SECONDS' -Because "run_always deploy should not hang when 1Password prompts or stalls"
+            $script:shContent | Should -Match 'OP_READ_TIMEOUT_SECONDS=20' -Because "WSL op.exe reads can exceed 8-10 seconds after app auth"
             $script:shContent | Should -Match 'timeout|gtimeout' -Because "Unix op read should be bounded"
             $script:shContent | Should -Match 'timed out after \$OP_READ_TIMEOUT_SECONDS seconds' -Because "timeout should take the non-fatal skip path"
         }


### PR DESCRIPTION
## Summary
- load PowerShell startup secrets with bounded per-secret `op read` calls instead of one bulk inject
- increase Codex/GUI 1Password startup timeout to 60 seconds and runtime deploy reads to 20 seconds
- update docs and tests for the slower first 1Password app auth path

## Root cause
The GitHub MCP config uses `bearer_token_env_var = GITHUB_PAT_TOKEN`, so `codex mcp login github` is misleading for this setup. The warning appears when the Codex process starts without `GITHUB_PAT_TOKEN`. The previous startup loader timed out after 8 seconds before 1Password returned the PAT.

## Validation
- `git diff --check`
- `Invoke-Pester -Path scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1,scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1,scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1 -Output Detailed` (101 passed)
- forced repo `secret.ps1` load with env cleared: `GITHUB_PAT_TOKEN`, `GH_TOKEN`, `GITHUB_WORK_TOKEN`, and `TAVILY_API_KEY` all populated without printing secret values
- `codex mcp list` reported GitHub MCP auth as `Bearer token` after the forced load