### PR TITLE
standardize window keybindings

### DIFF
--- a/chezmoi/editors/cursor/keybindings.json
+++ b/chezmoi/editors/cursor/keybindings.json
@@ -8,11 +8,11 @@
     "when": "terminalFocus"
   },
   {
-    "key": "ctrl+alt+h",
+    "key": "ctrl+alt+\\",
     "command": "workbench.action.splitEditorRight"
   },
   {
-    "key": "ctrl+alt+v",
+    "key": "ctrl+alt+-",
     "command": "workbench.action.splitEditorDown"
   },
   {
@@ -24,19 +24,35 @@
     "command": "workbench.action.toggleEditorWidths"
   },
   {
-    "key": "ctrl+shift+h",
+    "key": "alt+h",
     "command": "workbench.action.focusLeftGroup"
   },
   {
-    "key": "ctrl+shift+j",
+    "key": "alt+j",
     "command": "workbench.action.focusBelowGroup"
   },
   {
-    "key": "ctrl+shift+k",
+    "key": "alt+k",
     "command": "workbench.action.focusAboveGroup"
   },
   {
-    "key": "ctrl+shift+l",
+    "key": "alt+l",
     "command": "workbench.action.focusRightGroup"
+  },
+  {
+    "key": "alt+shift+h",
+    "command": "workbench.action.moveActiveEditorGroupLeft"
+  },
+  {
+    "key": "alt+shift+j",
+    "command": "workbench.action.moveActiveEditorGroupDown"
+  },
+  {
+    "key": "alt+shift+k",
+    "command": "workbench.action.moveActiveEditorGroupUp"
+  },
+  {
+    "key": "alt+shift+l",
+    "command": "workbench.action.moveActiveEditorGroupRight"
   }
 ]

--- a/chezmoi/editors/vscode/keybindings.json
+++ b/chezmoi/editors/vscode/keybindings.json
@@ -8,11 +8,11 @@
     "when": "terminalFocus"
   },
   {
-    "key": "ctrl+alt+h",
+    "key": "ctrl+alt+\\",
     "command": "workbench.action.splitEditorRight"
   },
   {
-    "key": "ctrl+alt+v",
+    "key": "ctrl+alt+-",
     "command": "workbench.action.splitEditorDown"
   },
   {
@@ -24,19 +24,35 @@
     "command": "workbench.action.toggleEditorWidths"
   },
   {
-    "key": "ctrl+shift+h",
+    "key": "alt+h",
     "command": "workbench.action.focusLeftGroup"
   },
   {
-    "key": "ctrl+shift+j",
+    "key": "alt+j",
     "command": "workbench.action.focusBelowGroup"
   },
   {
-    "key": "ctrl+shift+k",
+    "key": "alt+k",
     "command": "workbench.action.focusAboveGroup"
   },
   {
-    "key": "ctrl+shift+l",
+    "key": "alt+l",
     "command": "workbench.action.focusRightGroup"
+  },
+  {
+    "key": "alt+shift+h",
+    "command": "workbench.action.moveActiveEditorGroupLeft"
+  },
+  {
+    "key": "alt+shift+j",
+    "command": "workbench.action.moveActiveEditorGroupDown"
+  },
+  {
+    "key": "alt+shift+k",
+    "command": "workbench.action.moveActiveEditorGroupUp"
+  },
+  {
+    "key": "alt+shift+l",
+    "command": "workbench.action.moveActiveEditorGroupRight"
   }
 ]

