### PR TITLE
Add LuaLS and oil trash deletes

### DIFF
--- a/chezmoi/dot_config/nvim/lua/plugins/init.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/init.lua
@@ -55,6 +55,7 @@ return {
         keys = { { "-", "<cmd>Oil<cr>", desc = "Open parent directory" } },
         opts = {
             default_file_explorer = true,
+            delete_to_trash = true,
             view_options = { show_hidden = true },
             win_options = {
                 conceallevel = 3,

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -391,7 +391,7 @@ let
     };
     lua-language-server = {
       pkg = pkgs.lua-language-server;
-      winget = null;
+      winget = "LuaLS.lua-language-server";
       category = "lsp";
     };
     stylua = {
@@ -658,6 +658,10 @@ lib.mapAttrs (_: names: resolve names) grouped
     };
     taplo = {
       command = "taplo";
+      args = [ "--version" ];
+    };
+    lua-language-server = {
+      command = "lua-language-server";
       args = [ "--version" ];
     };
     stylua = {

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -217,6 +217,16 @@ Describe 'Package catalog consistency' {
     }
 
     Context 'StyLua package' {
+        It 'should generate Lua Language Server with command verification' {
+            $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
+            $wingetSource = @($json.Sources | Where-Object { $_.SourceDetails.Name -eq 'winget' }) | Select-Object -First 1
+            $package = @($wingetSource.Packages | Where-Object { $_.PackageIdentifier -eq 'LuaLS.lua-language-server' }) | Select-Object -First 1
+
+            $package | Should -Not -BeNullOrEmpty
+            $package.verifyCommand.command | Should -Be 'lua-language-server'
+            @($package.verifyCommand.args) | Should -Contain '--version'
+        }
+
         It 'should generate StyLua with command verification' {
             $json = Get-Content -LiteralPath $script:wingetJsonPath -Raw | ConvertFrom-Json
             $wingetSource = @($json.Sources | Where-Object { $_.SourceDetails.Name -eq 'winget' }) | Select-Object -First 1

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -116,6 +116,13 @@
           }
         },
         {
+          "PackageIdentifier": "LuaLS.lua-language-server",
+          "verifyCommand": {
+            "args": ["--version"],
+            "command": "lua-language-server"
+          }
+        },
+        {
           "PackageIdentifier": "Neovim.Neovim",
           "verifyCommand": {
             "args": ["--version"],


### PR DESCRIPTION
## Summary
- enable Oil deletes to use the OS trash instead of permanent deletion
- add Lua Language Server to the cross-platform package catalog
- generate the Windows winget catalog entry for LuaLS with command verification
- cover LuaLS winget generation in PackageCatalog tests

## Validation
- task commit ran nix fmt and pre-commit run --all-files
- PackageCatalog.Tests.ps1: 36 passed
- nix build .#winget-export plus CI-equivalent jq diff passed
- Windows lua-language-server --version returned 3.18.2-dev
- Neovim sees lua-language-server as executable
