### PR TITLE
Load OP service token for dcnvim

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -159,9 +159,9 @@ if ! have claude; then
   fi
   if have npm; then
     log "installing @anthropic-ai/claude-code (user-local prefix)"
-    mkdir -p "$HOME/.local/npm"
-    npm config set prefix "$HOME/.local/npm" >/dev/null
-    if npm install -g @anthropic-ai/claude-code >/dev/null 2>&1; then
+    npm_prefix="$HOME/.local/npm"
+    mkdir -p "$npm_prefix"
+    if NPM_CONFIG_PREFIX="$npm_prefix" npm install -g @anthropic-ai/claude-code >/dev/null 2>&1; then
       # PATH wiring for next shells
       for f in "$HOME/.profile" "$HOME/.bashrc"; do
         grep -q '\.local/npm/bin' "$f" 2>/dev/null ||

--- a/chezmoi/dot_config/shell/secret.ps1
+++ b/chezmoi/dot_config/shell/secret.ps1
@@ -66,6 +66,73 @@ function Get-DotfilesSecretLoadTimeoutSeconds {
     return $timeoutSeconds
 }
 
+function ConvertTo-DotfilesWindowsCommandLineArgument {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [string]$Argument
+    )
+
+    if ($null -eq $Argument) {
+        return '""'
+    }
+
+    if ($Argument -notmatch '[\s"]' -and $Argument.Length -gt 0) {
+        return $Argument
+    }
+
+    $builder = [System.Text.StringBuilder]::new()
+    [void]$builder.Append('"')
+    $backslashCount = 0
+
+    foreach ($char in $Argument.ToCharArray()) {
+        if ($char -eq '\') {
+            $backslashCount++
+            continue
+        }
+
+        if ($char -eq '"') {
+            [void]$builder.Append('\' * (($backslashCount * 2) + 1))
+            [void]$builder.Append('"')
+            $backslashCount = 0
+            continue
+        }
+
+        if ($backslashCount -gt 0) {
+            [void]$builder.Append('\' * $backslashCount)
+            $backslashCount = 0
+        }
+        [void]$builder.Append($char)
+    }
+
+    if ($backslashCount -gt 0) {
+        [void]$builder.Append('\' * ($backslashCount * 2))
+    }
+    [void]$builder.Append('"')
+    return $builder.ToString()
+}
+
+function Set-DotfilesProcessStartInfoArguments {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Diagnostics.ProcessStartInfo]$StartInfo,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    if ($StartInfo.GetType().GetProperty('ArgumentList')) {
+        foreach ($argument in @($Arguments)) {
+            [void]$StartInfo.ArgumentList.Add([string]$argument)
+        }
+        return
+    }
+
+    $StartInfo.Arguments = (@($Arguments) |
+            ForEach-Object { ConvertTo-DotfilesWindowsCommandLineArgument -Argument ([string]$_) }) -join ' '
+}
+
 function Invoke-DotfilesOpRead {
     [CmdletBinding()]
     param(
@@ -93,9 +160,9 @@ function Invoke-DotfilesOpRead {
         $startInfo.CreateNoWindow = $true
         $startInfo.RedirectStandardOutput = $true
         $startInfo.RedirectStandardError = $true
-        foreach ($argument in @('--cache=false', '--account', $Account, 'read', $Reference)) {
-            $startInfo.ArgumentList.Add($argument)
-        }
+        Set-DotfilesProcessStartInfoArguments `
+            -StartInfo $startInfo `
+            -Arguments @('--cache=false', '--account', $Account, 'read', $Reference)
 
         $process = [System.Diagnostics.Process]::new()
         $process.StartInfo = $startInfo
@@ -206,6 +273,8 @@ try {
 finally {
     Remove-Item Function:\Resolve-DotfilesOpCli -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-DotfilesSecretLoadTimeoutSeconds -ErrorAction SilentlyContinue
+    Remove-Item Function:\ConvertTo-DotfilesWindowsCommandLineArgument -ErrorAction SilentlyContinue
+    Remove-Item Function:\Set-DotfilesProcessStartInfoArguments -ErrorAction SilentlyContinue
     Remove-Item Function:\Test-DotfilesShouldLoadSecret -ErrorAction SilentlyContinue
     Remove-Item Function:\Invoke-DotfilesOpRead -ErrorAction SilentlyContinue
     Remove-Item Function:\Set-DotfilesSecretEnvironmentValue -ErrorAction SilentlyContinue

--- a/chezmoi/dot_config/shell/secret.ps1
+++ b/chezmoi/dot_config/shell/secret.ps1
@@ -8,9 +8,27 @@
 if (-not $env:GITHUB_PAT_TOKEN -and $env:GH_TOKEN) { $env:GITHUB_PAT_TOKEN = $env:GH_TOKEN }
 if (-not $env:GH_TOKEN -and $env:GITHUB_PAT_TOKEN) { $env:GH_TOKEN = $env:GITHUB_PAT_TOKEN }
 
-if ($env:GITHUB_PAT_TOKEN -and $env:GH_TOKEN -and $env:TAVILY_API_KEY -and $env:GITHUB_WORK_TOKEN) { return }
 if (-not $env:DOTFILES_FORCE_SECRET_LOAD) {
     return
+}
+
+$script:DotfilesSecretLoadOnly = @()
+if ($env:DOTFILES_SECRET_LOAD_ONLY) {
+    $script:DotfilesSecretLoadOnly = @(
+        $env:DOTFILES_SECRET_LOAD_ONLY -split '[,\s]+' |
+            Where-Object { $_ }
+    )
+}
+
+function Test-DotfilesShouldLoadSecret {
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    if ($script:DotfilesSecretLoadOnly.Count -eq 0) {
+        return $true
+    }
+
+    return $script:DotfilesSecretLoadOnly -contains $Name
 }
 
 function Resolve-DotfilesOpCli {
@@ -66,20 +84,25 @@ function Invoke-DotfilesOpRead {
         return $null
     }
 
-    $stdout = [System.IO.Path]::GetTempFileName()
-    $stderr = [System.IO.Path]::GetTempFileName()
+    $process = $null
 
     try {
-        $process = Start-Process `
-            -FilePath $opBin `
-            -ArgumentList @('--cache=false', 'read', $Reference, '--account', $Account) `
-            -PassThru `
-            -WindowStyle Hidden `
-            -RedirectStandardOutput $stdout `
-            -RedirectStandardError $stderr
+        $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        $startInfo.FileName = $opBin
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
+        foreach ($argument in @('--cache=false', '--account', $Account, 'read', $Reference)) {
+            $startInfo.ArgumentList.Add($argument)
+        }
+
+        $process = [System.Diagnostics.Process]::new()
+        $process.StartInfo = $startInfo
+        [void]$process.Start()
 
         if ($process.WaitForExit($TimeoutSeconds * 1000) -and $process.ExitCode -eq 0) {
-            $value = Get-Content -LiteralPath $stdout -Raw -ErrorAction SilentlyContinue
+            $value = $process.StandardOutput.ReadToEnd()
             if ($null -eq $value) {
                 return $null
             }
@@ -91,7 +114,7 @@ function Invoke-DotfilesOpRead {
             Write-Warning "1Password secret read timed out after $TimeoutSeconds seconds; continuing without '$Reference'."
         }
         else {
-            $errorContent = Get-Content -LiteralPath $stderr -Raw -ErrorAction SilentlyContinue
+            $errorContent = $process.StandardError.ReadToEnd()
             $errorText = if ($null -ne $errorContent) { $errorContent.Trim() } else { '' }
             if ($errorText) {
                 Write-Warning "1Password secret read failed for '$Reference': $errorText"
@@ -105,7 +128,9 @@ function Invoke-DotfilesOpRead {
         Write-Warning "1Password secret read failed for '$Reference': $($_.Exception.Message)"
     }
     finally {
-        Remove-Item -LiteralPath $stdout, $stderr -Force -ErrorAction SilentlyContinue
+        if ($process) {
+            $process.Dispose()
+        }
     }
 
     return $null
@@ -130,6 +155,9 @@ function Set-DotfilesSecretEnvironmentValue {
     if ([Environment]::GetEnvironmentVariable($Name, 'Process')) {
         return
     }
+    if (-not (Test-DotfilesShouldLoadSecret -Name $Name)) {
+        return
+    }
 
     $value = Invoke-DotfilesOpRead -Reference $Reference -Account $Account -TimeoutSeconds $TimeoutSeconds
     if ($value) {
@@ -141,6 +169,12 @@ try {
     $timeoutSeconds = Get-DotfilesSecretLoadTimeoutSeconds
     $personalAccount = if ($env:OP_ACCOUNT) { $env:OP_ACCOUNT } else { 'EJLA3HRAVZBCXIQ7SRSFGQBTNU' }
     $workAccount = 'aimatecoltd.1password.com'
+    $serviceAccountTokenRef = if ($env:DOTFILES_OP_SERVICE_ACCOUNT_TOKEN_REF) {
+        $env:DOTFILES_OP_SERVICE_ACCOUNT_TOKEN_REF
+    }
+    else {
+        'op://Employee/1password Service Account/password'
+    }
 
     Set-DotfilesSecretEnvironmentValue `
         -Name 'GITHUB_PAT_TOKEN' `
@@ -162,12 +196,20 @@ try {
         -Reference 'op://devcontainer/GITHUB_PERSONAL_ACCESS_TOKEN_KOHEI-MIKI-IM8/credential' `
         -Account $workAccount `
         -TimeoutSeconds $timeoutSeconds
+
+    Set-DotfilesSecretEnvironmentValue `
+        -Name 'OP_SERVICE_ACCOUNT_TOKEN' `
+        -Reference $serviceAccountTokenRef `
+        -Account $workAccount `
+        -TimeoutSeconds $timeoutSeconds
 }
 finally {
     Remove-Item Function:\Resolve-DotfilesOpCli -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-DotfilesSecretLoadTimeoutSeconds -ErrorAction SilentlyContinue
+    Remove-Item Function:\Test-DotfilesShouldLoadSecret -ErrorAction SilentlyContinue
     Remove-Item Function:\Invoke-DotfilesOpRead -ErrorAction SilentlyContinue
     Remove-Item Function:\Set-DotfilesSecretEnvironmentValue -ErrorAction SilentlyContinue
 
-    Remove-Variable timeoutSeconds, personalAccount, workAccount -ErrorAction SilentlyContinue
+    Remove-Variable timeoutSeconds, personalAccount, workAccount, serviceAccountTokenRef -ErrorAction SilentlyContinue
+    Remove-Variable DotfilesSecretLoadOnly -Scope Script -ErrorAction SilentlyContinue
 }

--- a/chezmoi/dot_config/shell/secret.sh
+++ b/chezmoi/dot_config/shell/secret.sh
@@ -15,7 +15,6 @@ if [ -z "${GH_TOKEN:-}" ] && [ -n "${GITHUB_PAT_TOKEN:-}" ]; then
   export GH_TOKEN="$GITHUB_PAT_TOKEN"
 fi
 
-[ -n "${GITHUB_PAT_TOKEN:-}" ] && [ -n "${GH_TOKEN:-}" ] && [ -n "${TAVILY_API_KEY:-}" ] && [ -n "${GITHUB_WORK_TOKEN:-}" ] && return 0
 [ -n "${DOTFILES_FORCE_SECRET_LOAD:-}" ] || return 0
 
 # Under WSL the Linux `op` CLI cannot bridge to the Windows 1Password app.
@@ -35,6 +34,7 @@ command -v "$_op_cmd" >/dev/null 2>&1 || {
 
 _personal_acct="${OP_ACCOUNT:-EJLA3HRAVZBCXIQ7SRSFGQBTNU}"
 _work_acct="aimatecoltd.1password.com"
+_op_service_account_token_ref="${DOTFILES_OP_SERVICE_ACCOUNT_TOKEN_REF:-op://Employee/1password Service Account/password}"
 _secret_timeout="${DOTFILES_SECRET_LOAD_TIMEOUT_SECONDS:-60}"
 case "$_secret_timeout" in
 '' | *[!0-9]* | 0) _secret_timeout=60 ;;
@@ -55,19 +55,30 @@ _dotfiles_op_read() {
 
   if [ -n "$_timeout_cmd" ]; then
     if [ -n "$_op_cache_arg" ]; then
-      _output=$("$_timeout_cmd" "${_secret_timeout}s" "$_op_cmd" "$_op_cache_arg" read "$_ref" --account "$_acct" 2>/dev/null) || return $?
+      _output=$("$_timeout_cmd" "${_secret_timeout}s" "$_op_cmd" "$_op_cache_arg" --account "$_acct" read "$_ref" 2>/dev/null) || return $?
     else
-      _output=$("$_timeout_cmd" "${_secret_timeout}s" "$_op_cmd" read "$_ref" --account "$_acct" 2>/dev/null) || return $?
+      _output=$("$_timeout_cmd" "${_secret_timeout}s" "$_op_cmd" --account "$_acct" read "$_ref" 2>/dev/null) || return $?
     fi
   else
     if [ -n "$_op_cache_arg" ]; then
-      _output=$("$_op_cmd" "$_op_cache_arg" read "$_ref" --account "$_acct" 2>/dev/null) || return $?
+      _output=$("$_op_cmd" "$_op_cache_arg" --account "$_acct" read "$_ref" 2>/dev/null) || return $?
     else
-      _output=$("$_op_cmd" read "$_ref" --account "$_acct" 2>/dev/null) || return $?
+      _output=$("$_op_cmd" --account "$_acct" read "$_ref" 2>/dev/null) || return $?
     fi
   fi
 
   printf '%s' "$_output" | tr -d '\r'
+}
+
+_dotfiles_should_load_secret() {
+  local _name="$1"
+  local _only
+  [ -n "${DOTFILES_SECRET_LOAD_ONLY:-}" ] || return 0
+  _only=" $(printf '%s' "$DOTFILES_SECRET_LOAD_ONLY" | tr ',[:space:]' '   ') "
+  case "$_only" in
+  *" $_name "*) return 0 ;;
+  *) return 1 ;;
+  esac
 }
 
 _dotfiles_set_secret() {
@@ -79,6 +90,7 @@ _dotfiles_set_secret() {
 
   eval "_current=\${${_name}:-}"
   [ -n "$_current" ] && return 0
+  _dotfiles_should_load_secret "$_name" || return 0
 
   _value=$(_dotfiles_op_read "$_ref" "$_acct") || {
     printf '[secret/env.sh] warning: %s read failed for %s\n' "$_op_cmd" "$_name" >&2
@@ -87,7 +99,7 @@ _dotfiles_set_secret() {
   [ -n "$_value" ] || return 0
 
   case "$_name" in
-  GITHUB_PAT_TOKEN | TAVILY_API_KEY | GITHUB_WORK_TOKEN)
+  GITHUB_PAT_TOKEN | TAVILY_API_KEY | GITHUB_WORK_TOKEN | OP_SERVICE_ACCOUNT_TOKEN)
     export "$_name=$_value"
     ;;
   esac
@@ -104,6 +116,7 @@ if [ -z "${GH_TOKEN:-}" ] && [ -n "${GITHUB_PAT_TOKEN:-}" ]; then
 fi
 
 _dotfiles_set_secret GITHUB_WORK_TOKEN 'op://devcontainer/GITHUB_PERSONAL_ACCESS_TOKEN_KOHEI-MIKI-IM8/credential' "$_work_acct"
+_dotfiles_set_secret OP_SERVICE_ACCOUNT_TOKEN "$_op_service_account_token_ref" "$_work_acct"
 
-unset -f _dotfiles_op_read _dotfiles_set_secret
-unset _op_cmd _op_cache_arg _personal_acct _work_acct _secret_timeout _timeout_cmd
+unset -f _dotfiles_op_read _dotfiles_should_load_secret _dotfiles_set_secret
+unset _op_cmd _op_cache_arg _personal_acct _work_acct _op_service_account_token_ref _secret_timeout _timeout_cmd

--- a/chezmoi/shells/Microsoft.PowerShell_profile.ps1
+++ b/chezmoi/shells/Microsoft.PowerShell_profile.ps1
@@ -473,6 +473,38 @@ function dcnvim {
     }
     $dotfilesUrlQuoted = ConvertTo-DcnvimBashSingleQuoted $dotfilesUrl
     $dotfilesRefQuoted = ConvertTo-DcnvimBashSingleQuoted $dotfilesRef
+
+    $homeDir = if ($env:HOME) { $env:HOME } else { $HOME }
+    if (-not $env:OP_SERVICE_ACCOUNT_TOKEN -and $homeDir) {
+        $secretLoader = Join-Path $homeDir ".config\shell\secret.ps1"
+        if (Test-Path -LiteralPath $secretLoader -PathType Leaf) {
+            $hadForceSecretLoad = Test-Path Env:\DOTFILES_FORCE_SECRET_LOAD
+            $previousForceSecretLoad = $env:DOTFILES_FORCE_SECRET_LOAD
+            $hadSecretLoadOnly = Test-Path Env:\DOTFILES_SECRET_LOAD_ONLY
+            $previousSecretLoadOnly = $env:DOTFILES_SECRET_LOAD_ONLY
+            try {
+                $env:DOTFILES_FORCE_SECRET_LOAD = "1"
+                $env:DOTFILES_SECRET_LOAD_ONLY = "OP_SERVICE_ACCOUNT_TOKEN"
+                . $secretLoader
+            }
+            finally {
+                if ($hadForceSecretLoad) {
+                    $env:DOTFILES_FORCE_SECRET_LOAD = $previousForceSecretLoad
+                }
+                else {
+                    Remove-Item Env:\DOTFILES_FORCE_SECRET_LOAD -ErrorAction SilentlyContinue
+                }
+
+                if ($hadSecretLoadOnly) {
+                    $env:DOTFILES_SECRET_LOAD_ONLY = $previousSecretLoadOnly
+                }
+                else {
+                    Remove-Item Env:\DOTFILES_SECRET_LOAD_ONLY -ErrorAction SilentlyContinue
+                }
+            }
+        }
+    }
+
     & devcontainer up `
         --workspace-folder $Workspace | Out-Null
     if ($LASTEXITCODE -ne 0) {

--- a/scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1
@@ -330,8 +330,17 @@ Describe 'PowerShell dcnvim profile function' {
         $script:fzfCallCount = 0
         $script:oldDotfilesRepositoryUrl = $env:DOTFILES_REPOSITORY_URL
         $script:oldDotfilesRepositoryRef = $env:DOTFILES_REPOSITORY_REF
+        $script:oldHome = $env:HOME
+        $script:oldOpServiceAccountToken = $env:OP_SERVICE_ACCOUNT_TOKEN
+        $script:oldForceSecretLoad = $env:DOTFILES_FORCE_SECRET_LOAD
+        $script:oldSecretLoadOnly = $env:DOTFILES_SECRET_LOAD_ONLY
+        $env:HOME = Join-Path $TestDrive "home"
+        New-Item -ItemType Directory -Path $env:HOME -Force | Out-Null
         Remove-Item Env:\DOTFILES_REPOSITORY_URL -ErrorAction SilentlyContinue
         Remove-Item Env:\DOTFILES_REPOSITORY_REF -ErrorAction SilentlyContinue
+        Remove-Item Env:\OP_SERVICE_ACCOUNT_TOKEN -ErrorAction SilentlyContinue
+        Remove-Item Env:\DOTFILES_FORCE_SECRET_LOAD -ErrorAction SilentlyContinue
+        Remove-Item Env:\DOTFILES_SECRET_LOAD_ONLY -ErrorAction SilentlyContinue
 
         function global:Get-Command {
             [CmdletBinding()]
@@ -370,9 +379,12 @@ Describe 'PowerShell dcnvim profile function' {
             $command = if ($callArgs.Count -gt 0) { [string]$callArgs[0] } else { "" }
             $payload = if ($callArgs.Count -gt 0) { [string]$callArgs[-1] } else { "" }
             $script:devcontainerCalls.Add([PSCustomObject]@{
-                    Command = $command
-                    Args    = $callArgs
-                    Payload = $payload
+                    Command             = $command
+                    Args                = $callArgs
+                    Payload             = $payload
+                    OpServiceAccountSet = [bool]$env:OP_SERVICE_ACCOUNT_TOKEN
+                    ForceSecretLoad     = $env:DOTFILES_FORCE_SECRET_LOAD
+                    SecretLoadOnly      = $env:DOTFILES_SECRET_LOAD_ONLY
                 }) | Out-Null
 
             switch ($command) {
@@ -467,6 +479,34 @@ Describe 'PowerShell dcnvim profile function' {
         else {
             $env:DOTFILES_REPOSITORY_REF = $script:oldDotfilesRepositoryRef
         }
+
+        if ($null -eq $script:oldHome) {
+            Remove-Item Env:\HOME -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:HOME = $script:oldHome
+        }
+
+        if ($null -eq $script:oldOpServiceAccountToken) {
+            Remove-Item Env:\OP_SERVICE_ACCOUNT_TOKEN -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:OP_SERVICE_ACCOUNT_TOKEN = $script:oldOpServiceAccountToken
+        }
+
+        if ($null -eq $script:oldForceSecretLoad) {
+            Remove-Item Env:\DOTFILES_FORCE_SECRET_LOAD -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:DOTFILES_FORCE_SECRET_LOAD = $script:oldForceSecretLoad
+        }
+
+        if ($null -eq $script:oldSecretLoadOnly) {
+            Remove-Item Env:\DOTFILES_SECRET_LOAD_ONLY -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:DOTFILES_SECRET_LOAD_ONLY = $script:oldSecretLoadOnly
+        }
     }
 
     It 'should quote tmux session names for bash payloads' {
@@ -517,6 +557,25 @@ Describe 'PowerShell dcnvim profile function' {
         $exec.Payload | Should -Match "command -v tmux"
         $exec.Payload | Should -Match ([regex]::Escape("tmux new -A -s 'repo' 'nvim .'"))
     }
+
+    It 'should load OP service account token before devcontainer up' {
+        $workspace = New-DcnvimWorkspace (Join-Path $TestDrive "repo")
+        $secretDir = Join-Path $env:HOME ".config\shell"
+        New-Item -ItemType Directory -Path $secretDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $secretDir "secret.ps1") -Encoding ascii -Value @'
+if (-not $env:DOTFILES_FORCE_SECRET_LOAD) { throw "DOTFILES_FORCE_SECRET_LOAD was not set" }
+if ($env:DOTFILES_SECRET_LOAD_ONLY -ne "OP_SERVICE_ACCOUNT_TOKEN") { throw "DOTFILES_SECRET_LOAD_ONLY was not scoped" }
+$env:OP_SERVICE_ACCOUNT_TOKEN = "loaded-by-secret-loader"
+'@
+
+        dcnvim -Workspace $workspace
+
+        $script:devcontainerCalls[0].Command | Should -Be "up"
+        $script:devcontainerCalls[0].OpServiceAccountSet | Should -BeTrue
+        Test-Path Env:\DOTFILES_FORCE_SECRET_LOAD | Should -BeFalse
+        Test-Path Env:\DOTFILES_SECRET_LOAD_ONLY | Should -BeFalse
+    }
+
 
     It 'should use custom dotfiles repo URL in bootstrap payload' {
         $workspace = New-DcnvimWorkspace (Join-Path $TestDrive "repo")

--- a/scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1
@@ -139,6 +139,76 @@ exit /b 42
         $env:GITHUB_WORK_TOKEN | Should -BeNullOrEmpty
     }
 
+    It 'Windows PowerShell 5.1 でも space を含む secret reference を読み込めること' {
+        $windowsPowerShell = Get-Command powershell.exe -CommandType Application -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if (-not $windowsPowerShell) {
+            Set-ItResult -Skipped -Because 'powershell.exe is unavailable on this platform'
+            return
+        }
+
+        $fakeOp = Join-Path $TestDrive 'op-spaced-reference.exe'
+        $fakeOpSourcePath = Join-Path $TestDrive 'op-spaced-reference.cs'
+        $fakeOpSource = @'
+using System;
+
+public static class Program
+{
+    public static int Main(string[] args)
+    {
+        if (
+            args.Length == 5 &&
+            args[0] == "--cache=false" &&
+            args[1] == "--account" &&
+            args[2] == "aimatecoltd.1password.com" &&
+            args[3] == "read" &&
+            args[4] == "op://Employee/1password Service Account/password")
+        {
+            Console.WriteLine("service-token");
+            return 0;
+        }
+
+        Console.Error.WriteLine("bad args: " + string.Join("|", args));
+        return 1;
+    }
+}
+'@
+        Set-Content -LiteralPath $fakeOpSourcePath -Encoding ascii -Value $fakeOpSource
+
+        $fakeOpSourceLiteral = $fakeOpSourcePath.Replace("'", "''")
+        $fakeOpLiteral = $fakeOp.Replace("'", "''")
+        $compileCommand = @"
+`$source = Get-Content -LiteralPath '$fakeOpSourceLiteral' -Raw
+Add-Type -TypeDefinition `$source -Language CSharp -OutputAssembly '$fakeOpLiteral' -OutputType ConsoleApplication
+"@
+        try {
+            $compileOutput = & $windowsPowerShell.Source -NoLogo -NoProfile -ExecutionPolicy Bypass -Command $compileCommand 2>&1
+            if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $fakeOp)) {
+                throw "powershell.exe Add-Type failed: $($compileOutput -join [Environment]::NewLine)"
+            }
+        }
+        catch {
+            Set-ItResult -Skipped -Because "failed to build fake op.exe: $($_.Exception.Message)"
+            return
+        }
+
+        $loader = $script:secretLoaderPath.Replace("'", "''")
+        $command = @"
+`$env:DOTFILES_OP_BIN = '$fakeOpLiteral'
+`$env:DOTFILES_FORCE_SECRET_LOAD = '1'
+`$env:DOTFILES_SECRET_LOAD_ONLY = 'OP_SERVICE_ACCOUNT_TOKEN'
+`$env:DOTFILES_SECRET_LOAD_TIMEOUT_SECONDS = '3'
+Remove-Item Env:OP_SERVICE_ACCOUNT_TOKEN -ErrorAction SilentlyContinue
+. '$loader'
+[Console]::WriteLine('token=' + `$env:OP_SERVICE_ACCOUNT_TOKEN)
+"@
+
+        $output = & $windowsPowerShell.Source -NoLogo -NoProfile -ExecutionPolicy Bypass -Command $command
+
+        $LASTEXITCODE | Should -Be 0
+        $output | Should -Contain 'token=service-token'
+    }
+
     It 'pwsh -Command では force 未設定なら fallback を起動しないこと' {
         $fakeOp = Join-Path $TestDrive 'op-marker.cmd'
         $marker = Join-Path $TestDrive 'op-called.txt'

--- a/scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1
@@ -468,7 +468,11 @@ Describe 'GitHub token switching templates' {
 
         $content | Should -Match 'GITHUB_PAT_TOKEN'
         $content | Should -Match 'GITHUB_WORK_TOKEN'
+        $content | Should -Match 'OP_SERVICE_ACCOUNT_TOKEN'
+        $content | Should -Match 'DOTFILES_OP_SERVICE_ACCOUNT_TOKEN_REF'
+        $content | Should -Match 'DOTFILES_SECRET_LOAD_ONLY'
         $content | Should -Match '--cache=false'
+        $content | Should -Match "'--account'"
         $content | Should -Match "'read'"
         $content | Should -Match 'GitHubUsedUserPAT'
         $content | Should -Match '\$timeoutSeconds = 60'
@@ -489,6 +493,10 @@ Describe 'GitHub token switching templates' {
         $content | Should -Match '\bread\b'
         $content | Should -Match 'GitHubUsedUserPAT'
         $content | Should -Match 'GITHUB_PERSONAL_ACCESS_TOKEN_KOHEI-MIKI-IM8'
+        $content | Should -Match 'OP_SERVICE_ACCOUNT_TOKEN'
+        $content | Should -Match 'DOTFILES_OP_SERVICE_ACCOUNT_TOKEN_REF'
+        $content | Should -Match 'DOTFILES_SECRET_LOAD_ONLY'
+        $content | Should -Match '--account "\$_acct" read "\$_ref"'
         $content | Should -Not -Match '\binject\b' -Because 'forced shell loading should use bounded individual reads instead of bulk inject'
     }
 

--- a/scripts/sh/dcnvim.sh
+++ b/scripts/sh/dcnvim.sh
@@ -77,6 +77,35 @@ dcnvim() {
   local dotfiles_url_quoted dotfiles_ref_quoted
   dotfiles_url_quoted="$(_dcnvim_shell_quote "$dotfiles_url")"
   dotfiles_ref_quoted="$(_dcnvim_shell_quote "$dotfiles_ref")"
+
+  if [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ] && [ -f "$HOME/.config/shell/secret.sh" ]; then
+    local __dcnvim_had_force_secret_load=0
+    local __dcnvim_previous_force_secret_load="${DOTFILES_FORCE_SECRET_LOAD:-}"
+    local __dcnvim_had_secret_load_only=0
+    local __dcnvim_previous_secret_load_only="${DOTFILES_SECRET_LOAD_ONLY:-}"
+    if [ "${DOTFILES_FORCE_SECRET_LOAD+x}" = x ]; then
+      __dcnvim_had_force_secret_load=1
+    fi
+    if [ "${DOTFILES_SECRET_LOAD_ONLY+x}" = x ]; then
+      __dcnvim_had_secret_load_only=1
+    fi
+
+    export DOTFILES_FORCE_SECRET_LOAD=1
+    export DOTFILES_SECRET_LOAD_ONLY=OP_SERVICE_ACCOUNT_TOKEN
+    # shellcheck source=/dev/null
+    source "$HOME/.config/shell/secret.sh"
+    if [ "$__dcnvim_had_force_secret_load" = 1 ]; then
+      export DOTFILES_FORCE_SECRET_LOAD="$__dcnvim_previous_force_secret_load"
+    else
+      unset DOTFILES_FORCE_SECRET_LOAD
+    fi
+    if [ "$__dcnvim_had_secret_load_only" = 1 ]; then
+      export DOTFILES_SECRET_LOAD_ONLY="$__dcnvim_previous_secret_load_only"
+    else
+      unset DOTFILES_SECRET_LOAD_ONLY
+    fi
+  fi
+
   devcontainer up \
     --workspace-folder "$workspace" \
     >/dev/null || {

--- a/tests/bash/bootstrap_entrypoint.bats
+++ b/tests/bash/bootstrap_entrypoint.bats
@@ -39,3 +39,35 @@ EOF
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"bootstrap complete"* ]]
 }
+
+@test "bootstrap.sh installs claude code without writing workspace npm config" {
+	rm "$STUB_BIN/claude"
+	export HOME="$TEST_HOME"
+	export NPM_LOG="$BATS_TEST_TMPDIR/npm.log"
+	write_stub npm '
+printf "args=%s\n" "$*" >>"$NPM_LOG"
+printf "prefix=%s\n" "${NPM_CONFIG_PREFIX:-}" >>"$NPM_LOG"
+if [ "${1:-}" = "config" ]; then exit 70; fi
+exit 0
+'
+	filtered_path=""
+	IFS=: read -r -a path_entries <<<"$PATH"
+	for path_entry in "${path_entries[@]}"; do
+		[ -n "$path_entry" ] || continue
+		[ -x "$path_entry/claude" ] && continue
+		if [ -z "$filtered_path" ]; then
+			filtered_path="$path_entry"
+		else
+			filtered_path="$filtered_path:$path_entry"
+		fi
+	done
+	export PATH="$STUB_BIN:$filtered_path"
+
+	run timeout 30 bash "$REPO_ROOT/bootstrap.sh" 2>&1
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"bootstrap complete"* ]]
+	grep -q "args=install -g @anthropic-ai/claude-code" "$NPM_LOG"
+	grep -q "prefix=$TEST_HOME/.local/npm" "$NPM_LOG"
+	! grep -q "args=config set prefix" "$NPM_LOG"
+}

--- a/tests/bash/dcnvim.bats
+++ b/tests/bash/dcnvim.bats
@@ -34,6 +34,7 @@ write_devcontainer_stub() {
 	write_stub devcontainer '
 {
   printf "argc=%s\n" "$#"
+  printf "op_token=%s\n" "${OP_SERVICE_ACCOUNT_TOKEN:-}"
   for arg in "$@"; do
     printf "arg=%s\n" "$arg"
   done
@@ -114,6 +115,25 @@ printf "%s\n" "$FZF_SELECTED"
 	[[ "$payload" == *"command -v nvim"* ]]
 	[[ "$payload" == *"command -v tmux"* ]]
 	[[ "$payload" == *"tmux new -A -s 'project' 'nvim .'"* ]]
+}
+
+@test "explicit workspace loads OP service account token before devcontainer up" {
+	workspace="$BATS_TEST_TMPDIR/project"
+	mkdir -p "$workspace/.devcontainer" "$HOME/.config/shell"
+cat >"$HOME/.config/shell/secret.sh" <<'EOF'
+[ "${DOTFILES_FORCE_SECRET_LOAD:-}" = "1" ] || return 99
+[ "${DOTFILES_SECRET_LOAD_ONLY:-}" = "OP_SERVICE_ACCOUNT_TOKEN" ] || return 98
+export OP_SERVICE_ACCOUNT_TOKEN="loaded-by-secret-loader"
+EOF
+	write_devcontainer_stub
+
+	run dcnvim "$workspace"
+
+	[ "$status" -eq 0 ]
+	log="$(cat "$DEVCONTAINER_LOG")"
+	[[ "$log" == *"op_token=loaded-by-secret-loader"* ]]
+	[ -z "${DOTFILES_FORCE_SECRET_LOAD:-}" ]
+	[ -z "${DOTFILES_SECRET_LOAD_ONLY:-}" ]
 }
 
 @test "workspace picker uses ghq and fzf when cwd has no devcontainer" {


### PR DESCRIPTION
## Summary
- Load `OP_SERVICE_ACCOUNT_TOKEN` through the managed secret loaders.
- Scope forced secret loading so `dcnvim` only asks for the service account token before `devcontainer up`.
- Preserve secret references with spaces in the PowerShell loader and add regression tests for PowerShell and bash `dcnvim`.

## Root Cause
`econa-engine` already passed `${localEnv:OP_SERVICE_ACCOUNT_TOKEN}` into the devcontainer, but the host shell that launched `dcnvim` did not have that variable set. The container then fell back to its Linux `op` CLI without a configured account and prompted interactively.

## Validation
- `bats tests/bash/dcnvim.bats tests/bash/dcnvim_session_name.bats`
- `Invoke-Pester -Path scripts/powershell/tests/chezmoi/DcnvimProfile.Tests.ps1,scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1 -Output Detailed`
- `task commit -- "Load OP service token for dcnvim"`
- Verified `OP_SERVICE_ACCOUNT_TOKEN` reaches the `econa-engine` devcontainer and that container-side `op account list` succeeds with the service account token.