### PR TITLE
fix: launch wezterm through op wrapper shortcut

### DIFF
--- a/chezmoi/.chezmoiscripts/run_after_update-wezterm-shortcut_windows.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/run_after_update-wezterm-shortcut_windows.ps1.tmpl
@@ -1,0 +1,49 @@
+$launcher = Join-Path $HOME ".local\bin\wezterm-launch.cmd"
+$startMenuShortcutPath = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\WezTerm.lnk"
+$taskbarShortcutPath = Join-Path $env:APPDATA "Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\WezTerm.lnk"
+$weztermExeCandidates = @(
+    (Join-Path $env:ProgramFiles "WezTerm\wezterm-gui.exe"),
+    (Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links\wezterm-gui.exe"),
+    (Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links\wezterm.exe")
+)
+
+if (-not (Test-Path -LiteralPath $launcher -PathType Leaf)) {
+    return
+}
+
+$weztermExe = $weztermExeCandidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } | Select-Object -First 1
+$workingDirectory = Split-Path -Parent $launcher
+if ($weztermExe) {
+    $workingDirectory = Split-Path -Parent $weztermExe
+}
+
+function Set-DotfilesWezTermShortcut {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter()]
+        [bool]$Create
+    )
+
+    if (-not $Create -and -not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return
+    }
+
+    $shortcutDir = Split-Path -Parent $Path
+    if (-not (Test-Path -LiteralPath $shortcutDir -PathType Container)) {
+        New-Item -ItemType Directory -Path $shortcutDir -Force | Out-Null
+    }
+
+    $shell = New-Object -ComObject WScript.Shell
+    $shortcut = $shell.CreateShortcut($Path)
+    $shortcut.TargetPath = $launcher
+    $shortcut.WorkingDirectory = $workingDirectory
+    if ($weztermExe) {
+        $shortcut.IconLocation = "$weztermExe,0"
+    }
+    $shortcut.Save()
+}
+
+Set-DotfilesWezTermShortcut -Path $startMenuShortcutPath -Create $true
+Set-DotfilesWezTermShortcut -Path $taskbarShortcutPath -Create $false

--- a/docs/chezmoi/secrets.md
+++ b/docs/chezmoi/secrets.md
@@ -29,6 +29,8 @@ SSH Agent / `op-ssh-sign` のパスは [1Password CLI 運用](../1password/READM
   - Orca 経由で起動される Codex 用。GitHub MCP は shell profile 実行前に `GITHUB_PAT_TOKEN` を読むため、Orca 自体を `op run --env-file` の内側で起動する。
 - `chezmoi/dot_local/bin/executable_op-run-gui-launch.ps1`
   - GUI launcher 用。account 別の `op run --env-file` を timeout 付きで実行し、1Password が locked / unavailable の場合も GUI 本体を token なしで起動する。
+- `chezmoi/.chezmoiscripts/run_after_update-wezterm-shortcut_windows.ps1.tmpl`
+  - WezTerm の Start Menu shortcut と既存 taskbar pin を `wezterm-launch.cmd` に向け、通常起動でも Codex の GitHub MCP startup secrets を継承させる。
 - `chezmoi/dot_local/bin/executable_codex.cmd`
   - Codex CLI 直起動用。`~/.local/bin` が `WinGet\Links` より PATH の前にあるため、`codex` はこの wrapper を通ってから実体の `codex.exe` を起動する。
 - `chezmoi/.chezmoidata/mcp_servers.yaml`

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -551,6 +551,17 @@ Describe 'chezmoi テンプレート バリデーション' {
             $content | Should -Match 'WScript\.Shell' -Because 'Windows shortcuts need COM shortcut editing'
         }
 
+        It 'should point WezTerm shortcuts at the injected launcher' {
+            $scriptPath = Join-Path $script:chezmoiRoot ".chezmoiscripts/run_after_update-wezterm-shortcut_windows.ps1.tmpl"
+            Test-Path -LiteralPath $scriptPath | Should -BeTrue
+            $content = Get-Content -LiteralPath $scriptPath -Raw
+
+            $content | Should -Match 'wezterm-launch\.cmd' -Because 'normal WezTerm launches should inject GitHub MCP startup secrets'
+            $content | Should -Match 'WezTerm\.lnk' -Because 'the Start Menu shortcut is the launch surface Windows users normally hit'
+            $content | Should -Match 'User Pinned\\TaskBar\\WezTerm\.lnk' -Because 'existing pinned taskbar shortcuts can keep launching wezterm-gui.exe directly'
+            $content | Should -Match 'WScript\.Shell' -Because 'Windows shortcuts need COM shortcut editing'
+        }
+
         It 'should launch direct Codex CLI through 1Password env-file injection' {
             $launcherPath = Join-Path $script:chezmoiRoot "dot_local/bin/executable_codex.cmd"
             Test-Path -LiteralPath $launcherPath | Should -BeTrue


### PR DESCRIPTION
## Summary
- add a chezmoi Windows after-update script that points the user WezTerm Start Menu shortcut at `~/.local/bin/wezterm-launch.cmd`
- update an existing pinned taskbar `WezTerm.lnk` when present, so pinned launches stop bypassing the 1Password wrapper
- document the shortcut management and add a regression assertion

## Root cause
The running WezTerm process was launched by Explorer directly as `C:\Program Files\WezTerm\wezterm-gui.exe`. That bypassed `wezterm-launch.cmd`, so the process never received the `op run --env-file` environment or `WSLENV` bridge. Codex started inside that WezTerm could still start without `GITHUB_PAT_TOKEN`, producing the GitHub MCP login warning.

## Validation
- inspected the running process tree: `explorer.exe -> wezterm-gui.exe -> pwsh.exe -> codex.exe`
- inspected the pinned taskbar shortcut before the fix: target was `C:\Program Files\WezTerm\wezterm-gui.exe`
- ran the new shortcut script locally and verified both user Start Menu and taskbar shortcuts now target `C:\Users\KoheiMiki\.local\bin\wezterm-launch.cmd`
- `git diff --check`
- `Invoke-Pester -Path scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1,scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1 -Output Detailed` (62 passed)
- `task commit` pre-commit suite passed: BOM check, treefmt, powershell tests, and chezmoi template lint