--- a/chezmoi/editors/zed/keymap.json
+++ b/chezmoi/editors/zed/keymap.json
@@ -8,14 +8,14 @@
   {
     "context": "Workspace",
     "bindings": {
-      "ctrl-alt-h": "pane::SplitRight",
-      "ctrl-alt-v": "pane::SplitDown",
+      "ctrl-alt-\\": "pane::SplitRight",
+      "ctrl-alt--": "pane::SplitDown",
       "ctrl-alt-x": "pane::CloseActiveItem",
       "ctrl-alt-w": "workspace::ToggleZoom",
-      "ctrl-shift-h": ["workspace::ActivatePaneInDirection", "Left"],
-      "ctrl-shift-j": ["workspace::ActivatePaneInDirection", "Down"],
-      "ctrl-shift-k": ["workspace::ActivatePaneInDirection", "Up"],
-      "ctrl-shift-l": ["workspace::ActivatePaneInDirection", "Right"]
+      "alt-h": ["workspace::ActivatePaneInDirection", "Left"],
+      "alt-j": ["workspace::ActivatePaneInDirection", "Down"],
+      "alt-k": ["workspace::ActivatePaneInDirection", "Up"],
+      "alt-l": ["workspace::ActivatePaneInDirection", "Right"]
     }
   },
   {

--- a/chezmoi/terminals/warp/keybindings.yaml
+++ b/chezmoi/terminals/warp/keybindings.yaml
@@ -1,7 +1,8 @@
 # Warp keybindings — managed via chezmoi
 # Format: flat YAML map of action_name to key-binding (no root key)
 # Reference: https://github.com/warpdotdev/keysets/blob/main/FORMAT.md
-# All terminal multiplexer operations use Ctrl+Alt prefix.
+# Pane focus follows tiling window-manager style Alt+H/J/K/L.
+# Pane resize uses Ctrl+Alt+H/J/K/L.
 #
 # Not configurable here (no action name in Warp):
 #   close pane (Ctrl+Alt+X), toggle zoom (Ctrl+Alt+W)
@@ -16,10 +17,16 @@ pane_group:add_right: ctrl-alt-\
 pane_group:add_down: ctrl-alt--
 
 # Pane navigation
-pane_group:navigate_left: ctrl-alt-h
-pane_group:navigate_down: ctrl-alt-j
-pane_group:navigate_up: ctrl-alt-k
-pane_group:navigate_right: ctrl-alt-l
+pane_group:navigate_left: alt-h
+pane_group:navigate_down: alt-j
+pane_group:navigate_up: alt-k
+pane_group:navigate_right: alt-l
+
+# Pane resize
+pane_group:resize_left: ctrl-alt-h
+pane_group:resize_down: ctrl-alt-j
+pane_group:resize_up: ctrl-alt-k
+pane_group:resize_right: ctrl-alt-l
 
 # AI natural language search
 input:toggle_natural_language_command_search: ctrl-space

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -120,21 +120,21 @@ config.keys = {
     { key = "x", mods = "CTRL|ALT", action = act.CloseCurrentPane({ confirm = true }) },
     { key = "w", mods = "CTRL|ALT", action = act.TogglePaneZoomState },
 
-    -- Pane navigation (Ctrl+Alt + H/J/K/L)
-    { key = "h", mods = "CTRL|ALT", action = act.ActivatePaneDirection("Left") },
-    { key = "j", mods = "CTRL|ALT", action = act.ActivatePaneDirection("Down") },
-    { key = "k", mods = "CTRL|ALT", action = act.ActivatePaneDirection("Up") },
-    { key = "l", mods = "CTRL|ALT", action = act.ActivatePaneDirection("Right") },
+    -- Pane navigation (Alt + H/J/K/L)
+    { key = "h", mods = "ALT", action = act.ActivatePaneDirection("Left") },
+    { key = "j", mods = "ALT", action = act.ActivatePaneDirection("Down") },
+    { key = "k", mods = "ALT", action = act.ActivatePaneDirection("Up") },
+    { key = "l", mods = "ALT", action = act.ActivatePaneDirection("Right") },
 
-    -- Window focus (Ctrl+Alt+Shift + H/L)
-    { key = "h", mods = "CTRL|ALT|SHIFT", action = focus_adjacent_window("left") },
-    { key = "l", mods = "CTRL|ALT|SHIFT", action = focus_adjacent_window("right") },
+    -- Window focus (Alt+Shift + H/L)
+    { key = "h", mods = "ALT|SHIFT", action = focus_adjacent_window("left") },
+    { key = "l", mods = "ALT|SHIFT", action = focus_adjacent_window("right") },
 
-    -- Pane resize (Ctrl+Alt + Arrow)
-    { key = "LeftArrow", mods = "CTRL|ALT", action = act.AdjustPaneSize({ "Left", 5 }) },
-    { key = "DownArrow", mods = "CTRL|ALT", action = act.AdjustPaneSize({ "Down", 5 }) },
-    { key = "UpArrow", mods = "CTRL|ALT", action = act.AdjustPaneSize({ "Up", 5 }) },
-    { key = "RightArrow", mods = "CTRL|ALT", action = act.AdjustPaneSize({ "Right", 5 }) },
+    -- Pane resize (Ctrl+Alt + H/J/K/L)
+    { key = "h", mods = "CTRL|ALT", action = act.AdjustPaneSize({ "Left", 5 }) },
+    { key = "j", mods = "CTRL|ALT", action = act.AdjustPaneSize({ "Down", 5 }) },
+    { key = "k", mods = "CTRL|ALT", action = act.AdjustPaneSize({ "Up", 5 }) },
+    { key = "l", mods = "CTRL|ALT", action = act.AdjustPaneSize({ "Right", 5 }) },
 
     -- Tab management (Ctrl+Alt+T or Leader+t=new, Leader+x=close, Ctrl+Tab=nav)
     { key = "t", mods = "CTRL|ALT", action = act.SpawnTab("CurrentPaneDomain") },

--- a/chezmoi/terminals/windows-terminal/settings.json
+++ b/chezmoi/terminals/windows-terminal/settings.json
@@ -91,6 +91,22 @@
       "id": "User.moveFocus.down"
     },
     {
+      "command": { "action": "swapPane", "direction": "left" },
+      "id": "User.swapPane.left"
+    },
+    {
+      "command": { "action": "swapPane", "direction": "down" },
+      "id": "User.swapPane.down"
+    },
+    {
+      "command": { "action": "swapPane", "direction": "up" },
+      "id": "User.swapPane.up"
+    },
+    {
+      "command": { "action": "swapPane", "direction": "right" },
+      "id": "User.swapPane.right"
+    },
+    {
       "command": { "action": "resizePane", "direction": "up" },
       "id": "User.resizePane.up"
     },
@@ -116,20 +132,24 @@
     { "id": "User.find", "keys": "ctrl+shift+f" },
     { "id": "User.paste", "keys": "ctrl+v" },
     { "id": "User.splitPane.horizontal", "keys": "ctrl+alt+\\" },
-    { "id": "User.resizePane.right", "keys": "ctrl+alt+right" },
     { "id": "User.splitPane.vertical", "keys": "ctrl+alt+minus" },
     { "id": "User.closePane", "keys": "ctrl+alt+x" },
     { "id": "User.togglePaneZoom", "keys": "ctrl+alt+w" },
-    { "id": "User.moveFocus.left", "keys": "ctrl+alt+h" },
-    { "id": "User.moveFocus.up", "keys": "ctrl+alt+k" },
-    { "id": "User.moveFocus.right", "keys": "ctrl+alt+l" },
-    { "id": "User.moveFocus.down", "keys": "ctrl+alt+j" },
+    { "id": "User.moveFocus.left", "keys": "alt+h" },
+    { "id": "User.moveFocus.up", "keys": "alt+k" },
+    { "id": "User.moveFocus.right", "keys": "alt+l" },
+    { "id": "User.moveFocus.down", "keys": "alt+j" },
+    { "id": "User.swapPane.left", "keys": "alt+shift+h" },
+    { "id": "User.swapPane.up", "keys": "alt+shift+k" },
+    { "id": "User.swapPane.right", "keys": "alt+shift+l" },
+    { "id": "User.swapPane.down", "keys": "alt+shift+j" },
+    { "id": "User.resizePane.left", "keys": "ctrl+alt+h" },
+    { "id": "User.resizePane.up", "keys": "ctrl+alt+k" },
+    { "id": "User.resizePane.right", "keys": "ctrl+alt+l" },
+    { "id": "User.resizePane.down", "keys": "ctrl+alt+j" },
     { "id": "User.nextTab", "keys": "ctrl+tab" },
     { "id": "User.toggleFullscreen", "keys": "f11" },
     { "id": "User.newTab", "keys": "ctrl+alt+t" },
-    { "id": "User.resizePane.left", "keys": "ctrl+alt+left" },
-    { "id": "User.resizePane.up", "keys": "ctrl+alt+up" },
-    { "id": "User.resizePane.down", "keys": "ctrl+alt+down" },
     { "id": "User.resetFontSize", "keys": "ctrl+shift+0" },
     { "id": "User.increaseFontSize", "keys": "ctrl+shift+plus" },
     { "id": "User.decreaseFontSize", "keys": "ctrl+shift+minus" }

--- a/docs/chezmoi/keybindings.md
+++ b/docs/chezmoi/keybindings.md
@@ -10,13 +10,15 @@
 
 ## 統一ルール
 
-| グループ           | 役割                | 例                             |
-| ------------------ | ------------------- | ------------------------------ |
-| `Ctrl+Shift`       | 移動/ナビゲーション | ペイン移動 (`H/J/K/L`)         |
-| `Ctrl+Alt`         | レイアウト変更      | 分割、ペイン close、ズーム     |
-| `Shift+Enter`      | 複数行入力          | AI CLI / terminal prompt 改行  |
-| `Space` (`Leader`) | ツール機能呼び出し  | 検索、エクスプローラ、タブ操作 |
-| `Alt` (Shell)      | CLI 補助操作        | fzf/zoxide ウィジェット        |
+| グループ           | 役割                          | 例                                    |
+| ------------------ | ----------------------------- | ------------------------------------- |
+| `Alt`              | GUI pane/window focus         | `Alt+H/J/K/L`                         |
+| `Alt+Shift`        | GUI pane/window move/swap     | `Alt+Shift+H/J/K/L`（対応アプリのみ） |
+| `Ctrl+Alt`         | GUI pane/window resize/layout | `Ctrl+Alt+H/J/K/L`, split/close/zoom  |
+| `Ctrl`             | Unix/Vim/tmux focus           | `Ctrl+H/J/K/L`                        |
+| `Shift+Enter`      | 複数行入力                    | AI CLI / terminal prompt 改行         |
+| `Space` (`Leader`) | ツール機能呼び出し            | 検索、エクスプローラ、タブ操作        |
+| `Alt` (Shell)      | CLI 補助操作                  | fzf/zoxide ウィジェット (`Q/D/T/R`)   |
 
 ## 現在の適用状況
 
@@ -24,18 +26,23 @@
 
 - WezTerm
   - `Shift+Enter`: AI CLI / terminal prompt の複数行入力
-  - `Ctrl+Shift+H/J/K/L`: ペイン移動
-  - `Ctrl+Alt+H/V/X/W`: 分割/close/ズーム
+  - `Alt+H/J/K/L`: ペイン移動
+  - `Alt+Shift+H/L`: WezTerm window focus
+  - `Ctrl+Alt+H/J/K/L`: ペイン resize
+  - `Ctrl+Alt+\` / `Ctrl+Alt+-` / `Ctrl+Alt+X/W`: 分割/close/ズーム
   - `Leader` (`Ctrl+Space`) + `t/x/h/l/1-9`: タブ操作
   - `Leader` (`Ctrl+Space`) + `c/v`: コピー/ペースト
 - Windows Terminal
   - `Shift+Enter`: AI CLI / terminal prompt の複数行入力 (`CSI u`)
   - `Ctrl+Enter`: Windows Terminal 用 fallback (`CSI u`)
-  - `Ctrl+Shift+H/J/K/L`: ペイン移動
-  - `Ctrl+Alt+H/V/X/W`: 分割/close/ズーム
+  - `Alt+H/J/K/L`: ペイン移動
+  - `Alt+Shift+H/J/K/L`: ペイン swap
+  - `Ctrl+Alt+H/J/K/L`: ペイン resize
+  - `Ctrl+Alt+\` / `Ctrl+Alt+-` / `Ctrl+Alt+X/W`: 分割/close/ズーム
 - Warp
-  - `Ctrl+Shift+H/J/K/L`: ペイン移動
-  - `Ctrl+Alt+H/V`: 分割
+  - `Alt+H/J/K/L`: ペイン移動
+  - `Ctrl+Alt+H/J/K/L`: ペイン resize
+  - `Ctrl+Alt+\` / `Ctrl+Alt+-`: 分割
   - `Ctrl+Space`: AI natural language search（nvim/WezTerm leader に合わせた統一キー）
   - `Ctrl+Enter`: AI agent へ送信（Warp ハードコード、変更不可）
   - `Ctrl+Y`: AI agent 会話を継続（Warp ハードコード、変更不可）
@@ -44,6 +51,7 @@
 
 - Neovim
   - `Leader` は `Space`
+  - `Ctrl+H/J/K/L`: window 移動（tmux 境界越えも同じ）
   - `Ctrl+Z`: undo
   - `Ctrl+Y`: redo
   - `Space+e`: エクスプローラ
@@ -55,12 +63,20 @@
 - VS Code / Cursor
   - `Vim` 拡張は利用しない
   - terminal focus の `Shift+Enter`: AI CLI / terminal prompt の複数行入力
-  - `Ctrl+Shift+H/J/K/L`: editor group 移動
-  - `Ctrl+Alt+H/V/X/W`: split/close/toggle widths
+  - `Alt+H/J/K/L`: editor group 移動
+  - `Alt+Shift+H/J/K/L`: editor group move
+  - `Ctrl+Alt+\` / `Ctrl+Alt+-` / `Ctrl+Alt+X/W`: split/close/toggle widths
   - それ以外は標準キーバインドを優先
+- Zed
+  - `Alt+H/J/K/L`: pane 移動
+  - `Ctrl+Alt+\` / `Ctrl+Alt+-` / `Ctrl+Alt+X/W`: split/close/zoom
 
 ### Shells
 
+- tmux (Unix/Linux/WSL)
+  - `Ctrl+H/J/K/L`: pane 移動（vim-tmux-navigator と共有）
+  - `Prefix` (`Ctrl+A`) + `\` / `-`: pane 分割
+  - `Prefix` (`Ctrl+A`) + `h/l`: window 前後移動
 - zsh
   - `Alt+Q`: zoxide interactive jump (`zoxide query -i`)
   - `Alt+D/T/R`: fzf ウィジェット
@@ -88,5 +104,6 @@
 ## 運用ルール
 
 - 新しいショートカットを追加する前に、この表のどのグループに属するかを先に決める
-- 既存ショートカットと衝突する場合は、`Ctrl+Shift` (移動) を優先して維持する
+- GUI アプリの pane/window 操作は `Alt` / `Alt+Shift` / `Ctrl+Alt` の役割を優先する
+- tmux/Neovim など Unix/Vim 系は `Ctrl+H/J/K/L` を優先して維持する
 - `Vim` 拡張前提の操作説明は追加しない

--- a/scripts/powershell/tests/chezmoi/Keybindings.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/Keybindings.Tests.ps1
@@ -1,0 +1,176 @@
+#Requires -Module Pester
+
+BeforeAll {
+    $script:repoRoot = Resolve-Path (Join-Path $PSScriptRoot "../../../..")
+    $script:chezmoiRoot = Join-Path $script:repoRoot "chezmoi"
+
+    function Get-JsonContent {
+        param([string]$Path)
+        Get-Content -LiteralPath (Join-Path $script:repoRoot $Path) -Raw | ConvertFrom-Json
+    }
+
+    function Get-WindowsTerminalCommandForKey {
+        param(
+            [Parameter(Mandatory)]
+            $Settings,
+            [Parameter(Mandatory)]
+            [string]$Keys
+        )
+
+        $binding = @($Settings.keybindings | Where-Object { $_.keys -eq $Keys }) | Select-Object -First 1
+        if (-not $binding) { return $null }
+
+        $inlineCommand = $binding.PSObject.Properties["command"]
+        if ($inlineCommand) { return $inlineCommand.Value }
+
+        $idProperty = $binding.PSObject.Properties["id"]
+        if (-not $idProperty) { return $null }
+        $id = $idProperty.Value
+        if (-not $id) { return $null }
+
+        $action = @($Settings.actions | Where-Object { $_.id -eq $id }) | Select-Object -First 1
+        if (-not $action) { return $null }
+
+        return $action.command
+    }
+
+    function Assert-WindowsTerminalDirectionalAction {
+        param(
+            [Parameter(Mandatory)]
+            $Settings,
+            [Parameter(Mandatory)]
+            [string]$Keys,
+            [Parameter(Mandatory)]
+            [string]$Action,
+            [Parameter(Mandatory)]
+            [string]$Direction
+        )
+
+        $command = Get-WindowsTerminalCommandForKey -Settings $Settings -Keys $Keys
+        $command | Should -Not -BeNullOrEmpty -Because "$Keys should be bound"
+        $command.action | Should -Be $Action -Because "$Keys should use $Action"
+        $command.direction | Should -Be $Direction -Because "$Keys should point $Direction"
+    }
+
+    function Assert-KeyCommand {
+        param(
+            [Parameter(Mandatory)]
+            $Bindings,
+            [Parameter(Mandatory)]
+            [string]$Key,
+            [Parameter(Mandatory)]
+            [string]$Command
+        )
+
+        $binding = @($Bindings | Where-Object { $_.key -eq $Key -and $_.command -eq $Command }) | Select-Object -First 1
+        $binding | Should -Not -BeNullOrEmpty -Because "$Key should run $Command"
+    }
+
+    function Get-ZedWorkspaceBinding {
+        $zed = Get-JsonContent "chezmoi/editors/zed/keymap.json"
+        $workspace = @($zed | Where-Object { $_.context -eq "Workspace" }) | Select-Object -First 1
+        $workspace | Should -Not -BeNullOrEmpty
+        return $workspace.bindings
+    }
+}
+
+Describe '標準キーバインド方針' {
+    It 'docs は GUI と Unix/Vim 系の標準レイヤーを明示すること' {
+        $docs = Get-Content -LiteralPath (Join-Path $script:repoRoot "docs/chezmoi/keybindings.md") -Raw
+
+        $docs | Should -Match 'Alt\+H/J/K/L' -Because "GUI pane/window focus should use Alt+H/J/K/L"
+        $docs | Should -Match 'Alt\+Shift\+H/J/K/L' -Because "GUI pane/window move should add Shift"
+        $docs | Should -Match 'Ctrl\+Alt\+H/J/K/L' -Because "GUI pane/window resize should use Ctrl+Alt+H/J/K/L"
+        $docs | Should -Match 'Ctrl\+H/J/K/L' -Because "Unix/Vim/tmux focus should keep the standard Ctrl+H/J/K/L layer"
+    }
+
+    It 'Windows Terminal は Alt focus, Alt+Shift swap, Ctrl+Alt resize に揃えること' {
+        $settings = Get-JsonContent "chezmoi/terminals/windows-terminal/settings.json"
+
+        Assert-WindowsTerminalDirectionalAction $settings "alt+h" "moveFocus" "left"
+        Assert-WindowsTerminalDirectionalAction $settings "alt+j" "moveFocus" "down"
+        Assert-WindowsTerminalDirectionalAction $settings "alt+k" "moveFocus" "up"
+        Assert-WindowsTerminalDirectionalAction $settings "alt+l" "moveFocus" "right"
+
+        Assert-WindowsTerminalDirectionalAction $settings "alt+shift+h" "swapPane" "left"
+        Assert-WindowsTerminalDirectionalAction $settings "alt+shift+j" "swapPane" "down"
+        Assert-WindowsTerminalDirectionalAction $settings "alt+shift+k" "swapPane" "up"
+        Assert-WindowsTerminalDirectionalAction $settings "alt+shift+l" "swapPane" "right"
+
+        Assert-WindowsTerminalDirectionalAction $settings "ctrl+alt+h" "resizePane" "left"
+        Assert-WindowsTerminalDirectionalAction $settings "ctrl+alt+j" "resizePane" "down"
+        Assert-WindowsTerminalDirectionalAction $settings "ctrl+alt+k" "resizePane" "up"
+        Assert-WindowsTerminalDirectionalAction $settings "ctrl+alt+l" "resizePane" "right"
+    }
+
+    It 'WezTerm は Alt focus と Ctrl+Alt resize に揃えること' {
+        $content = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot "terminals/wezterm/wezterm.lua") -Raw
+
+        $content | Should -Match '\{ key = "h", mods = "ALT", action = act\.ActivatePaneDirection\("Left"\) \}'
+        $content | Should -Match '\{ key = "j", mods = "ALT", action = act\.ActivatePaneDirection\("Down"\) \}'
+        $content | Should -Match '\{ key = "k", mods = "ALT", action = act\.ActivatePaneDirection\("Up"\) \}'
+        $content | Should -Match '\{ key = "l", mods = "ALT", action = act\.ActivatePaneDirection\("Right"\) \}'
+
+        $content | Should -Match '\{ key = "h", mods = "CTRL\|ALT", action = act\.AdjustPaneSize\(\{ "Left", 5 \}\) \}'
+        $content | Should -Match '\{ key = "j", mods = "CTRL\|ALT", action = act\.AdjustPaneSize\(\{ "Down", 5 \}\) \}'
+        $content | Should -Match '\{ key = "k", mods = "CTRL\|ALT", action = act\.AdjustPaneSize\(\{ "Up", 5 \}\) \}'
+        $content | Should -Match '\{ key = "l", mods = "CTRL\|ALT", action = act\.AdjustPaneSize\(\{ "Right", 5 \}\) \}'
+    }
+
+    It 'Warp は Alt focus と Ctrl+Alt resize に揃えること' {
+        $content = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot "terminals/warp/keybindings.yaml") -Raw
+
+        $content | Should -Match '(?m)^pane_group:navigate_left:\s*alt-h$'
+        $content | Should -Match '(?m)^pane_group:navigate_down:\s*alt-j$'
+        $content | Should -Match '(?m)^pane_group:navigate_up:\s*alt-k$'
+        $content | Should -Match '(?m)^pane_group:navigate_right:\s*alt-l$'
+
+        $content | Should -Match '(?m)^pane_group:resize_left:\s*ctrl-alt-h$'
+        $content | Should -Match '(?m)^pane_group:resize_down:\s*ctrl-alt-j$'
+        $content | Should -Match '(?m)^pane_group:resize_up:\s*ctrl-alt-k$'
+        $content | Should -Match '(?m)^pane_group:resize_right:\s*ctrl-alt-l$'
+    }
+
+    It 'VS Code と Cursor は Alt focus, Alt+Shift move に揃えること' {
+        foreach ($path in @(
+                "chezmoi/editors/vscode/keybindings.json",
+                "chezmoi/editors/cursor/keybindings.json"
+            )) {
+            $bindings = Get-JsonContent $path
+
+            Assert-KeyCommand $bindings "alt+h" "workbench.action.focusLeftGroup"
+            Assert-KeyCommand $bindings "alt+j" "workbench.action.focusBelowGroup"
+            Assert-KeyCommand $bindings "alt+k" "workbench.action.focusAboveGroup"
+            Assert-KeyCommand $bindings "alt+l" "workbench.action.focusRightGroup"
+
+            Assert-KeyCommand $bindings "alt+shift+h" "workbench.action.moveActiveEditorGroupLeft"
+            Assert-KeyCommand $bindings "alt+shift+j" "workbench.action.moveActiveEditorGroupDown"
+            Assert-KeyCommand $bindings "alt+shift+k" "workbench.action.moveActiveEditorGroupUp"
+            Assert-KeyCommand $bindings "alt+shift+l" "workbench.action.moveActiveEditorGroupRight"
+        }
+    }
+
+    It 'Zed は Alt focus に揃えること' {
+        $bindings = Get-ZedWorkspaceBinding
+
+        $bindings.PSObject.Properties["alt-h"].Value[0] | Should -Be "workspace::ActivatePaneInDirection"
+        $bindings.PSObject.Properties["alt-h"].Value[1] | Should -Be "Left"
+        $bindings.PSObject.Properties["alt-j"].Value[0] | Should -Be "workspace::ActivatePaneInDirection"
+        $bindings.PSObject.Properties["alt-j"].Value[1] | Should -Be "Down"
+        $bindings.PSObject.Properties["alt-k"].Value[0] | Should -Be "workspace::ActivatePaneInDirection"
+        $bindings.PSObject.Properties["alt-k"].Value[1] | Should -Be "Up"
+        $bindings.PSObject.Properties["alt-l"].Value[0] | Should -Be "workspace::ActivatePaneInDirection"
+        $bindings.PSObject.Properties["alt-l"].Value[1] | Should -Be "Right"
+    }
+
+    It 'Unix/Linux/WSL の tmux と Neovim は Ctrl+H/J/K/L focus を維持すること' {
+        $tmux = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot "dot_tmux.conf") -Raw
+        $nvim = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot "dot_config/nvim/lua/config/keymaps.lua") -Raw
+
+        foreach ($key in @("h", "j", "k", "l")) {
+            $tmux | Should -Match "bind-key -n C-$key"
+            $nvim | Should -Match "map\(`"n`", `"<C-$key>`""
+            $nvim | Should -Match "map\(`"t`", `"<C-$key>`""
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Standardize GUI pane/window keybindings around Alt focus, Alt+Shift move/swap, and Ctrl+Alt resize/layout.
- Update Windows Terminal, WezTerm, Warp, VS Code, Cursor, and Zed configs.
- Document the Unix/Linux/WSL exception where tmux and Neovim keep the standard Ctrl+H/J/K/L focus layer.
- Add PowerShell tests to lock the keybinding policy.

## Validation

- `task fmt:check`
- `./scripts/powershell/tests/Invoke-Tests.ps1 -Path .\chezmoi\Keybindings.Tests.ps1, .\chezmoi\ChezmoiTemplate.Tests.ps1 -MinimumCoverage 0`
- `task commit -- "standardize window keybindings"` ran repo pre-commit hooks before commit.
- `task chezmoi` applied the new settings locally to Windows and WSL before publishing.