### PR TITLE
Update nixpkgs lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Update the `nixpkgs_3` lock entry in `flake.lock`.
- Move nixpkgs from `567a49d1913ce81ac6e9582e3553dd90a955875f` to `e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3`.

## Validation

- `task commit -- "Update nixpkgs lock"`
  - `nix fmt`
  - `pre-commit run --all-files`
- Commit hook checks during amend
