### PR TITLE
fix: extend 1password runtime read timeout

### DIFF
--- a/chezmoi/.chezmoiscripts/deploy/kaggle/run_always_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/kaggle/run_always_deploy.ps1.tmpl
@@ -5,7 +5,7 @@ $ErrorActionPreference = "Stop"
 $KaggleDir = "$env:USERPROFILE\.kaggle"
 $OpAccount = "{{ .op_account_personal }}"
 $SecretRef = "op://Private/Kaggle/c4patuuzwob2vcwt43qqphoyeu"
-$OpReadTimeoutSeconds = 20
+$OpReadTimeoutSeconds = 60
 
 $opCmd = Get-Command op -ErrorAction SilentlyContinue
 if (-not $opCmd) {

--- a/chezmoi/.chezmoiscripts/deploy/kaggle/run_always_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/kaggle/run_always_deploy.sh.tmpl
@@ -5,7 +5,7 @@ set -euo pipefail
 
 OP_ACCOUNT="{{ .op_account_personal }}"
 SECRET_REF="op://Private/Kaggle/c4patuuzwob2vcwt43qqphoyeu"
-OP_READ_TIMEOUT_SECONDS=20
+OP_READ_TIMEOUT_SECONDS=60
 
 OP_CACHE_ARGS=()
 if [ -n "${WSL_DISTRO_NAME:-}" ] && command -v op.exe >/dev/null 2>&1; then

--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.ps1.tmpl
@@ -8,7 +8,7 @@ $PersonalAccount = "{{ .op_account_personal }}"
 $WorkAccount = "{{ .op_account_work }}"
 $PersonalPubkeyRef = "op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key"
 $WorkPubkeyRef = "op://Employee/GitHub Work/public key"
-$OpReadTimeoutSeconds = 20
+$OpReadTimeoutSeconds = 60
 
 function Deploy-Content {
   param(

--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.sh.tmpl
@@ -8,7 +8,7 @@ PERSONAL_ACCOUNT="{{ .op_account_personal }}"
 WORK_ACCOUNT="{{ .op_account_work }}"
 PERSONAL_PUBKEY_REF="op://Private/xnoq6xbcdktkph76e2bg37ou6y/public key"
 WORK_PUBKEY_REF="op://Employee/GitHub Work/public key"
-OP_READ_TIMEOUT_SECONDS=20
+OP_READ_TIMEOUT_SECONDS=60
 
 HOME_DIR="${HOME:-/home/$(whoami)}"
 

--- a/docs/1password/linux.md
+++ b/docs/1password/linux.md
@@ -20,7 +20,7 @@ shell startup や deploy script では、prompt や app integration 待ちで止
 timeout を付ける。
 
 ```bash
-timeout 30s op read "op://Private/Example/credential" --account my.1password.com
+timeout 60s op read "op://Private/Example/credential" --account my.1password.com
 ```
 
 失敗しても続行したい箇所では warning / fallback を使う。

--- a/docs/1password/windows.md
+++ b/docs/1password/windows.md
@@ -61,7 +61,7 @@ shell 起動や deploy script で `op` を呼ぶ場合は、timeout を短くし
 
 目安:
 
-- shell startup fallback: 20-30 秒程度まで許容し、失敗時は warning で続行する。
+- shell startup fallback / runtime deploy read: 60 秒程度まで許容し、失敗時は warning で続行する。
 - GUI launcher: ユーザー体験を優先し、短めの timeout 後に token なし起動へ fallback する。
 - 必須 secret: timeout したら明示的に失敗させる。
 

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -655,11 +655,11 @@ Describe 'chezmoi テンプレート バリデーション' {
             $linuxContent = Get-Content -LiteralPath $script:kaggleDeployLinux -Raw
 
             $windowsContent | Should -Match '\$OpReadTimeoutSeconds' -Because "run_always scripts must not hang when 1Password app integration prompts or stalls"
-            $windowsContent | Should -Match '\$OpReadTimeoutSeconds = 20' -Because "1Password reads can exceed 8-10 seconds after app auth"
+            $windowsContent | Should -Match '\$OpReadTimeoutSeconds = 60' -Because "1Password reads can exceed 20 seconds after app auth"
             $windowsContent | Should -Match 'WaitForExit\(\$timeoutMs\)' -Because "Windows op read should be bounded"
             $windowsContent | Should -Match 'Kill\(' -Because "timed-out Windows op reads should be terminated"
             $linuxContent | Should -Match 'OP_READ_TIMEOUT_SECONDS' -Because "run_always scripts must not hang when 1Password app integration prompts or stalls"
-            $linuxContent | Should -Match 'OP_READ_TIMEOUT_SECONDS=20' -Because "WSL op.exe reads can exceed 8-10 seconds after app auth"
+            $linuxContent | Should -Match 'OP_READ_TIMEOUT_SECONDS=60' -Because "WSL op.exe reads can exceed 20 seconds after app auth"
             $linuxContent | Should -Match 'timeout|gtimeout' -Because "Unix op read should be bounded"
             $linuxContent | Should -Match 'timed out after \$OP_READ_TIMEOUT_SECONDS seconds' -Because "timeout failures should be reported as non-fatal skips"
         }

--- a/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
@@ -173,7 +173,7 @@ Describe 'SSH deploy スクリプト' {
 
         It '1Password 実行時読み込みに timeout があること' {
             $script:ps1Content | Should -Match '\$OpReadTimeoutSeconds' -Because "run_always deploy should not hang when 1Password prompts or stalls"
-            $script:ps1Content | Should -Match '\$OpReadTimeoutSeconds = 20' -Because "1Password reads can exceed 8-10 seconds after app auth"
+            $script:ps1Content | Should -Match '\$OpReadTimeoutSeconds = 60' -Because "1Password reads can exceed 20 seconds after app auth"
             $script:ps1Content | Should -Match 'WaitForExit\(\$timeoutMs\)' -Because "Windows op read should be bounded"
             $script:ps1Content | Should -Match 'Kill\(' -Because "timed-out Windows op reads should be terminated"
             $script:ps1Content | Should -Match 'timed out after \$OpReadTimeoutSeconds seconds' -Because "timeout should take the non-fatal skip path"
@@ -202,7 +202,7 @@ Describe 'SSH deploy スクリプト' {
 
         It '1Password 実行時読み込みに timeout があること' {
             $script:shContent | Should -Match 'OP_READ_TIMEOUT_SECONDS' -Because "run_always deploy should not hang when 1Password prompts or stalls"
-            $script:shContent | Should -Match 'OP_READ_TIMEOUT_SECONDS=20' -Because "WSL op.exe reads can exceed 8-10 seconds after app auth"
+            $script:shContent | Should -Match 'OP_READ_TIMEOUT_SECONDS=60' -Because "WSL op.exe reads can exceed 20 seconds after app auth"
             $script:shContent | Should -Match 'timeout|gtimeout' -Because "Unix op read should be bounded"
             $script:shContent | Should -Match 'timed out after \$OP_READ_TIMEOUT_SECONDS seconds' -Because "timeout should take the non-fatal skip path"
         }


### PR DESCRIPTION
## Summary
- raise runtime deploy `op read` timeouts for Kaggle and SSH secrets from 20s to 60s
- update OS-specific 1Password docs to match the 60s runtime-read guideline
- update Pester assertions that pin the timeout value

## Root cause
A Windows Kaggle runtime `op read` completed successfully after about 23.7s when measured without printing the secret. The previous 20s bound could therefore skip valid secrets even after 1Password auth succeeded.

## Validation
- `git diff --check`
- `Invoke-Pester -Path scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1,scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1 -Output Detailed` (81 passed)
- `task commit` pre-commit suite: BOM check, treefmt, powershell tests, and chezmoi template lint passed