### PR TITLE
feat: add cross-platform one-command bootstrap

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  labels:
+    - dotfiles-e2e
+
+config-variables: null

--- a/.github/e2e/bootstrap-compose.yml
+++ b/.github/e2e/bootstrap-compose.yml
@@ -1,0 +1,7 @@
+services:
+  acceptance:
+    image: nginx:1.29-alpine
+    ports:
+      - "127.0.0.1:8642:80"
+      - "127.0.0.1:9119:80"
+      - "127.0.0.1:6080:80"

--- a/.github/workflows/ci-bootstrap-build.yml
+++ b/.github/workflows/ci-bootstrap-build.yml
@@ -1,0 +1,90 @@
+name: Bootstrap Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "nix/**"
+      - ".github/workflows/ci-bootstrap-build.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "nix/**"
+      - ".github/workflows/ci-bootstrap-build.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux:
+    name: Bootstrap Build (Linux)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    env:
+      DOTFILES_USER: runner
+      DOTFILES_HOME: /home/runner
+      DOTFILES_UID: "1000"
+      DOTFILES_GID: "1000"
+      DOTFILES_GROUP: runner
+      DOTFILES_SYSTEM: x86_64-linux
+      DOTFILES_NIXOS_HARDWARE_CONFIG: ${{ github.workspace }}/nix/tests/hardware-configuration.nix
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Linux declarative outputs
+        run: |
+          set -euo pipefail
+          nix build .#systemConfigs.ubuntu --impure --no-link
+          nix build .#systemConfigs.debian --impure --no-link
+          nix build .#nixosConfigurations.linux.config.system.build.toplevel --impure --no-link
+          nix build .#homeConfigurations.x86_64-linux.activationPackage --impure --no-link
+          nix build .#package-support-report --no-link
+
+  darwin:
+    name: Bootstrap Build (Darwin)
+    runs-on: macos-14
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    env:
+      DOTFILES_USER: runner
+      DOTFILES_HOME: /Users/runner
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build macOS declarative output
+        run: nix build .#darwinConfigurations.macos.system --impure --no-link
+
+  complete:
+    name: Bootstrap Build
+    needs: [linux, darwin]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - run: echo "All bootstrap outputs built successfully."

--- a/.github/workflows/ci-bootstrap-e2e-linux.yml
+++ b/.github/workflows/ci-bootstrap-e2e-linux.yml
@@ -142,8 +142,20 @@ jobs:
             sleep 2
           done
           [[ $(sudo machinectl show "$MACHINE_NAME" --property=State --value) == running ]]
-          sudo machinectl shell --quiet "root@$MACHINE_NAME" /bin/bash -lc \
-            'systemctl is-system-running | grep -E "^(running|degraded)$"'
+          machine_ready=0
+          for _ in $(seq 1 60); do
+            if sudo machinectl shell --quiet "root@$MACHINE_NAME" /bin/bash -lc \
+              'systemctl is-system-running | grep -E "^(running|degraded)$"' \
+              >/dev/null 2>&1; then
+              machine_ready=1
+              break
+            fi
+            sleep 2
+          done
+          if ((machine_ready == 0)); then
+            tail -200 debian-nspawn.log
+            exit 1
+          fi
 
           run_inside() {
             sudo machinectl shell --quiet "dotfiles@$MACHINE_NAME" /bin/bash -lc "$1"

--- a/.github/workflows/ci-bootstrap-e2e-linux.yml
+++ b/.github/workflows/ci-bootstrap-e2e-linux.yml
@@ -1,0 +1,206 @@
+name: Linux Bootstrap E2E
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "install.sh"
+      - "scripts/sh/**"
+      - "nix/**"
+      - "docker/hermes-agent/**"
+      - ".github/e2e/**"
+      - ".github/workflows/ci-bootstrap-e2e-linux.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "install.sh"
+      - "scripts/sh/**"
+      - "nix/**"
+      - "docker/hermes-agent/**"
+      - ".github/e2e/**"
+      - ".github/workflows/ci-bootstrap-e2e-linux.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TESTED_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+jobs:
+  ubuntu:
+    name: Ubuntu Destructive
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    env:
+      DOTFILES_COMPOSE_FILE: ${{ github.workspace }}/.github/e2e/bootstrap-compose.yml
+      DOTFILES_CHECKOUT_TARGET: ${{ github.workspace }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: First one-command convergence
+        run: |
+          ./install.sh
+          export PATH="/run/system-manager/sw/bin:/etc/profiles/per-user/$USER/bin:$HOME/.nix-profile/bin:$PATH"
+          . ./scripts/sh/install-common.sh
+          export DOTFILES_USER="$USER"
+          dotfiles_run_in_group docker ./scripts/sh/verify-environment.sh --runtime
+
+      - name: Second idempotent convergence
+        run: |
+          ./install.sh
+          export PATH="/run/system-manager/sw/bin:/etc/profiles/per-user/$USER/bin:$HOME/.nix-profile/bin:$PATH"
+          . ./scripts/sh/install-common.sh
+          export DOTFILES_USER="$USER"
+          dotfiles_run_in_group docker ./scripts/sh/verify-environment.sh --runtime
+
+      - name: Write Ubuntu attestation
+        if: always()
+        run: |
+          . ./scripts/sh/install-common.sh
+          export DOTFILES_USER="$USER"
+          {
+            echo "sha=$TESTED_SHA"
+            echo "system_manager=$(readlink -f /run/system-manager/system 2>/dev/null || true)"
+            echo "docker=$(dotfiles_run_in_group docker docker version --format '{{.Server.Version}}' 2>/dev/null || true)"
+            echo "support_report=$(nix build .#package-support-report --no-link --print-out-paths 2>/dev/null | sha256sum | cut -d' ' -f1 || true)"
+          } > ubuntu-attestation.txt
+
+      - name: Upload Ubuntu attestation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: ubuntu-bootstrap-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ubuntu-attestation.txt
+
+  debian:
+    name: Debian systemd Destructive
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install systemd-nspawn prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes debootstrap systemd-container
+
+      - name: Run Debian bootstrap twice
+        env:
+          DEBIAN_ROOT: ${{ runner.temp }}/debian-root
+          MACHINE_NAME: dotfiles-debian-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          sudo debootstrap --variant=minbase bookworm "$DEBIAN_ROOT" https://deb.debian.org/debian
+          sudo systemd-nspawn -D "$DEBIAN_ROOT" /bin/bash -lc '
+            apt-get update
+            DEBIAN_FRONTEND=noninteractive apt-get install --yes ca-certificates curl git sudo xz-utils systemd systemd-sysv dbus
+            useradd --create-home --shell /bin/bash dotfiles
+            printf "dotfiles ALL=(ALL) NOPASSWD: ALL\n" >/etc/sudoers.d/dotfiles
+            chmod 0440 /etc/sudoers.d/dotfiles
+          '
+
+          {
+            sudo systemd-nspawn \
+              --directory="$DEBIAN_ROOT" \
+              --machine="$MACHINE_NAME" \
+              --boot \
+              --capability=all \
+              --bind="$GITHUB_WORKSPACE:/workspace"
+          } >debian-nspawn.log 2>&1 &
+          nspawn_pid=$!
+          cleanup() {
+            sudo machinectl terminate "$MACHINE_NAME" >/dev/null 2>&1 || true
+            wait "$nspawn_pid" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          for _ in $(seq 1 60); do
+            if [[ $(sudo machinectl show "$MACHINE_NAME" --property=State --value 2>/dev/null || true) == running ]]; then
+              break
+            fi
+            sleep 2
+          done
+          [[ $(sudo machinectl show "$MACHINE_NAME" --property=State --value) == running ]]
+          sudo machinectl shell --quiet "root@$MACHINE_NAME" /bin/bash -lc \
+            'systemctl is-system-running | grep -E "^(running|degraded)$"'
+
+          run_inside() {
+            sudo machinectl shell --quiet "dotfiles@$MACHINE_NAME" /bin/bash -lc "$1"
+          }
+
+          # The variables below must expand inside the Debian machine.
+          # shellcheck disable=SC2016
+          bootstrap='export DOTFILES_COMPOSE_FILE=/workspace/.github/e2e/bootstrap-compose.yml; cd /workspace; ./install.sh'
+          # shellcheck disable=SC2016
+          verify='export DOTFILES_COMPOSE_FILE=/workspace/.github/e2e/bootstrap-compose.yml; export PATH=/run/system-manager/sw/bin:/etc/profiles/per-user/dotfiles/bin:$HOME/.nix-profile/bin:$PATH; cd /workspace; ./scripts/sh/verify-environment.sh --runtime'
+          run_inside "$bootstrap"
+          run_inside "$verify"
+          run_inside "$bootstrap"
+          run_inside "$verify"
+
+          {
+            echo "sha=$TESTED_SHA"
+            # shellcheck disable=SC2016
+            run_inside 'echo system_manager=$(readlink -f /run/system-manager/system); echo docker=$(docker version --format "{{.Server.Version}}")'
+          } >debian-attestation.txt
+
+      - name: Upload Debian logs and attestation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: debian-bootstrap-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            debian-attestation.txt
+            debian-nspawn.log
+
+  nixos:
+    name: NixOS VM
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run idempotent NixOS VM test
+        run: nix build .#checks.x86_64-linux.bootstrap-nixos-vm --no-link --print-build-logs
+
+      - name: Write NixOS attestation
+        if: always()
+        run: printf 'sha=%s\ncheck=bootstrap-nixos-vm\n' "$TESTED_SHA" > nixos-attestation.txt
+
+      - name: Upload NixOS attestation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: nixos-bootstrap-${{ github.run_id }}-${{ github.run_attempt }}
+          path: nixos-attestation.txt

--- a/.github/workflows/ci-bootstrap-e2e-self-hosted.yml
+++ b/.github/workflows/ci-bootstrap-e2e-self-hosted.yml
@@ -1,0 +1,125 @@
+name: Protected Bootstrap E2E
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "install.cmd"
+      - "install.sh"
+      - "scripts/powershell/**"
+      - "scripts/sh/**"
+      - "nix/**"
+      - "windows/**"
+      - "docker/hermes-agent/**"
+      - ".github/e2e/**"
+      - ".github/workflows/ci-bootstrap-e2e-self-hosted.yml"
+
+concurrency:
+  group: destructive-bootstrap-${{ github.event.pull_request.number }}-${{ github.job }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  windows:
+    name: Windows Destructive E2E
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    environment: destructive-e2e
+    runs-on: [self-hosted, Windows, X64, dotfiles-e2e]
+    timeout-minutes: 120
+    steps:
+      - name: Checkout exact PR head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: First Windows convergence and acceptance
+        shell: pwsh
+        run: |
+          & .\install.cmd -NoPause
+          if ($LASTEXITCODE -ne 0) { throw "First install.cmd run failed: $LASTEXITCODE" }
+          & .\scripts\powershell\Test-Environment.ps1 -Runtime
+
+      - name: Second Windows idempotent convergence and acceptance
+        shell: pwsh
+        run: |
+          & .\install.cmd -NoPause
+          if ($LASTEXITCODE -ne 0) { throw "Second install.cmd run failed: $LASTEXITCODE" }
+          & .\scripts\powershell\Test-Environment.ps1 -Runtime
+
+      - name: Write Windows attestation
+        if: always()
+        shell: pwsh
+        run: |
+          $sha = '${{ github.event.pull_request.head.sha }}'
+          $generation = (& wsl -d NixOS -- readlink -f /run/current-system 2>$null) -join "`n"
+          $dockerVersion = (& docker version --format '{{.Server.Version}}' 2>$null) -join "`n"
+          $wslWorkspace = ((& wsl wslpath -a "$env:GITHUB_WORKSPACE") -join "`n").Trim()
+          $supportReport = (& wsl -d NixOS -- bash -lc "cd '$wslWorkspace' && nix build .#package-support-report --no-link --print-out-paths 2>/dev/null | sha256sum | cut -d' ' -f1") -join "`n"
+          @(
+            "sha=$sha"
+            "nix_generation=$generation"
+            "docker=$dockerVersion"
+            "support_report=$supportReport"
+          ) | Set-Content -LiteralPath windows-attestation.txt -Encoding utf8
+
+      - name: Upload Windows attestation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: windows-bootstrap-${{ github.run_id }}-${{ github.run_attempt }}
+          path: windows-attestation.txt
+
+  macos:
+    name: macOS Destructive E2E
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    environment: destructive-e2e
+    runs-on: [self-hosted, macOS, ARM64, dotfiles-e2e]
+    timeout-minutes: 120
+    env:
+      DOTFILES_COMPOSE_FILE: ${{ github.workspace }}/.github/e2e/bootstrap-compose.yml
+      DOTFILES_CHECKOUT_TARGET: ${{ github.workspace }}
+    steps:
+      - name: Checkout exact PR head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: First macOS convergence and acceptance
+        run: |
+          ./install.sh
+          export PATH="/run/current-system/sw/bin:/etc/profiles/per-user/$USER/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH"
+          ./scripts/sh/verify-environment.sh --runtime
+
+      - name: Second macOS idempotent convergence and acceptance
+        run: |
+          ./install.sh
+          export PATH="/run/current-system/sw/bin:/etc/profiles/per-user/$USER/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH"
+          ./scripts/sh/verify-environment.sh --runtime
+
+      - name: Write macOS attestation
+        if: always()
+        run: |
+          export PATH="/run/current-system/sw/bin:/etc/profiles/per-user/$USER/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH"
+          {
+            echo "sha=${{ github.event.pull_request.head.sha }}"
+            echo "nix_generation=$(readlink /run/current-system 2>/dev/null || true)"
+            echo "docker=$(docker version --format '{{.Server.Version}}' 2>/dev/null || true)"
+            echo "support_report=$(nix build .#package-support-report --no-link --print-out-paths 2>/dev/null | shasum -a 256 | cut -d' ' -f1 || true)"
+          } > macos-attestation.txt
+
+      - name: Upload macOS attestation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: macos-bootstrap-${{ github.run_id }}-${{ github.run_attempt }}
+          path: macos-attestation.txt

--- a/.github/workflows/ci-consistency.yml
+++ b/.github/workflows/ci-consistency.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
 
+      - name: Verify package provider coverage
+        run: |
+          nix build .#package-support-report -o /tmp/package-support-report
+          jq -e 'length == 0' /tmp/package-support-report/errors.json
+
       - name: Build winget-export from SSOT
         run: nix build .#winget-export -o /tmp/winget-export
 

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -8,6 +8,12 @@ on:
       - "nix/**"
       - "flake.nix"
       - "flake.lock"
+      - "install.sh"
+      - "scripts/sh/**"
+      - "tests/bash/**"
+      - ".github/e2e/**"
+      - ".github/workflows/ci-bootstrap-build.yml"
+      - ".github/workflows/ci-bootstrap-e2e-linux.yml"
       - ".github/workflows/ci-nix.yml"
   pull_request:
     branches: [main]
@@ -15,6 +21,12 @@ on:
       - "nix/**"
       - "flake.nix"
       - "flake.lock"
+      - "install.sh"
+      - "scripts/sh/**"
+      - "tests/bash/**"
+      - ".github/e2e/**"
+      - ".github/workflows/ci-bootstrap-build.yml"
+      - ".github/workflows/ci-bootstrap-e2e-linux.yml"
       - ".github/workflows/ci-nix.yml"
 
 concurrency:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ repos:
         pass_filenames: false
       - id: powershell-tests
         name: powershell tests
-        entry: bash -c '[ "$(uname)" = "Linux" ] && exit 0; pwsh.exe -NoProfile -Command "& ./scripts/powershell/tests/Invoke-Tests.ps1 -MinimumCoverage 80"'
+        entry: scripts/sh/run-windows-powershell-tests.sh -NoProfile -Command "& ./scripts/powershell/tests/Invoke-Tests.ps1 -MinimumCoverage 80"
         language: system
         pass_filenames: false
         types: [powershell]
       - id: chezmoi-template-lint
         name: chezmoi template lint
-        entry: bash -c '[ "$(uname)" = "Linux" ] && exit 0; pwsh.exe -NoProfile -Command "& ./scripts/powershell/tests/Invoke-Tests.ps1 -Path ./scripts/powershell/tests/chezmoi -MinimumCoverage 0"'
+        entry: scripts/sh/run-windows-powershell-tests.sh -NoProfile -Command "& ./scripts/powershell/tests/Invoke-Tests.ps1 -Path ./scripts/powershell/tests/chezmoi -MinimumCoverage 0"
         language: system
         pass_filenames: false
         files: '\.tmpl$'

--- a/README.md
+++ b/README.md
@@ -10,21 +10,34 @@
 [![ci-consistency](https://github.com/rurusasu/dotfiles/actions/workflows/ci-consistency.yml/badge.svg)](https://github.com/rurusasu/dotfiles/actions/workflows/ci-consistency.yml)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-NixOS/Home Manager + chezmoi を使った dotfiles の一元管理リポジトリ
+Windows、macOS、NixOS、Ubuntu、Debian を 1 コマンドで収束させる個人用 dotfiles リポジトリです。パッケージ定義は Nix catalog、ユーザー設定は Home Manager と chezmoi、OS サービスは各プラットフォームの宣言レイヤーで一元管理します。
 
 ## 技術スタック
 
-| Category        | Technology                |
-| --------------- | ------------------------- |
-| OS              | NixOS (WSL2)              |
-| Package Manager | Nix Flakes                |
-| User Config     | Chezmoi + Home Manager    |
-| Shell           | Zsh + Starship            |
-| Editor          | Neovim (nixvim)           |
-| Terminal        | Windows Terminal, WezTerm |
-| Formatter       | treefmt-nix               |
+| Category           | Technology                                         |
+| ------------------ | -------------------------------------------------- |
+| OS                 | Windows + NixOS-WSL, macOS, NixOS, Ubuntu, Debian  |
+| Package catalog    | Nix Flakes (`nix/packages/sets.nix`)               |
+| System convergence | winget handlers, nix-darwin, System Manager, NixOS |
+| User environment   | Home Manager + chezmoi                             |
+| Containers         | Docker Desktop / rootful Docker + Docker Compose   |
+| Formatter          | treefmt-nix                                        |
 
 ## クイックスタート
+
+clone 後、OS ごとの入口を 1 回実行します。Full support の installer は Nix、OS パッケージ、Home Manager、chezmoi、Docker Compose を適用し、最後に runtime acceptance を実行します。途中で失敗した場合も同じコマンドを再実行できます。
+
+### Windows
+
+PowerShell または Command Prompt で実行します。管理者処理は installer が必要に応じて分離します。
+
+```powershell
+git clone https://github.com/rurusasu/dotfiles.git
+cd dotfiles
+.\install.cmd
+```
+
+`install.cmd` は winget/npm 系パッケージ、Docker Desktop、WSL2/NixOS、Home Manager、chezmoi を適用し、Docker・Compose・WSL・`hello-world` の acceptance が成功してから完了を表示します。
 
 ### macOS (Apple Silicon)
 
@@ -38,41 +51,46 @@ cd dotfiles
 ./install.sh
 ```
 
-Homebrew、Docker Desktop、Nix を必要に応じて導入し、Home Manager と
-chezmoi の設定を適用した後、Hermes の Docker Compose 環境を起動します。
-再実行可能な設計ですが、初回の Nix/Docker イメージのビルドには時間が
-かかります。
+Nix installer と nix-darwin がシステムを収束させ、nix-homebrew が Homebrew と Docker Desktop cask を管理します。Home Manager、chezmoi、Docker Compose、runtime acceptance まで同じコマンド内で実行します。macOS では WSL や NixOS を導入しません。
 
-### Windows
+### NixOS / Ubuntu / Debian
 
-Windows PowerShell で以下を実行:
+Linux では同じ入口が `/etc/NIXOS` と `/etc/os-release` を見て自動振り分けします。
 
-```powershell
-# 1. リポジトリをクローン
+```bash
 git clone https://github.com/rurusasu/dotfiles.git
 cd dotfiles
-
-# 2. インストール実行（管理者権限は自動で取得されます）
-\.\install.cmd
-
-# 参考: PowerShell スクリプトを直接実行する場合
-# .\scripts\powershell\install.ps1
+./install.sh
 ```
 
-これにより:
+- NixOS: `nixos-rebuild switch` に Home Manager と rootful Docker を含めます。
+- Ubuntu / Debian: Nix を必要に応じて導入し、System Manager + Home Manager + rootful Docker を適用します。
+- どちらも既存ユーザーの UID、GID、home、primary group を保持します。
 
-1. NixOS WSL がダウンロード・インポートされる
-2. `~/.dotfiles` がこのリポジトリへのシンボリックリンクとして作成される
-3. `nixos-rebuild switch` が実行され設定が適用される
-4. Windows 側のユーザー設定は chezmoi apply で適用する
+NixOS は現在の `/etc/nixos/hardware-configuration.nix` を必須の host profile として読み込みます。固定ディスク構成はリポジトリに持たず、このファイルが存在しない場合は activation 前に停止します。
+
+### その他の Linux
+
+Full support ではありません。Docker や systemd の収束を行わない Home Manager のみの fallback を、明示的に opt-in した場合だけ実行できます。
+
+```bash
+DOTFILES_ALLOW_USER_ONLY=1 ./install.sh
+```
+
+### 成功条件と CI
+
+「コマンドが終了した」だけでは成功扱いにしません。必須 CLI、chezmoi drift、Docker daemon、Compose 全サービス、`docker run --rm hello-world` を acceptance で確認します。Ubuntu、Debian、NixOS は hosted E2E、Windows と macOS は保護された専用 runner で installer を 2 回実行します。runner の構築と承認手順は [self-hosted bootstrap runners](./docs/ci/self-hosted-bootstrap-runners.md) を参照してください。
 
 ## 方針
 
-Nix はパッケージ/システム設定、chezmoi はユーザー設定を管理します。詳細は [docs/chezmoi/](./docs/chezmoi/) を参照。
+Nix catalog は各 OS の provider を定義し、OS の宣言レイヤーと Home Manager がそれを消費します。chezmoi は shell、Git、terminal、editor などの設定ファイルを管理します。
 
 - ユーザー設定: `chezmoi/`
-- Home Manager: `nix/profiles/home/` (packages, tmux, nixvim, extensions)
-- ホスト設定: `nix/hosts/`
+- Home Manager: `nix/home/common.nix`
+- macOS: `nix/darwin/`
+- Ubuntu / Debian: `nix/system-manager/`
+- NixOS / WSL: `nix/hosts/`
+- パッケージ provider catalog: `nix/packages/sets.nix`
 
 ## ディレクトリ構造
 
@@ -86,7 +104,7 @@ dotfiles/
 ├── windows/                # Windows-side config files
 ├── docs/                   # Documentation
 ├── Taskfile.yml            # Task runner
-├── install.sh              # macOS launcher
+├── install.sh              # macOS / NixOS / Ubuntu / Debian launcher
 ├── install.cmd             # Windows launcher for install.ps1
 ├── scripts/powershell/install.ps1 # NixOS WSL installer entrypoint
 └── flake.nix               # Nix flake entry point
@@ -198,6 +216,22 @@ wsl --shutdown
 ```bash
 # ドライランでエラーを確認
 sudo nixos-rebuild dry-build --flake ~/.dotfiles --impure
+```
+
+### installer が途中で停止した
+
+同じ installer を再実行すると、完了済みの宣言状態を再利用して停止した phase から収束できます。runtime だけを再確認する場合:
+
+```bash
+./scripts/sh/verify-environment.sh --runtime
+systemctl status system-manager.target docker.service docker.socket
+docker compose -f docker/hermes-agent/compose.yml ps
+```
+
+NixOS では `system-manager.target` の代わりに `readlink /run/current-system` と `nixos-rebuild list-generations` を確認します。macOS は `darwin-rebuild --list-generations` と Docker Desktop の起動状態を確認します。Windows は次を実行します。
+
+```powershell
+.\scripts\powershell\Test-Environment.ps1 -Runtime
 ```
 
 ### Windows Terminal 設定が反映されない

--- a/chezmoi/.chezmoiscripts/deploy/cli/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/cli/run_onchange_deploy.sh.tmpl
@@ -1,5 +1,5 @@
 {{ if ne .chezmoi.os "windows" -}}
-#!/bin/bash
+#!/usr/bin/env bash
 # Deploy CLI tool configurations for Linux/macOS
 # hash: {{ include "cli/starship/starship.toml" | sha256sum }}{{ include "cli/fd/ignore" | sha256sum }}{{ include "cli/ripgrep/config" | sha256sum }}{{ include "cli/ghq/config" | sha256sum }}{{ include "cli/zoxide/env" | sha256sum }}
 

--- a/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/editors/run_onchange_deploy.sh.tmpl
@@ -1,5 +1,5 @@
 {{ if ne .chezmoi.os "windows" -}}
-#!/bin/bash
+#!/usr/bin/env bash
 # Deploy editor configurations for Linux/macOS
 # hash: {{ include "editors/vscode/settings.json" | sha256sum }}{{ include "editors/vscode/keybindings.json" | sha256sum }}{{ include "editors/cursor/settings.json" | sha256sum }}{{ include "editors/cursor/keybindings.json" | sha256sum }}{{ include "editors/zed/settings.json" | sha256sum }}{{ include "editors/zed/keymap.json" | sha256sum }}
 

--- a/chezmoi/.chezmoiscripts/deploy/kaggle/run_always_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/kaggle/run_always_deploy.sh.tmpl
@@ -1,5 +1,5 @@
 {{ if ne .chezmoi.os "windows" -}}
-#!/bin/bash
+#!/usr/bin/env bash
 # Deploy Kaggle API credentials for Linux/macOS
 set -euo pipefail
 

--- a/chezmoi/.chezmoiscripts/deploy/llms/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/llms/run_onchange_deploy.sh.tmpl
@@ -1,5 +1,5 @@
 {{ if ne .chezmoi.os "windows" -}}
-#!/bin/bash
+#!/usr/bin/env bash
 # Deploy LLM tool configurations for Linux/macOS
 # hash: {{ include "dot_claude/settings.json.tmpl" | sha256sum }}{{ include "dot_claude/dot_claude.json.tmpl" | sha256sum }}{{ include "dot_claude/CLAUDE.md" | sha256sum }}{{ include "dot_codex/config.toml.tmpl" | sha256sum }}{{ include "dot_cursor/rules" | sha256sum }}{{ include "dot_cursor/cli-config.json.tmpl" | sha256sum }}{{ include "dot_gemini/settings.json.tmpl" | sha256sum }}
 

--- a/chezmoi/.chezmoiscripts/deploy/llms/run_onchange_deploy_claude_code_mcp.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/llms/run_onchange_deploy_claude_code_mcp.sh.tmpl
@@ -1,5 +1,5 @@
 {{ if ne .chezmoi.os "windows" -}}
-#!/bin/bash
+#!/usr/bin/env bash
 # chezmoi:template:hash={{ include ".chezmoidata/mcp_servers.yaml" | sha256sum }}
 
 if ! command -v claude >/dev/null 2>&1; then

--- a/chezmoi/.chezmoiscripts/deploy/shells/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/shells/run_onchange_deploy.sh.tmpl
@@ -1,5 +1,5 @@
 {{ if ne .chezmoi.os "windows" -}}
-#!/bin/bash
+#!/usr/bin/env bash
 # Deploy shell configurations for Linux/macOS
 # zshrc is managed by Home Manager (programs.zsh) on all HM-managed platforms.
 # hash: {{ include "shells/bashrc" | sha256sum }}{{ include "shells/profile" | sha256sum }}{{ include "dot_config/shell/secret.sh" | sha256sum }}{{ include "dot_config/shell/secrets.env" | sha256sum }}{{ include "dot_config/shell/secrets-work.env" | sha256sum }}

--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.sh.tmpl
@@ -1,5 +1,5 @@
 {{ if ne .chezmoi.os "windows" -}}
-#!/bin/bash
+#!/usr/bin/env bash
 # Deploy SSH configuration for Linux/macOS
 # hash: {{ include "ssh/config.tmpl" | sha256sum }}
 set -euo pipefail

--- a/chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/terminals/run_onchange_deploy.sh.tmpl
@@ -1,5 +1,5 @@
 {{ if ne .chezmoi.os "windows" -}}
-#!/bin/bash
+#!/usr/bin/env bash
 # Deploy terminal configurations for Linux/macOS
 # hash: {{ include "terminals/wezterm/wezterm.lua" | sha256sum }}{{ include "terminals/warp/keybindings.yaml" | sha256sum }}{{ include "terminals/warp/settings.toml" | sha256sum }}
 

--- a/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_darwin.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_darwin.sh.tmpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 # Claude Code プラグイン マーケットプレース インストールスクリプト
 # Generated from: {{ range .claude_marketplaces }}{{ .repo }} {{ end }}

--- a/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_linux.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_linux.sh.tmpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 # Claude Code プラグイン マーケットプレース インストールスクリプト
 # Generated from: {{ range .claude_marketplaces }}{{ .repo }} {{ end }}

--- a/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl
@@ -1,5 +1,5 @@
 {{ if ne .chezmoi.os "windows" -}}
-#!/bin/bash
+#!/usr/bin/env bash
 # pnpm グローバルパッケージ インストールスクリプト (Linux/macOS)
 # SSOT: nix/packages/all.nix (pnpmGlobal)
 # Generated from: {{ range .pnpm_global_packages }}{{ . }} {{ end }}

--- a/chezmoi/.chezmoiscripts/setup/precommit/run_onchange_setup.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/setup/precommit/run_onchange_setup.sh.tmpl
@@ -1,5 +1,5 @@
 {{ if ne .chezmoi.os "windows" -}}
-#!/bin/bash
+#!/usr/bin/env bash
 # Setup pre-commit hooks for Linux/macOS
 # hash: {{ include "../.pre-commit-config.yaml" | sha256sum }}
 

--- a/chezmoi/.chezmoiscripts/sync/editors/run_onchange_sync.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/sync/editors/run_onchange_sync.sh.tmpl
@@ -1,5 +1,5 @@
 {{ if ne .chezmoi.os "windows" -}}
-#!/bin/bash
+#!/usr/bin/env bash
 # Sync editor extensions for Linux/macOS (install missing, remove unlisted)
 # hash: {{ include "editors/vscode/extensions.json" | sha256sum }}{{ include "editors/cursor/extensions.json" | sha256sum }}
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,34 +4,39 @@
 
 ## 設計原則
 
-**「Windows と Linux で同じ開発環境を構築する」** を目標に、以下の原則で管理する。
+**「OS ごとに 1 コマンドで同じ開発環境へ収束する」** を目標に、以下の原則で管理する。
 
-1. **Nix (Home Manager) がパッケージの Single Source of Truth (SSOT)**
-   - 全 CLI ツールは `nix/packages/sets.nix` に一元定義
-   - Linux/macOS: Home Manager が `home.packages` としてインストール
-   - Windows: `nix build .#winget-export` で winget/npm/pnpm の JSON を導出
+1. **Nix catalog がパッケージ provider の Single Source of Truth (SSOT)**
+   - 全ツールと OS ごとの provider は `nix/packages/sets.nix` に一元定義
+   - Unix 系 CLI は Home Manager、macOS cask は nix-homebrew、Linux system package は NixOS/System Manager が消費
+   - Windows は `nix build .#winget-export` で winget/npm/pnpm JSON を導出
 2. **chezmoi が設定ファイルの SSOT**
    - 全 OS 共通の dotfiles をテンプレートで管理
    - OS 固有の差分は `.chezmoiignore.tmpl` とテンプレート分岐で吸収
-3. **OS 固有の処理は最小限に分離**
-   - NixOS モジュール: システムレベル設定 (nix gc, Docker, WSL 固有)
-   - PowerShell ハンドラー: Windows セットアップ自動化
+3. **システム収束は OS に適した宣言レイヤーへ分離**
+   - Windows: PowerShell handlers + winget
+   - macOS: nix-darwin + nix-homebrew
+   - Ubuntu/Debian: System Manager
+   - NixOS/WSL: NixOS module
+4. **Full support は runtime acceptance までを契約に含める**
+   - 必須 CLI、chezmoi drift、Docker、Compose 全サービス、hello-world を確認
+   - installer は同じコマンドを安全に再実行できる
 
 ## 全体構造
 
 ```
 dotfiles/
-├── nix/                    # NixOS/Home Manager configuration
+├── nix/                    # Cross-platform declarative configuration
 │   ├── packages/
-│   │   ├── sets.nix        # ★ SSOT: catalog (全パッケージ + winget + category)
+│   │   ├── sets.nix        # ★ SSOT: package + provider catalog
 │   │   └── winget.nix      # winget/npm/pnpm JSON 生成 derivation
-│   ├── home/               # Home Manager 設定
-│   │   ├── packages.nix    # sets.nix → home.packages
-│   │   └── wsl/users.nix   # WSL ユーザー HM 設定
+│   ├── darwin/             # nix-darwin + nix-homebrew
+│   ├── system-manager/     # Ubuntu/Debian services and users
+│   ├── home/               # Shared Home Manager configuration
 │   ├── flakes/             # Flake inputs/outputs, treefmt
-│   ├── hosts/              # Host-specific configs (WSL, Linux)
+│   ├── hosts/              # NixOS hosts (native Linux, WSL)
 │   ├── modules/            # Custom NixOS modules (system-level)
-│   └── lib/                # Helper functions
+│   └── tests/              # NixOS VM acceptance
 ├── chezmoi/                # User dotfiles (shell/git/terminal/VS Code/LLM)
 ├── scripts/                # All scripts
 │   ├── sh/                 # Shell scripts (Linux/WSL)
@@ -42,59 +47,47 @@ dotfiles/
 │   └── .wslconfig          # WSL configuration
 ├── docs/                   # Documentation
 ├── Taskfile.yml            # Task runner (WSL 経由で nix fmt 等を実行)
-├── install.ps1             # NixOS WSL installer (auto-elevates to admin)
+├── install.cmd             # Windows one-command entrypoint
+├── install.sh              # macOS/Linux one-command dispatcher
 ├── flake.nix               # Nix flake entry point
 └── flake.lock
 ```
 
 ## セットアップフロー
 
-```
-Windows                              WSL (NixOS)
-────────                             ───────────
-install.ps1
-    │
-    ├─► Download NixOS WSL
-    │
-    ├─► Import to WSL
-    │
-    └─► scripts/sh/nixos-wsl-postinstall.sh ──► ~/.dotfiles (symlink)
-                                                  │
-                                                  ▼
-                                             nixos-rebuild switch
-                                                  │
-                                                  ▼
-                                             NixOS configured
-```
+| Platform      | Entrypoint                                | System layer                             | User layer             | Runtime        |
+| ------------- | ----------------------------------------- | ---------------------------------------- | ---------------------- | -------------- |
+| Windows       | `install.cmd`                             | PowerShell handlers, winget, NixOS-WSL   | Home Manager + chezmoi | Docker Desktop |
+| macOS ARM64   | `./install.sh`                            | nix-darwin + nix-homebrew                | Home Manager + chezmoi | Docker Desktop |
+| Ubuntu/Debian | `./install.sh`                            | System Manager                           | Home Manager + chezmoi | rootful Docker |
+| NixOS         | `./install.sh`                            | NixOS generation + host hardware profile | Home Manager + chezmoi | rootful Docker |
+| Other Linux   | `DOTFILES_ALLOW_USER_ONLY=1 ./install.sh` | none                                     | Home Manager only      | not managed    |
+
+Full support の共通フローは `preflight → Nix/bootstrap → system switch → Home Manager → chezmoi → Compose → runtime acceptance` です。失敗時はその phase で停止し、同じ入口を再実行します。
 
 ## 役割分担
 
-| 役割                  | ツール          | 説明                                         |
-| --------------------- | --------------- | -------------------------------------------- |
-| パッケージ定義 (SSOT) | Nix             | `nix/packages/sets.nix` に全ツールを一元定義 |
-| パッケージ (Linux)    | Home Manager    | `home.packages` で宣言的インストール         |
-| パッケージ (Windows)  | winget/npm/pnpm | nix から生成した JSON でインストール         |
-| ユーザー設定          | chezmoi         | dotfiles (shell, git, terminal, editor)      |
-| システム設定          | NixOS           | OS レベルの設定 (nix gc, Docker, WSL)        |
-| タスク実行            | Taskfile        | Windows から WSL コマンドを実行              |
+| 役割                    | ツール                  | 説明                                                           |
+| ----------------------- | ----------------------- | -------------------------------------------------------------- |
+| Provider 定義 (SSOT)    | Nix catalog             | package、winget、npm、Darwin cask、Linux module を一元定義     |
+| Unix ユーザーパッケージ | Home Manager            | macOS、NixOS、Ubuntu、Debian で共通の `home.packages`          |
+| Windows パッケージ      | winget/npm/pnpm         | catalog から生成した JSON を handlers が適用                   |
+| macOS システム          | nix-darwin/nix-homebrew | Homebrew、Docker Desktop、Home Manager を 1 generation で適用  |
+| Ubuntu/Debian システム  | System Manager          | user identity、Nix、Docker service/socket、Home Manager を適用 |
+| NixOS システム          | NixOS module            | native/WSL host、Docker、Home Manager を generation に統合     |
+| ユーザー設定            | chezmoi                 | shell、Git、terminal、editor の OS 差分をテンプレート化        |
+| 受入検証                | platform verifier       | runtime acceptance と drift を検出                             |
 
 ## パッケージ管理フロー
 
 ```
 nix/packages/sets.nix (SSOT)
-│
-├── catalog          ─── { pkg, winget, category } per package
-│
-├── packages         ─── nix/home/packages.nix ─── Home Manager (Linux/macOS)
-│                                                    └── home.packages = [...]
-│
-├── wingetMap        ─── nix/packages/winget.nix ── nix build .#winget-export
-│   (自動導出)           └── windows/winget/packages.json (generated)
-│                        └── windows/npm/packages.json    (generated)
-│                        └── windows/pnpm/packages.json  (generated)
-│
-└── windowsOnly      ─── Windows 専用パッケージ (winget/msstore/npm/pnpm)
-    (nix対応なし)
+├── Home Manager ───────── macOS / NixOS / Ubuntu / Debian CLI
+├── darwinCasks ────────── nix-homebrew casks
+├── linuxSystemModules ─── NixOS / System Manager packages and services
+├── wingetMap + npmMap ─── generated Windows manifests
+├── supportReport ──────── per-OS provider/unsupported evidence
+└── providerErrors ─────── CI failure when coverage is missing
 ```
 
 ### ツール追加手順
@@ -264,112 +257,20 @@ Should -Invoke Invoke-Wsl -Times 1 -Exactly
 
 ## テスト戦略
 
-### テストピラミッド
+検証は「静的契約 → build → 破壊的 convergence → runtime acceptance」の順で強くなります。
 
-```
-       /   Smoke Test   \    ← CI: nix shell --version、winget + --version
-      /    Build Test    \   ← CI: nix build .#default（実ビルド）
-     / Consistency Test  \   ← CI: winget-export diff（JSON 整合性）
-    /     Unit Tests      \  ← CI: Pester（PowerShell ハンドラー）
-   /   Static Analysis    \  ← CI: flake check、lint、fmt
-```
+| Workflow                           | Runner                            | Guarantee                                                                  |
+| ---------------------------------- | --------------------------------- | -------------------------------------------------------------------------- |
+| `ci-nix.yml`                       | hosted Linux                      | Statix、treefmt、flake evaluation、package smoke                           |
+| `ci-consistency.yml`               | hosted Linux                      | catalog から生成した winget/npm/pnpm JSON の一致                           |
+| `ci-powershell.yml`                | hosted Windows                    | handlers、entrypoint、Windows acceptance の Pester                         |
+| `ci-bootstrap-build.yml`           | hosted Linux/macOS                | nix-darwin、System Manager、NixOS、Home Manager、support report の実 build |
+| `ci-bootstrap-e2e-linux.yml`       | hosted Linux                      | Ubuntu/Debian/NixOS installer 2 周、Compose、Docker runtime                |
+| `ci-bootstrap-e2e-self-hosted.yml` | protected dedicated Windows/macOS | real installer 2 周、Docker Desktop、head SHA attestation                  |
 
-### CI ワークフロー全体像
+Full support の破壊的 job は 1 周目で clean bootstrap、2 周目で idempotency を検証し、各周回の後に runtime acceptance を実行します。artifact の SHA が PR head と一致し、skip や Environment approval 待ちがないことを merge 条件にします。
 
-```mermaid
-flowchart TD
-    PR["Pull Request"]
-
-    PR -->|"nix/** flake.*"| NX
-    PR -->|"nix/** flake.*\npostinstall"| NW
-    PR -->|"windows/winget/packages.json\nnix/packages/sets.nix"| WG
-    PR -->|"nix/packages/** windows/winget/**"| CO
-    PR -->|"scripts/powershell/**"| PS
-
-    subgraph NX["test-nix.yml (ubuntu-latest)"]
-        N1["① nix flake check\n評価エラー検知"]
-        N2["② nix build .#default\n実ビルド"]
-        N3["③ nix build .#nixosConfigurations.nixos...\nWSL system toplevel 実ビルド"]
-        N4["④ nix shell smoke test\nchezmoi git gh fd rg bat jq eza zoxide fzf unzip"]
-        N5["⑤ nix fmt\nフォーマット確認"]
-        N1 --> N2 --> N3 --> N4 --> N5
-    end
-
-    subgraph NW["ci-nixos-wsl.yml (windows-2025 + WSL2)"]
-        NW1["① 一時 NixOS-WSL distro 作成"]
-        NW2["② postinstall 実行"]
-        NW3["③ nixos-rebuild switch 検証\nwelcome banner 消滅確認"]
-        NW4["④ distro unregister"]
-        NW1 --> NW2 --> NW3 --> NW4
-    end
-
-    subgraph WG["test-winget.yml (windows-2025)"]
-        W1["① winget import\npackages.json 全量インストール"]
-        W2["② smoke test\nchezmoi git gh fd rg jq eza zoxide fzf"]
-        W1 --> W2
-    end
-
-    subgraph CO["test-consistency.yml (ubuntu-latest)"]
-        C1["① nix build .#winget-export\nNix から JSON 生成"]
-        C2["② diff\n生成 JSON ↔ リポジトリ JSON"]
-        C1 --> C2
-    end
-
-    subgraph PS["test-powershell.yml (windows-2025)"]
-        P1["① Pester\nユニットテスト"]
-        P2["② Codecov\nカバレッジ"]
-        P1 --> P2
-    end
-```
-
-### ワークフロー詳細
-
-| Workflow               | ランナー      | 何を保証するか                                                        | トリガー                                                |
-| ---------------------- | ------------- | --------------------------------------------------------------------- | ------------------------------------------------------- |
-| `test-nix.yml`         | ubuntu-latest | Nix 式・NixOS WSL toplevel が評価/ビルドでき、ツールが動く            | `nix/**`, `flake.*`                                     |
-| `ci-nixos-wsl.yml`     | windows-2025  | 一時 NixOS-WSL distro で postinstall と `nixos-rebuild switch` が通る | `nix/**`, `flake.*`, `nixos-wsl-postinstall.sh`         |
-| `test-winget.yml`      | windows-2025  | winget パッケージがインストールでき、ツールが動く                     | `windows/winget/packages.json`, `nix/packages/sets.nix` |
-| `test-consistency.yml` | ubuntu-latest | Nix 定義と `windows/winget/packages.json` が一致                      | `nix/packages/**`, `windows/winget/**`                  |
-| `test-powershell.yml`  | windows-2025  | PowerShell ハンドラーのロジックが正しく動く                           | `scripts/powershell/**`                                 |
-
-### テストレベルの判断基準
-
-| レベル           | 対象                          | 方法                                                                 | ワークフロー     |
-| ---------------- | ----------------------------- | -------------------------------------------------------------------- | ---------------- |
-| Static Analysis  | Nix 構文、フォーマット        | `nix flake check`, `nix fmt`                                         | test-nix         |
-| Unit Test        | PowerShell ハンドラー         | Pester + モック                                                      | test-powershell  |
-| Consistency Test | SSOT ↔ 生成 JSON              | winget-export diff                                                   | test-consistency |
-| Build Test       | Nix package sets              | `nix build .#default`（実ビルド）                                    | test-nix         |
-| Build Test       | NixOS WSL system              | `nix build .#nixosConfigurations.nixos.config.system.build.toplevel` | test-nix         |
-| E2E Test         | NixOS-WSL 初回反映            | 一時 distro + `nixos-rebuild switch` + welcome 消滅確認              | ci-nixos-wsl     |
-| Smoke Test       | core CLI ツール（Nix 側）     | `nix shell` + `--version`                                            | test-nix         |
-| Smoke Test       | core CLI ツール（Windows 側） | `winget import` + `--version`                                        | test-winget      |
-
-### 検証ツール一覧
-
-| ツール  | Nix smoke test | winget smoke test | 備考                             |
-| ------- | :------------: | :---------------: | -------------------------------- |
-| chezmoi |       ✅       |        ✅         |                                  |
-| git     |       ✅       |        ✅         |                                  |
-| gh      |       ✅       |        ✅         |                                  |
-| fd      |       ✅       |        ✅         |                                  |
-| rg      |       ✅       |        ✅         | ripgrep                          |
-| bat     |       ✅       |        ❌         | winget ID なし                   |
-| jq      |       ✅       |        ✅         |                                  |
-| eza     |       ✅       |        ✅         |                                  |
-| zoxide  |       ✅       |        ✅         |                                  |
-| fzf     |       ✅       |        ✅         |                                  |
-| unzip   |       ✅       |        ❌         | winget ID なし                   |
-| p7zip   |       ❌       |        ❌         | winget ID なし、CLI 動作が不安定 |
-
-### CI で意図的に実行しないもの
-
-- **Windows GUI アプリの E2E**: VS Code, Docker Desktop 等は UAC・GUI インストーラーが自動化非対応
-- **NixOS VM test (`nixosTest`)**: systemd サービスのテストが必要になった時点で追加
-
-### GitHub Actions（public repo）
-
-public リポジトリは **Linux/Windows/macOS ランナーすべて無制限無料**。
+fork PR は self-hosted runner を実行できません。Windows/macOS job は同一 repository の PR 条件、`destructive-e2e` Environment、`dotfiles-e2e` label の全てを要求します。詳細は [self-hosted runner guide](./ci/self-hosted-bootstrap-runners.md) を参照してください。
 
 ---
 

--- a/docs/ci/self-hosted-bootstrap-runners.md
+++ b/docs/ci/self-hosted-bootstrap-runners.md
@@ -1,0 +1,39 @@
+# Self-hosted bootstrap E2E runners
+
+The Windows and macOS bootstrap jobs are intentionally destructive. Register only disposable machines dedicated to this repository; never attach a workstation used for normal development.
+
+## Repository and Environment protection
+
+1. Register each runner at repository scope, not organization scope.
+2. Add the custom `dotfiles-e2e` label while retaining the platform labels:
+   - Windows: `self-hosted`, `Windows`, `X64`, `dotfiles-e2e`
+   - macOS: `self-hosted`, `macOS`, `ARM64`, `dotfiles-e2e`
+3. Create the GitHub Environment `destructive-e2e`, add required reviewers, and restrict deployment branches to protected branches.
+4. Verify the workflow gate still requires a same-repository pull request before approving a deployment. Fork pull requests must never receive a self-hosted runner.
+
+Each runner must use a dedicated account. Do not sign in to 1Password, GitHub, iCloud, a browser profile, or any other personal service, and do not store personal secrets on the machine. Repository checkout credentials are disabled after checkout.
+
+## Required privileges
+
+The Windows runner account must be a local administrator so the non-interactive service can perform elevation-required setup without a UAC desktop prompt. Enable WSL2 virtualization before registering the runner.
+
+The macOS runner account needs passwordless `sudo` only for the commands used by Nix installation and `darwin-rebuild`. Keep the sudoers rule narrow and remove it with the runner.
+
+Install or permit Docker Desktop on both machines and complete the applicable Docker Desktop license acceptance before the first run. The E2E workflow exercises Linux containers and Docker Compose; Apple Container is not a substitute for this compatibility test.
+
+## Clean-bootstrap reset
+
+Snapshot each machine immediately after OS updates, runner registration, virtualization setup, and Docker license acceptance. Before testing a new bootstrap branch, reset to that snapshot and confirm:
+
+- no prior dotfiles checkout or Home Manager generation remains;
+- Windows has no test NixOS WSL distribution and macOS has no prior nix-darwin generation;
+- Docker has no test containers, volumes, images, or custom contexts;
+- the dedicated account contains no credentials or personal data.
+
+The workflow itself runs the installer twice without a reset between runs. The first pass proves convergence from the clean snapshot; the second proves idempotency.
+
+## Registration and removal
+
+Download the current runner package and registration command from **Repository settings → Actions → Runners → New self-hosted runner**. Use an ephemeral registration token, install the runner as a service under the dedicated account, and confirm all four expected labels before approving a job.
+
+After the test campaign, stop and uninstall the service, remove the runner in repository settings, delete the local runner directory, revoke any temporary credentials, and destroy or reset the machine snapshot. Never reuse a destructive E2E machine as a personal workstation.

--- a/docs/nix/package-management.md
+++ b/docs/nix/package-management.md
@@ -1,100 +1,96 @@
 # パッケージ管理
 
-## SSOT: `nix/packages/sets.nix`
+## Single Source of Truth
 
-全プラットフォームのパッケージ定義を一元管理する Single Source of Truth。
-`catalog` attrset に全パッケージを定義し、カテゴリ別グルーピング・winget 対応・フラットリストを自動導出する。
+`nix/packages/sets.nix` の catalog が全プラットフォームの package provider を一元管理します。Home Manager だけを SSOT とするのではなく、1 つの catalog から OS ごとの実装を導出します。
 
-```
-nix/packages/sets.nix
-├── catalog        → { pkg, winget, npm, category } の attrset
-├── packages       → Home Manager で Linux/macOS にインストール
-├── wingetMap      → nix attr → winget PackageIdentifier の対応表
-├── npmMap         → nix attr → npm package spec の対応表
-└── windowsOnly    → Windows 専用アプリ (winget/msstore/npm/pnpm)
-```
+| Catalog output        | Consumer                            | Platform                     |
+| --------------------- | ----------------------------------- | ---------------------------- |
+| `all` / category sets | `nix/home/common.nix`               | macOS、NixOS、Ubuntu、Debian |
+| `darwinCasks`         | nix-homebrew in nix-darwin          | macOS                        |
+| `linuxSystemModules`  | NixOS / System Manager modules      | Linux                        |
+| `wingetMap`, `npmMap` | `nix/packages/winget.nix`           | Windows                      |
+| `supportReport`       | `package-support-report` derivation | CI and review                |
+| `providerErrors`      | flake check                         | all platforms                |
 
-## パッケージ追加
+Windows だけに存在する GUI や OS component は `windowsOnlySupport` に置き、macOS/Linux で対応しない理由を必ず記録します。クロスプラットフォームのツールを理由なしに Windows-only へ入れることはできません。
 
-### クロスプラットフォームツール (Linux + Windows)
+## Provider の追加
 
-`nix/packages/sets.nix` の `catalog` attrset にエントリを追加:
-
-```nix
-mypackage = { pkg = pkgs.mypackage; winget = "Publisher.Package"; category = "dev"; };
-```
-
-Set `winget = null` if there is no Windows equivalent.
-
-### Linux 専用ツール
-
-`catalog` にエントリを追加し、`winget = null` とする。
-
-### Windows 専用アプリ
-
-`windowsOnly` セクションに追加:
+一般的な CLI は catalog に Nix package と Windows provider を記述します。実際の schema は既存 entry に合わせてください。
 
 ```nix
-windowsOnly = {
-  winget = [
-    "Publisher.NewApp"  # ← 追加
-  ];
-  msstore = [ ... ];
-  pnpm = [ ... ];
+mypackage = {
+  package = pkgs.mypackage;
+  category = "dev";
+  windows = {
+    provider = "winget";
+    id = "Publisher.Package";
+  };
 };
 ```
 
-## 反映手順
+macOS cask や Linux system module が必要な application は、それぞれの provider metadata も同じ entry に追加します。どの OS にも provider がない場合は、その OS の `unsupported` reason が必要です。
 
-### Linux (WSL/NixOS)
+## OS ごとの反映
 
-```bash
-sudo nixos-rebuild switch --flake ~/.dotfiles#nixos
+通常は個別コマンドではなく one-command installer を再実行します。
+
+```text
+Windows:          install.cmd
+macOS:            ./install.sh
+NixOS:            ./install.sh
+Ubuntu / Debian:  ./install.sh
 ```
 
-### Windows (winget JSON 再生成)
+- Windows は catalog から生成された winget/npm/pnpm manifest を PowerShell handlers が適用します。
+- macOS は nix-darwin が Home Manager と nix-homebrew cask を同じ switch に含めます。
+- Ubuntu/Debian は System Manager が Home Manager と system package/service を適用します。
+- NixOS は NixOS generation に Home Manager と system module を統合します。
+
+その他 Linux の `DOTFILES_ALLOW_USER_ONLY=1 ./install.sh` は Home Manager のみで、Docker や OS service は管理しません。
+
+## 生成ファイル
+
+Windows manifest は直接編集しません。更新時は以下を生成し、repository の JSON と一致させます。
 
 ```bash
-# WSL 上で実行
 nix build .#winget-export -o /tmp/winget-export
-cp /tmp/winget-export/winget/packages.json /mnt/d/ruru/dotfiles/windows/winget/packages.json
-cp /tmp/winget-export/npm/packages.json /mnt/d/ruru/dotfiles/windows/npm/packages.json
-cp /tmp/winget-export/pnpm/packages.json /mnt/d/ruru/dotfiles/windows/pnpm/packages.json
-
-# Windows 上で反映
-pwsh -File scripts/powershell/install.ps1 -UserPhaseOnly -NoPause
+cp /tmp/winget-export/winget/packages.json windows/winget/packages.json
+cp /tmp/winget-export/npm/packages.json windows/npm/packages.json
+cp /tmp/winget-export/pnpm/packages.json windows/pnpm/packages.json
 ```
 
-## ファイル構成
+provider coverage は次で確認できます。
 
-| ファイル                       | 役割                                                     |
-| ------------------------------ | -------------------------------------------------------- |
-| `nix/packages/sets.nix`        | SSOT: catalog (全パッケージ + winget + category)         |
-| `nix/home/packages.nix`        | Home Manager module (`home.packages = allPkgs.packages`) |
-| `nix/home/wsl/users.nix`       | WSL ユーザーの Home Manager 設定                         |
-| `nix/packages/winget.nix`      | `nix build .#winget-export` 用 derivation                |
-| `nix/flakes/packages.nix`      | `nix profile install .#default` 用 perSystem buildEnv    |
-| `nix/modules/host/default.nix` | システムレベルのみ (nix settings, git, Docker)           |
+```bash
+nix build .#package-support-report
+cat result/package-support-report.json
+```
 
-## Home Manager と systemPackages の使い分け
+`package-support-report` は各 catalog entry の Windows、Darwin、Linux provider または unsupported reason を記録します。自動推測できない provider gap は `reviewedUnsupported` に package 名と理由を明示し、新規 entry の未検討 platform は `checks.*.package-provider-coverage` で失敗させます。consistency CI は生成 manifest drift も失敗にします。
 
-| 対象                                         | 管理先                                 |
-| -------------------------------------------- | -------------------------------------- |
-| CLI ツール (git, ripgrep, neovim 等)         | Home Manager (`nix/home/packages.nix`) |
-| システム設定に必要なもの (git for nix flake) | `environment.systemPackages`           |
-| NixOS モジュール連携 (Docker, ZSH)           | `nix/modules/host/default.nix`         |
+## システム package と Home Manager の境界
 
-## CI による整合性チェック
+| 対象                                             | 管理先                              |
+| ------------------------------------------------ | ----------------------------------- |
+| shell から使う共通 CLI                           | Home Manager `home.packages`        |
+| Docker daemon/socket、ユーザー group、OS service | NixOS / System Manager / nix-darwin |
+| macOS GUI application                            | nix-homebrew cask                   |
+| Windows GUI/OS application                       | winget/msstore handler              |
+| shell、Git、terminal、editor 設定                | chezmoi                             |
 
-`test-consistency.yml` が以下を検証:
+同じ package を Home Manager と system layer の両方へ重複させるのは、system service が絶対 path を必要とする場合に限定します。
 
-1. `nix build .#winget-export` で Windows package JSON を生成
-2. `windows/winget/packages.json`, `windows/npm/packages.json`, `windows/pnpm/packages.json` との diff をチェック
-3. 差分があれば CI が失敗 → `nix build .#winget-export` の再実行を促す
+## 主なファイル
 
-## 注意点
-
-- `windows/winget/packages.json`, `windows/npm/packages.json`, `windows/pnpm/packages.json` は **生成ファイル**。直接編集しない
-- WSL では `flake.lock` が `~/.dotfiles` に作られる
-- `allowUnfree` は NixOS config (`nix/modules/host/default.nix`) で設定済み
-- `nix profile install .#default` で使える package sets は `nix/flakes/packages.nix` の perSystem で定義
+| File                              | Responsibility                           |
+| --------------------------------- | ---------------------------------------- |
+| `nix/packages/sets.nix`           | provider catalog and derived sets        |
+| `nix/packages/support-report.nix` | coverage report derivation               |
+| `nix/packages/winget.nix`         | generated Windows manifests              |
+| `nix/home/common.nix`             | shared Home Manager packages             |
+| `nix/darwin/default.nix`          | macOS system and casks                   |
+| `nix/system-manager/`             | Ubuntu/Debian system packages and Docker |
+| `nix/hosts/linux/`                | native NixOS system packages and Docker  |
+| `nix/flakes/packages.nix`         | package sets, report, and checks         |

--- a/docs/scripts/powershell/testing.md
+++ b/docs/scripts/powershell/testing.md
@@ -56,6 +56,30 @@ cd scripts/powershell/tests
 
 **現在の状態**: 230+ テスト成功（100%）、カバレッジ 95%+
 
+## Windows environment acceptance
+
+Unit testsだけでなく、`install.cmd` の最後に [Test-Environment.ps1](../../../scripts/powershell/Test-Environment.ps1) を実行します。`Setup Complete!` は acceptance が成功した後にだけ表示されます。
+
+```powershell
+.\scripts\powershell\Test-Environment.ps1 -Runtime
+```
+
+acceptance は次を検証します。
+
+- winget、git、gh、chezmoi、rg、fd、jq、nvim、Node.js、Python、Go、Rust、Docker、WSL の command resolution
+- `docker info` と `docker compose version`
+- `chezmoi apply --dry-run`
+- `wsl --status`
+- runtime mode の `docker run --rm hello-world`
+
+外部 process は `Invoke-Docker`、`Invoke-Chezmoi`、`Invoke-Wsl` wrapper 経由で呼び出し、[Test-Environment.Tests.ps1](../../../scripts/powershell/tests/Test-Environment.Tests.ps1) では wrapper と `Get-Command` を mock します。
+
+```powershell
+.\Invoke-Tests.ps1 -Path .\Test-Environment.Tests.ps1 -MinimumCoverage 0
+```
+
+保護された Windows self-hosted E2E は real `install.cmd` と `Test-Environment.ps1 -Runtime` を 2 回実行し、1 周目の convergence と 2 周目の idempotency を確認します。
+
 ## pre-commit 統合
 
 PowerShell ファイルの変更時に自動でテストが実行されます。

--- a/docs/superpowers/plans/2026-07-17-cross-platform-e2e.md
+++ b/docs/superpowers/plans/2026-07-17-cross-platform-e2e.md
@@ -1,0 +1,311 @@
+# Windows Integration and Destructive E2E Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Connect Windows to the shared acceptance contract and prove one-command convergence with destructive Linux, NixOS, Windows, and macOS E2E checks.
+
+**Architecture:** Preserve Windows handlers and add a platform-specific verifier adapter. Hosted runners perform builds plus destructive Linux tests; dedicated protected self-hosted machines perform Docker Desktop/WSL and macOS nix-darwin tests. All destructive jobs run twice and attest the tested head SHA.
+
+**Tech Stack:** PowerShell/Pester, Bash/Bats, GitHub Actions, Docker, WSL2, NixOS VM tests, self-hosted runners.
+
+## Global Constraints
+
+- Fork PRs never execute self-hosted jobs.
+- Self-hosted jobs require the `destructive-e2e` Environment and dedicated `dotfiles-e2e` labels.
+- Windows and macOS runtime E2E must run the real installers twice.
+- A skipped destructive test is not equivalent to a successful Full support test.
+
+---
+
+### Task 1: Add Windows environment acceptance
+
+**Files:**
+
+- Create: `scripts/powershell/Test-Environment.ps1`
+- Create: `scripts/powershell/tests/Test-Environment.Tests.ps1`
+- Modify: `scripts/powershell/install.ps1`
+
+**Interfaces:**
+
+- Produces: `Test-DotfilesEnvironment -Runtime` returning a `SetupResult`-compatible outcome.
+- Consumes existing external-command wrappers; it does not directly invoke executables in handler code.
+
+- [ ] **Step 1: Write failing Pester tests**
+
+Add Pester cases with mocked `Get-Command` and `Invoke-ExternalCommand`:
+
+```powershell
+It 'should run Docker chezmoi and WSL acceptance checks' {
+    Test-DotfilesEnvironment -Runtime
+    Should -Invoke Invoke-ExternalCommand -ParameterFilter { $FilePath -eq 'docker' -and $ArgumentList -contains 'hello-world' }
+    Should -Invoke Invoke-ExternalCommand -ParameterFilter { $FilePath -eq 'chezmoi' -and $ArgumentList -contains '--dry-run' }
+    Should -Invoke Invoke-ExternalCommand -ParameterFilter { $FilePath -eq 'wsl' }
+}
+
+It 'should fail when a required command is missing' {
+    Mock Get-Command { $null } -ParameterFilter { $Name -eq 'nvim' }
+    { Test-DotfilesEnvironment } | Should -Throw '*Missing command: nvim*'
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```powershell
+pwsh -NoProfile -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/Test-Environment.Tests.ps1 -MinimumCoverage 0
+```
+
+Expected: FAIL because `Test-DotfilesEnvironment` is undefined.
+
+- [ ] **Step 3: Implement the verifier**
+
+```powershell
+function Test-DotfilesEnvironment {
+    [CmdletBinding()]
+    param([switch]$Runtime)
+    $required = @('winget','git','gh','chezmoi','rg','fd','jq','nvim','node','python','go','rustup','docker','wsl')
+    foreach ($name in $required) {
+        if (-not (Get-Command $name -ErrorAction SilentlyContinue)) { throw "Missing command: $name" }
+    }
+    Invoke-ExternalCommand -FilePath 'docker' -ArgumentList @('info') -ThrowOnError
+    Invoke-ExternalCommand -FilePath 'docker' -ArgumentList @('compose','version') -ThrowOnError
+    Invoke-ExternalCommand -FilePath 'chezmoi' -ArgumentList @('apply','--dry-run') -ThrowOnError
+    if ($Runtime) {
+        Invoke-ExternalCommand -FilePath 'docker' -ArgumentList @('run','--rm','hello-world') -ThrowOnError
+    }
+}
+```
+
+Invoke it after all install phases and before printing completion.
+
+- [ ] **Step 4: Verify and commit**
+
+Run the targeted test and `scripts/powershell/tests/Invoke-Tests.ps1 -MinimumCoverage 0`.
+
+Expected: PASS.
+
+```bash
+git add scripts/powershell/Test-Environment.ps1 scripts/powershell/install.ps1 scripts/powershell/tests/Test-Environment.Tests.ps1
+git commit -m "test: verify the installed Windows environment"
+```
+
+### Task 2: Add hosted build and destructive Linux workflows
+
+**Files:**
+
+- Create: `.github/workflows/ci-bootstrap-build.yml`
+- Create: `.github/workflows/ci-bootstrap-e2e-linux.yml`
+- Modify: `.github/workflows/ci-nix.yml`
+- Test: `scripts/powershell/tests/CiWorkflow.Tests.ps1`
+
+**Interfaces:**
+
+- Produces required checks `Bootstrap Build`, `Ubuntu Destructive`, `Debian systemd Destructive`, `NixOS VM`.
+
+- [ ] **Step 1: Add failing workflow contract tests**
+
+Assert path filters, pinned action SHAs, timeouts, two installer invocations, runtime verification, and artifact
+upload with `if: always()`.
+
+- [ ] **Step 2: Verify RED**
+
+Run the targeted `CiWorkflow.Tests.ps1` test file.
+
+Expected: FAIL because workflows are absent.
+
+- [ ] **Step 3: Implement build matrix**
+
+Build `darwinConfigurations.macos.system`, both `systemConfigs`, both NixOS toplevels, standalone HM, and
+`package-support-report`. Use hosted runners and never start Docker Desktop in this workflow.
+
+- [ ] **Step 4: Implement destructive Linux jobs**
+
+Ubuntu job core steps:
+
+```yaml
+- run: ./install.sh
+- run: ./scripts/sh/verify-environment.sh --runtime
+- run: ./install.sh
+- run: ./scripts/sh/verify-environment.sh --runtime
+```
+
+Debian must boot a privileged systemd-nspawn environment and run the same four commands inside it. NixOS
+must use a NixOS VM test that executes two system activations and `docker run --rm hello-world`.
+
+- [ ] **Step 5: Verify syntax/contracts and commit**
+
+Run:
+
+```bash
+pwsh -NoProfile -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/CiWorkflow.Tests.ps1 -MinimumCoverage 0
+nix flake check --no-build
+```
+
+Expected: PASS.
+
+```bash
+git add .github/workflows/ci-bootstrap-build.yml .github/workflows/ci-bootstrap-e2e-linux.yml .github/workflows/ci-nix.yml scripts/powershell/tests/CiWorkflow.Tests.ps1
+git commit -m "ci: test destructive Linux bootstrap paths"
+```
+
+### Task 3: Add protected self-hosted Windows and macOS E2E
+
+**Files:**
+
+- Create: `.github/workflows/ci-bootstrap-e2e-self-hosted.yml`
+- Modify: `scripts/powershell/tests/CiWorkflow.Tests.ps1`
+- Create: `docs/ci/self-hosted-bootstrap-runners.md`
+
+**Interfaces:**
+
+- Produces checks `Windows Destructive E2E` and `macOS Destructive E2E` for the PR head SHA.
+
+- [ ] **Step 1: Write failing security/workflow tests**
+
+Require same-repository PR condition, Environment name, exact runner labels, concurrency, timeout, two real
+installer runs, runtime verifier, and SHA artifact.
+
+- [ ] **Step 2: Verify RED**
+
+Run targeted CI workflow tests.
+
+Expected: FAIL because the workflow is absent.
+
+- [ ] **Step 3: Implement the protected workflow**
+
+Use this gate on both jobs:
+
+```yaml
+if: >-
+  github.event_name == 'pull_request' &&
+  github.event.pull_request.head.repo.full_name == github.repository
+environment: destructive-e2e
+```
+
+Windows uses `runs-on: [self-hosted, Windows, X64, dotfiles-e2e]`, runs `install.cmd` twice, then
+`Test-Environment.ps1 -Runtime`. macOS uses `[self-hosted, macOS, ARM64, dotfiles-e2e]`, runs
+`./install.sh` twice, then `verify-environment.sh --runtime`.
+
+Each job writes `${{ github.event.pull_request.head.sha }}` plus Nix generation, Docker version, and support
+report hash to an attestation text file uploaded with `actions/upload-artifact` pinned by SHA.
+
+- [ ] **Step 4: Document exact runner setup**
+
+Document repository registration, labels, dedicated account, `destructive-e2e` approval, no personal secrets,
+sudo/elevation prerequisites, Docker license acceptance, clean-bootstrap reset, and runner removal.
+
+- [ ] **Step 5: Verify and commit**
+
+Run CI workflow Pester tests and `git diff --check`.
+
+Expected: PASS.
+
+```bash
+git add .github/workflows/ci-bootstrap-e2e-self-hosted.yml scripts/powershell/tests/CiWorkflow.Tests.ps1 docs/ci/self-hosted-bootstrap-runners.md
+git commit -m "ci: run protected Windows and macOS bootstrap E2E"
+```
+
+### Task 4: Update user and architecture documentation
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `docs/architecture.md`
+- Modify: `docs/nix/package-management.md`
+- Modify: `docs/scripts/powershell/testing.md`
+- Test: `tests/bash/bootstrap_docs.bats`
+
+**Interfaces:**
+
+- Documents exactly three Full support entrypoints: `install.cmd`, macOS `./install.sh`, Linux `./install.sh`.
+
+- [ ] **Step 1: Add failing documentation tests**
+
+Add these documentation assertions:
+
+```bash
+@test "README documents all bootstrap entrypoints and reruns" {
+  grep -q 'install.cmd' "$REPO_ROOT/README.md"
+  [ "$(grep -c './install.sh' "$REPO_ROOT/README.md")" -ge 2 ]
+  grep -q 'DOTFILES_ALLOW_USER_ONLY=1' "$REPO_ROOT/README.md"
+  grep -qi 're-run\|rerun\|再実行' "$REPO_ROOT/README.md"
+  grep -q 'self-hosted-bootstrap-runners.md' "$REPO_ROOT/README.md"
+  grep -q 'package-support-report' "$REPO_ROOT/docs/nix/package-management.md"
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bats tests/bash/bootstrap_docs.bats`
+
+Expected: FAIL because docs describe the old macOS-only dispatcher.
+
+- [ ] **Step 3: Update documentation**
+
+Replace old flow diagrams with the four declarative layers, document:
+
+```text
+Windows: install.cmd
+macOS: ./install.sh
+NixOS/Ubuntu/Debian: ./install.sh
+Other Linux: DOTFILES_ALLOW_USER_ONLY=1 ./install.sh
+```
+
+Include failure diagnostics and the fact that Full support success requires runtime acceptance.
+
+- [ ] **Step 4: Run complete local verification**
+
+```bash
+bats tests/bash
+pwsh -NoProfile -File scripts/powershell/tests/Invoke-Tests.ps1 -MinimumCoverage 0
+nix fmt -- --fail-on-change
+nix flake check --no-build
+nix build .#package-support-report
+nix build .#darwinConfigurations.macos.system --impure --no-link
+nix build .#systemConfigs.ubuntu --impure --no-link
+nix build .#systemConfigs.debian --impure --no-link
+git diff --check
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md docs/architecture.md docs/nix/package-management.md docs/scripts/powershell/testing.md tests/bash/bootstrap_docs.bats
+git commit -m "docs: document one-command setup on every OS"
+```
+
+### Task 5: Execute destructive acceptance and record results
+
+**Files:**
+
+- No source changes unless a test-first defect fix is required.
+
+**Interfaces:**
+
+- Consumes configured `dotfiles-e2e` Windows/macOS runners and GitHub Environment approval.
+- Produces green checks for the exact PR head SHA.
+
+- [ ] **Step 1: Push the implementation branch and open the PR**
+
+Use the repository publishing workflow; do not merge yet.
+
+- [ ] **Step 2: Approve the protected Environment jobs**
+
+Confirm both jobs target the exact PR head SHA and same-repository branch before approval.
+
+- [ ] **Step 3: Read all E2E logs and attestations**
+
+Expected: Ubuntu, Debian, NixOS, Windows, and macOS each show first run, runtime acceptance, second run, runtime
+acceptance, and an attestation matching the head SHA.
+
+- [ ] **Step 4: Fix failures only with systematic debugging and TDD**
+
+For any failure, capture the failing phase, add a minimal automated reproducer, verify RED, implement one root
+cause fix, and rerun the affected local and remote suites.
+
+- [ ] **Step 5: Merge only after all required checks are green**
+
+Expected: no skipped Full support E2E job and no pending Environment deployment.

--- a/docs/superpowers/plans/2026-07-17-cross-platform-foundation.md
+++ b/docs/superpowers/plans/2026-07-17-cross-platform-foundation.md
@@ -1,0 +1,365 @@
+# Cross-platform Catalog and Flake Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Nix package catalog describe every OS provider explicitly and add pinned flake inputs/apps required by macOS and generic Linux.
+
+**Architecture:** Extend the existing `sets.nix` SSOT instead of creating a second manifest. Generate a machine-readable provider report and fail evaluation when a Windows package lacks either a Darwin/Linux provider or an explicit unsupported reason. Pin nix-darwin, nix-homebrew, and System Manager in the existing flake-parts graph.
+
+**Tech Stack:** Nix flakes, flake-parts, jq, Pester, GitHub Actions.
+
+## Global Constraints
+
+- Home Manager remains the shared macOS/Linux user layer.
+- `windows/winget/packages.json`, npm JSON, and pnpm JSON remain generated files.
+- True Windows-only components stay supported only on Windows with an explicit reason for both other OSes.
+- GUI and CLI products use separate catalog entries.
+- All behavior changes follow red-green-refactor and end in focused commits.
+
+---
+
+### Task 1: Pin cross-platform system inputs and expose runner apps
+
+**Files:**
+
+- Modify: `flake.nix`
+- Create: `nix/flakes/apps.nix`
+- Modify: `nix/flakes/default.nix`
+- Test: `tests/bash/flake_outputs.bats`
+
+**Interfaces:**
+
+- Produces: flake inputs `nix-darwin`, `nix-homebrew`, `system-manager`.
+- Produces: apps `.#darwin-rebuild` and `.#system-manager` that use locked inputs.
+
+- [ ] **Step 1: Write failing flake wiring tests**
+
+```bash
+@test "flake pins darwin homebrew and system manager inputs" {
+  run grep -E 'nix-darwin|nix-homebrew|system-manager' "$REPO_ROOT/flake.nix"
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | wc -l | tr -d ' ')" -ge 3 ]
+}
+
+@test "flake imports locked platform runner apps" {
+  grep -q './apps.nix' "$REPO_ROOT/nix/flakes/default.nix"
+  grep -q 'darwin-rebuild' "$REPO_ROOT/nix/flakes/apps.nix"
+  grep -q 'system-manager' "$REPO_ROOT/nix/flakes/apps.nix"
+}
+```
+
+- [ ] **Step 2: Verify the tests fail for missing inputs/apps**
+
+Run: `bats tests/bash/flake_outputs.bats`
+
+Expected: FAIL because `apps.nix` and the three inputs do not exist.
+
+- [ ] **Step 3: Add pinned inputs and app wrappers**
+
+Add to `flake.nix`:
+
+```nix
+nix-darwin = {
+  url = "github:nix-darwin/nix-darwin/master";
+  inputs.nixpkgs.follows = "nixpkgs";
+};
+nix-homebrew.url = "github:zhaofengli/nix-homebrew";
+system-manager = {
+  url = "github:numtide/system-manager";
+  inputs.nixpkgs.follows = "nixpkgs";
+};
+```
+
+Create `nix/flakes/apps.nix`:
+
+```nix
+{ inputs, ... }:
+{
+  perSystem =
+    { system, ... }:
+    {
+      apps = {
+        darwin-rebuild = inputs.nix-darwin.apps.${system}.darwin-rebuild;
+        system-manager = inputs.system-manager.apps.${system}.default;
+      };
+    };
+}
+```
+
+Import `./apps.nix` from `nix/flakes/default.nix`.
+
+- [ ] **Step 4: Update the lock and verify app metadata**
+
+Run:
+
+```bash
+nix flake lock --update-input nix-darwin --update-input nix-homebrew --update-input system-manager
+bats tests/bash/flake_outputs.bats
+nix flake show --json | jq -e '.apps."aarch64-darwin"."darwin-rebuild" and .apps."x86_64-linux"."system-manager"'
+```
+
+Expected: Bats PASS and jq exits 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add flake.nix flake.lock nix/flakes/apps.nix nix/flakes/default.nix tests/bash/flake_outputs.bats
+git commit -m "feat: pin cross-platform system managers"
+```
+
+### Task 2: Add explicit provider metadata to the package SSOT
+
+**Files:**
+
+- Modify: `nix/packages/sets.nix`
+- Test: `scripts/powershell/tests/PackageCatalog.Tests.ps1`
+- Test: `tests/bash/package_catalog.bats`
+
+**Interfaces:**
+
+- Produces: `supportReport`, `darwinCasks`, `linuxSystemModules`, and `providerErrors` attrs from `sets.nix`.
+- Preserves: `all`, `wingetMap`, `windowsOnly`, npm/pnpm metadata consumed by existing exporters.
+
+- [ ] **Step 1: Add failing provider-coverage tests**
+
+Add Pester assertions that `Docker.DockerDesktop`, `dprint.dprint`, `hadolint.hadolint`,
+`Microsoft.VisualStudioCode`, `OpenAI.Codex`, `Oven-sh.Bun`, and `zig.zig` are no longer in
+`windowsOnly.winget`. Add a Bats test:
+
+```bash
+@test "catalog defines provider coverage outputs" {
+  grep -q 'supportReport' "$REPO_ROOT/nix/packages/sets.nix"
+  grep -q 'providerErrors' "$REPO_ROOT/nix/packages/sets.nix"
+  grep -q 'darwinCasks' "$REPO_ROOT/nix/packages/sets.nix"
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+bats tests/bash/package_catalog.bats
+pwsh -NoProfile -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/PackageCatalog.Tests.ps1 -MinimumCoverage 0
+```
+
+Expected: FAIL because provider attrs and migrations are absent.
+
+- [ ] **Step 3: Extend each catalog entry with provider/support fields**
+
+Use this exact shape for normal entries:
+
+```nix
+codex = {
+  pkg = pkgs.codex;
+  winget = "OpenAI.Codex";
+  category = "llm";
+  support = {
+    windows = { provider = "winget"; };
+    darwin = { provider = "nix"; };
+    linux = { provider = "nix"; };
+  };
+};
+```
+
+Use this exact shape for casks and system modules:
+
+```nix
+docker-desktop = {
+  winget = "Docker.DockerDesktop";
+  category = "system";
+  support = {
+    windows = { provider = "winget"; };
+    darwin = { provider = "homebrew-cask"; cask = "docker-desktop"; };
+    linux = { provider = "system-manager"; systemModule = "docker"; };
+  };
+};
+```
+
+Use explicit unsupported reasons for OS-native entries:
+
+```nix
+windows-terminal = {
+  winget = "Microsoft.WindowsTerminal";
+  category = "windows-system";
+  support = {
+    windows = { provider = "winget"; };
+    darwin = { unsupported = "Windows shell host"; };
+    linux = { unsupported = "Windows shell host"; };
+  };
+};
+```
+
+Apply these migrations:
+
+| Windows ID                               | Darwin                       | Linux                                            |
+| ---------------------------------------- | ---------------------------- | ------------------------------------------------ |
+| `AgileBits.1Password`                    | cask `1password`             | Nix `_1password-gui`                             |
+| `Anthropic.Claude`                       | cask `claude`                | unsupported: no supported Linux desktop provider |
+| `TheBrowserCompany.Arc`                  | cask `arc`                   | unsupported: vendor has no Linux build           |
+| `Docker.DockerDesktop`                   | cask `docker-desktop`        | system module `docker`                           |
+| `GitHub.Copilot`                         | unsupported: Windows app     | unsupported: Windows app                         |
+| `dprint.dprint`                          | Nix `dprint`                 | Nix `dprint`                                     |
+| `hadolint.hadolint`                      | Nix `hadolint`               | Nix `hadolint`                                   |
+| `Google.Chrome`                          | cask `google-chrome`         | Nix `google-chrome`                              |
+| `Microsoft.PowerToys`                    | unsupported                  | unsupported                                      |
+| `Microsoft.VCRedist.2015+.x64`           | unsupported                  | unsupported                                      |
+| `Microsoft.VisualStudio.2022.BuildTools` | unsupported                  | unsupported                                      |
+| `Microsoft.VisualStudioCode`             | cask `visual-studio-code`    | Nix `vscode`                                     |
+| `Microsoft.WindowsTerminal`              | unsupported                  | unsupported                                      |
+| `Microsoft.WSL`                          | unsupported                  | unsupported                                      |
+| `OpenAI.Codex`                           | Nix `codex`                  | Nix `codex`                                      |
+| `StablyAI.Orca`                          | unsupported: Windows package | unsupported: Windows package                     |
+| `TablePlus.TablePlus`                    | cask `tableplus`             | unsupported: no pinned Nix provider              |
+| `Oven-sh.Bun`                            | Nix `bun`                    | Nix `bun`                                        |
+| `zig.zig`                                | Nix `zig`                    | Nix `zig`                                        |
+
+Keep Microsoft Store Codex desktop separate from Codex CLI and give it explicit unsupported reasons.
+
+- [ ] **Step 4: Derive provider outputs and errors**
+
+Add these derivations, using `builtins.hasAttr` for dynamic platform lookup:
+
+```nix
+supportReport = lib.mapAttrs (_: entry: entry.support) catalog;
+darwinCasks = lib.mapAttrsToList (_: entry: entry.support.darwin.cask)
+  (lib.filterAttrs (_: entry: entry.support.darwin ? cask) catalog);
+linuxSystemModules = lib.mapAttrsToList (_: entry: entry.support.linux.systemModule)
+  (lib.filterAttrs (_: entry: entry.support.linux ? systemModule) catalog);
+providerErrors = lib.concatMap
+  (name:
+    lib.concatMap
+      (platform:
+        let
+          hasPlatform = builtins.hasAttr platform catalog.${name}.support;
+          platformData = if hasPlatform then catalog.${name}.support.${platform} else { };
+          resolved =
+            (platformData ? provider)
+            || ((platformData ? unsupported) && platformData.unsupported != "");
+        in
+        lib.optional (!resolved) "${name}: missing ${platform} provider or unsupported reason")
+      [ "windows" "darwin" "linux" ])
+  (lib.attrNames catalog);
+```
+
+Update existing catalog readers so entries without Nix or Winget providers remain valid:
+
+```nix
+p = catalog.${n}.pkg or null;
+wingetMap = lib.filterAttrs (_: v: v != null)
+  (lib.mapAttrs (_: v: v.winget or null) catalog);
+```
+
+- [ ] **Step 5: Verify GREEN and generated Windows compatibility**
+
+Run:
+
+```bash
+bats tests/bash/package_catalog.bats
+pwsh -NoProfile -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/PackageCatalog.Tests.ps1 -MinimumCoverage 0
+nix build .#winget-export -o /tmp/winget-export
+diff <(jq -S . /tmp/winget-export/winget/packages.json) <(jq -S . windows/winget/packages.json)
+```
+
+Expected: tests PASS; the diff identifies only deterministic ordering/metadata updates that Task 3 regenerates.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add nix/packages/sets.nix scripts/powershell/tests/PackageCatalog.Tests.ps1 tests/bash/package_catalog.bats
+git commit -m "feat: model package providers across operating systems"
+```
+
+### Task 3: Generate and enforce the package support report
+
+**Files:**
+
+- Create: `nix/packages/support-report.nix`
+- Modify: `nix/flakes/packages.nix`
+- Modify: `nix/packages/winget.nix`
+- Modify: `windows/winget/packages.json`
+- Modify: `.github/workflows/ci-consistency.yml`
+- Test: `tests/bash/package_catalog.bats`
+
+**Interfaces:**
+
+- Produces: `.#package-support-report` containing `support.json`.
+- Produces: flake check `package-provider-coverage` that fails on `providerErrors`.
+
+- [ ] **Step 1: Add a failing report build test**
+
+```bash
+@test "support report derivation and CI gate are wired" {
+  grep -q 'package-support-report' "$REPO_ROOT/nix/flakes/packages.nix"
+  grep -q 'package-provider-coverage' "$REPO_ROOT/.github/workflows/ci-consistency.yml"
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bats tests/bash/package_catalog.bats`
+
+Expected: FAIL because the derivation and CI step do not exist.
+
+- [ ] **Step 3: Implement the derivation and check**
+
+Create `nix/packages/support-report.nix`:
+
+```nix
+{ pkgs, lib, gwqSrc ? null }:
+let
+  sets = import ./sets.nix { inherit pkgs lib gwqSrc; };
+  report = builtins.toJSON sets.supportReport;
+  errors = builtins.toJSON sets.providerErrors;
+in
+pkgs.runCommand "package-support-report" { } ''
+  mkdir -p "$out"
+  printf '%s' '${report}' | ${pkgs.jq}/bin/jq . > "$out/support.json"
+  printf '%s' '${errors}' | ${pkgs.jq}/bin/jq . > "$out/errors.json"
+  test "$(${pkgs.jq}/bin/jq length "$out/errors.json")" -eq 0
+''
+```
+
+Expose it as `packages.package-support-report` and `checks.package-provider-coverage` in
+`nix/flakes/packages.nix`.
+
+- [ ] **Step 4: Regenerate manifests and add CI commands**
+
+Run:
+
+```bash
+nix build .#winget-export -o /tmp/winget-export
+cp /tmp/winget-export/winget/packages.json windows/winget/packages.json
+cp /tmp/winget-export/npm/packages.json windows/npm/packages.json
+cp /tmp/winget-export/pnpm/packages.json windows/pnpm/packages.json
+```
+
+Add CI:
+
+```yaml
+- name: Verify package provider coverage
+  run: |
+    nix build .#package-support-report -o /tmp/package-support-report
+    jq -e 'length == 0' /tmp/package-support-report/errors.json
+```
+
+- [ ] **Step 5: Verify all foundation checks**
+
+Run:
+
+```bash
+bats tests/bash/package_catalog.bats tests/bash/flake_outputs.bats
+nix flake check --no-build
+nix build .#package-support-report
+nix build .#winget-export
+git diff --check
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add nix/packages/support-report.nix nix/flakes/packages.nix nix/packages/winget.nix windows .github/workflows/ci-consistency.yml tests/bash/package_catalog.bats
+git commit -m "test: enforce cross-platform package coverage"
+```

--- a/docs/superpowers/plans/2026-07-17-linux-system-manager-bootstrap.md
+++ b/docs/superpowers/plans/2026-07-17-linux-system-manager-bootstrap.md
@@ -1,0 +1,314 @@
+# Linux and NixOS One-command Bootstrap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `./install.sh` fully configure NixOS, Ubuntu, and Debian, while requiring explicit opt-in for user-only fallback on other Linux distributions.
+
+**Architecture:** A thin dispatcher selects NixOS rebuild, System Manager, or standalone Home Manager. Ubuntu/Debian use the same System Manager module with host metadata passed by environment, and activate Home Manager in the same switch. Docker is a systemd service/socket managed by the system layer.
+
+**Tech Stack:** Bash, Bats, NixOS modules, System Manager, Home Manager, systemd, Docker.
+
+## Global Constraints
+
+- Full support requires systemd on Ubuntu/Debian.
+- Other Linux must fail unless `DOTFILES_ALLOW_USER_ONLY=1` is set.
+- The current user is not silently replaced or recreated with a different UID/GID.
+- Docker and Compose runtime checks are mandatory for Full support.
+
+---
+
+### Task 1: Expand the POSIX platform dispatcher
+
+**Files:**
+
+- Modify: `install.sh`
+- Modify: `tests/bash/install_dispatcher.bats`
+- Create: `scripts/sh/install-nixos.sh`
+- Create: `scripts/sh/install-linux.sh`
+- Create: `scripts/sh/install-home-manager.sh`
+
+**Interfaces:**
+
+- Produces routing targets for `Darwin`, NixOS, Ubuntu, Debian, unsupported Linux, and Windows-like shells.
+
+- [ ] **Step 1: Add failing routing tests**
+
+Add stubs for `/etc/os-release` through `DOTFILES_OS_RELEASE_FILE` and test:
+
+```bash
+TEST_UNAME_S=Linux TEST_UNAME_M=x86_64 DOTFILES_NIXOS_MARKER="$marker" ./install.sh --example
+TEST_UNAME_S=Linux DOTFILES_OS_RELEASE_FILE="$ubuntu_release" ./install.sh --example
+TEST_UNAME_S=Linux DOTFILES_OS_RELEASE_FILE="$debian_release" ./install.sh --example
+DOTFILES_ALLOW_USER_ONLY=1 TEST_UNAME_S=Linux DOTFILES_OS_RELEASE_FILE="$fedora_release" ./install.sh
+```
+
+Require unsupported Linux without opt-in to exit nonzero and mention `DOTFILES_ALLOW_USER_ONLY=1`.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bats tests/bash/install_dispatcher.bats`
+
+Expected: Linux cases fail because `install.sh` only supports Apple Silicon macOS.
+
+- [ ] **Step 3: Implement minimal routing**
+
+```bash
+case "$os" in
+  Darwin) exec "$ROOT/scripts/sh/install-macos.sh" "$@" ;;
+  Linux)
+    if [ -e "${DOTFILES_NIXOS_MARKER:-/etc/NIXOS}" ]; then
+      exec "$ROOT/scripts/sh/install-nixos.sh" "$@"
+    fi
+    . "${DOTFILES_OS_RELEASE_FILE:-/etc/os-release}"
+    case "${ID:-}" in
+      ubuntu|debian) exec "$ROOT/scripts/sh/install-linux.sh" "$@" ;;
+      *)
+        [ "${DOTFILES_ALLOW_USER_ONLY:-0}" = 1 ] || {
+          printf 'Unsupported Linux. Set DOTFILES_ALLOW_USER_ONLY=1 for Home Manager only.\n' >&2
+          exit 1
+        }
+        exec "$ROOT/scripts/sh/install-home-manager.sh" "$@"
+        ;;
+    esac
+    ;;
+  MINGW*|MSYS*|CYGWIN*) printf 'Windows setup uses install.cmd.\n' >&2; exit 1 ;;
+esac
+```
+
+- [ ] **Step 4: Verify and commit**
+
+Run: `bash -n install.sh scripts/sh/install-*.sh && bats tests/bash/install_dispatcher.bats`
+
+Expected: PASS.
+
+```bash
+git add install.sh scripts/sh/install-nixos.sh scripts/sh/install-linux.sh scripts/sh/install-home-manager.sh tests/bash/install_dispatcher.bats
+git commit -m "feat: route one-command setup across Linux systems"
+```
+
+### Task 2: Add Ubuntu/Debian System Manager outputs
+
+**Files:**
+
+- Create: `nix/system-manager/default.nix`
+- Create: `nix/system-manager/docker.nix`
+- Create: `nix/flakes/system-manager.nix`
+- Modify: `nix/flakes/default.nix`
+- Test: `tests/bash/linux_config.bats`
+
+**Interfaces:**
+
+- Consumes: `DOTFILES_USER`, `DOTFILES_HOME`, UID/GID environment values.
+- Produces: `systemConfigs.ubuntu` and `systemConfigs.debian`.
+
+- [ ] **Step 1: Write failing module tests**
+
+Add these tests:
+
+```bash
+@test "flake exposes Ubuntu and Debian System Manager configs" {
+  grep -q 'ubuntu = mkConfig' "$REPO_ROOT/nix/flakes/system-manager.nix"
+  grep -q 'debian = mkConfig' "$REPO_ROOT/nix/flakes/system-manager.nix"
+}
+
+@test "System Manager integrates Home Manager Nix and Docker" {
+  grep -q 'home-manager.nixosModules.home-manager' "$REPO_ROOT/nix/flakes/system-manager.nix"
+  grep -q 'nix.enable = true' "$REPO_ROOT/nix/system-manager/default.nix"
+  grep -q 'systemd.services.docker' "$REPO_ROOT/nix/system-manager/docker.nix"
+  grep -q 'systemd.sockets.docker' "$REPO_ROOT/nix/system-manager/docker.nix"
+  grep -q 'docker-buildx' "$REPO_ROOT/nix/system-manager/docker.nix"
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bats tests/bash/linux_config.bats`
+
+Expected: FAIL because System Manager files are absent.
+
+- [ ] **Step 3: Implement the shared system module**
+
+Use the existing user; do not assign fixed IDs:
+
+```nix
+{ pkgs, lib, inputs, ... }:
+let
+  user = builtins.getEnv "DOTFILES_USER";
+  home = builtins.getEnv "DOTFILES_HOME";
+  uid = lib.toInt (builtins.getEnv "DOTFILES_UID");
+  gid = lib.toInt (builtins.getEnv "DOTFILES_GID");
+in {
+  nix.enable = true;
+  services.userborn.enable = true;
+  users.groups.${user}.gid = gid;
+  users.groups.docker = { };
+  users.users.${user} = {
+    isNormalUser = true;
+    inherit uid home;
+    group = user;
+    extraGroups = [ "docker" ];
+  };
+  home-manager = {
+    useGlobalPkgs = true;
+    useUserPackages = true;
+    backupFileExtension = "hm-backup";
+    users.${user} = import ../home/common.nix;
+    extraSpecialArgs = { inherit inputs; };
+  };
+}
+```
+
+Implement `docker.nix` from the official System Manager pattern with `docker`, `docker-compose`,
+`docker-buildx`, `/etc/docker/daemon.json`, `docker.service`, `docker.socket`, and tmpfiles. Socket group
+must be `docker`; service must be wanted by `system-manager.target`.
+
+- [ ] **Step 4: Wire named configs**
+
+```nix
+system = let requested = builtins.getEnv "DOTFILES_SYSTEM"; in
+  if requested == "" then "x86_64-linux" else requested;
+mkConfig = inputs.system-manager.lib.makeSystemConfig {
+  modules = [
+    inputs.home-manager.nixosModules.home-manager
+    { nixpkgs.hostPlatform = system; }
+    ../system-manager/default.nix
+    ../system-manager/docker.nix
+  ];
+};
+flake.systemConfigs = {
+  ubuntu = mkConfig;
+  debian = mkConfig;
+};
+```
+
+- [ ] **Step 5: Build and commit**
+
+Run:
+
+```bash
+DOTFILES_USER="$USER" DOTFILES_HOME="$HOME" DOTFILES_UID="$(id -u)" DOTFILES_GID="$(id -g)" DOTFILES_SYSTEM=x86_64-linux nix build .#systemConfigs.ubuntu --impure --no-link
+bats tests/bash/linux_config.bats
+```
+
+Expected: build and tests pass.
+
+```bash
+git add nix/system-manager nix/flakes/system-manager.nix nix/flakes/default.nix tests/bash/linux_config.bats
+git commit -m "feat: manage Ubuntu and Debian with System Manager"
+```
+
+### Task 3: Implement the generic Linux bootstrap
+
+**Files:**
+
+- Modify: `scripts/sh/install-linux.sh`
+- Modify: `scripts/sh/install-home-manager.sh`
+- Test: `tests/bash/install_linux.bats`
+
+**Interfaces:**
+
+- Invokes: `nix run .#system-manager -- switch --flake .#ubuntu|debian --sudo --impure`.
+- Invokes fallback: Home Manager activation package only after explicit opt-in.
+
+- [ ] **Step 1: Write failing phase/idempotency tests**
+
+Require Nix install only when absent, exact System Manager config selection, environment propagation,
+chezmoi/Compose/acceptance ordering, and second-run no reinstall.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bats tests/bash/install_linux.bats`
+
+Expected: FAIL because scripts are empty dispatch targets.
+
+- [ ] **Step 3: Implement the Full support flow**
+
+```bash
+ensure_systemd
+ensure_nix
+dotfiles_link_checkout "$ROOT"
+export DOTFILES_USER="${SUDO_USER:-$USER}"
+export DOTFILES_HOME="$HOME"
+export DOTFILES_UID="$(id -u "$DOTFILES_USER")"
+export DOTFILES_GID="$(id -g "$DOTFILES_USER")"
+export DOTFILES_SYSTEM="$(nix eval --impure --raw --expr builtins.currentSystem)"
+config="$(. /etc/os-release; printf '%s' "$ID")"
+(cd "$ROOT" && nix run .#system-manager -- switch --flake ".#$config" --sudo --impure)
+apply_chezmoi
+start_hermes_stack
+run_as_docker_group "$ROOT/scripts/sh/verify-environment.sh" --runtime
+```
+
+Validate that user/home/UID/GID are nonempty numeric values before invoking Nix.
+
+- [ ] **Step 4: Implement explicit Home Manager fallback**
+
+Build `.#homeConfigurations.${DOTFILES_SYSTEM}.activationPackage --impure`, run `activate`, apply chezmoi,
+and print `User-only setup complete; Docker/systemd were not configured.` Do not invoke runtime acceptance.
+
+- [ ] **Step 5: Verify and commit**
+
+Run: `bash -n scripts/sh/install-linux.sh scripts/sh/install-home-manager.sh && bats tests/bash/install_linux.bats`
+
+Expected: PASS.
+
+```bash
+git add scripts/sh/install-linux.sh scripts/sh/install-home-manager.sh tests/bash/install_linux.bats
+git commit -m "feat: bootstrap Ubuntu and Debian in one command"
+```
+
+### Task 4: Converge native NixOS through the same acceptance path
+
+**Files:**
+
+- Modify: `scripts/sh/install-nixos.sh`
+- Modify: `nix/hosts/linux/configuration.nix`
+- Test: `tests/bash/install_nixos.bats`
+
+**Interfaces:**
+
+- Invokes `sudo nixos-rebuild switch --flake "$ROOT#linux" --impure`.
+- Reuses `verify-environment.sh --runtime`.
+
+- [ ] **Step 1: Add failing NixOS orchestration tests**
+
+Add this primary test and companion nonzero-status cases for rebuild, Compose, and verification:
+
+```bash
+@test "NixOS rebuilds then applies chezmoi Compose and acceptance" {
+  run "$INSTALLER"
+  [ "$status" -eq 0 ]
+  grep -q 'nixos-rebuild switch --flake .*#linux --impure' "$COMMAND_LOG"
+  [ "$(line_of nixos-rebuild)" -lt "$(line_of chezmoi)" ]
+  [ "$(line_of chezmoi)" -lt "$(line_of 'docker compose')" ]
+  [ "$(line_of 'docker compose')" -lt "$(line_of verify-environment)" ]
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bats tests/bash/install_nixos.bats`
+
+Expected: FAIL because `install-nixos.sh` has no implementation.
+
+- [ ] **Step 3: Implement and ensure Docker module completeness**
+
+Use the same exported metadata as Linux, call `nixos-rebuild`, then run chezmoi, Compose, and runtime
+verification. Ensure `virtualisation.docker.enable`, Compose/Buildx packages, and docker group membership are
+present in `nix/hosts/linux/configuration.nix`.
+
+- [ ] **Step 4: Verify and commit**
+
+Run:
+
+```bash
+bats tests/bash/install_nixos.bats
+nix build .#nixosConfigurations.linux.config.system.build.toplevel --no-link
+```
+
+Expected: PASS.
+
+```bash
+git add scripts/sh/install-nixos.sh nix/hosts/linux/configuration.nix tests/bash/install_nixos.bats
+git commit -m "feat: converge NixOS through one-command setup"
+```

--- a/docs/superpowers/plans/2026-07-17-macos-darwin-bootstrap.md
+++ b/docs/superpowers/plans/2026-07-17-macos-darwin-bootstrap.md
@@ -1,0 +1,271 @@
+# macOS nix-darwin One-command Bootstrap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace imperative Homebrew/Home Manager setup with one `./install.sh` path that applies nix-darwin, nix-homebrew, Home Manager, Docker Desktop, chezmoi, and Compose.
+
+**Architecture:** The shell script only bootstraps Command Line Tools and Nix, then invokes the pinned `.#darwin-rebuild` app. nix-darwin owns system activation, nix-homebrew owns Homebrew, and catalog-derived casks own GUI apps. Runtime setup remains a bounded post-switch phase.
+
+**Tech Stack:** Bash, Bats, nix-darwin, nix-homebrew, Home Manager, Homebrew, Docker Desktop.
+
+## Global Constraints
+
+- Apple Silicon macOS 26+ is Full support.
+- Homebrew casks are declarative; no normal-path direct `brew install --cask` or DMG fallback.
+- The same command must pass twice.
+- Docker Desktop personal-use license acceptance remains explicit.
+
+---
+
+### Task 1: Add the macOS nix-darwin configuration
+
+**Files:**
+
+- Create: `nix/darwin/default.nix`
+- Create: `nix/flakes/darwin.nix`
+- Modify: `nix/flakes/default.nix`
+- Modify: `nix/home/common.nix`
+- Test: `tests/bash/macos_config.bats`
+
+**Interfaces:**
+
+- Consumes: `sets.darwinCasks` and pinned flake inputs from the foundation plan.
+- Produces: `darwinConfigurations.macos`.
+
+- [ ] **Step 1: Write failing static/evaluation tests**
+
+Add these tests:
+
+```bash
+@test "flake exposes a macOS nix-darwin configuration" {
+  grep -q 'darwinConfigurations.macos' "$REPO_ROOT/nix/flakes/darwin.nix"
+}
+
+@test "Darwin uses nix-homebrew catalog casks and Home Manager" {
+  grep -q 'nix-homebrew.enable = true' "$REPO_ROOT/nix/darwin/default.nix"
+  grep -q 'casks = sets.darwinCasks' "$REPO_ROOT/nix/darwin/default.nix"
+  grep -q 'home-manager.darwinModules.home-manager' "$REPO_ROOT/nix/flakes/darwin.nix"
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bats tests/bash/macos_config.bats`
+
+Expected: FAIL because the Darwin modules do not exist.
+
+- [ ] **Step 3: Implement the Darwin module**
+
+Create `nix/darwin/default.nix` with:
+
+```nix
+{ config, pkgs, lib, inputs, ... }:
+let
+  user = builtins.getEnv "DOTFILES_USER";
+  home = builtins.getEnv "DOTFILES_HOME";
+  sets = import ../packages/sets.nix {
+    inherit pkgs lib;
+    gwqSrc = inputs.gwq-src;
+  };
+in {
+  assertions = [
+    { assertion = user != ""; message = "DOTFILES_USER is required"; }
+    { assertion = home != ""; message = "DOTFILES_HOME is required"; }
+  ];
+  system.primaryUser = user;
+  system.stateVersion = 6;
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+  nix-homebrew = {
+    enable = true;
+    enableRosetta = true;
+    inherit user;
+    autoMigrate = true;
+  };
+  homebrew = {
+    enable = true;
+    casks = sets.darwinCasks;
+    onActivation = { autoUpdate = false; upgrade = false; cleanup = "none"; };
+  };
+  users.users.${user}.home = home;
+  home-manager = {
+    useGlobalPkgs = true;
+    useUserPackages = true;
+    backupFileExtension = "hm-backup";
+    users.${user} = import ../home/common.nix;
+    extraSpecialArgs = { inherit inputs; };
+  };
+}
+```
+
+- [ ] **Step 4: Wire `darwinConfigurations.macos`**
+
+Use `inputs.nix-darwin.lib.darwinSystem` with modules
+`inputs.nix-homebrew.darwinModules.nix-homebrew`,
+`inputs.home-manager.darwinModules.home-manager`, and `../darwin/default.nix`.
+
+- [ ] **Step 5: Verify the build**
+
+Run:
+
+```bash
+DOTFILES_USER="$USER" DOTFILES_HOME="$HOME" nix build .#darwinConfigurations.macos.system --impure --no-link
+bats tests/bash/macos_config.bats
+```
+
+Expected: build and tests exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add nix/darwin nix/flakes/darwin.nix nix/flakes/default.nix nix/home/common.nix tests/bash/macos_config.bats
+git commit -m "feat: add nix-darwin system configuration"
+```
+
+### Task 2: Refactor the macOS installer around nix-darwin
+
+**Files:**
+
+- Create: `scripts/sh/install-common.sh`
+- Modify: `scripts/sh/install-macos.sh`
+- Test: `tests/bash/install_macos.bats`
+
+**Interfaces:**
+
+- Produces functions `dotfiles_log`, `dotfiles_die`, `dotfiles_have`, `dotfiles_wait_for`, `dotfiles_load_nix`, `dotfiles_link_checkout`.
+- Invokes: `nix run .#darwin-rebuild -- switch --flake .#macos --impure`.
+
+- [ ] **Step 1: Replace old expectations with failing nix-darwin expectations**
+
+Add assertions to the fresh-install and installed-prerequisites cases:
+
+```bash
+grep -q 'nix run .#darwin-rebuild -- switch --flake .#macos --impure' "$COMMAND_LOG"
+! grep -q 'brew install --cask' "$COMMAND_LOG"
+! grep -q 'desktop.docker.com/mac' "$COMMAND_LOG"
+[ "$(grep -c 'nixos.org/nix/install' "$COMMAND_LOG" || true)" -le 1 ]
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bats tests/bash/install_macos.bats`
+
+Expected: FAIL because the current script directly installs Homebrew/Docker and standalone Home Manager.
+
+- [ ] **Step 3: Extract common bootstrap helpers**
+
+Implement helpers with these signatures:
+
+```bash
+dotfiles_log() { printf '\033[1;34m[%s]\033[0m %s\n' "$DOTFILES_LOG_PREFIX" "$*"; }
+dotfiles_die() { printf '\033[1;31m[%s]\033[0m %s\n' "$DOTFILES_LOG_PREFIX" "$*" >&2; exit 1; }
+dotfiles_have() { command -v "$1" >/dev/null 2>&1; }
+dotfiles_load_nix() { [ ! -r "$DOTFILES_NIX_PROFILE_SCRIPT" ] || . "$DOTFILES_NIX_PROFILE_SCRIPT"; }
+```
+
+Move the existing safe checkout backup/link behavior without changing semantics.
+
+- [ ] **Step 4: Implement the minimal Darwin switch flow**
+
+The main order must be:
+
+```bash
+preflight
+ensure_command_line_tools
+ensure_nix
+dotfiles_link_checkout "$ROOT"
+export DOTFILES_USER="${SUDO_USER:-$USER}"
+export DOTFILES_HOME="$HOME"
+export DOTFILES_ROOT="$ROOT"
+(cd "$ROOT" && nix run .#darwin-rebuild -- switch --flake .#macos --impure)
+setup_docker_runtime
+apply_chezmoi
+start_hermes_stack
+verify_environment --runtime
+```
+
+Delete `ensure_homebrew`, direct cask installation, DMG fallback, and standalone Home Manager activation.
+
+- [ ] **Step 5: Verify GREEN and shell quality**
+
+Run:
+
+```bash
+bash -n scripts/sh/install-common.sh scripts/sh/install-macos.sh
+bats tests/bash/install_macos.bats
+nix fmt -- --fail-on-change
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/sh/install-common.sh scripts/sh/install-macos.sh tests/bash/install_macos.bats
+git commit -m "feat: converge macOS with nix-darwin"
+```
+
+### Task 3: Add shared runtime acceptance
+
+**Files:**
+
+- Create: `scripts/sh/verify-environment.sh`
+- Test: `tests/bash/verify_environment.bats`
+- Modify: `scripts/sh/install-macos.sh`
+
+**Interfaces:**
+
+- Produces CLI: `verify-environment.sh [--runtime]`.
+- Returns nonzero on any required missing tool, Docker failure, chezmoi drift, or Compose health failure.
+
+- [ ] **Step 1: Write failing acceptance tests**
+
+Add these concrete cases:
+
+```bash
+@test "missing required command fails verification" {
+  rm "$STUB_BIN/nvim"
+  run "$VERIFIER"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"missing command: nvim"* ]]
+}
+
+@test "runtime verification exercises Docker" {
+  run "$VERIFIER" --runtime
+  [ "$status" -eq 0 ]
+  grep -q '^docker run --rm hello-world$' "$COMMAND_LOG"
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bats tests/bash/verify_environment.bats`
+
+Expected: FAIL because the verifier is absent.
+
+- [ ] **Step 3: Implement exact required checks**
+
+```bash
+required=(nix brew darwin-rebuild git gh chezmoi rg fd jq nvim node python3 go rustup docker)
+for command_name in "${required[@]}"; do
+  command -v "$command_name" >/dev/null 2>&1 || fail "missing command: $command_name"
+done
+docker compose version >/dev/null
+chezmoi apply --dry-run >/dev/null
+docker info >/dev/null
+if [ "$runtime" -eq 1 ]; then
+  docker run --rm hello-world >/dev/null
+  docker compose -f "$COMPOSE_FILE" config >/dev/null
+  docker compose -f "$COMPOSE_FILE" ps --status running >/dev/null
+fi
+```
+
+- [ ] **Step 4: Verify and commit**
+
+Run: `bats tests/bash/verify_environment.bats tests/bash/install_macos.bats`
+
+Expected: PASS.
+
+```bash
+git add scripts/sh/verify-environment.sh scripts/sh/install-macos.sh tests/bash/verify_environment.bats
+git commit -m "test: verify the installed macOS environment"
+```

--- a/docs/superpowers/specs/2026-07-17-cross-platform-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-07-17-cross-platform-bootstrap-design.md
@@ -1,0 +1,446 @@
+# Cross-platform One-command Bootstrap Design
+
+## Goal
+
+Windows、Apple Silicon macOS、NixOS、Ubuntu、Debianで、clone済みの本リポジトリから
+OSごとに1つのコマンドを実行すると、パッケージマネージャー、共通アプリケーション、
+ユーザー設定、DockerとDocker Compose、対象サービスまでが宣言された状態へ収束する
+仕組みを作る。
+
+同じコマンドを再実行しても壊れないことを必須とし、単なる設定評価だけでなく、専用の
+実行環境へ実際に適用する破壊的E2Eで完成状態を検証する。
+
+## Design decisions
+
+### Declarative layers
+
+OS間の共通部分をHome Managerから外すのではなく、次の三層に分ける。
+
+1. `nix/packages/sets.nix`: アプリケーションとCLIのSingle Source of Truth
+2. Home Manager: macOS/Linux共通のユーザーパッケージとdotfiles連携
+3. OS system layer:
+   - Windows: Winget + PowerShell handlers
+   - macOS: nix-darwin + nix-homebrew + Home Manager module
+   - NixOS: NixOS module + Home Manager module
+   - Ubuntu/Debian: System Manager + Home Manager module
+
+Home Managerは共通ユーザー層として維持する。Docker daemon、Homebrew cask、systemd、
+Windows管理者設定のようなシステム状態をHome Managerへ押し込まない。
+
+### Supported tiers
+
+| OS                  | Architecture   | Support          | One command                               | System layer                    |
+| ------------------- | -------------- | ---------------- | ----------------------------------------- | ------------------------------- |
+| Windows 11          | x86_64         | Full             | `install.cmd`                             | Winget + PowerShell + WSL/NixOS |
+| macOS 26+           | aarch64        | Full             | `./install.sh`                            | nix-darwin + nix-homebrew       |
+| NixOS               | x86_64/aarch64 | Full             | `./install.sh`                            | NixOS modules                   |
+| Ubuntu with systemd | x86_64/aarch64 | Full             | `./install.sh`                            | System Manager                  |
+| Debian with systemd | x86_64/aarch64 | Full             | `./install.sh`                            | System Manager                  |
+| Other Linux         | x86_64/aarch64 | User-only opt-in | `DOTFILES_ALLOW_USER_ONLY=1 ./install.sh` | standalone Home Manager         |
+
+未検証ディストリビューションで部分的なセットアップを成功扱いにしない。その他Linuxは
+明示的なopt-in時だけHome Managerとchezmoiを適用し、Docker/systemdを含むFull support
+ではないことを終了時に表示する。
+
+Intel macOS、Windows on ARM、systemdを使用しない汎用Linuxは今回のFull support対象外とする。
+
+## Flake architecture
+
+`flake.nix`から次の出力を提供する。
+
+```text
+flake.nix
+├── nixosConfigurations
+│   ├── nixos              # existing NixOS-WSL
+│   └── linux              # native NixOS
+├── darwinConfigurations
+│   └── macos              # nix-darwin + nix-homebrew + Home Manager
+├── systemConfigs
+│   ├── ubuntu             # System Manager + Home Manager
+│   └── debian             # System Manager + Home Manager
+├── homeConfigurations
+│   ├── x86_64-linux       # unsupported-Linux fallback
+│   └── aarch64-linux
+├── packages
+│   ├── winget-export
+│   └── package-support-report
+├── apps
+│   ├── darwin-rebuild     # pinned nix-darwin input wrapper
+│   └── system-manager     # pinned System Manager input wrapper
+└── checks
+    ├── package-provider-coverage
+    ├── darwin-configuration
+    ├── linux-system-configurations
+    └── home-configurations
+```
+
+`system-manager`、`nix-darwin`、`nix-homebrew`をflake inputとしてpinし、すべての
+Home Manager/Nix modulesが同じ`nixpkgs` revisionへ追従する。
+
+ユーザー名、home directory、リポジトリpathはbootstrapが環境変数
+`DOTFILES_USER`、`DOTFILES_HOME`、`DOTFILES_ROOT`として渡す。これらを必要とする
+build/switchには`--impure`を使用する。値が空、相対path、rootユーザーとの不整合である
+場合は評価前に停止する。
+
+## Cross-platform application catalog
+
+### Catalog model
+
+既存の`nix/packages/sets.nix`をSSOTとして維持するが、`windowsOnly`へ混在している
+クロスプラットフォームアプリをprovider付きcatalogへ移す。
+
+概念上、各entryは次の情報を持つ。
+
+```nix
+{
+  name = "docker";
+  category = "system";
+  providers = {
+    windows.winget = "Docker.DockerDesktop";
+    darwin.cask = "docker-desktop";
+    linux.systemModule = "docker";
+  };
+  unsupported = { };
+}
+```
+
+CLIやNixで共通提供できるアプリは既存の`pkg = pkgs.<name>`を利用する。GUIや
+OS-native componentだけ`darwin.cask`、`windows.winget`、`linux.systemModule`を
+持つ。provider名は実装上attrsetへ正規化してもよいが、以下のinvariantを変えない。
+
+### Catalog invariants
+
+- WingetまたはMicrosoft Storeへ出力される全entryは、macOSとLinuxについて
+  provider、または理由付き`unsupported`を持つ。
+- `windowsOnly`にはPowerToys、VCRedist、Visual Studio Build Tools、Windows Terminal、
+  WSLのような真のWindows固有componentだけを残す。
+- Docker、VS Code、Chrome、1Password、Bun、Zig、dprint、hadolintなど、他OSに
+  providerが存在するものを`windowsOnly`へ置かない。
+- 同じアプリをHome ManagerとHomebrew caskの両方で重複インストールしない。
+- platform availabilityはNix derivationの`meta.platforms`だけに暗黙依存せず、catalogの
+  support metadataでも検証する。
+- GUI版とCLI版が異なる製品の場合は別entryとする。例えばCodex CLIとCodex desktopを
+  同一entryとして扱わない。
+
+`package-support-report`はWindows、macOS、Linuxごとのproviderとunsupported reasonを
+JSONで出力する。CIはproviderも理由もないcellが1つでもあれば失敗する。
+
+## One-command entrypoints
+
+### Shared POSIX dispatcher
+
+リポジトリ直下の`install.sh`をmacOS専用dispatcherからPOSIX共通dispatcherへ変更する。
+
+1. `uname`、`/etc/os-release`、NixOS marker、architectureを検出する。
+2. `DOTFILES_PLATFORM` overrideはテスト専用時だけ許可する。
+3. 対象に応じて次へ`exec`する。
+   - macOS: `scripts/sh/install-macos.sh`
+   - NixOS: `scripts/sh/install-nixos.sh`
+   - Ubuntu/Debian: `scripts/sh/install-linux.sh`
+   - その他Linux: opt-inを確認して`scripts/sh/install-home-manager.sh`
+4. Windows-like shellでは`install.cmd`を案内して非ゼロ終了する。
+
+全installerは`set -euo pipefail`、phase名付きlog、bounded wait、再実行可能なstate detectionを
+共通libraryから利用する。外部downloadはHTTPS、可能なものはchecksumまたはpin済みflake
+inputで検証する。
+
+### Windows
+
+入口は既存の`install.cmd`を維持する。
+
+- Phase 1でWinget manifestからユーザーアプリをインストールする。
+- 管理者PhaseでWSL、Docker Desktop、OS設定を適用する。
+- NixOS-WSLとHome Managerをswitchする。
+- chezmoiとDocker Compose servicesを適用する。
+- generated Winget/npm/pnpm manifestはcatalogからのみ生成する。
+- installer最後に共通acceptance commandを実行する。
+
+既存PowerShell handler architectureを維持し、provider catalogとの整合性検証だけを追加する。
+
+### macOS
+
+`./install.sh`は次の順で収束させる。
+
+1. Apple Silicon、macOS version、管理者権限、Command Line Toolsをpreflightする。
+2. Command Line Toolsがない場合はインストールを開始し、完了をbounded pollingして同じ実行を
+   継続する。timeout時だけ再実行方法を表示する。
+3. Nix daemonがなければ公式multi-user installerで導入する。
+4. Nix profileを現在のprocessへ読み込む。
+5. 実行checkoutを`~/.dotfiles`へ安全にlinkする。異なる既存pathはtimestamp付きbackupへ移す。
+6. `nix run .#darwin-rebuild -- switch --flake .#macos --impure`を実行する。
+7. nix-darwinがHome Manager moduleを同じgenerationでactivationする。
+8. nix-homebrewがHomebrew本体を管理し、nix-darwinの`homebrew.casks`がDocker Desktopなどの
+   caskを収束させる。
+9. Docker Desktopのlicense acceptanceとprivileged setupを行い、engineを起動して
+   `docker info`をbounded pollingする。
+10. chezmoiを適用し、Compose servicesをbuild/up/health-checkする。
+11. 共通acceptance commandを実行する。
+
+Homebrewをshell scriptから直接`brew install --cask`しない。Docker Desktop DMG fallbackも
+通常経路から外し、nix-homebrew/nix-darwinの宣言を唯一の通常providerとする。upstream cask
+障害に備えたbreak-glass手順はdocumentationに残してよいが、自動fallbackで宣言状態を
+迂回しない。
+
+### NixOS
+
+NixOSでは既存Nixを使用し、`nixos-rebuild switch --flake .#<detected-config> --impure`を実行する。
+
+- Home Manager moduleを同じsystem generationでactivationする。
+- Docker daemon、Compose plugin、ユーザーのdocker group membershipをNixOS moduleで管理する。
+- switch後にchezmoiとCompose servicesを収束させる。
+- WSLではWindows Docker Desktop連携とnative Docker daemonを同時に有効化せず、既存host optionで
+  どちらか一方を選ぶ。
+
+### Ubuntu and Debian
+
+Nixがない場合は公式multi-user installerを導入し、次を実行する。
+
+```bash
+nix run .#system-manager -- switch --flake .#ubuntu --sudo --impure
+```
+
+Debianでは`#debian`を使用する。`apps.system-manager`はflake lock済みinputを参照し、
+unpinned URLをruntimeで取得しない。
+
+System Managerが次を管理する。
+
+- system-wide Nix settings
+- Docker Engine、Compose、Buildx
+- `/etc/docker/daemon.json`
+- Docker systemd service/socket
+- 対象ユーザーとdocker group membership
+- Home Manager user configuration
+
+group membership変更後は、新しいlogin sessionが必要な場合がある。installerは現在sessionで
+`sg docker`相当を利用してacceptanceを完了し、終了時に再loginが必要であることを表示する。
+
+## Convergence and failure handling
+
+- installerはphaseごとに`check`, `apply`, `verify`の境界を持つ。
+- package manager、Nix、Homebrew、Dockerを導入済みなら再インストールしない。
+- declarative switch、chezmoi apply、Compose upは毎回実行し、最新宣言へ収束させる。
+- timeoutを持たないpollingやinteractive promptをCI modeで残さない。
+- failure時はphase名、失敗command、関連service status、再実行commandを表示する。
+- `docker system prune`、volume削除、ユーザーhomeの削除は行わない。
+- 既存設定をbackupする場合はpathをsummaryへ出力する。
+- installerが成功を返すのは、そのOSのFull acceptanceがすべて通った場合だけとする。
+
+## Acceptance command
+
+OS別installerの末尾とE2E workflowは、共通の`verify-environment` entrypointを実行する。
+read-only checkを基本とし、`--runtime`でDocker smoke workloadを実行する。
+
+最低限、次を検証する。
+
+1. package manager and declarative layer:
+   - Windows: `winget`, handler completion marker
+   - macOS: `nix`, `darwin-rebuild`, `brew`, Home Manager generation
+   - Linux: `nix`, System Manager/NixOS generation, Home Manager generation
+2. common CLI: `git`, `gh`, `chezmoi`, `rg`, `fd`, `jq`, `nvim`, `node`, `python`, `go`,
+   `rustup`, `docker`, `docker compose`
+3. catalog support reportに対象OSの未解決entryがないこと
+4. chezmoi source/stateがcheckoutと一致し、`chezmoi apply --dry-run`でunexpected diffがないこと
+5. Docker daemonへ対象ユーザーで接続できること
+6. `docker run --rm hello-world`相当のruntime smoke
+7. `docker compose config`、build、up、service health、localhost endpoints
+
+secretや外部OAuthを必要とするserviceは、secret未設定時に明示的な`not-configured`状態を返せる。
+ただしDocker、共通CLI、declarative generation、chezmoiはskip不可とする。
+
+## Test strategy
+
+### Unit tests
+
+#### POSIX/Bats
+
+- dispatcherのmacOS/NixOS/Ubuntu/Debian/unsupported Linux routing
+- installer phase順序と引数
+- Nix未導入・導入済みの両経路
+- nix-darwin/System Manager/NixOS switch command
+- user/home/root validation
+- timeout、download failure、switch failure、Docker readiness failure
+- 既存`~/.dotfiles`のbackupと冪等性
+- second runがinstallerを再導入せずdeclarative switchへ進むこと
+
+#### Windows/Pester
+
+- `install.cmd`からuser/admin phase完了までのorchestration
+- catalogから生成したWinget manifestの適用
+- Docker Desktop、WSL、NixOS、Home Manager、chezmoi、Composeの順序
+- second runとrecovery path
+- acceptance command failureのpropagation
+
+すべての新規behaviorは、失敗するtestを先に追加してから最小実装を行う。
+
+### Flake and catalog checks
+
+- `nix flake check --no-build`
+- 全supported architectureのHome Manager evaluation
+- `darwinConfigurations.macos.system`のbuild
+- NixOS toplevel/VMのbuild
+- Ubuntu/Debian `systemConfigs`のbuild
+- Winget/npm/pnpm generated filesのdiff
+- package-provider coverage reportの未解決cell検査
+- nix-darwinのHomebrew cask listとcatalogのDarwin providersの一致
+- System Manager packages/modulesとcatalog Linux providersの一致
+
+### Destructive Linux E2E
+
+GitHub-hosted ephemeral Ubuntu runnerへ`./install.sh`を実際に適用する。
+
+1. checkout直後のrunnerでNix/System Manager/Docker/Home Managerを導入する。
+2. `verify-environment --runtime`を実行する。
+3. `./install.sh`を二回目実行する。
+4. generation、Docker、chezmoi、Composeが引き続きhealthyであることを確認する。
+
+Debianはprivileged systemd-nspawn VM/container、または同等の破棄可能なsystemd環境を
+Ubuntu runner上に作り、同じ二回実行を行う。systemdなしの単純Docker containerによる
+疑似testで代替しない。
+
+NixOSはNixOS VM testでswitch、Home Manager、Docker runtime、二回目activationを検証する。
+
+### Destructive Windows E2E
+
+Docker DesktopとWSL2を実行可能な専用self-hosted Windows 11 runnerを使用する。
+
+- labels: `self-hosted`, `Windows`, `X64`, `dotfiles-e2e`
+- `install.cmd`を実行し、必要なelevationを非対話で許可する専用test accountを使用する。
+- Winget、Docker Desktop、WSL/NixOS、Home Manager、chezmoi、Composeを実適用する。
+- acceptanceを実行後、`install.cmd`を再実行して冪等性を検証する。
+
+### Destructive macOS E2E
+
+GitHub-hosted arm64 macOS runnerはnested virtualization非対応でDocker Desktop engineを
+起動できないため、専用のphysical Apple Silicon Macをself-hosted runnerとして使用する。
+
+- labels: `self-hosted`, `macOS`, `ARM64`, `dotfiles-e2e`
+- Command Line Tools以外を事前条件にしないclean-bootstrap profileを定期的に使用する。
+- `./install.sh`でNix、nix-darwin、nix-homebrew、Homebrew casks、Docker Desktop、
+  Home Manager、chezmoi、Composeを実適用する。
+- `verify-environment --runtime`を実行する。
+- `./install.sh`を二回目実行し、再インストールがなく、同じ宣言へ収束することを確認する。
+- Docker Desktop licenseは個人利用を前提とし、runner ownerが事前に利用条件を承認する。
+
+永続runnerの通常PR testでは既存generationからの収束と冪等性を検証する。Nix未導入状態からの
+clean bootstrapは、専用volume/hostを初期化できるscheduledまたはmanual jobでも検証する。
+
+### Self-hosted runner security and gating
+
+このリポジトリがpublicであることを前提に、破壊的self-hosted jobsは次を必須にする。
+
+- fork PRでは実行しない。
+- 同一repository内branchだけを対象にする。
+- GitHub Environment `destructive-e2e`のowner approval後だけ開始する。
+- owner以外がworkflow_dispatchで任意SHAを指定できないようactor/refを検証する。
+- runnerは本リポジトリ専用account/hostとし、個人tokenや他repository secretsを置かない。
+- `concurrency`で同一OSの同時実行を禁止する。
+- job timeoutとinstaller phase timeoutを設定する。
+- workflowはcommit SHA、generation、provider report、acceptance resultをartifactとして保存する。
+
+PRをmerge可能にするには、hosted unit/build checksに加え、Ubuntu destructive E2E、Windows
+destructive E2E、macOS destructive E2Eが同一head SHAで成功していなければならない。
+
+## CI workflow layout
+
+```text
+ci-bootstrap-unit.yml
+├── bats
+├── pester
+└── catalog-provider-coverage
+
+ci-bootstrap-build.yml
+├── nixos-build
+├── system-manager-ubuntu-build
+├── system-manager-debian-build
+├── home-manager-linux-build
+└── nix-darwin-build
+
+ci-bootstrap-e2e-linux.yml
+├── ubuntu-destructive
+├── debian-systemd-destructive
+└── nixos-vm
+
+ci-bootstrap-e2e-self-hosted.yml
+├── windows-destructive
+└── macos-destructive
+```
+
+既存workflowを無条件に増やさず、重複するci-nix、ci-winget、ci-devcontainer checkは上記へ
+統合または呼び出し可能workflow化する。required check nameは移行中も安定させる。
+
+## Documentation
+
+READMEのQuick Startを次の三入口へ統一する。
+
+```powershell
+install.cmd
+```
+
+```bash
+./install.sh  # macOS
+```
+
+```bash
+./install.sh  # NixOS / Ubuntu / Debian
+```
+
+各OSについて、管理者認証、初回所要時間、Docker license、再実行可能性、supported tier、
+failure時のdiagnostic commandを記載する。
+
+次の運用資料も追加または更新する。
+
+- package provider追加手順
+- self-hosted macOS/Windows runner登録と専用label設定
+- `destructive-e2e` Environment保護設定
+- runnerのclean-bootstrap/reset手順
+- providerが存在しないOSにunsupported reasonを追加する基準
+
+## Delivery phases
+
+一つのPRで無制限に変更しないよう、依存順に実装する。ただし最終merge条件は全phaseの
+acceptanceが揃うことである。
+
+1. catalog schema、provider report、flake inputs/outputs
+2. macOS nix-darwin/nix-homebrew migrationとtests
+3. Ubuntu/Debian System Manager bootstrapとtests
+4. NixOS/Windows entrypointの共通acceptance統合
+5. destructive E2E workflowsとrunner documentation
+6. README/architecture migration、全matrix verification
+
+実装計画では各phaseをtest-firstの小さなcommit単位へ分解する。
+
+## Out of scope
+
+- Apple `container` runtime、Colima、Podman、OrbStackへの自動fallback
+- Intel macOSとWindows on ARMのFull support
+- Fedora/Arch等でのexperimental System Manager `allowAnyDistro`
+- Docker Desktop企業ライセンスの自動判定
+- 自動OAuth login、1Password vault内容、個人secretのCI投入
+- self-hosted runner hardwareの購入・OS再インストール自動化
+
+## References
+
+- [Home Manager installation and module modes](https://nix-community.github.io/home-manager/installation.html)
+- [nix-darwin manual](https://nix-darwin.github.io/nix-darwin/manual/)
+- [nix-homebrew](https://github.com/zhaofengli/nix-homebrew)
+- [System Manager documentation](https://system-manager.net/main/)
+- [System Manager Docker example](https://system-manager.net/main/examples/docker/)
+- [System Manager Home Manager example](https://system-manager.net/main/examples/home-manager/)
+- [GitHub-hosted runner limitations](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)
+- [GitHub self-hosted runner requirements](https://docs.github.com/en/actions/reference/runners/self-hosted-runners)
+- [GitHub self-hosted runner security warning](https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/add-runners)
+
+## Acceptance criteria
+
+完了には次をすべて満たす必要がある。
+
+1. Windowsで`install.cmd`一回からFull acceptanceが成功する。
+2. Apple Silicon macOSで`./install.sh`一回からFull acceptanceが成功する。
+3. NixOS、Ubuntu、Debianで`./install.sh`一回からFull acceptanceが成功する。
+4. 各Full support OSで同じcommandの二回目も成功する。
+5. Windows package entryのmacOS/Linux providerまたはunsupported reasonが100%埋まる。
+6. hosted build/evaluation matrixが全て成功する。
+7. Ubuntu、Debian、NixOS destructive E2Eが成功する。
+8. 専用self-hosted Windows/macOS destructive E2Eが同一head SHAで成功する。
+9. Docker runtimeとCompose health checkを含む共通acceptanceが成功する。
+10. generated manifests、flake lock、documentationが実装と一致する。

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,39 @@
 {
   "nodes": {
+    "brew-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784068757,
+        "narHash": "sha256-7KnV7rTlMpys+2J+TFVxUDDyKPLXFs4wIMtckMC72VM=",
+        "owner": "Homebrew",
+        "repo": "brew",
+        "rev": "6bd951d96e7ebc54787799dba77bfb26ec956c4c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Homebrew",
+        "ref": "6.0.11",
+        "repo": "brew",
+        "type": "github"
+      }
+    },
     "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1767039857,
@@ -34,6 +67,28 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "system-manager",
+          "userborn",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -49,6 +104,29 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "system-manager",
+          "userborn",
+          "pre-commit-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -85,6 +163,45 @@
       "original": {
         "owner": "nix-community",
         "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784123936,
+        "narHash": "sha256-IOWwQMJhUxcojm0MRvuKs1fKLH727u4+hHeEOPhdUyA=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "a4cf1d10853b0d2be19b9eca35d749e201d70b55",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "ref": "master",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nix-homebrew": {
+      "inputs": {
+        "brew-src": "brew-src"
+      },
+      "locked": {
+        "lastModified": 1784159664,
+        "narHash": "sha256-I/B6YoRLImHEqNWh8bs+tPjEDeteACeFhcLyoSMo1GE=",
+        "owner": "zhaofengli",
+        "repo": "nix-homebrew",
+        "rev": "842eeb863ecca0eeb463f7a814cdc51e1d925776",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zhaofengli",
+        "repo": "nix-homebrew",
         "type": "github"
       }
     },
@@ -203,17 +320,70 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks-nix": {
+      "inputs": {
+        "flake-compat": [
+          "system-manager",
+          "userborn",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "system-manager",
+          "userborn",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769069492,
+        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "gwq-src": "gwq-src",
         "home-manager": "home-manager",
+        "nix-darwin": "nix-darwin",
+        "nix-homebrew": "nix-homebrew",
         "nixos-vscode-server": "nixos-vscode-server",
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs_3",
-        "systems": "systems_2",
+        "system-manager": "system-manager",
+        "systems": "systems_3",
         "treefmt-nix": "treefmt-nix",
         "workmux": "workmux"
+      }
+    },
+    "system-manager": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "userborn": "userborn"
+      },
+      "locked": {
+        "lastModified": 1784202359,
+        "narHash": "sha256-CNL64qFM9XkMBVrRaTeH8YdOjweqYEkHTLlkinqScgI=",
+        "owner": "numtide",
+        "repo": "system-manager",
+        "rev": "eff12332d0fc59be8ccb57fec7df9eb05547ec5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "system-manager",
+        "type": "github"
       }
     },
     "systems": {
@@ -246,6 +416,21 @@
         "type": "github"
       }
     },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
@@ -263,6 +448,35 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "userborn": {
+      "inputs": {
+        "flake-compat": [
+          "system-manager",
+          "flake-compat"
+        ],
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "system-manager",
+          "nixpkgs"
+        ],
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix",
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1770377964,
+        "narHash": "sha256-q2pnlX2IW0kg80GLFnwWd/GigIpkuZnyKPLhrgJql3E=",
+        "owner": "jfroche",
+        "repo": "userborn",
+        "rev": "55c2cd7952c207a62736a5bbd9499ea73da18d24",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jfroche",
+        "ref": "system-manager",
+        "repo": "userborn",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,15 @@
     systems.url = "github:nix-systems/default";
     nixos-wsl.url = "github:nix-community/NixOS-WSL";
     nixos-vscode-server.url = "github:nix-community/nixos-vscode-server";
+    nix-darwin = {
+      url = "github:nix-darwin/nix-darwin/master";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nix-homebrew.url = "github:zhaofengli/nix-homebrew";
+    system-manager = {
+      url = "github:numtide/system-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/install.sh
+++ b/install.sh
@@ -5,19 +5,47 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 os="$(uname -s)"
 arch="$(uname -m)"
 
-if [[ $os == "Darwin" && $arch == "arm64" ]]; then
-  exec "$ROOT/scripts/sh/install-macos.sh" "$@"
-fi
-
-if [[ $os == MINGW* || $os == MSYS* || $os == CYGWIN* ]]; then
-  printf 'Windows setup uses install.cmd.\n' >&2
-  exit 1
-fi
-
-if [[ $os == "Darwin" ]]; then
+case "$os" in
+Darwin)
+  if [[ $arch == "arm64" ]]; then
+    exec "$ROOT/scripts/sh/install-macos.sh" "$@"
+  fi
   printf 'This installer supports Apple Silicon Macs only (detected %s).\n' "$arch" >&2
   exit 1
-fi
+  ;;
+Linux)
+  if [[ -e ${DOTFILES_NIXOS_MARKER:-/etc/NIXOS} ]]; then
+    exec "$ROOT/scripts/sh/install-nixos.sh" "$@"
+  fi
 
-printf 'This installer supports Apple Silicon macOS only. Use the existing NixOS/Linux instructions on %s.\n' "$os" >&2
-exit 1
+  os_release_file="${DOTFILES_OS_RELEASE_FILE:-/etc/os-release}"
+  if [[ ! -r $os_release_file ]]; then
+    printf 'Linux distribution metadata is unavailable: %s\n' "$os_release_file" >&2
+    exit 1
+  fi
+  ID=""
+  # shellcheck source=/dev/null
+  . "$os_release_file"
+
+  case "${ID:-}" in
+  ubuntu | debian)
+    exec "$ROOT/scripts/sh/install-linux.sh" "$@"
+    ;;
+  *)
+    if [[ ${DOTFILES_ALLOW_USER_ONLY:-0} != "1" ]]; then
+      printf 'Unsupported Linux distribution (%s). Set DOTFILES_ALLOW_USER_ONLY=1 for Home Manager only.\n' "${ID:-unknown}" >&2
+      exit 1
+    fi
+    exec "$ROOT/scripts/sh/install-home-manager.sh" "$@"
+    ;;
+  esac
+  ;;
+MINGW* | MSYS* | CYGWIN*)
+  printf 'Windows setup uses install.cmd.\n' >&2
+  exit 1
+  ;;
+*)
+  printf 'Unsupported operating system: %s.\n' "$os" >&2
+  exit 1
+  ;;
+esac

--- a/nix/darwin/default.nix
+++ b/nix/darwin/default.nix
@@ -1,0 +1,69 @@
+{
+  pkgs,
+  lib,
+  inputs,
+  ...
+}:
+let
+  user = builtins.getEnv "DOTFILES_USER";
+  home = builtins.getEnv "DOTFILES_HOME";
+  sets = import ../packages/sets.nix {
+    inherit pkgs lib;
+    gwqSrc = inputs.gwq-src;
+  };
+in
+{
+  assertions = [
+    {
+      assertion = user != "";
+      message = "DOTFILES_USER is required";
+    }
+    {
+      assertion = home != "";
+      message = "DOTFILES_HOME is required";
+    }
+  ];
+
+  system = {
+    primaryUser = user;
+    stateVersion = 6;
+    tools.darwin-uninstaller.enable = false;
+  };
+
+  nix.settings.experimental-features = [
+    "nix-command"
+    "flakes"
+  ];
+
+  # nix-darwin's generated documentation currently passes a removed
+  # nixos-render-docs flag. Omit the optional manual artifacts and the
+  # uninstaller's nested default system, which otherwise rebuilds them.
+  documentation.enable = false;
+
+  nix-homebrew = {
+    enable = true;
+    enableRosetta = true;
+    inherit user;
+    autoMigrate = true;
+  };
+
+  homebrew = {
+    enable = true;
+    casks = sets.darwinCasks;
+    onActivation = {
+      autoUpdate = false;
+      upgrade = false;
+      cleanup = "none";
+    };
+  };
+
+  users.users.${user}.home = home;
+
+  home-manager = {
+    useGlobalPkgs = true;
+    useUserPackages = true;
+    backupFileExtension = "hm-backup";
+    users.${user} = import ../home/common.nix;
+    extraSpecialArgs = { inherit inputs; };
+  };
+}

--- a/nix/flakes/apps.nix
+++ b/nix/flakes/apps.nix
@@ -1,0 +1,21 @@
+{ inputs, ... }:
+{
+  perSystem =
+    {
+      lib,
+      pkgs,
+      system,
+      ...
+    }:
+    {
+      apps =
+        lib.optionalAttrs pkgs.stdenv.isDarwin {
+          darwin-rebuild.program = lib.getExe inputs.nix-darwin.packages.${system}.darwin-rebuild;
+        }
+        // lib.optionalAttrs pkgs.stdenv.isLinux {
+          system-manager.program =
+            lib.getExe' inputs.system-manager.packages.${system}.default
+              "system-manager";
+        };
+    };
+}

--- a/nix/flakes/darwin.nix
+++ b/nix/flakes/darwin.nix
@@ -1,0 +1,24 @@
+{ inputs, ... }:
+let
+  system = "aarch64-darwin";
+  workmuxOverlay = _: _: {
+    workmux = inputs.workmux.packages.${system}.default.overrideAttrs (_: {
+      doCheck = false;
+    });
+  };
+in
+{
+  flake.darwinConfigurations.macos = inputs.nix-darwin.lib.darwinSystem {
+    inherit system;
+    specialArgs = { inherit inputs; };
+    modules = [
+      inputs.nix-homebrew.darwinModules.nix-homebrew
+      inputs.home-manager.darwinModules.home-manager
+      {
+        nixpkgs.config.allowUnfree = true;
+        nixpkgs.overlays = [ workmuxOverlay ];
+      }
+      ../darwin/default.nix
+    ];
+  };
+}

--- a/nix/flakes/default.nix
+++ b/nix/flakes/default.nix
@@ -2,9 +2,12 @@
 {
   imports = [
     inputs.treefmt-nix.flakeModule
+    ./apps.nix
+    ./darwin.nix
     ./home.nix
     ./hosts.nix
     ./packages.nix
+    ./system-manager.nix
     ./systems.nix
     ./treefmt.nix
   ];

--- a/nix/flakes/hosts.nix
+++ b/nix/flakes/hosts.nix
@@ -10,6 +10,9 @@ let
       doCheck = false;
     });
   };
+  hardwareConfig = builtins.getEnv "DOTFILES_NIXOS_HARDWARE_CONFIG";
+  requestedSystem = builtins.getEnv "DOTFILES_SYSTEM";
+  nativeLinuxSystem = if requestedSystem == "" then "x86_64-linux" else requestedSystem;
 in
 {
   flake = {
@@ -37,9 +40,11 @@ in
           }
         );
 
+    }
+    // inputs.nixpkgs.lib.optionalAttrs (hardwareConfig != "") {
       linux =
         let
-          system = "x86_64-linux";
+          system = nativeLinuxSystem;
         in
         withSystem system (
           { pkgs, ... }:
@@ -54,6 +59,7 @@ in
             hostPath = ../hosts/linux;
             homeModulePath = ../home/linux/users.nix;
             overlays = [ workmuxOverlay ];
+            extraModules = [ (/. + hardwareConfig) ];
           }
         );
     };

--- a/nix/flakes/lib/hosts.nix
+++ b/nix/flakes/lib/hosts.nix
@@ -22,10 +22,12 @@
           [
             inputs.home-manager.nixosModules.home-manager
             {
-              home-manager.useGlobalPkgs = true;
-              home-manager.useUserPackages = true;
-              home-manager.extraSpecialArgs = { inherit inputs; };
-              home-manager.users = import homeModulePath;
+              home-manager = {
+                useGlobalPkgs = true;
+                useUserPackages = true;
+                extraSpecialArgs = { inherit inputs; };
+                users = import homeModulePath;
+              };
             }
           ]
         else

--- a/nix/flakes/packages.nix
+++ b/nix/flakes/packages.nix
@@ -36,6 +36,11 @@
         inherit lib;
         gwqSrc = inputs.gwq-src;
       };
+      packageSupportReport = import ../packages/support-report.nix {
+        pkgs = unfreePkgs;
+        inherit lib;
+        gwqSrc = inputs.gwq-src;
+      };
     in
     {
       packages = {
@@ -83,6 +88,16 @@
         winget-export = import ../packages/winget.nix {
           inherit pkgs lib;
           gwqSrc = inputs.gwq-src;
+        };
+        package-support-report = packageSupportReport;
+      };
+
+      checks = {
+        package-provider-coverage = packageSupportReport;
+      }
+      // lib.optionalAttrs pkgs.stdenv.isLinux {
+        bootstrap-nixos-vm = import ../tests/bootstrap-nixos.nix {
+          inherit inputs pkgs;
         };
       };
     };

--- a/nix/flakes/system-manager.nix
+++ b/nix/flakes/system-manager.nix
@@ -1,0 +1,33 @@
+{ inputs, ... }:
+let
+  requestedSystem = builtins.getEnv "DOTFILES_SYSTEM";
+  system = if requestedSystem == "" then "x86_64-linux" else requestedSystem;
+  workmuxOverlay = _: _: {
+    workmux = inputs.workmux.packages.${system}.default.overrideAttrs (_: {
+      doCheck = false;
+    });
+  };
+  mkConfig =
+    distro:
+    inputs.system-manager.lib.makeSystemConfig {
+      overlays = [ workmuxOverlay ];
+      specialArgs = {
+        inherit inputs distro;
+      };
+      modules = [
+        inputs.home-manager.nixosModules.home-manager
+        {
+          nixpkgs.hostPlatform = system;
+          nixpkgs.config.allowUnfree = true;
+        }
+        ../system-manager/default.nix
+        ../system-manager/docker.nix
+      ];
+    };
+in
+{
+  flake.systemConfigs = {
+    ubuntu = mkConfig "ubuntu";
+    debian = mkConfig "debian";
+  };
+}

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -4,6 +4,7 @@
 # Used by:
 #   - nix/home/wsl/users.nix   → NixOS module integration
 #   - nix/flakes/home.nix      → standalone homeConfigurations
+#   - nix/darwin/default.nix   → nix-darwin Home Manager integration
 {
   pkgs,
   lib,
@@ -15,212 +16,218 @@ let
     inherit pkgs lib;
     gwqSrc = if inputs == null then null else inputs.gwq-src;
   };
-  user = builtins.getEnv "USER";
-  home = builtins.getEnv "HOME";
+  bootstrapUser = builtins.getEnv "DOTFILES_USER";
+  bootstrapHome = builtins.getEnv "DOTFILES_HOME";
+  user = if bootstrapUser != "" then bootstrapUser else builtins.getEnv "USER";
+  home = if bootstrapHome != "" then bootstrapHome else builtins.getEnv "HOME";
   fdOpts = "--hidden --follow --no-ignore-vcs --max-depth 10";
 in
 {
-  home.username = lib.mkDefault (if user != "" then user else "unknown");
-  home.homeDirectory = lib.mkDefault (if home != "" then home else "/home/unknown");
-  home.stateVersion = "25.05";
-  home.packages = sets.all;
-  programs.home-manager.enable = true;
+  home = {
+    username = lib.mkDefault (if user != "" then user else "unknown");
+    homeDirectory = lib.mkDefault (if home != "" then home else "/home/unknown");
+    stateVersion = "25.05";
+    packages = sets.all;
 
-  # ── Shell: zsh ──────────────────────────────────────────────────────────
-  programs.zsh = {
-    enable = true;
-
-    shellAliases = {
-      find = "fd";
-      grep = "rg";
-      l = "eza -lhaT --level=2 --icons=auto --hyperlink -F --group-directories-first --color=auto";
-      la = "eza -lhaT --level=2 --icons=auto --hyperlink -F --group-directories-first --color=auto";
-      ll = "eza -lhaT --level=2 --icons=auto --hyperlink -F --group-directories-first --color=auto";
-      ls = "eza -lhaT --level=1 --icons=auto --hyperlink -F --group-directories-first --color=auto";
+    sessionVariables = {
+      # qmd (markdown search engine)
+      QMD_EMBED_MODEL = "hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf";
+      QMD_RERANK_MODEL = "hf:giladgd/Qwen3-Reranker-4B-GGUF:Q8_0";
+      # fzf
+      FZF_DEFAULT_COMMAND = "fd ${fdOpts} --absolute-path --type f . .";
+      FZF_ALT_C_COMMAND = "fd ${fdOpts} --absolute-path --type d . .";
+      FZF_DEFAULT_OPTS = "--height=40% --layout=reverse --border --prompt='> '";
+      # pnpm global bin directory
+      PNPM_HOME = "$HOME/.local/share/pnpm";
     };
 
-    initContent = ''
-      # Kubernetes completions and aliases
-      if command -v kubectl >/dev/null 2>&1; then
-        source <(kubectl completion zsh)
-        alias k="kubectl"
-        alias kgn="kubectl get nodes"
-        alias kgp="kubectl get pods -A"
-        alias kgs="kubectl get svc -A"
-      fi
-      if command -v kind >/dev/null 2>&1; then
-        source <(kind completion zsh)
-      fi
-      if command -v helm >/dev/null 2>&1; then
-        source <(helm completion zsh)
-      fi
-      if command -v kubectx >/dev/null 2>&1; then
-        alias kctx="kubectx"
-      fi
-      if command -v kubens >/dev/null 2>&1; then
-        alias kns="kubens"
-      fi
+    # PATH: bun global binaries (claude-code, gemini-cli, etc.)
+    #       pnpm global binaries
+    sessionPath = [
+      "$HOME/.bun/bin"
+      "$HOME/.local/share/pnpm/bin"
+      "$HOME/.local/share/pnpm"
+    ]
+    ++ lib.optionals pkgs.stdenv.isDarwin [
+      "/opt/homebrew/bin"
+      "/opt/homebrew/sbin"
+      "/Applications/Docker.app/Contents/Resources/bin"
+    ];
+  };
 
-      # Task (taskfile.dev) completion
-      if command -v task >/dev/null 2>&1; then
-        eval "$(task --completion zsh)"
-      fi
+  programs = {
+    home-manager.enable = true;
 
-      # workmux completion
-      if command -v workmux >/dev/null 2>&1; then
-        eval "$(workmux completions zsh)"
-      fi
+    # ── Shell: zsh ────────────────────────────────────────────────────────
+    zsh = {
+      enable = true;
 
-      # Emit OSC 7 so terminals can open split/tab in current directory
-      autoload -Uz add-zsh-hook
-      __emit_osc7_cwd() {
-        printf '\033]7;file://%s%s\033\\' "$HOST" "$PWD"
-      }
-      add-zsh-hook precmd __emit_osc7_cwd
+      shellAliases = {
+        find = "fd";
+        grep = "rg";
+        l = "eza -lhaT --level=2 --icons=auto --hyperlink -F --group-directories-first --color=auto";
+        la = "eza -lhaT --level=2 --icons=auto --hyperlink -F --group-directories-first --color=auto";
+        ll = "eza -lhaT --level=2 --icons=auto --hyperlink -F --group-directories-first --color=auto";
+        ls = "eza -lhaT --level=1 --icons=auto --hyperlink -F --group-directories-first --color=auto";
+      };
 
-      # Disable mouse reporting at the shell prompt.
-      # TERM=wezterm exposes mouse-capable terminfo entries; without this,
-      # clicks send SGR sequences that zsh prints as literal characters.
-      # Programs that need mouse (nvim, tmux) re-enable it themselves.
-      __disable_mouse_reporting() {
-        printf '\033[?1000l\033[?1002l\033[?1003l\033[?1006l' 2>/dev/null
-      }
-      add-zsh-hook precmd __disable_mouse_reporting
-
-      # Alt+Q: zoxide interactive (history-based directory jump)
-      __zoxide_zi_widget() {
-        local result
-        result="$(zoxide query -i)" && cd "$result"
-        zle reset-prompt
-      }
-      zle -N __zoxide_zi_widget
-      bindkey '^[q' __zoxide_zi_widget
-
-      # Alt+D: fzf directory search and cd
-      __fzf_cd_widget() {
-        local dir
-        dir="$(fd ${fdOpts} --absolute-path -t d . . | fzf)" && cd "$dir"
-        zle reset-prompt
-      }
-      zle -N __fzf_cd_widget
-      bindkey '^[d' __fzf_cd_widget
-
-      # Alt+T: fzf file search and insert path
-      __fzf_file_widget() {
-        local selected
-        selected="$(fd ${fdOpts} --absolute-path . . | fzf)"
-        if [[ -n "$selected" ]]; then
-          LBUFFER="$LBUFFER$selected"
+      initContent = ''
+        # Kubernetes completions and aliases
+        if command -v kubectl >/dev/null 2>&1; then
+          source <(kubectl completion zsh)
+          alias k="kubectl"
+          alias kgn="kubectl get nodes"
+          alias kgp="kubectl get pods -A"
+          alias kgs="kubectl get svc -A"
         fi
-        zle reset-prompt
-      }
-      zle -N __fzf_file_widget
-      bindkey '^[t' __fzf_file_widget
-
-      # Alt+R: fzf command history search
-      __fzf_history_widget() {
-        local selected
-        selected="$(fc -ln 1 | fzf --tac)"
-        if [[ -n "$selected" ]]; then
-          BUFFER="$selected"
-          CURSOR=$#BUFFER
+        if command -v kind >/dev/null 2>&1; then
+          source <(kind completion zsh)
         fi
-        zle reset-prompt
-      }
-      zle -N __fzf_history_widget
-      bindkey '^[r' __fzf_history_widget
-
-      ${builtins.readFile ../../scripts/sh/dcnvim.sh}
-
-      # tm: ghq + fzf でリポジトリ選択 → tmux セッション作成/切替
-      tm() {
-        if ! command -v tmux &>/dev/null; then
-          cd "$(ghq list --full-path | fzf)" 2>/dev/null
-          return
+        if command -v helm >/dev/null 2>&1; then
+          source <(helm completion zsh)
         fi
-        local repo_slug session_name repo_dir
-        repo_slug=$(ghq list | fzf) || return
-        session_name=''${repo_slug##*/}
-        repo_dir="$(ghq root)/$repo_slug"
-        tmux has-session -t "$session_name" 2>/dev/null ||
-          tmux new-session -d -c "$repo_dir" -s "$session_name"
-        if [[ -n "''${TMUX:-}" ]]; then
-          tmux switch-client -t "$session_name"
-        else
-          tmux attach-session -t "$session_name"
+        if command -v kubectx >/dev/null 2>&1; then
+          alias kctx="kubectx"
         fi
-      }
-
-      # dotf: run task from dotfiles root without changing cwd
-      dotf() { (cd ~/.dotfiles && task "$@") }
-
-      codex() {
-        local __dotfiles_had_force_secret_load=0
-        local __dotfiles_previous_force_secret_load="''${DOTFILES_FORCE_SECRET_LOAD:-}"
-        if [ "''${DOTFILES_FORCE_SECRET_LOAD+x}" = x ]; then
-          __dotfiles_had_force_secret_load=1
+        if command -v kubens >/dev/null 2>&1; then
+          alias kns="kubens"
         fi
 
-        if { [ -z "''${GITHUB_PAT_TOKEN:-}" ] || [ -z "''${GITHUB_WORK_TOKEN:-}" ] || [ -z "''${TAVILY_API_KEY:-}" ]; } && [ -f "$HOME/.config/shell/secret.sh" ]; then
-          export DOTFILES_FORCE_SECRET_LOAD=1
-          source "$HOME/.config/shell/secret.sh"
-          if [ "$__dotfiles_had_force_secret_load" = 1 ]; then
-            export DOTFILES_FORCE_SECRET_LOAD="$__dotfiles_previous_force_secret_load"
-          else
-            unset DOTFILES_FORCE_SECRET_LOAD
+        # Task (taskfile.dev) completion
+        if command -v task >/dev/null 2>&1; then
+          eval "$(task --completion zsh)"
+        fi
+
+        # workmux completion
+        if command -v workmux >/dev/null 2>&1; then
+          eval "$(workmux completions zsh)"
+        fi
+
+        # Emit OSC 7 so terminals can open split/tab in current directory
+        autoload -Uz add-zsh-hook
+        __emit_osc7_cwd() {
+          printf '\033]7;file://%s%s\033\\' "$HOST" "$PWD"
+        }
+        add-zsh-hook precmd __emit_osc7_cwd
+
+        # Disable mouse reporting at the shell prompt.
+        # TERM=wezterm exposes mouse-capable terminfo entries; without this,
+        # clicks send SGR sequences that zsh prints as literal characters.
+        # Programs that need mouse (nvim, tmux) re-enable it themselves.
+        __disable_mouse_reporting() {
+          printf '\033[?1000l\033[?1002l\033[?1003l\033[?1006l' 2>/dev/null
+        }
+        add-zsh-hook precmd __disable_mouse_reporting
+
+        # Alt+Q: zoxide interactive (history-based directory jump)
+        __zoxide_zi_widget() {
+          local result
+          result="$(zoxide query -i)" && cd "$result"
+          zle reset-prompt
+        }
+        zle -N __zoxide_zi_widget
+        bindkey '^[q' __zoxide_zi_widget
+
+        # Alt+D: fzf directory search and cd
+        __fzf_cd_widget() {
+          local dir
+          dir="$(fd ${fdOpts} --absolute-path -t d . . | fzf)" && cd "$dir"
+          zle reset-prompt
+        }
+        zle -N __fzf_cd_widget
+        bindkey '^[d' __fzf_cd_widget
+
+        # Alt+T: fzf file search and insert path
+        __fzf_file_widget() {
+          local selected
+          selected="$(fd ${fdOpts} --absolute-path . . | fzf)"
+          if [[ -n "$selected" ]]; then
+            LBUFFER="$LBUFFER$selected"
           fi
-        fi
+          zle reset-prompt
+        }
+        zle -N __fzf_file_widget
+        bindkey '^[t' __fzf_file_widget
 
-        command codex "$@"
-      }
+        # Alt+R: fzf command history search
+        __fzf_history_widget() {
+          local selected
+          selected="$(fc -ln 1 | fzf --tac)"
+          if [[ -n "$selected" ]]; then
+            BUFFER="$selected"
+            CURSOR=$#BUFFER
+          fi
+          zle reset-prompt
+        }
+        zle -N __fzf_history_widget
+        bindkey '^[r' __fzf_history_widget
 
-      # 1Password-managed secrets (GITHUB_PAT_TOKEN, TAVILY_API_KEY, etc.)
-      [[ -f "$HOME/.config/shell/secret.sh" ]] && source "$HOME/.config/shell/secret.sh"
+        ${builtins.readFile ../../scripts/sh/dcnvim.sh}
 
-      # GitHub CLI token switching for personal/work repositories.
-      [[ -f "$HOME/.config/shell/gh-token-switch.sh" ]] && source "$HOME/.config/shell/gh-token-switch.sh"
-    '';
+        # tm: ghq + fzf でリポジトリ選択 → tmux セッション作成/切替
+        tm() {
+          if ! command -v tmux &>/dev/null; then
+            cd "$(ghq list --full-path | fzf)" 2>/dev/null
+            return
+          fi
+          local repo_slug session_name repo_dir
+          repo_slug=$(ghq list | fzf) || return
+          session_name=''${repo_slug##*/}
+          repo_dir="$(ghq root)/$repo_slug"
+          tmux has-session -t "$session_name" 2>/dev/null ||
+            tmux new-session -d -c "$repo_dir" -s "$session_name"
+          if [[ -n "''${TMUX:-}" ]]; then
+            tmux switch-client -t "$session_name"
+          else
+            tmux attach-session -t "$session_name"
+          fi
+        }
+
+        # dotf: run task from dotfiles root without changing cwd
+        dotf() { (cd ~/.dotfiles && task "$@") }
+
+        codex() {
+          local __dotfiles_had_force_secret_load=0
+          local __dotfiles_previous_force_secret_load="''${DOTFILES_FORCE_SECRET_LOAD:-}"
+          if [ "''${DOTFILES_FORCE_SECRET_LOAD+x}" = x ]; then
+            __dotfiles_had_force_secret_load=1
+          fi
+
+          if { [ -z "''${GITHUB_PAT_TOKEN:-}" ] || [ -z "''${GITHUB_WORK_TOKEN:-}" ] || [ -z "''${TAVILY_API_KEY:-}" ]; } && [ -f "$HOME/.config/shell/secret.sh" ]; then
+            export DOTFILES_FORCE_SECRET_LOAD=1
+            source "$HOME/.config/shell/secret.sh"
+            if [ "$__dotfiles_had_force_secret_load" = 1 ]; then
+              export DOTFILES_FORCE_SECRET_LOAD="$__dotfiles_previous_force_secret_load"
+            else
+              unset DOTFILES_FORCE_SECRET_LOAD
+            fi
+          fi
+
+          command codex "$@"
+        }
+
+        # 1Password-managed secrets (GITHUB_PAT_TOKEN, TAVILY_API_KEY, etc.)
+        [[ -f "$HOME/.config/shell/secret.sh" ]] && source "$HOME/.config/shell/secret.sh"
+
+        # GitHub CLI token switching for personal/work repositories.
+        [[ -f "$HOME/.config/shell/gh-token-switch.sh" ]] && source "$HOME/.config/shell/gh-token-switch.sh"
+      '';
+    };
+
+    # ── Prompt ────────────────────────────────────────────────────────────
+    starship.enable = true;
+
+    # ── Directory navigation ───────────────────────────────────────────────
+    zoxide = {
+      enable = true;
+      enableZshIntegration = true;
+    };
+
+    # ── direnv ─────────────────────────────────────────────────────────────
+    direnv = {
+      enable = true;
+      nix-direnv.enable = true;
+      enableZshIntegration = true;
+    };
   };
-
-  # ── Prompt ──────────────────────────────────────────────────────────────
-  programs.starship.enable = true;
-
-  # ── Directory navigation ─────────────────────────────────────────────────
-  programs.zoxide = {
-    enable = true;
-    enableZshIntegration = true;
-  };
-
-  # ── direnv ───────────────────────────────────────────────────────────────
-  programs.direnv = {
-    enable = true;
-    nix-direnv.enable = true;
-    enableZshIntegration = true;
-  };
-
-  # ── Environment variables ────────────────────────────────────────────────
-  home.sessionVariables = {
-    # qmd (markdown search engine)
-    QMD_EMBED_MODEL = "hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf";
-    QMD_RERANK_MODEL = "hf:giladgd/Qwen3-Reranker-4B-GGUF:Q8_0";
-    # fzf
-    FZF_DEFAULT_COMMAND = "fd ${fdOpts} --absolute-path --type f . .";
-    FZF_ALT_C_COMMAND = "fd ${fdOpts} --absolute-path --type d . .";
-    FZF_DEFAULT_OPTS = "--height=40% --layout=reverse --border --prompt='> '";
-    # pnpm global bin directory
-    PNPM_HOME = "$HOME/.local/share/pnpm";
-  };
-
-  # PATH: bun global binaries (claude-code, gemini-cli, etc.)
-  #       pnpm global binaries
-  home.sessionPath = [
-    "$HOME/.bun/bin"
-    "$HOME/.local/share/pnpm/bin"
-    "$HOME/.local/share/pnpm"
-  ]
-  ++ lib.optionals pkgs.stdenv.isDarwin [
-    "/opt/homebrew/bin"
-    "/opt/homebrew/sbin"
-    "/Applications/Docker.app/Contents/Resources/bin"
-  ];
 }

--- a/nix/home/linux/users.nix
+++ b/nix/home/linux/users.nix
@@ -1,16 +1,19 @@
 # User → Home Manager module mapping for native Linux host.
 # Imported by nix/flakes/hosts.nix as home-manager.users.
+let
+  bootstrapUser = builtins.getEnv "DOTFILES_USER";
+  user = if bootstrapUser == "" then "nixos" else bootstrapUser;
+in
 {
-  nixos =
+  ${user} =
     { ... }:
     {
       imports = [ ../common.nix ];
 
-      # NixOS rebuild shortcuts (also defined in wsl/users.nix for WSL context)
+      # Native NixOS must preserve the machine hardware profile, so route the
+      # shortcut through the same guarded one-command installer.
       programs.zsh.shellAliases = {
-        nrs = "nix flake update --flake ~/.dotfiles && sudo nixos-rebuild switch --flake ~/.dotfiles --impure && nix profile upgrade '.*' || nix profile install ~/.dotfiles#default";
-        nrt = "sudo nixos-rebuild test --flake ~/.dotfiles --impure";
-        nrb = "sudo nixos-rebuild boot --flake ~/.dotfiles --impure";
+        nrs = "~/.dotfiles/install.sh";
       };
     };
 }

--- a/nix/hosts/linux/configuration.nix
+++ b/nix/hosts/linux/configuration.nix
@@ -1,29 +1,58 @@
-{ ... }:
+{ lib, pkgs, ... }:
+let
+  bootstrapUser = builtins.getEnv "DOTFILES_USER";
+  bootstrapHome = builtins.getEnv "DOTFILES_HOME";
+  uidText = builtins.getEnv "DOTFILES_UID";
+  gidText = builtins.getEnv "DOTFILES_GID";
+  groupText = builtins.getEnv "DOTFILES_GROUP";
+  user = if bootstrapUser == "" then "nixos" else bootstrapUser;
+  home = if bootstrapHome == "" then "/home/${user}" else bootstrapHome;
+  primaryGroup = if groupText == "" then "users" else groupText;
+  isNumericId = value: builtins.match "[0-9]+" value != null;
+  uid = if isNumericId uidText then lib.toInt uidText else null;
+  gid = if isNumericId gidText then lib.toInt gidText else null;
+in
 {
+  assertions = [
+    {
+      assertion = uidText == "" || isNumericId uidText;
+      message = "DOTFILES_UID must be numeric when provided";
+    }
+    {
+      assertion = gidText == "" || isNumericId gidText;
+      message = "DOTFILES_GID must be numeric when provided";
+    }
+  ];
+
   system.stateVersion = "25.05";
 
-  # Boot — override per machine
-  boot.loader.grub.devices = [ "/dev/sda" ];
-  fileSystems."/" = {
-    device = "/dev/sda1";
-    fsType = "ext4";
+  users = {
+    mutableUsers = true;
+    groups.${primaryGroup} = lib.optionalAttrs (gid != null) { inherit gid; };
+    users.${user} = {
+      isNormalUser = true;
+      inherit home;
+      createHome = true;
+      group = primaryGroup;
+      extraGroups = [
+        "wheel"
+        "docker"
+      ];
+    }
+    // lib.optionalAttrs (uid != null) { inherit uid; };
   };
 
-  # User
-  users.users.nixos = {
-    isNormalUser = true;
-    extraGroups = [
-      "wheel"
-      "docker"
-    ];
-  };
-  users.groups.nixos = { };
+  environment.systemPackages = with pkgs; [
+    docker-compose
+    docker-buildx
+  ];
 
-  virtualisation.docker = {
-    enable = true;
-    rootless = {
-      enable = true;
-      setSocketVariable = true;
+  virtualisation.docker.enable = true;
+  virtualisation.docker.daemon.settings = {
+    "log-driver" = "json-file";
+    "log-opts" = {
+      "max-size" = "10m";
+      "max-file" = "3";
     };
   };
 }

--- a/nix/modules/wsl/default.nix
+++ b/nix/modules/wsl/default.nix
@@ -1,62 +1,99 @@
 { config, pkgs, ... }:
 {
-  environment.systemPackages = with pkgs; [
-    coreutils
-    nvidia-container-toolkit
-    _1password-cli
-    # Japanese input: fcitx5+mozc installed as system packages.
-    # i18n.inputMethod is intentionally NOT used here because it auto-generates
-    # app-org.fcitx.Fcitx5@autostart.service, which conflicts with the Home Manager
-    # user systemd service that runs fcitx5 with --disable=wayland (required for WSLg).
-    fcitx5
-    fcitx5-mozc
-    fcitx5-gtk
-  ];
+  environment = {
+    systemPackages = with pkgs; [
+      coreutils
+      nvidia-container-toolkit
+      _1password-cli
+      # Japanese input: fcitx5+mozc installed as system packages.
+      # i18n.inputMethod is intentionally NOT used here because it auto-generates
+      # app-org.fcitx.Fcitx5@autostart.service, which conflicts with the Home Manager
+      # user systemd service that runs fcitx5 with --disable=wayland (required for WSLg).
+      fcitx5
+      fcitx5-mozc
+      fcitx5-gtk
+    ];
 
-  # Merge /share/fcitx5 from all installed packages into /run/current-system/sw/share/fcitx5.
-  # Without this, fcitx5 cannot find addon/inputmethod conf files provided by
-  # separate packages like fcitx5-mozc (only the fcitx5 package itself is searched by default).
-  environment.pathsToLink = [ "/share/fcitx5" ];
+    # Merge /share/fcitx5 from all installed packages into /run/current-system/sw/share/fcitx5.
+    # Without this, fcitx5 cannot find addon/inputmethod conf files provided by
+    # separate packages like fcitx5-mozc (only the fcitx5 package itself is searched by default).
+    pathsToLink = [ "/share/fcitx5" ];
 
-  system.activationScripts.wslWhoami = {
-    text = ''
-      mkdir -p /usr/bin
-      ln -sf /run/current-system/sw/bin/whoami /usr/bin/whoami
-    '';
+    # Ensure nix-ld works for non-login shells (e.g. VS Code WSL server).
+    variables = {
+      NIX_LD = "/run/current-system/sw/share/nix-ld/lib/ld.so";
+      NIX_LD_LIBRARY_PATH = "/run/current-system/sw/share/nix-ld/lib";
+      WARP_ENABLE_WAYLAND = "1";
+    };
   };
 
-  # Delegate op CLI to Windows op.exe so 1Password desktop app (Windows Hello)
-  # can authenticate from WSL. The NixOS-native op binary has no socket from the
-  # Windows app; op.exe on Windows connects via the named pipe directly.
-  # op run is kept on the native binary because it injects secrets into Linux processes.
-  system.activationScripts.opWrapper =
-    let
-      opScript = pkgs.writeShellScript "op-wrapper" ''
-        OP_NATIVE="/etc/profiles/per-user/nixos/bin/op"
-        # op run injects secrets into Linux processes — keep on native binary
-        if [ "$1" = "run" ] && [ -x "$OP_NATIVE" ]; then
-          exec "$OP_NATIVE" "$@"
-        fi
-        # Find op.exe via Windows PATH (available in WSL via interop)
-        OP_EXE=$(IFS=:; for p in $PATH; do
-          [ -f "$p/op.exe" ] && echo "$p/op.exe" && break
-        done)
-        if [ -z "$OP_EXE" ]; then
-          echo "[ERROR] op.exe not found in PATH" >&2
-          exit 1
-        fi
-        OP_VARS=$(env | grep ^OP_ | cut -d= -f1 | tr '\n' ':')
-        export WSLENV="''${WSLENV:-}:''${OP_VARS%:}"
-        exec "$OP_EXE" "$@"
-      '';
-    in
-    {
+  system.activationScripts = {
+    wslWhoami = {
       text = ''
-        mkdir -p /usr/local/bin
-        cp ${opScript} /usr/local/bin/op
-        chmod +x /usr/local/bin/op
+        mkdir -p /usr/bin
+        ln -sf /run/current-system/sw/bin/whoami /usr/bin/whoami
       '';
     };
+
+    # Delegate op CLI to Windows op.exe so 1Password desktop app (Windows Hello)
+    # can authenticate from WSL. The NixOS-native op binary has no socket from the
+    # Windows app; op.exe on Windows connects via the named pipe directly.
+    # op run is kept on the native binary because it injects secrets into Linux processes.
+    opWrapper =
+      let
+        opScript = pkgs.writeShellScript "op-wrapper" ''
+          OP_NATIVE="/etc/profiles/per-user/nixos/bin/op"
+          # op run injects secrets into Linux processes — keep on native binary
+          if [ "$1" = "run" ] && [ -x "$OP_NATIVE" ]; then
+            exec "$OP_NATIVE" "$@"
+          fi
+          # Find op.exe via Windows PATH (available in WSL via interop)
+          OP_EXE=$(IFS=:; for p in $PATH; do
+            [ -f "$p/op.exe" ] && echo "$p/op.exe" && break
+          done)
+          if [ -z "$OP_EXE" ]; then
+            echo "[ERROR] op.exe not found in PATH" >&2
+            exit 1
+          fi
+          OP_VARS=$(env | grep ^OP_ | cut -d= -f1 | tr '\n' ':')
+          export WSLENV="''${WSLENV:-}:''${OP_VARS%:}"
+          exec "$OP_EXE" "$@"
+        '';
+      in
+      {
+        text = ''
+          mkdir -p /usr/local/bin
+          cp ${opScript} /usr/local/bin/op
+          chmod +x /usr/local/bin/op
+        '';
+      };
+
+    # Provide containerd hosts.toml for registry.localhost so kind nodes can
+    # mount /etc/containerd/certs.d and use the in-cluster Zot as a mirror.
+    # kind.yaml: extraMounts hostPath=/etc/containerd/certs.d
+    containerdCertsD = {
+      text = ''
+              mkdir -p /etc/containerd/certs.d/registry.localhost
+              cat > /etc/containerd/certs.d/registry.localhost/hosts.toml << 'EOF'
+        server = "http://registry.localhost"
+
+        [host."http://zot.infra.svc.cluster.local:5080"]
+          capabilities = ["pull", "resolve"]
+        EOF
+      '';
+    };
+
+    # Generate CDI spec on each activation so kind worker nodes can mount
+    # /etc/cdi and use GPU resources through containerd CDI.
+    nvidiaCdi = {
+      deps = [ "wslWhoami" ];
+      text = ''
+        mkdir -p /etc/cdi
+        ${pkgs.nvidia-container-toolkit}/bin/nvidia-ctk cdi generate \
+          --output /etc/cdi/nvidia.yaml 2>/dev/null || true
+      '';
+    };
+  };
 
   # Allow running dynamically linked binaries in WSL (e.g. VS Code Server).
   programs.nix-ld = {
@@ -94,32 +131,6 @@
 
   users.users.nixos.extraGroups = [ "docker" ];
 
-  # Provide containerd hosts.toml for registry.localhost so kind nodes can
-  # mount /etc/containerd/certs.d and use the in-cluster Zot as a mirror.
-  # kind.yaml: extraMounts hostPath=/etc/containerd/certs.d
-  system.activationScripts.containerdCertsD = {
-    text = ''
-            mkdir -p /etc/containerd/certs.d/registry.localhost
-            cat > /etc/containerd/certs.d/registry.localhost/hosts.toml << 'EOF'
-      server = "http://registry.localhost"
-
-      [host."http://zot.infra.svc.cluster.local:5080"]
-        capabilities = ["pull", "resolve"]
-      EOF
-    '';
-  };
-
-  # Generate CDI spec on each activation so kind worker nodes can mount
-  # /etc/cdi and use GPU resources through containerd CDI.
-  system.activationScripts.nvidiaCdi = {
-    deps = [ "wslWhoami" ];
-    text = ''
-      mkdir -p /etc/cdi
-      ${pkgs.nvidia-container-toolkit}/bin/nvidia-ctk cdi generate \
-        --output /etc/cdi/nvidia.yaml 2>/dev/null || true
-    '';
-  };
-
   # Re-register WSLInterop binfmt entry after systemd clears it on boot.
   # Without this, Windows .exe files (e.g. VS Code) cannot be executed from WSL.
   wsl.interop.register = true;
@@ -128,10 +139,4 @@
   # NixOS が networking.extraHosts 経由で /etc/hosts を管理できるようにする。
   wsl.wslConf.network.generateHosts = false;
 
-  # Ensure nix-ld works for non-login shells (e.g. VS Code WSL server).
-  environment.variables = {
-    NIX_LD = "/run/current-system/sw/share/nix-ld/lib/ld.so";
-    NIX_LD_LIBRARY_PATH = "/run/current-system/sw/share/nix-ld/lib";
-    WARP_ENABLE_WAYLAND = "1";
-  };
 }

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -19,6 +19,10 @@
 #   - wingetSkipInstall → catalog attr name or winget/msstore ID → skip normal automated install
 #   - wingetCiSkipInstall → catalog attr name or winget/msstore ID → skip CI winget install smoke test
 #   - wingetPathEntries  → catalog attr name or winget ID → extra Windows PATH directories
+#   - supportReport      → per-package Windows/Darwin/Linux provider metadata
+#   - darwinCasks        → Homebrew casks derived from provider metadata
+#   - linuxSystemModules → system-layer capabilities required on Linux
+#   - providerErrors     → unresolved provider metadata (must remain empty)
 #   - windowsOnly        → packages with no nix equivalent (winget/msstore/npm/pnpm)
 #
 # Imported by:
@@ -31,7 +35,7 @@
   gwqSrc ? null,
 }:
 let
-  catalog = {
+  rawCatalog = {
     # ── core ──────────────────────────────────────────────
     chezmoi = {
       pkg = pkgs.chezmoi;
@@ -183,6 +187,26 @@ let
       winget = "oschwartz10612.Poppler";
       category = "dev";
     };
+    dprint = {
+      pkg = pkgs.dprint;
+      winget = "dprint.dprint";
+      category = "dev";
+    };
+    hadolint = {
+      pkg = pkgs.hadolint;
+      winget = "hadolint.hadolint";
+      category = "dev";
+    };
+    bun = {
+      pkg = pkgs.bun;
+      winget = "Oven-sh.Bun";
+      category = "dev";
+    };
+    zig = {
+      pkg = pkgs.zig;
+      winget = "zig.zig";
+      category = "dev";
+    };
 
     # ── terminal ──────────────────────────────────────────
     wezterm = {
@@ -222,6 +246,17 @@ let
       winget = "Obsidian.Obsidian";
       category = "editors";
     };
+    vscode = {
+      pkg = pkgs.vscode;
+      winget = "Microsoft.VisualStudioCode";
+      category = "editors";
+      support = {
+        darwin = {
+          provider = "homebrew-cask";
+          cask = "visual-studio-code";
+        };
+      };
+    };
 
     # ── fonts ─────────────────────────────────────────────
     udev-gothic-nf = {
@@ -238,7 +273,7 @@ let
     };
     codex = {
       pkg = pkgs.codex;
-      winget = null;
+      winget = "OpenAI.Codex";
       category = "llm";
     };
     workmux = {
@@ -252,6 +287,97 @@ let
       pkg = pkgs.slack;
       winget = "SlackTechnologies.Slack";
       category = "communication";
+    };
+
+    # ── desktop applications ──────────────────────────────
+    _1password-gui = {
+      pkg = pkgs._1password-gui;
+      winget = "AgileBits.1Password";
+      category = "desktop";
+      support = {
+        darwin = {
+          provider = "homebrew-cask";
+          cask = "1password";
+        };
+      };
+    };
+    claude-desktop = {
+      winget = "Anthropic.Claude";
+      category = "desktop";
+      support = {
+        windows = {
+          provider = "winget";
+        };
+        darwin = {
+          provider = "homebrew-cask";
+          cask = "claude";
+        };
+        linux = {
+          unsupported = "Vendor does not publish a supported Linux desktop build";
+        };
+      };
+    };
+    arc-browser = {
+      winget = "TheBrowserCompany.Arc";
+      category = "desktop";
+      support = {
+        windows = {
+          provider = "winget";
+        };
+        darwin = {
+          provider = "homebrew-cask";
+          cask = "arc";
+        };
+        linux = {
+          unsupported = "Vendor does not publish a Linux build";
+        };
+      };
+    };
+    google-chrome = {
+      pkg = pkgs.google-chrome;
+      winget = "Google.Chrome";
+      category = "desktop";
+      support = {
+        darwin = {
+          provider = "homebrew-cask";
+          cask = "google-chrome";
+        };
+      };
+    };
+    tableplus = {
+      winget = "TablePlus.TablePlus";
+      category = "desktop";
+      support = {
+        windows = {
+          provider = "winget";
+        };
+        darwin = {
+          provider = "homebrew-cask";
+          cask = "tableplus";
+        };
+        linux = {
+          unsupported = "No pinned Nix provider is available";
+        };
+      };
+    };
+
+    # ── system capabilities ───────────────────────────────
+    docker-desktop = {
+      winget = "Docker.DockerDesktop";
+      category = "system";
+      support = {
+        windows = {
+          provider = "winget";
+        };
+        darwin = {
+          provider = "homebrew-cask";
+          cask = "docker-desktop";
+        };
+        linux = {
+          provider = "system-manager";
+          systemModule = "docker";
+        };
+      };
     };
 
     # ── k8s ───────────────────────────────────────────────
@@ -436,6 +562,125 @@ let
     };
   };
 
+  supports =
+    package: system:
+    package != null && builtins.elem system (package.meta.platforms or lib.platforms.all);
+
+  # Provider gaps are reviewed explicitly. Adding a package without a provider
+  # now fails providerErrors until its unsupported platform is listed here.
+  reviewedUnsupported = {
+    windows = lib.genAttrs [
+      "argocd"
+      "astro-language-server"
+      "bash-language-server"
+      "bat"
+      "bats"
+      "cilium-cli"
+      "claude-code"
+      "cmake"
+      "dive"
+      "ghostscript"
+      "gnumake"
+      "gopls"
+      "gwq"
+      "k9s"
+      "kind"
+      "kubectl"
+      "kubectx"
+      "kubernetes-helm"
+      "kubeseal"
+      "kustomize"
+      "marksman"
+      "neovim-remote"
+      "nixd"
+      "p7zip"
+      "pnpm"
+      "pre-commit"
+      "python3"
+      "rustfmt"
+      "sops"
+      "stern"
+      "tmux"
+      "treefmt"
+      "trivy"
+      "typescript-language-server"
+      "udev-gothic-nf"
+      "unzip"
+      "workmux"
+      "yaml-language-server"
+    ] (_: "No reviewed Windows package provider is selected");
+    darwin = { };
+    linux = { };
+  };
+
+  reviewedUnsupportedFor = platform: name: lib.attrByPath [ platform name ] null reviewedUnsupported;
+
+  defaultSupport =
+    name: entry:
+    let
+      package = entry.pkg or null;
+      unsupported = platform: reviewedUnsupportedFor platform name;
+    in
+    {
+      windows =
+        if (entry.winget or null) != null then
+          { provider = "winget"; }
+        else if (entry.npm or null) != null then
+          { provider = "npm"; }
+        else
+          let
+            reason = unsupported "windows";
+          in
+          if reason == null then { } else { unsupported = reason; };
+      darwin =
+        if supports package "aarch64-darwin" || supports package "x86_64-darwin" then
+          { provider = "nix"; }
+        else
+          let
+            reason = unsupported "darwin";
+          in
+          if reason == null then { } else { unsupported = reason; };
+      linux =
+        if supports package "x86_64-linux" || supports package "aarch64-linux" then
+          { provider = "nix"; }
+        else
+          let
+            reason = unsupported "linux";
+          in
+          if reason == null then { } else { unsupported = reason; };
+    };
+
+  catalog = lib.mapAttrs (
+    name: entry:
+    entry
+    // {
+      support = defaultSupport name entry // (entry.support or { });
+    }
+  ) rawCatalog;
+
+  mkWindowsOnlySupport = provider: reason: {
+    windows = { inherit provider; };
+    darwin = {
+      unsupported = reason;
+    };
+    linux = {
+      unsupported = reason;
+    };
+  };
+
+  windowsOnlySupport = {
+    "GitHub.Copilot" = mkWindowsOnlySupport "winget" "Windows application package";
+    "Microsoft.PowerToys" = mkWindowsOnlySupport "winget" "Windows system utility";
+    "Microsoft.VCRedist.2015+.x64" = mkWindowsOnlySupport "winget" "Windows runtime component";
+    "Microsoft.VisualStudio.2022.BuildTools" =
+      mkWindowsOnlySupport "winget" "Windows compiler toolchain";
+    "Microsoft.WindowsTerminal" = mkWindowsOnlySupport "winget" "Windows shell host";
+    "Microsoft.WSL" = mkWindowsOnlySupport "winget" "Windows subsystem component";
+    "StablyAI.Orca" = mkWindowsOnlySupport "winget" "Windows application package";
+    "9NT1R1C2HH7J" = mkWindowsOnlySupport "msstore" "Windows Store application";
+    "9PLM9XGG6VKS" = mkWindowsOnlySupport "msstore" "Windows Store desktop application";
+  };
+
   # Group package names by category
   grouped = lib.groupBy (name: catalog.${name}.category) (lib.attrNames catalog);
 
@@ -446,28 +691,60 @@ let
       map (
         n:
         let
-          p = catalog.${n}.pkg;
+          p = catalog.${n}.pkg or null;
         in
-        if builtins.elem pkgs.stdenv.hostPlatform.system (p.meta.platforms or lib.platforms.all) then
-          p
-        else
-          null
+        if p != null && supports p pkgs.stdenv.hostPlatform.system then p else null
       ) names
     );
 
   # Extract winget mappings (non-null only)
-  wingetMap = lib.filterAttrs (_: v: v != null) (lib.mapAttrs (_: v: v.winget) catalog);
+  wingetMap = lib.filterAttrs (_: v: v != null) (lib.mapAttrs (_: v: v.winget or null) catalog);
   npmMap = lib.filterAttrs (_: v: v != null) (lib.mapAttrs (_: v: v.npm or null) catalog);
+
+  supportReport = lib.mapAttrs (_: entry: entry.support) catalog // windowsOnlySupport;
+  darwinCasks = lib.mapAttrsToList (_: entry: entry.support.darwin.cask) (
+    lib.filterAttrs (_: entry: entry.support.darwin ? cask) catalog
+  );
+  linuxSystemModules = lib.mapAttrsToList (_: entry: entry.support.linux.systemModule) (
+    lib.filterAttrs (_: entry: entry.support.linux ? systemModule) catalog
+  );
+  providerErrors = lib.concatMap (
+    name:
+    lib.concatMap
+      (
+        platform:
+        let
+          hasPlatform = builtins.hasAttr platform supportReport.${name};
+          platformData = if hasPlatform then supportReport.${name}.${platform} else { };
+          resolved =
+            (platformData ? provider) || ((platformData ? unsupported) && platformData.unsupported != "");
+        in
+        lib.optional (!resolved) "${name}: missing ${platform} provider or reviewed unsupported reason"
+      )
+      [
+        "windows"
+        "darwin"
+        "linux"
+      ]
+  ) (lib.attrNames supportReport);
 
 in
 # Category-resolved package lists (auto-derived from catalog)
-lib.mapAttrs (_: names: resolve names) grouped
+lib.mapAttrs (_: resolve) grouped
 // {
   # All packages (flat list)
   all = resolve (lib.attrNames catalog);
 
   # Windows: nix attr name → winget PackageIdentifier
   inherit wingetMap npmMap;
+
+  inherit
+    supportReport
+    darwinCasks
+    linuxSystemModules
+    providerErrors
+    windowsOnlySupport
+    ;
 
   # Post-install verification commands for npm packages.
   # Keys match catalog attr names from npmMap.
@@ -811,25 +1088,13 @@ lib.mapAttrs (_: names: resolve names) grouped
   # Windows-only packages (no nix equivalent)
   windowsOnly = {
     winget = [
-      "AgileBits.1Password"
-      "Anthropic.Claude"
-      "TheBrowserCompany.Arc"
-      "Docker.DockerDesktop"
       "GitHub.Copilot"
-      "dprint.dprint"
-      "hadolint.hadolint"
-      "Google.Chrome"
       "Microsoft.PowerToys"
       "Microsoft.VCRedist.2015+.x64"
       "Microsoft.VisualStudio.2022.BuildTools"
-      "Microsoft.VisualStudioCode"
       "Microsoft.WindowsTerminal"
       "Microsoft.WSL"
-      "OpenAI.Codex"
       "StablyAI.Orca"
-      "TablePlus.TablePlus"
-      "Oven-sh.Bun"
-      "zig.zig"
     ];
     msstore = [
       "9NT1R1C2HH7J"

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -72,6 +72,11 @@ let
       winget = "jqlang.jq";
       category = "core";
     };
+    netcat = {
+      pkg = pkgs.netcat;
+      winget = null;
+      category = "core";
+    };
     eza = {
       pkg = pkgs.eza;
       winget = "eza-community.eza";
@@ -591,6 +596,7 @@ let
       "kubeseal"
       "kustomize"
       "marksman"
+      "netcat"
       "neovim-remote"
       "nixd"
       "p7zip"

--- a/nix/packages/support-report.nix
+++ b/nix/packages/support-report.nix
@@ -1,0 +1,16 @@
+{
+  pkgs,
+  lib,
+  gwqSrc ? null,
+}:
+let
+  sets = import ./sets.nix { inherit pkgs lib gwqSrc; };
+  reportFile = pkgs.writeText "package-support.json" (builtins.toJSON sets.supportReport);
+  errorsFile = pkgs.writeText "package-provider-errors.json" (builtins.toJSON sets.providerErrors);
+in
+pkgs.runCommand "package-support-report" { } ''
+  mkdir -p "$out"
+  ${pkgs.jq}/bin/jq . ${reportFile} > "$out/support.json"
+  ${pkgs.jq}/bin/jq . ${errorsFile} > "$out/errors.json"
+  test "$(${pkgs.jq}/bin/jq length "$out/errors.json")" -eq 0
+''

--- a/nix/packages/winget.nix
+++ b/nix/packages/winget.nix
@@ -146,9 +146,28 @@ let
       )
     );
 
+  # Catalog migrations change metadata lookup from PackageIdentifier to the
+  # catalog attr name. Apply the ID-keyed metadata as a fallback so generated
+  # Windows verification and installer behavior remain compatible.
+  attachWingetIdMetadata =
+    id: pkg:
+    attachSkipInstall sets.wingetSkipInstall id (
+      attachCiSkipInstall sets.wingetCiSkipInstall id (
+        attachPathEntries sets.wingetPathEntries id (
+          attachPortableLink sets.wingetPortableLinksById id (
+            attachDirectInstaller sets.wingetDirectInstallers id (
+              attachInstallTimeout sets.wingetInstallTimeoutSeconds id (
+                attachInstallArgs sets.wingetInstallArgs id (attachVerify sets.wingetVerifyById id pkg)
+              )
+            )
+          )
+        )
+      )
+    );
+
   # --- winget ---
   wingetFromMap = lib.mapAttrsToList (
-    name: id: attachWingetMetadata name { PackageIdentifier = id; }
+    name: id: attachWingetMetadata name (attachWingetIdMetadata id { PackageIdentifier = id; })
   ) sets.wingetMap;
 
   wingetFromWindowsOnly = map (

--- a/nix/system-manager/default.nix
+++ b/nix/system-manager/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  inputs,
+  ...
+}:
+let
+  user = builtins.getEnv "DOTFILES_USER";
+  home = builtins.getEnv "DOTFILES_HOME";
+  uidText = builtins.getEnv "DOTFILES_UID";
+  gidText = builtins.getEnv "DOTFILES_GID";
+  groupText = builtins.getEnv "DOTFILES_GROUP";
+  primaryGroup = if groupText == "" then user else groupText;
+  isNumericId = value: builtins.match "[0-9]+" value != null;
+  uid = if isNumericId uidText then lib.toInt uidText else 0;
+  gid = if isNumericId gidText then lib.toInt gidText else 0;
+in
+{
+  assertions = [
+    {
+      assertion = user != "";
+      message = "DOTFILES_USER is required";
+    }
+    {
+      assertion = home != "" && lib.hasPrefix "/" home;
+      message = "DOTFILES_HOME must be an absolute path";
+    }
+    {
+      assertion = isNumericId uidText;
+      message = "DOTFILES_UID must be a numeric existing-user UID";
+    }
+    {
+      assertion = isNumericId gidText;
+      message = "DOTFILES_GID must be a numeric existing-user GID";
+    }
+    {
+      assertion = primaryGroup != "";
+      message = "DOTFILES_GROUP or DOTFILES_USER is required";
+    }
+  ];
+
+  nix.enable = true;
+  services.userborn.enable = true;
+
+  # Merge with the host account database and pin the managed identity to the
+  # UID/GID discovered by the installer. This prevents account replacement.
+  users = {
+    mutableUsers = true;
+    groups.${primaryGroup}.gid = gid;
+    groups.docker = { };
+    users.${user} = {
+      isNormalUser = true;
+      inherit uid home;
+      group = primaryGroup;
+      extraGroups = [ "docker" ];
+    };
+  };
+
+  home-manager = {
+    useGlobalPkgs = true;
+    useUserPackages = true;
+    backupFileExtension = "hm-backup";
+    users.${user} = import ../home/common.nix;
+    extraSpecialArgs = { inherit inputs; };
+  };
+}

--- a/nix/system-manager/docker.nix
+++ b/nix/system-manager/docker.nix
@@ -1,0 +1,68 @@
+{ pkgs, ... }:
+{
+  environment.systemPackages = with pkgs; [
+    docker
+    docker-compose
+    docker-buildx
+  ];
+
+  environment.etc."docker/daemon.json".text = builtins.toJSON {
+    "log-driver" = "json-file";
+    "log-opts" = {
+      "max-size" = "10m";
+      "max-file" = "3";
+    };
+  };
+
+  systemd = {
+    services.docker = {
+      enable = true;
+      description = "Docker Application Container Engine";
+      documentation = [ "https://docs.docker.com" ];
+      after = [
+        "network-online.target"
+        "firewalld.service"
+        "containerd.service"
+      ];
+      wants = [ "network-online.target" ];
+      requires = [ "docker.socket" ];
+      wantedBy = [ "system-manager.target" ];
+
+      serviceConfig = {
+        Type = "notify";
+        ExecStart = "${pkgs.docker}/bin/dockerd --host=fd://";
+        ExecReload = "/bin/kill -s HUP $MAINPID";
+        TimeoutStartSec = 0;
+        RestartSec = 2;
+        Restart = "always";
+        StartLimitBurst = 3;
+        StartLimitInterval = "60s";
+        LimitNOFILE = 1048576;
+        LimitNPROC = "infinity";
+        LimitCORE = "infinity";
+        TasksMax = "infinity";
+        Delegate = "yes";
+        KillMode = "process";
+        OOMScoreAdjust = -500;
+      };
+    };
+
+    sockets.docker = {
+      enable = true;
+      description = "Docker Socket for the API";
+      wantedBy = [ "sockets.target" ];
+      socketConfig = {
+        ListenStream = "/var/run/docker.sock";
+        SocketMode = "0660";
+        SocketUser = "root";
+        SocketGroup = "docker";
+      };
+    };
+
+    tmpfiles.rules = [
+      "d /var/lib/docker 0710 root root -"
+      "d /var/run/docker 0755 root root -"
+      "d /etc/docker 0755 root root -"
+    ];
+  };
+}

--- a/nix/tests/bootstrap-nixos.nix
+++ b/nix/tests/bootstrap-nixos.nix
@@ -82,14 +82,14 @@ pkgs.testers.runNixOSTest {
       ];
     };
 
-  testScript = ''
+  testScript = { nodes, ... }: ''
     start_all()
     machine.wait_for_unit("multi-user.target")
     machine.wait_for_unit("docker.service")
     machine.succeed("docker load < ${helloWorldImage}")
     machine.succeed("docker load < ${acceptanceImage}")
 
-    install = "su - nixos -c 'env DOTFILES_NIXOS_PREBUILT_SYSTEM=/run/current-system DOTFILES_NIXOS_HARDWARE_CONFIG=/etc/nixos/hardware-configuration.nix DOTFILES_COMPOSE_FILE=${dotfilesSource}/.github/e2e/bootstrap-compose.yml DOTFILES_CHECKOUT_TARGET=${dotfilesSource} ${dotfilesSource}/install.sh'"
+    install = "su - nixos -c 'env DOTFILES_NIXOS_PREBUILT_SYSTEM=${nodes.machine.system.build.toplevel} DOTFILES_NIXOS_HARDWARE_CONFIG=/etc/nixos/hardware-configuration.nix DOTFILES_COMPOSE_FILE=${dotfilesSource}/.github/e2e/bootstrap-compose.yml DOTFILES_CHECKOUT_TARGET=${dotfilesSource} ${dotfilesSource}/install.sh'"
     machine.succeed(install)
     machine.succeed(install)
     machine.succeed("su - nixos -c 'export PATH=/run/current-system/sw/bin:/etc/profiles/per-user/nixos/bin:$HOME/.nix-profile/bin:$PATH; cd ${dotfilesSource}; sg docker -c \"DOTFILES_VERIFY_SYSTEM_LAYER=nixos DOTFILES_COMPOSE_FILE=${dotfilesSource}/.github/e2e/bootstrap-compose.yml ./scripts/sh/verify-environment.sh --runtime\"'")

--- a/nix/tests/bootstrap-nixos.nix
+++ b/nix/tests/bootstrap-nixos.nix
@@ -1,0 +1,87 @@
+{
+  inputs,
+  pkgs,
+}:
+let
+  inherit (pkgs) lib;
+  dotfilesSource = ../..;
+  inputSources = lib.filter (source: source != null) (
+    lib.mapAttrsToList (_: input: input.outPath or null) inputs
+  );
+  helloWorldImage = pkgs.dockerTools.buildImage {
+    name = "hello-world";
+    tag = "latest";
+    copyToRoot = pkgs.buildEnv {
+      name = "hello-world-root";
+      paths = [ pkgs.busybox ];
+      pathsToLink = [ "/bin" ];
+    };
+    config.Cmd = [
+      "/bin/sh"
+      "-c"
+      "echo Hello from Docker!"
+    ];
+  };
+  acceptanceImage = pkgs.dockerTools.buildImage {
+    name = "nginx";
+    tag = "1.29-alpine";
+    copyToRoot = pkgs.buildEnv {
+      name = "acceptance-root";
+      paths = [ pkgs.busybox ];
+      pathsToLink = [ "/bin" ];
+    };
+    config.Cmd = [
+      "/bin/httpd"
+      "-f"
+      "-p"
+      "80"
+    ];
+  };
+in
+pkgs.testers.runNixOSTest {
+  name = "bootstrap-nixos-vm";
+
+  nodes.machine =
+    { lib, ... }:
+    {
+      imports = [
+        inputs.home-manager.nixosModules.home-manager
+        ../hosts/linux/configuration.nix
+        ./hardware-configuration.nix
+      ];
+
+      home-manager = {
+        useGlobalPkgs = true;
+        useUserPackages = true;
+        users.nixos = {
+          home.stateVersion = "25.05";
+          programs.home-manager.enable = true;
+        };
+      };
+
+      virtualisation = {
+        diskSize = 8192;
+        memorySize = 4096;
+      };
+
+      nix.settings.experimental-features = [
+        "nix-command"
+        "flakes"
+      ];
+      system.extraDependencies = inputSources ++ [ dotfilesSource ];
+    };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_unit("docker.service")
+    machine.succeed("docker load < ${helloWorldImage}")
+    machine.succeed("docker load < ${acceptanceImage}")
+
+    install = "su - nixos -c 'env DOTFILES_NIXOS_HARDWARE_CONFIG=/etc/nixos/hardware-configuration.nix DOTFILES_COMPOSE_FILE=${dotfilesSource}/.github/e2e/bootstrap-compose.yml DOTFILES_CHECKOUT_TARGET=${dotfilesSource} ${dotfilesSource}/install.sh'"
+    machine.succeed(install)
+    machine.succeed(install)
+    machine.succeed("su - nixos -c 'export PATH=/run/current-system/sw/bin:/etc/profiles/per-user/nixos/bin:$HOME/.nix-profile/bin:$PATH; cd ${dotfilesSource}; sg docker -c \"DOTFILES_VERIFY_SYSTEM_LAYER=nixos DOTFILES_COMPOSE_FILE=${dotfilesSource}/.github/e2e/bootstrap-compose.yml ./scripts/sh/verify-environment.sh --runtime\"'")
+    machine.succeed("docker compose -f ${dotfilesSource}/.github/e2e/bootstrap-compose.yml ps --status running --services | grep acceptance")
+  '';
+}

--- a/nix/tests/bootstrap-nixos.nix
+++ b/nix/tests/bootstrap-nixos.nix
@@ -98,7 +98,7 @@ pkgs.testers.runNixOSTest {
     install = "su - nixos -c 'env DOTFILES_NIXOS_PREBUILT_SYSTEM=${nodes.machine.system.build.toplevel} DOTFILES_NIXOS_HARDWARE_CONFIG=/etc/nixos/hardware-configuration.nix DOTFILES_COMPOSE_FILE=/home/nixos/dotfiles/.github/e2e/bootstrap-compose.yml DOTFILES_CHECKOUT_TARGET=/home/nixos/dotfiles /home/nixos/dotfiles/install.sh'"
     machine.succeed(install)
     machine.succeed(install)
-    machine.succeed("su - nixos -c 'export PATH=/run/current-system/sw/bin:/etc/profiles/per-user/nixos/bin:$HOME/.nix-profile/bin:$PATH; cd /home/nixos/dotfiles; sg docker -c \"DOTFILES_VERIFY_SYSTEM_LAYER=nixos DOTFILES_COMPOSE_FILE=/home/nixos/dotfiles/.github/e2e/bootstrap-compose.yml ./scripts/sh/verify-environment.sh --runtime\"'")
+    machine.succeed("su - nixos -c 'export PATH=/run/current-system/sw/bin:/etc/profiles/per-user/nixos/bin:$HOME/.nix-profile/bin:$PATH; cd /home/nixos/dotfiles; DOTFILES_VERIFY_SYSTEM_LAYER=nixos DOTFILES_COMPOSE_FILE=/home/nixos/dotfiles/.github/e2e/bootstrap-compose.yml ./scripts/sh/verify-environment.sh --runtime'")
     machine.succeed("docker compose -f /home/nixos/dotfiles/.github/e2e/bootstrap-compose.yml ps --status running --services | grep acceptance")
   '';
 }

--- a/nix/tests/bootstrap-nixos.nix
+++ b/nix/tests/bootstrap-nixos.nix
@@ -80,6 +80,10 @@ pkgs.testers.runNixOSTest {
         "nix-command"
         "flakes"
       ];
+
+      # NixOS tests disable switch-to-configuration by default to reduce
+      # rebuilds. This E2E intentionally activates the generated closure.
+      system.switch.enable = true;
     };
 
   testScript = { nodes, ... }: ''

--- a/nix/tests/bootstrap-nixos.nix
+++ b/nix/tests/bootstrap-nixos.nix
@@ -92,11 +92,13 @@ pkgs.testers.runNixOSTest {
     machine.wait_for_unit("docker.service")
     machine.succeed("docker load < ${helloWorldImage}")
     machine.succeed("docker load < ${acceptanceImage}")
+    machine.succeed("cp -r ${dotfilesSource} /home/nixos/dotfiles")
+    machine.succeed("chmod -R u+w /home/nixos/dotfiles && chown -R nixos:users /home/nixos/dotfiles")
 
-    install = "su - nixos -c 'env DOTFILES_NIXOS_PREBUILT_SYSTEM=${nodes.machine.system.build.toplevel} DOTFILES_NIXOS_HARDWARE_CONFIG=/etc/nixos/hardware-configuration.nix DOTFILES_COMPOSE_FILE=${dotfilesSource}/.github/e2e/bootstrap-compose.yml DOTFILES_CHECKOUT_TARGET=${dotfilesSource} ${dotfilesSource}/install.sh'"
+    install = "su - nixos -c 'env DOTFILES_NIXOS_PREBUILT_SYSTEM=${nodes.machine.system.build.toplevel} DOTFILES_NIXOS_HARDWARE_CONFIG=/etc/nixos/hardware-configuration.nix DOTFILES_COMPOSE_FILE=/home/nixos/dotfiles/.github/e2e/bootstrap-compose.yml DOTFILES_CHECKOUT_TARGET=/home/nixos/dotfiles /home/nixos/dotfiles/install.sh'"
     machine.succeed(install)
     machine.succeed(install)
-    machine.succeed("su - nixos -c 'export PATH=/run/current-system/sw/bin:/etc/profiles/per-user/nixos/bin:$HOME/.nix-profile/bin:$PATH; cd ${dotfilesSource}; sg docker -c \"DOTFILES_VERIFY_SYSTEM_LAYER=nixos DOTFILES_COMPOSE_FILE=${dotfilesSource}/.github/e2e/bootstrap-compose.yml ./scripts/sh/verify-environment.sh --runtime\"'")
-    machine.succeed("docker compose -f ${dotfilesSource}/.github/e2e/bootstrap-compose.yml ps --status running --services | grep acceptance")
+    machine.succeed("su - nixos -c 'export PATH=/run/current-system/sw/bin:/etc/profiles/per-user/nixos/bin:$HOME/.nix-profile/bin:$PATH; cd /home/nixos/dotfiles; sg docker -c \"DOTFILES_VERIFY_SYSTEM_LAYER=nixos DOTFILES_COMPOSE_FILE=/home/nixos/dotfiles/.github/e2e/bootstrap-compose.yml ./scripts/sh/verify-environment.sh --runtime\"'")
+    machine.succeed("docker compose -f /home/nixos/dotfiles/.github/e2e/bootstrap-compose.yml ps --status running --services | grep acceptance")
   '';
 }

--- a/nix/tests/bootstrap-nixos.nix
+++ b/nix/tests/bootstrap-nixos.nix
@@ -3,11 +3,7 @@
   pkgs,
 }:
 let
-  inherit (pkgs) lib;
   dotfilesSource = ../..;
-  inputSources = lib.filter (source: source != null) (
-    lib.mapAttrsToList (_: input: input.outPath or null) inputs
-  );
   helloWorldImage = pkgs.dockerTools.buildImage {
     name = "hello-world";
     tag = "latest";
@@ -59,6 +55,22 @@ pkgs.testers.runNixOSTest {
         };
       };
 
+      environment.systemPackages = with pkgs; [
+        nix
+        git
+        gh
+        chezmoi
+        ripgrep
+        fd
+        jq
+        neovim
+        nodejs_24
+        python3
+        go
+        rustup
+        netcat
+      ];
+
       virtualisation = {
         diskSize = 8192;
         memorySize = 4096;
@@ -68,7 +80,6 @@ pkgs.testers.runNixOSTest {
         "nix-command"
         "flakes"
       ];
-      system.extraDependencies = inputSources ++ [ dotfilesSource ];
     };
 
   testScript = ''
@@ -78,7 +89,7 @@ pkgs.testers.runNixOSTest {
     machine.succeed("docker load < ${helloWorldImage}")
     machine.succeed("docker load < ${acceptanceImage}")
 
-    install = "su - nixos -c 'env DOTFILES_NIXOS_HARDWARE_CONFIG=/etc/nixos/hardware-configuration.nix DOTFILES_COMPOSE_FILE=${dotfilesSource}/.github/e2e/bootstrap-compose.yml DOTFILES_CHECKOUT_TARGET=${dotfilesSource} ${dotfilesSource}/install.sh'"
+    install = "su - nixos -c 'env DOTFILES_NIXOS_PREBUILT_SYSTEM=/run/current-system DOTFILES_NIXOS_HARDWARE_CONFIG=/etc/nixos/hardware-configuration.nix DOTFILES_COMPOSE_FILE=${dotfilesSource}/.github/e2e/bootstrap-compose.yml DOTFILES_CHECKOUT_TARGET=${dotfilesSource} ${dotfilesSource}/install.sh'"
     machine.succeed(install)
     machine.succeed(install)
     machine.succeed("su - nixos -c 'export PATH=/run/current-system/sw/bin:/etc/profiles/per-user/nixos/bin:$HOME/.nix-profile/bin:$PATH; cd ${dotfilesSource}; sg docker -c \"DOTFILES_VERIFY_SYSTEM_LAYER=nixos DOTFILES_COMPOSE_FILE=${dotfilesSource}/.github/e2e/bootstrap-compose.yml ./scripts/sh/verify-environment.sh --runtime\"'")

--- a/nix/tests/hardware-configuration.nix
+++ b/nix/tests/hardware-configuration.nix
@@ -1,0 +1,12 @@
+_: {
+  boot.loader.grub.enable = false;
+  fileSystems."/" = {
+    device = "/dev/vda1";
+    fsType = "ext4";
+  };
+
+  # This profile exists only for evaluation/build CI. Real machines always use
+  # their own /etc/nixos/hardware-configuration.nix through install.sh.
+  security.sudo.wheelNeedsPassword = false;
+  environment.etc."nixos/hardware-configuration.nix".source = ./hardware-configuration.nix;
+}

--- a/scripts/powershell/Test-Environment.ps1
+++ b/scripts/powershell/Test-Environment.ps1
@@ -1,0 +1,86 @@
+<#
+.SYNOPSIS
+    Verifies the Windows dotfiles environment after installation.
+
+.DESCRIPTION
+    Checks the commands managed by the Windows bootstrap and exercises Docker,
+    Docker Compose, chezmoi, and WSL. Use -Runtime to run a disposable
+    hello-world container as the final runtime acceptance check.
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$Runtime
+)
+
+. (Join-Path $PSScriptRoot "lib\Invoke-ExternalCommand.ps1")
+
+function Assert-DotfilesAcceptanceExitCode {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Label
+    )
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Label failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Test-DotfilesEnvironment {
+    [CmdletBinding()]
+    param(
+        [switch]$Runtime
+    )
+
+    $requiredCommands = @(
+        "winget",
+        "git",
+        "gh",
+        "chezmoi",
+        "rg",
+        "fd",
+        "jq",
+        "nvim",
+        "node",
+        "python",
+        "go",
+        "rustup",
+        "docker",
+        "wsl"
+    )
+
+    foreach ($name in $requiredCommands) {
+        if (-not (Get-Command -Name $name -ErrorAction SilentlyContinue)) {
+            throw "Missing command: $name"
+        }
+    }
+
+    Invoke-Docker -Arguments @("info") | Out-Null
+    Assert-DotfilesAcceptanceExitCode -Label "docker info"
+
+    Invoke-Docker -Arguments @("compose", "version") | Out-Null
+    Assert-DotfilesAcceptanceExitCode -Label "docker compose version"
+
+    Invoke-Chezmoi -Arguments @("apply", "--dry-run") | Out-Null
+    Assert-DotfilesAcceptanceExitCode -Label "chezmoi apply --dry-run"
+
+    Invoke-Wsl -Arguments @("--status") | Out-Null
+    Assert-DotfilesAcceptanceExitCode -Label "wsl --status"
+
+    if ($Runtime) {
+        Invoke-Docker -Arguments @("run", "--rm", "hello-world") | Out-Null
+        Assert-DotfilesAcceptanceExitCode -Label "docker run --rm hello-world"
+    }
+
+    return [pscustomobject]@{
+        HandlerName = "EnvironmentAcceptance"
+        Success     = $true
+        Message     = "Windows environment acceptance passed"
+        Error       = $null
+    }
+}
+
+if ($MyInvocation.InvocationName -ne ".") {
+    Test-DotfilesEnvironment -Runtime:$Runtime
+}

--- a/scripts/powershell/Test-Environment.ps1
+++ b/scripts/powershell/Test-Environment.ps1
@@ -43,7 +43,7 @@ function Test-DotfilesEnvironment {
         "jq",
         "nvim",
         "node",
-        "python",
+        "uv",
         "go",
         "rustup",
         "docker",

--- a/scripts/powershell/install.ps1
+++ b/scripts/powershell/install.ps1
@@ -38,6 +38,7 @@ $OutputEncoding = [System.Text.UTF8Encoding]::new()
 $libPath = Join-Path $PSScriptRoot "lib"
 . (Join-Path $libPath "WindowsEnvironment.ps1")
 Repair-WindowsSetupEnvironment
+. (Join-Path $PSScriptRoot "Test-Environment.ps1")
 
 if (-not $PSBoundParameters.ContainsKey("InstallDir")) {
     $InstallDir = Join-Path $env:USERPROFILE "NixOS"
@@ -225,6 +226,17 @@ if ($adminRequired) {
 else {
     Write-Host "No admin-required tasks detected. Running admin phase without elevation." -ForegroundColor Green
     & $adminScriptPath @phaseParams -AdminOnly:$true
+}
+
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "Environment Acceptance" -ForegroundColor Cyan
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host ""
+
+$acceptanceResult = Test-DotfilesEnvironment -Runtime
+if (-not $acceptanceResult.Success) {
+    throw $acceptanceResult.Message
 }
 
 Write-Host ""

--- a/scripts/powershell/tests/CiWorkflow.Tests.ps1
+++ b/scripts/powershell/tests/CiWorkflow.Tests.ps1
@@ -262,10 +262,12 @@ Describe 'CI workflow configuration' {
 
         $workflow | Should -Match 'name:\s+NixOS VM'
         $workflow | Should -Match 'bootstrap-nixos-vm'
-        $test | Should -Match 'dotfilesSource.*install\.sh'
+        $test | Should -Match 'dotfilesSource\s*=\s*\.\./\.\.'
         $test | Should -Match 'testScript\s*=\s*\{\s*nodes,\s*\.\.\.\s*\}:'
         $test | Should -Match 'DOTFILES_NIXOS_PREBUILT_SYSTEM=\$\{nodes\.machine\.system\.build\.toplevel\}'
         $test | Should -Match 'system\.switch\.enable\s*=\s*true'
+        $test | Should -Match 'cp -r \$\{dotfilesSource\} /home/nixos/dotfiles'
+        $test | Should -Match '/home/nixos/dotfiles/install\.sh'
         ([regex]::Matches($test, 'machine\.succeed\(install\)')).Count | Should -Be 2
         $test | Should -Match 'verify-environment\.sh --runtime'
         $test | Should -Match 'bootstrap-compose\.yml'

--- a/scripts/powershell/tests/CiWorkflow.Tests.ps1
+++ b/scripts/powershell/tests/CiWorkflow.Tests.ps1
@@ -268,6 +268,7 @@ Describe 'CI workflow configuration' {
         $test | Should -Match 'system\.switch\.enable\s*=\s*true'
         $test | Should -Match 'cp -r \$\{dotfilesSource\} /home/nixos/dotfiles'
         $test | Should -Match '/home/nixos/dotfiles/install\.sh'
+        $test | Should -Not -Match 'sg docker -c'
         ([regex]::Matches($test, 'machine\.succeed\(install\)')).Count | Should -Be 2
         $test | Should -Match 'verify-environment\.sh --runtime'
         $test | Should -Match 'bootstrap-compose\.yml'

--- a/scripts/powershell/tests/CiWorkflow.Tests.ps1
+++ b/scripts/powershell/tests/CiWorkflow.Tests.ps1
@@ -265,6 +265,7 @@ Describe 'CI workflow configuration' {
         $test | Should -Match 'dotfilesSource.*install\.sh'
         $test | Should -Match 'testScript\s*=\s*\{\s*nodes,\s*\.\.\.\s*\}:'
         $test | Should -Match 'DOTFILES_NIXOS_PREBUILT_SYSTEM=\$\{nodes\.machine\.system\.build\.toplevel\}'
+        $test | Should -Match 'system\.switch\.enable\s*=\s*true'
         ([regex]::Matches($test, 'machine\.succeed\(install\)')).Count | Should -Be 2
         $test | Should -Match 'verify-environment\.sh --runtime'
         $test | Should -Match 'bootstrap-compose\.yml'

--- a/scripts/powershell/tests/CiWorkflow.Tests.ps1
+++ b/scripts/powershell/tests/CiWorkflow.Tests.ps1
@@ -263,7 +263,8 @@ Describe 'CI workflow configuration' {
         $workflow | Should -Match 'name:\s+NixOS VM'
         $workflow | Should -Match 'bootstrap-nixos-vm'
         $test | Should -Match 'dotfilesSource.*install\.sh'
-        $test | Should -Match 'DOTFILES_NIXOS_PREBUILT_SYSTEM=/run/current-system'
+        $test | Should -Match 'testScript\s*=\s*\{\s*nodes,\s*\.\.\.\s*\}:'
+        $test | Should -Match 'DOTFILES_NIXOS_PREBUILT_SYSTEM=\$\{nodes\.machine\.system\.build\.toplevel\}'
         ([regex]::Matches($test, 'machine\.succeed\(install\)')).Count | Should -Be 2
         $test | Should -Match 'verify-environment\.sh --runtime'
         $test | Should -Match 'bootstrap-compose\.yml'

--- a/scripts/powershell/tests/CiWorkflow.Tests.ps1
+++ b/scripts/powershell/tests/CiWorkflow.Tests.ps1
@@ -214,4 +214,100 @@ Describe 'CI workflow configuration' {
         $devcontainerWorkflow | Should -Match 'nix profile install devcontainer failed after \$attempt attempts'
         $devcontainerWorkflow | Should -Match 'retrying in \$\{sleep_seconds\}s'
     }
+
+    It 'should build every declarative bootstrap output on hosted runners' {
+        $workflowPath = Join-Path $script:repoRoot ".github/workflows/ci-bootstrap-build.yml"
+        $workflowPath | Should -Exist
+        $workflow = Get-Content -LiteralPath $workflowPath -Raw
+
+        $workflow | Should -Match 'name:\s+Bootstrap Build'
+        $workflow | Should -Match 'timeout-minutes:'
+        $workflow | Should -Match 'actions/checkout@[0-9a-f]{40}'
+        $workflow | Should -Match 'cachix/install-nix-action@[0-9a-f]{40}'
+        $workflow | Should -Match 'darwinConfigurations\.macos\.system'
+        $workflow | Should -Match 'systemConfigs\.ubuntu'
+        $workflow | Should -Match 'systemConfigs\.debian'
+        $workflow | Should -Match 'nixosConfigurations\.linux\.config\.system\.build\.toplevel'
+        $workflow | Should -Match 'homeConfigurations\.x86_64-linux\.activationPackage'
+        $workflow | Should -Match 'package-support-report'
+    }
+
+    It 'should run Ubuntu and Debian destructive installers twice with runtime acceptance' {
+        $workflowPath = Join-Path $script:repoRoot ".github/workflows/ci-bootstrap-e2e-linux.yml"
+        $workflowPath | Should -Exist
+        $workflow = Get-Content -LiteralPath $workflowPath -Raw
+
+        $workflow | Should -Match 'name:\s+Ubuntu Destructive'
+        $workflow | Should -Match 'name:\s+Debian systemd Destructive'
+        $workflow | Should -Match 'timeout-minutes:'
+        $workflow | Should -Match 'systemd-nspawn'
+        $workflow | Should -Match 'dotfiles_run_in_group docker.*verify-environment\.sh --runtime'
+        $workflow | Should -Match 'systemd systemd-sysv dbus'
+        ([regex]::Matches($workflow, '(?m)^\s+- "flake\.nix"\s*$')).Count | Should -Be 2
+        ([regex]::Matches($workflow, '(?m)^\s+- "flake\.lock"\s*$')).Count | Should -Be 2
+        ([regex]::Matches($workflow, '(?m)^\s*(?:sudo\s+)?\./install\.sh\s*$')).Count | Should -BeGreaterOrEqual 2
+        ([regex]::Matches($workflow, 'scripts/sh/verify-environment\.sh --runtime')).Count | Should -BeGreaterOrEqual 2
+        $workflow | Should -Match 'actions/upload-artifact@[0-9a-f]{40}'
+        $workflow | Should -Match 'if:\s+always\(\)'
+    }
+
+    It 'should run idempotent NixOS activation and Docker acceptance in a VM' {
+        $workflowPath = Join-Path $script:repoRoot ".github/workflows/ci-bootstrap-e2e-linux.yml"
+        $testPath = Join-Path $script:repoRoot "nix/tests/bootstrap-nixos.nix"
+        $workflowPath | Should -Exist
+        $testPath | Should -Exist
+        $workflow = Get-Content -LiteralPath $workflowPath -Raw
+        $test = Get-Content -LiteralPath $testPath -Raw
+
+        $workflow | Should -Match 'name:\s+NixOS VM'
+        $workflow | Should -Match 'bootstrap-nixos-vm'
+        $test | Should -Match 'dotfilesSource.*install\.sh'
+        ([regex]::Matches($test, 'machine\.succeed\(install\)')).Count | Should -Be 2
+        $test | Should -Match 'verify-environment\.sh --runtime'
+        $test | Should -Match 'bootstrap-compose\.yml'
+        $test | Should -Match 'docker compose.*ps'
+    }
+
+    It 'should protect destructive Windows and macOS self-hosted jobs' {
+        $workflowPath = Join-Path $script:repoRoot ".github/workflows/ci-bootstrap-e2e-self-hosted.yml"
+        $workflowPath | Should -Exist
+        $workflow = Get-Content -LiteralPath $workflowPath -Raw
+
+        ([regex]::Matches($workflow, "github\.event\.pull_request\.head\.repo\.full_name == github\.repository")).Count | Should -Be 2
+        ([regex]::Matches($workflow, 'environment:\s+destructive-e2e')).Count | Should -Be 2
+        $workflow | Should -Match 'runs-on:\s+\[self-hosted, Windows, X64, dotfiles-e2e\]'
+        $workflow | Should -Match 'runs-on:\s+\[self-hosted, macOS, ARM64, dotfiles-e2e\]'
+        $workflow | Should -Match 'concurrency:'
+        $workflow | Should -Match '"flake\.nix"'
+        $workflow | Should -Match '"flake\.lock"'
+        ([regex]::Matches($workflow, 'timeout-minutes:')).Count | Should -BeGreaterOrEqual 2
+    }
+
+    It 'should run both real self-hosted installers twice and attest the PR head SHA' {
+        $workflowPath = Join-Path $script:repoRoot ".github/workflows/ci-bootstrap-e2e-self-hosted.yml"
+        $workflow = Get-Content -LiteralPath $workflowPath -Raw
+
+        ([regex]::Matches($workflow, '(?m)^\s*& \.\\install\.cmd -NoPause\s*$')).Count | Should -Be 2
+        $workflow | Should -Match 'Test-Environment\.ps1 -Runtime'
+        ([regex]::Matches($workflow, '(?m)^\s*\./install\.sh\s*$')).Count | Should -Be 2
+        $workflow | Should -Match 'verify-environment\.sh --runtime'
+        $workflow | Should -Match 'github\.event\.pull_request\.head\.sha'
+        ([regex]::Matches($workflow, 'actions/upload-artifact@[0-9a-f]{40}')).Count | Should -Be 2
+        ([regex]::Matches($workflow, 'if:\s+always\(\)')).Count | Should -BeGreaterOrEqual 2
+    }
+
+    It 'should document dedicated destructive runner security and cleanup' {
+        $docPath = Join-Path $script:repoRoot "docs/ci/self-hosted-bootstrap-runners.md"
+        $docPath | Should -Exist
+        $content = Get-Content -LiteralPath $docPath -Raw
+
+        $content | Should -Match 'dotfiles-e2e'
+        $content | Should -Match 'destructive-e2e'
+        $content | Should -Match 'dedicated account|専用アカウント'
+        $content | Should -Match 'personal secrets|個人.*secret'
+        $content | Should -Match 'sudo|elevation|昇格'
+        $content | Should -Match 'Docker.*license|Docker.*ライセンス'
+        $content | Should -Match 'reset|リセット'
+        $content | Should -Match 'remove|削除'
+    }
 }

--- a/scripts/powershell/tests/CiWorkflow.Tests.ps1
+++ b/scripts/powershell/tests/CiWorkflow.Tests.ps1
@@ -241,6 +241,7 @@ Describe 'CI workflow configuration' {
         $workflow | Should -Match 'name:\s+Debian systemd Destructive'
         $workflow | Should -Match 'timeout-minutes:'
         $workflow | Should -Match 'systemd-nspawn'
+        $workflow | Should -Match '(?s)for _ in \$\(seq 1 60\).*machinectl shell.*systemctl is-system-running'
         $workflow | Should -Match 'dotfiles_run_in_group docker.*verify-environment\.sh --runtime'
         $workflow | Should -Match 'systemd systemd-sysv dbus'
         ([regex]::Matches($workflow, '(?m)^\s+- "flake\.nix"\s*$')).Count | Should -Be 2
@@ -262,6 +263,7 @@ Describe 'CI workflow configuration' {
         $workflow | Should -Match 'name:\s+NixOS VM'
         $workflow | Should -Match 'bootstrap-nixos-vm'
         $test | Should -Match 'dotfilesSource.*install\.sh'
+        $test | Should -Match 'DOTFILES_NIXOS_PREBUILT_SYSTEM=/run/current-system'
         ([regex]::Matches($test, 'machine\.succeed\(install\)')).Count | Should -Be 2
         $test | Should -Match 'verify-environment\.sh --runtime'
         $test | Should -Match 'bootstrap-compose\.yml'

--- a/scripts/powershell/tests/Install.Entrypoint.Tests.ps1
+++ b/scripts/powershell/tests/Install.Entrypoint.Tests.ps1
@@ -240,8 +240,16 @@ if ($AdminOnly -eq $false) {
 Write-Host "STUB_ADMIN_PHASE_COMPLETE"
 exit 0
 '@
+        $stubAcceptance = @'
+function Test-DotfilesEnvironment {
+    param([switch]$Runtime)
+    Write-Host "STUB_ACCEPTANCE_COMPLETE"
+    return [pscustomobject]@{ Success = $true; Message = "OK" }
+}
+'@
         [System.IO.File]::WriteAllText((Join-Path $scriptDir "install.user.ps1"), $stubUser, [System.Text.UTF8Encoding]::new($false))
         [System.IO.File]::WriteAllText((Join-Path $scriptDir "install.admin.ps1"), $stubAdmin, [System.Text.UTF8Encoding]::new($false))
+        [System.IO.File]::WriteAllText((Join-Path $scriptDir "Test-Environment.ps1"), $stubAcceptance, [System.Text.UTF8Encoding]::new($false))
 
         $result = Invoke-TestCmdProcess `
             -WorkingDirectory $workDir `
@@ -251,6 +259,7 @@ exit 0
         $result.Stdout | Should -Match "STUB_USER_PHASE_COMPLETE"
         $result.Stdout | Should -Match "Phase 2a: Non-Admin Setup"
         $result.Stdout | Should -Match "STUB_PHASE2A_COMPLETE"
+        $result.Stdout | Should -Match "STUB_ACCEPTANCE_COMPLETE"
         $result.Stdout | Should -Match "Setup Complete!"
     }
 }

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -324,6 +324,15 @@ Describe 'Package catalog consistency' {
         }
     }
 
+    Context 'Linux readiness dependencies' {
+        It 'should manage the netcat provider used by Linux readiness checks' {
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+
+            $sets | Should -Match '(?s)netcat\s*=\s*\{.*?pkg\s*=\s*pkgs\.netcat;.*?winget\s*=\s*null;'
+            $sets | Should -Match '(?s)reviewedUnsupported\s*=\s*\{.*?windows\s*=\s*lib\.genAttrs\s*\[.*?"netcat"'
+        }
+    }
+
     Context 'Windows native Rust browser automation tools' {
         It 'should manage agent-browser as a Windows npm global package with verification' {
             $sets = Get-Content -LiteralPath $script:setsPath -Raw

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -86,12 +86,13 @@ Describe 'Package catalog consistency' {
             @($warp.directInstaller.installerArgs) | Should -Contain '/VERYSILENT'
         }
 
-        It 'should update flake inputs in the Nix rebuild aliases before applying the system' {
+        It 'should update WSL inputs and route native NixOS through the hardware-safe installer' {
             $wslUsers = Get-Content -LiteralPath (Join-Path $script:repoRoot "nix/home/wsl/users.nix") -Raw
             $linuxUsers = Get-Content -LiteralPath (Join-Path $script:repoRoot "nix/home/linux/users.nix") -Raw
 
             $wslUsers | Should -Match 'nrs\s*=\s*"nix flake update --flake ~/.dotfiles && sudo nixos-rebuild switch --flake ~/.dotfiles --impure'
-            $linuxUsers | Should -Match 'nrs\s*=\s*"nix flake update --flake ~/.dotfiles && sudo nixos-rebuild switch --flake ~/.dotfiles --impure'
+            $linuxUsers | Should -Match 'nrs\s*=\s*"~/.dotfiles/install\.sh"'
+            $linuxUsers | Should -Not -Match 'nrs\s*=.*nixos-rebuild'
         }
 
         It 'should update flake inputs before every scripted NixOS rebuild entry point' {
@@ -357,6 +358,48 @@ Describe 'Package catalog consistency' {
             @($package.installArgs) | Should -Contain '--override'
             @($package.installArgs) | Should -Contain '--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --passive --wait --norestart'
             $package.installTimeoutSeconds | Should -Be 1800
+        }
+    }
+
+    Context 'Cross-platform package providers' {
+        It 'should expose provider coverage outputs from the package SSOT' {
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+
+            $sets | Should -Match 'supportReport'
+            $sets | Should -Match 'providerErrors'
+            $sets | Should -Match 'darwinCasks'
+            $sets | Should -Match 'linuxSystemModules'
+        }
+
+        It 'should move cross-platform applications out of windowsOnly winget packages' {
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+            $windowsOnly = [regex]::Match($sets, '(?s)windowsOnly\s*=\s*\{.*?\n\s*\};').Value
+
+            @(
+                'Docker.DockerDesktop'
+                'dprint.dprint'
+                'hadolint.hadolint'
+                'Google.Chrome'
+                'Microsoft.VisualStudioCode'
+                'OpenAI.Codex'
+                'Oven-sh.Bun'
+                'zig.zig'
+            ) | ForEach-Object {
+                $windowsOnly | Should -Not -Match ([regex]::Escape('"' + $_ + '"'))
+            }
+        }
+
+        It 'should map Docker to Winget Homebrew cask and Linux system module providers' {
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+
+            $sets | Should -Match '(?s)docker-desktop\s*=\s*\{.*?winget\s*=\s*"Docker\.DockerDesktop".*?darwin\s*=\s*\{.*?cask\s*=\s*"docker-desktop".*?linux\s*=\s*\{.*?systemModule\s*=\s*"docker"'
+        }
+
+        It 'should keep true Windows-only components with explicit unsupported reasons' {
+            $sets = Get-Content -LiteralPath $script:setsPath -Raw
+
+            $sets | Should -Match '(?s)mkWindowsOnlySupport\s*=\s*provider:\s*reason:\s*\{.*?darwin\s*=\s*\{\s*unsupported\s*=\s*reason;\s*\};.*?linux\s*=\s*\{\s*unsupported\s*=\s*reason;\s*\};'
+            $sets | Should -Match '"Microsoft\.PowerToys"\s*=\s*mkWindowsOnlySupport\s*"winget"\s*"Windows system utility";'
         }
     }
 }

--- a/scripts/powershell/tests/Test-Environment.Tests.ps1
+++ b/scripts/powershell/tests/Test-Environment.Tests.ps1
@@ -12,8 +12,10 @@ Describe 'Test-DotfilesEnvironment' {
         $script:dockerCalls = @()
         $script:chezmoiCalls = @()
         $script:wslCalls = @()
+        $script:commandLookups = @()
 
         Mock Get-Command {
+            $script:commandLookups += $Name
             return [pscustomobject]@{ Name = $Name; Source = "C:\tools\$Name.exe" }
         }
         Mock Invoke-Docker {
@@ -39,6 +41,13 @@ Describe 'Test-DotfilesEnvironment' {
         ($script:dockerCalls | ForEach-Object { $_ -join ' ' }) | Should -Contain 'run --rm hello-world'
         ($script:chezmoiCalls | ForEach-Object { $_ -join ' ' }) | Should -Contain 'apply --dry-run'
         ($script:wslCalls | ForEach-Object { $_ -join ' ' }) | Should -Contain '--status'
+    }
+
+    It 'should verify managed uv instead of an unmanaged Python command' {
+        Test-DotfilesEnvironment
+
+        $script:commandLookups | Should -Contain 'uv'
+        $script:commandLookups | Should -Not -Contain 'python'
     }
 
     It 'should fail when a required command is missing' {

--- a/scripts/powershell/tests/Test-Environment.Tests.ps1
+++ b/scripts/powershell/tests/Test-Environment.Tests.ps1
@@ -1,0 +1,69 @@
+#Requires -Module Pester
+
+BeforeAll {
+    $script:target = Join-Path (Split-Path -Parent $PSScriptRoot) "Test-Environment.ps1"
+    $script:installTarget = Join-Path (Split-Path -Parent $PSScriptRoot) "install.ps1"
+    . $PSScriptRoot/../lib/Invoke-ExternalCommand.ps1
+    . $script:target
+}
+
+Describe 'Test-DotfilesEnvironment' {
+    BeforeEach {
+        $script:dockerCalls = @()
+        $script:chezmoiCalls = @()
+        $script:wslCalls = @()
+
+        Mock Get-Command {
+            return [pscustomobject]@{ Name = $Name; Source = "C:\tools\$Name.exe" }
+        }
+        Mock Invoke-Docker {
+            $script:dockerCalls += , @($Arguments)
+            $global:LASTEXITCODE = 0
+        }
+        Mock Invoke-Chezmoi {
+            $script:chezmoiCalls += , @($Arguments)
+            $global:LASTEXITCODE = 0
+        }
+        Mock Invoke-Wsl {
+            $script:wslCalls += , @($Arguments)
+            $global:LASTEXITCODE = 0
+        }
+    }
+
+    It 'should run Docker chezmoi and WSL acceptance checks' {
+        $result = Test-DotfilesEnvironment -Runtime
+
+        $result.Success | Should -BeTrue
+        ($script:dockerCalls | ForEach-Object { $_ -join ' ' }) | Should -Contain 'info'
+        ($script:dockerCalls | ForEach-Object { $_ -join ' ' }) | Should -Contain 'compose version'
+        ($script:dockerCalls | ForEach-Object { $_ -join ' ' }) | Should -Contain 'run --rm hello-world'
+        ($script:chezmoiCalls | ForEach-Object { $_ -join ' ' }) | Should -Contain 'apply --dry-run'
+        ($script:wslCalls | ForEach-Object { $_ -join ' ' }) | Should -Contain '--status'
+    }
+
+    It 'should fail when a required command is missing' {
+        Mock Get-Command {
+            if ($Name -eq 'nvim') { return $null }
+            return [pscustomobject]@{ Name = $Name; Source = "C:\tools\$Name.exe" }
+        }
+
+        { Test-DotfilesEnvironment } | Should -Throw '*Missing command: nvim*'
+    }
+
+    It 'should fail when an acceptance command exits nonzero' {
+        Mock Invoke-Docker {
+            $global:LASTEXITCODE = if ($Arguments -contains 'info') { 1 } else { 0 }
+        }
+
+        { Test-DotfilesEnvironment } | Should -Throw '*docker info failed*'
+    }
+
+    It 'should run acceptance before printing final completion' {
+        $content = Get-Content -LiteralPath $script:installTarget -Raw
+        $acceptanceIndex = $content.IndexOf('Test-DotfilesEnvironment -Runtime')
+        $completionIndex = $content.IndexOf('Setup Complete!')
+
+        $acceptanceIndex | Should -BeGreaterThan -1
+        $completionIndex | Should -BeGreaterThan $acceptanceIndex
+    }
+}

--- a/scripts/sh/install-common.sh
+++ b/scripts/sh/install-common.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+DOTFILES_LOG_PREFIX="${DOTFILES_LOG_PREFIX:-dotfiles-install}"
+DOTFILES_NIX_PROFILE_SCRIPT="${DOTFILES_NIX_PROFILE_SCRIPT:-/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh}"
+DOTFILES_WAIT_SLEEP_SECONDS="${DOTFILES_WAIT_SLEEP_SECONDS:-2}"
+
+dotfiles_log() {
+  printf '\033[1;34m[%s]\033[0m %s\n' "$DOTFILES_LOG_PREFIX" "$*"
+}
+
+dotfiles_die() {
+  printf '\033[1;31m[%s]\033[0m %s\n' "$DOTFILES_LOG_PREFIX" "$*" >&2
+  exit 1
+}
+
+dotfiles_have() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+dotfiles_wait_for() {
+  local attempts="$1"
+  local label="$2"
+  shift 2
+
+  local attempt
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if "$@" >/dev/null 2>&1; then
+      return 0
+    fi
+    if ((attempt < attempts)); then
+      sleep "$DOTFILES_WAIT_SLEEP_SECONDS"
+    fi
+  done
+
+  dotfiles_die "Timed out waiting for $label after $attempts attempts."
+}
+
+dotfiles_load_nix() {
+  if [[ -r $DOTFILES_NIX_PROFILE_SCRIPT ]]; then
+    # shellcheck source=/dev/null
+    . "$DOTFILES_NIX_PROFILE_SCRIPT"
+  fi
+}
+
+dotfiles_canonical_directory() {
+  (
+    cd "$1" || exit 1
+    pwd -P
+  )
+}
+
+dotfiles_link_checkout() {
+  local root="$1"
+  local target="${DOTFILES_CHECKOUT_TARGET:-$HOME/.dotfiles}"
+
+  if [[ -d $target ]] &&
+    [[ "$(dotfiles_canonical_directory "$target")" == "$(dotfiles_canonical_directory "$root")" ]]; then
+    return
+  fi
+
+  if [[ -e $target || -L $target ]]; then
+    local backup
+    backup="$target.backup.$(date +%Y%m%d%H%M%S)"
+    mv "$target" "$backup"
+    dotfiles_log "Moved existing $target to $backup"
+  fi
+
+  ln -s "$root" "$target"
+}
+
+dotfiles_run_in_group() {
+  local group="$1"
+  shift
+
+  if [[ " $(id -Gn) " == *" $group "* ]]; then
+    "$@"
+    return
+  fi
+
+  local user="${DOTFILES_USER:-${USER:-}}"
+  [[ -n $user ]] || dotfiles_die "Unable to determine the user for group $group."
+  [[ " $(id -Gn "$user") " == *" $group "* ]] ||
+    dotfiles_die "User $user is not a member of group $group after activation."
+  dotfiles_have sg || dotfiles_die "sg is required to enter the newly activated $group group."
+
+  local command_string
+  printf -v command_string '%q ' "$@"
+  sg "$group" -c "$command_string"
+}

--- a/scripts/sh/install-home-manager.sh
+++ b/scripts/sh/install-home-manager.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+export DOTFILES_LOG_PREFIX="home-manager-install"
+# shellcheck source=/dev/null
+. "$ROOT/scripts/sh/install-common.sh"
+
+ensure_opt_in() {
+  [[ ${DOTFILES_ALLOW_USER_ONLY:-0} == "1" ]] ||
+    dotfiles_die "Set DOTFILES_ALLOW_USER_ONLY=1 to accept setup without Docker/systemd management."
+}
+
+ensure_nix() {
+  dotfiles_load_nix
+  if ! dotfiles_have nix; then
+    dotfiles_log "Installing Nix in single-user mode..."
+    curl -fsSL https://nixos.org/nix/install | sh -s -- --no-daemon
+    dotfiles_load_nix
+    if [[ -r $HOME/.nix-profile/etc/profile.d/nix.sh ]]; then
+      # shellcheck source=/dev/null
+      . "$HOME/.nix-profile/etc/profile.d/nix.sh"
+    fi
+  fi
+
+  dotfiles_have nix || dotfiles_die "Nix installation completed but nix is unavailable."
+  mkdir -p "$HOME/.config/nix"
+  local feature_line="extra-experimental-features = nix-command flakes"
+  touch "$HOME/.config/nix/nix.conf"
+  grep -Fxq "$feature_line" "$HOME/.config/nix/nix.conf" ||
+    printf '%s\n' "$feature_line" >>"$HOME/.config/nix/nix.conf"
+}
+
+capture_user_identity() {
+  export DOTFILES_USER="${SUDO_USER:-${USER:-}}"
+  export DOTFILES_HOME="$HOME"
+  [[ -n $DOTFILES_USER && $DOTFILES_HOME == /* ]] ||
+    dotfiles_die "A current user and absolute home directory are required."
+
+  export DOTFILES_SYSTEM
+  DOTFILES_SYSTEM="$(nix eval --impure --raw --expr builtins.currentSystem)"
+  case "$DOTFILES_SYSTEM" in
+  x86_64-linux | aarch64-linux) ;;
+  *) dotfiles_die "Unsupported Linux Nix system: $DOTFILES_SYSTEM" ;;
+  esac
+}
+
+activate_home_manager() {
+  local activation
+  activation="$({
+    cd "$ROOT"
+    nix build --impure --no-link --print-out-paths \
+      ".#homeConfigurations.\"$DOTFILES_SYSTEM\".activationPackage"
+  })"
+  [[ -n $activation && $activation != *$'\n'* && -x $activation/activate ]] ||
+    dotfiles_die "Home Manager activation package was not produced."
+  "$activation/activate"
+  export PATH="$HOME/.nix-profile/bin:$HOME/.local/state/nix/profile/bin:$PATH"
+  hash -r
+}
+
+apply_chezmoi() {
+  dotfiles_have chezmoi || dotfiles_die "chezmoi is unavailable after Home Manager activation."
+  chezmoi init --source "$ROOT/chezmoi"
+  chezmoi apply --force
+}
+
+main() {
+  ensure_opt_in
+  [[ $(uname -s) == "Linux" ]] || dotfiles_die "Linux is required."
+  ensure_nix
+  dotfiles_link_checkout "$ROOT"
+  capture_user_identity
+  activate_home_manager
+  apply_chezmoi
+  printf 'User-only setup complete; Docker/systemd were not configured.\n'
+}
+
+main "$@"

--- a/scripts/sh/install-linux.sh
+++ b/scripts/sh/install-linux.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+export DOTFILES_LOG_PREFIX="linux-install"
+# shellcheck source=/dev/null
+. "$ROOT/scripts/sh/install-common.sh"
+
+COMPOSE_FILE="${DOTFILES_COMPOSE_FILE:-$ROOT/docker/hermes-agent/compose.yml}"
+OS_RELEASE_FILE="${DOTFILES_OS_RELEASE_FILE:-/etc/os-release}"
+SYSTEMD_DIR="${DOTFILES_SYSTEMD_DIR:-/run/systemd/system}"
+SERVICE_WAIT_ATTEMPTS="${DOTFILES_SERVICE_WAIT_ATTEMPTS:-60}"
+VERIFY_ENVIRONMENT="${DOTFILES_VERIFY_ENVIRONMENT:-$ROOT/scripts/sh/verify-environment.sh}"
+LINUX_CONFIG=""
+
+preflight() {
+  [[ $(uname -s) == "Linux" ]] || dotfiles_die "Linux is required."
+  [[ -r $OS_RELEASE_FILE ]] || dotfiles_die "Linux release metadata is missing: $OS_RELEASE_FILE"
+
+  # shellcheck source=/dev/null
+  . "$OS_RELEASE_FILE"
+  case "${ID:-}" in
+  ubuntu | debian) LINUX_CONFIG="$ID" ;;
+  *) dotfiles_die "Full Linux setup supports Ubuntu and Debian only (detected ${ID:-unknown})." ;;
+  esac
+
+  local required
+  for required in \
+    "$ROOT/flake.nix" \
+    "$ROOT/chezmoi" \
+    "$COMPOSE_FILE" \
+    "$VERIFY_ENVIRONMENT"; do
+    [[ -e $required ]] || dotfiles_die "Required repository path is missing: $required"
+  done
+}
+
+ensure_systemd() {
+  [[ -d $SYSTEMD_DIR ]] || dotfiles_die "A running systemd system instance is required."
+  dotfiles_have systemctl || dotfiles_die "systemctl is required."
+
+  local state
+  state="$(systemctl is-system-running 2>/dev/null || true)"
+  case "$state" in
+  running | degraded) ;;
+  *) dotfiles_die "systemd is not ready (state: ${state:-unknown})." ;;
+  esac
+}
+
+ensure_nix() {
+  dotfiles_load_nix
+  if ! dotfiles_have nix; then
+    dotfiles_log "Installing Nix in multi-user daemon mode..."
+    curl -fsSL https://nixos.org/nix/install | sh -s -- --daemon
+    dotfiles_load_nix
+  fi
+
+  dotfiles_have nix || dotfiles_die "Nix installation completed but nix is unavailable."
+  mkdir -p "$HOME/.config/nix"
+  local feature_line="extra-experimental-features = nix-command flakes"
+  touch "$HOME/.config/nix/nix.conf"
+  grep -Fxq "$feature_line" "$HOME/.config/nix/nix.conf" ||
+    printf '%s\n' "$feature_line" >>"$HOME/.config/nix/nix.conf"
+}
+
+capture_host_identity() {
+  export DOTFILES_USER="${SUDO_USER:-${USER:-}}"
+  export DOTFILES_HOME="$HOME"
+  [[ -n $DOTFILES_USER && $DOTFILES_HOME == /* ]] ||
+    dotfiles_die "A current user and absolute home directory are required."
+
+  DOTFILES_UID="$(id -u "$DOTFILES_USER")"
+  DOTFILES_GID="$(id -g "$DOTFILES_USER")"
+  DOTFILES_GROUP="$(id -gn "$DOTFILES_USER")"
+  export DOTFILES_UID DOTFILES_GID DOTFILES_GROUP
+  [[ $DOTFILES_UID =~ ^[0-9]+$ && $DOTFILES_GID =~ ^[0-9]+$ && -n $DOTFILES_GROUP ]] ||
+    dotfiles_die "The existing user must have numeric UID/GID values."
+
+  export DOTFILES_SYSTEM
+  DOTFILES_SYSTEM="$(nix eval --impure --raw --expr builtins.currentSystem)"
+  case "$DOTFILES_SYSTEM" in
+  x86_64-linux | aarch64-linux) ;;
+  *) dotfiles_die "Unsupported Linux Nix system: $DOTFILES_SYSTEM" ;;
+  esac
+}
+
+apply_linux_system() {
+  dotfiles_log "Applying System Manager and Home Manager for $LINUX_CONFIG..."
+  (
+    cd "$ROOT"
+    nix run .#system-manager -- \
+      --nix-option pure-eval false \
+      switch --flake ".#$LINUX_CONFIG" --sudo
+  )
+
+  export PATH="/run/system-manager/sw/bin:/etc/profiles/per-user/$DOTFILES_USER/bin:$HOME/.nix-profile/bin:$HOME/.local/state/nix/profile/bin:$PATH"
+  hash -r
+}
+
+apply_chezmoi() {
+  dotfiles_have chezmoi || dotfiles_die "chezmoi is unavailable after System Manager activation."
+  chezmoi init --source "$ROOT/chezmoi"
+  chezmoi apply --force
+}
+
+docker_command() {
+  dotfiles_run_in_group docker docker "$@"
+}
+
+show_compose_diagnostics() {
+  docker_command compose -f "$COMPOSE_FILE" ps || true
+  docker_command compose -f "$COMPOSE_FILE" logs --tail=100 || true
+}
+
+start_hermes_stack() {
+  dotfiles_log "Validating Hermes Docker Compose configuration..."
+  docker_command compose -f "$COMPOSE_FILE" config
+  dotfiles_log "Building Hermes images..."
+  docker_command compose -f "$COMPOSE_FILE" build --pull
+  dotfiles_log "Starting Hermes services..."
+  if ! docker_command compose -f "$COMPOSE_FILE" up -d --force-recreate --wait; then
+    show_compose_diagnostics
+    dotfiles_die "Hermes Docker Compose startup failed."
+  fi
+  docker_command compose -f "$COMPOSE_FILE" ps
+  dotfiles_wait_for "$SERVICE_WAIT_ATTEMPTS" "Hermes API port" \
+    nc -z 127.0.0.1 "${HERMES_API_PORT:-8642}"
+  dotfiles_wait_for "$SERVICE_WAIT_ATTEMPTS" "Hermes dashboard port" \
+    nc -z 127.0.0.1 "${HERMES_DASHBOARD_PORT:-9119}"
+  dotfiles_wait_for "$SERVICE_WAIT_ATTEMPTS" "Hermes browser viewer port" \
+    nc -z 127.0.0.1 "${HERMES_BROWSER_VIEW_PORT:-6080}"
+}
+
+main() {
+  preflight
+  ensure_systemd
+  ensure_nix
+  dotfiles_link_checkout "$ROOT"
+  capture_host_identity
+  apply_linux_system
+  apply_chezmoi
+  start_hermes_stack
+  dotfiles_run_in_group docker "$VERIFY_ENVIRONMENT" --runtime
+  dotfiles_log "Linux setup complete."
+}
+
+main "$@"

--- a/scripts/sh/install-linux.sh
+++ b/scripts/sh/install-linux.sh
@@ -44,6 +44,11 @@ ensure_systemd() {
     state="$(systemctl is-system-running 2>/dev/null || true)"
     case "$state" in
     running | degraded) return ;;
+    starting)
+      # Hosted runners can remain globally "starting" while the manager is
+      # already available for the System Manager activation below.
+      [[ -n $(systemctl show --property=Version --value 2>/dev/null || true) ]] && return
+      ;;
     esac
     if ((attempt < SYSTEMD_WAIT_ATTEMPTS)); then
       sleep "$DOTFILES_WAIT_SLEEP_SECONDS"

--- a/scripts/sh/install-linux.sh
+++ b/scripts/sh/install-linux.sh
@@ -10,6 +10,7 @@ COMPOSE_FILE="${DOTFILES_COMPOSE_FILE:-$ROOT/docker/hermes-agent/compose.yml}"
 OS_RELEASE_FILE="${DOTFILES_OS_RELEASE_FILE:-/etc/os-release}"
 SYSTEMD_DIR="${DOTFILES_SYSTEMD_DIR:-/run/systemd/system}"
 SERVICE_WAIT_ATTEMPTS="${DOTFILES_SERVICE_WAIT_ATTEMPTS:-60}"
+SYSTEMD_WAIT_ATTEMPTS="${DOTFILES_SYSTEMD_WAIT_ATTEMPTS:-30}"
 VERIFY_ENVIRONMENT="${DOTFILES_VERIFY_ENVIRONMENT:-$ROOT/scripts/sh/verify-environment.sh}"
 LINUX_CONFIG=""
 
@@ -38,12 +39,18 @@ ensure_systemd() {
   [[ -d $SYSTEMD_DIR ]] || dotfiles_die "A running systemd system instance is required."
   dotfiles_have systemctl || dotfiles_die "systemctl is required."
 
-  local state
-  state="$(systemctl is-system-running 2>/dev/null || true)"
-  case "$state" in
-  running | degraded) ;;
-  *) dotfiles_die "systemd is not ready (state: ${state:-unknown})." ;;
-  esac
+  local attempt state=""
+  for ((attempt = 1; attempt <= SYSTEMD_WAIT_ATTEMPTS; attempt++)); do
+    state="$(systemctl is-system-running 2>/dev/null || true)"
+    case "$state" in
+    running | degraded) return ;;
+    esac
+    if ((attempt < SYSTEMD_WAIT_ATTEMPTS)); then
+      sleep "$DOTFILES_WAIT_SLEEP_SECONDS"
+    fi
+  done
+
+  dotfiles_die "systemd is not ready after $SYSTEMD_WAIT_ATTEMPTS attempts (state: ${state:-unknown})."
 }
 
 ensure_nix() {

--- a/scripts/sh/install-macos.sh
+++ b/scripts/sh/install-macos.sh
@@ -2,181 +2,56 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+export DOTFILES_LOG_PREFIX="macos-install"
+# shellcheck source=/dev/null
+. "$ROOT/scripts/sh/install-common.sh"
+
 COMPOSE_FILE="$ROOT/docker/hermes-agent/compose.yml"
-BREW_BIN="${DOTFILES_BREW_BIN:-/opt/homebrew/bin/brew}"
 DOCKER_APP="${DOTFILES_DOCKER_APP_PATH:-/Applications/Docker.app}"
 DOCKER_SETUP_MARKER="${DOTFILES_DOCKER_SETUP_MARKER:-$HOME/.config/dotfiles/docker-desktop-installed}"
-DOCKER_FALLBACK_URL="${DOTFILES_DOCKER_FALLBACK_URL:-https://desktop.docker.com/mac/main/arm64/233772/Docker.dmg}"
-DOCKER_FALLBACK_SHA256="${DOTFILES_DOCKER_FALLBACK_SHA256:-a35a0b14fbf182fb2ef9f8e650ace9a8ebcc81ad4872d51bccc4496f5cdb0158}"
-NIX_PROFILE_SCRIPT="${DOTFILES_NIX_PROFILE_SCRIPT:-/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh}"
 DOCKER_WAIT_ATTEMPTS="${DOTFILES_DOCKER_WAIT_ATTEMPTS:-120}"
 SERVICE_WAIT_ATTEMPTS="${DOTFILES_SERVICE_WAIT_ATTEMPTS:-60}"
-NIX_BUILD_ATTEMPTS="${DOTFILES_NIX_BUILD_ATTEMPTS:-3}"
-WAIT_SLEEP_SECONDS="${DOTFILES_WAIT_SLEEP_SECONDS:-2}"
-
-log() {
-  printf '\033[1;34m[macos-install]\033[0m %s\n' "$*"
-}
-
-die() {
-  printf '\033[1;31m[macos-install]\033[0m %s\n' "$*" >&2
-  exit 1
-}
-
-have() {
-  command -v "$1" >/dev/null 2>&1
-}
-
-wait_for() {
-  local attempts="$1"
-  local label="$2"
-  shift 2
-  local attempt
-  for ((attempt = 1; attempt <= attempts; attempt++)); do
-    if "$@" >/dev/null 2>&1; then
-      return 0
-    fi
-    if ((attempt < attempts)); then
-      sleep "$WAIT_SLEEP_SECONDS"
-    fi
-  done
-  die "Timed out waiting for $label after $attempts attempts."
-}
+VERIFY_ENVIRONMENT="${DOTFILES_VERIFY_ENVIRONMENT:-$ROOT/scripts/sh/verify-environment.sh}"
 
 preflight() {
   local os arch version major required
   os="$(uname -s)"
   arch="$(uname -m)"
-  [[ $os == "Darwin" ]] || die "macOS is required (detected $os)."
-  [[ $arch == "arm64" ]] || die "Apple Silicon is required (detected $arch)."
+  [[ $os == "Darwin" ]] || dotfiles_die "macOS is required (detected $os)."
+  [[ $arch == "arm64" ]] || dotfiles_die "Apple Silicon is required (detected $arch)."
 
   version="$(sw_vers -productVersion)"
   major="${version%%.*}"
-  [[ $major =~ ^[0-9]+$ ]] || die "Unable to parse macOS version: $version"
-  ((major >= 26)) || die "macOS 26 or later is required (detected $version)."
-
-  if ! xcode-select -p >/dev/null 2>&1; then
-    xcode-select --install || true
-    die "Command Line Tools installation was requested. Complete it, then rerun ./install.sh."
-  fi
+  [[ $major =~ ^[0-9]+$ ]] || dotfiles_die "Unable to parse macOS version: $version"
+  ((major >= 26)) || dotfiles_die "macOS 26 or later is required (detected $version)."
 
   for required in \
     "$ROOT/flake.nix" \
     "$ROOT/chezmoi" \
-    "$COMPOSE_FILE"; do
-    [[ -e $required ]] || die "Required repository path is missing: $required"
+    "$COMPOSE_FILE" \
+    "$VERIFY_ENVIRONMENT"; do
+    [[ -e $required ]] || dotfiles_die "Required repository path is missing: $required"
   done
 }
 
-ensure_homebrew() {
-  if ! have brew; then
-    log "Installing Homebrew..."
-    NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+ensure_command_line_tools() {
+  if xcode-select -p >/dev/null 2>&1; then
+    return
   fi
 
-  if have brew; then
-    eval "$(brew shellenv)"
-  elif [[ -x $BREW_BIN ]]; then
-    eval "$("$BREW_BIN" shellenv)"
-  else
-    die "Homebrew installation completed but brew is unavailable."
-  fi
-}
-
-ensure_rosetta() {
-  if ! pkgutil --pkg-info com.apple.pkg.RosettaUpdateAuto >/dev/null 2>&1; then
-    log "Installing Rosetta 2 for linux/amd64 containers..."
-    softwareupdate --install-rosetta --agree-to-license
-  fi
-}
-
-install_docker_desktop_fallback() {
-  log "Homebrew could not unpack Docker Desktop; using the verified official DMG fallback..."
-  if ! have 7zz; then
-    brew install sevenzip
-  fi
-  have 7zz || die "7-Zip is required for the Docker Desktop fallback."
-
-  local temp_dir dmg_path extract_dir actual_sha source_app
-  temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-docker.XXXXXX")"
-  dmg_path="$temp_dir/Docker.dmg"
-  extract_dir="$temp_dir/extracted"
-
-  curl -fL "$DOCKER_FALLBACK_URL" -o "$dmg_path" || {
-    rm -rf "$temp_dir"
-    die "Docker Desktop fallback download failed."
-  }
-  actual_sha="$(shasum -a 256 "$dmg_path" | awk '{print $1}')"
-  if [[ $actual_sha != "$DOCKER_FALLBACK_SHA256" ]]; then
-    rm -rf "$temp_dir"
-    die "Docker Desktop fallback checksum mismatch."
-  fi
-
-  mkdir -p "$extract_dir"
-  7zz x -snld20 "-o$extract_dir" "$dmg_path" >/dev/null || {
-    rm -rf "$temp_dir"
-    die "Docker Desktop fallback DMG extraction failed."
-  }
-  source_app="$extract_dir/Docker/Docker.app"
-  if [[ ! -d $source_app ]]; then
-    rm -rf "$temp_dir"
-    die "Docker.app was not found in the verified fallback DMG."
-  fi
-
-  ditto "$source_app" "$DOCKER_APP" || {
-    rm -rf "$temp_dir"
-    die "Copying Docker.app to Applications failed."
-  }
-  codesign --verify --deep --strict "$DOCKER_APP" || {
-    rm -rf "$temp_dir"
-    die "Docker.app signature verification failed."
-  }
-  rm -rf "$temp_dir"
-}
-
-ensure_docker_desktop() {
-  if [[ ! -d $DOCKER_APP ]]; then
-    log "Installing Docker Desktop..."
-    if ! brew install --cask docker-desktop; then
-      install_docker_desktop_fallback
-    fi
-  fi
-
-  local installer="$DOCKER_APP/Contents/MacOS/install"
-  [[ -x $installer ]] || die "Docker Desktop installer not found: $installer"
-
-  if [[ ! -f $DOCKER_SETUP_MARKER ]]; then
-    log "Accepting the Docker Desktop license and applying user configuration..."
-    sudo "$installer" --accept-license --user="$USER"
-    mkdir -p "$(dirname "$DOCKER_SETUP_MARKER")"
-    touch "$DOCKER_SETUP_MARKER"
-  fi
-
-  ensure_rosetta
-  export PATH="$DOCKER_APP/Contents/Resources/bin:$PATH"
-  if ! docker info >/dev/null 2>&1; then
-    docker desktop start --timeout 120
-    wait_for "$DOCKER_WAIT_ATTEMPTS" "Docker Desktop engine" docker info
-  fi
-  docker compose version >/dev/null
-}
-
-load_nix_profile() {
-  if [[ -r $NIX_PROFILE_SCRIPT ]]; then
-    # shellcheck source=/dev/null
-    . "$NIX_PROFILE_SCRIPT"
-  fi
+  xcode-select --install || true
+  dotfiles_die "Command Line Tools installation was requested. Complete it, then rerun ./install.sh."
 }
 
 ensure_nix() {
-  load_nix_profile
-  if ! have nix; then
-    log "Installing Nix in multi-user daemon mode..."
+  dotfiles_load_nix
+  if ! dotfiles_have nix; then
+    dotfiles_log "Installing Nix in multi-user daemon mode..."
     curl -fsSL https://nixos.org/nix/install | sh -s -- --daemon
-    load_nix_profile
+    dotfiles_load_nix
   fi
 
-  have nix || die "Nix installation completed but nix is unavailable."
+  dotfiles_have nix || dotfiles_die "Nix installation completed but nix is unavailable."
   mkdir -p "$HOME/.config/nix"
   local feature_line="extra-experimental-features = nix-command flakes"
   touch "$HOME/.config/nix/nix.conf"
@@ -184,57 +59,52 @@ ensure_nix() {
     printf '%s\n' "$feature_line" >>"$HOME/.config/nix/nix.conf"
 }
 
-canonical_directory() {
+apply_darwin_system() {
+  export DOTFILES_USER="${SUDO_USER:-$USER}"
+  export DOTFILES_HOME="$HOME"
+  export DOTFILES_ROOT="$ROOT"
+  local nix_bin
+  nix_bin="$(command -v nix)"
+
+  dotfiles_log "Applying nix-darwin, nix-homebrew, and Home Manager..."
   (
-    cd "$1"
-    pwd -P
+    cd "$ROOT"
+    sudo /usr/bin/env \
+      "NIX_CONFIG=extra-experimental-features = nix-command flakes" \
+      "DOTFILES_USER=$DOTFILES_USER" \
+      "DOTFILES_HOME=$DOTFILES_HOME" \
+      "DOTFILES_ROOT=$DOTFILES_ROOT" \
+      "$nix_bin" run .#darwin-rebuild -- switch --flake .#macos --impure
   )
+
+  export PATH="/run/current-system/sw/bin:$HOME/.nix-profile/bin:$HOME/.local/state/nix/profile/bin:/opt/homebrew/bin:/opt/homebrew/sbin:$DOCKER_APP/Contents/Resources/bin:$PATH"
+  hash -r
 }
 
-link_dotfiles() {
-  local target="$HOME/.dotfiles"
-  if [[ -d $target ]] &&
-    [[ "$(canonical_directory "$target")" == "$(canonical_directory "$ROOT")" ]]; then
-    return
+setup_docker_runtime() {
+  [[ -d $DOCKER_APP ]] ||
+    dotfiles_die "Docker Desktop was not installed by nix-darwin: $DOCKER_APP"
+
+  local installer="$DOCKER_APP/Contents/MacOS/install"
+  [[ -x $installer ]] || dotfiles_die "Docker Desktop installer not found: $installer"
+
+  if [[ ! -f $DOCKER_SETUP_MARKER ]]; then
+    dotfiles_log "Accepting the Docker Desktop license for personal use..."
+    sudo "$installer" --accept-license --user="${SUDO_USER:-$USER}"
+    mkdir -p "$(dirname "$DOCKER_SETUP_MARKER")"
+    touch "$DOCKER_SETUP_MARKER"
   fi
 
-  if [[ -e $target || -L $target ]]; then
-    local backup="$HOME/.dotfiles.backup.$(date +%Y%m%d%H%M%S)"
-    mv "$target" "$backup"
-    log "Moved existing $target to $backup"
+  dotfiles_have docker || dotfiles_die "Docker CLI is unavailable after nix-darwin activation."
+  if ! docker info >/dev/null 2>&1; then
+    docker desktop start --timeout 120
+    dotfiles_wait_for "$DOCKER_WAIT_ATTEMPTS" "Docker Desktop engine" docker info
   fi
-
-  ln -s "$ROOT" "$target"
-}
-
-activate_home_manager() {
-  log "Building Home Manager configuration..."
-  local activation attempt built
-  activation=""
-  built=0
-  for ((attempt = 1; attempt <= NIX_BUILD_ATTEMPTS; attempt++)); do
-    if activation="$(
-      cd "$ROOT"
-      nix build --no-link --print-out-paths \
-        .#homeConfigurations.aarch64-darwin.activationPackage --impure
-    )"; then
-      built=1
-      break
-    fi
-    if ((attempt < NIX_BUILD_ATTEMPTS)); then
-      log "Home Manager build failed; retrying ($attempt/$NIX_BUILD_ATTEMPTS)..."
-      sleep "$WAIT_SLEEP_SECONDS"
-    fi
-  done
-  ((built == 1)) || die "Home Manager build failed after $NIX_BUILD_ATTEMPTS attempts."
-  [[ -x "$activation/activate" ]] ||
-    die "Home Manager activation script not found: $activation/activate"
-  "$activation/activate"
-  export PATH="$HOME/.nix-profile/bin:$HOME/.local/state/nix/profile/bin:$PATH"
+  docker compose version >/dev/null
 }
 
 apply_chezmoi() {
-  have chezmoi || die "chezmoi is unavailable after Home Manager activation."
+  dotfiles_have chezmoi || dotfiles_die "chezmoi is unavailable after nix-darwin activation."
   chezmoi init --source "$ROOT/chezmoi"
   chezmoi apply --force
 }
@@ -245,35 +115,35 @@ show_compose_diagnostics() {
 }
 
 start_hermes_stack() {
-  log "Validating Hermes Docker Compose configuration..."
+  dotfiles_log "Validating Hermes Docker Compose configuration..."
   docker compose -f "$COMPOSE_FILE" config
-  log "Building Hermes images..."
+  dotfiles_log "Building Hermes images..."
   docker compose -f "$COMPOSE_FILE" build --pull
-  log "Starting Hermes services..."
+  dotfiles_log "Starting Hermes services..."
   if ! docker compose -f "$COMPOSE_FILE" up -d --force-recreate --wait; then
     show_compose_diagnostics
-    die "Hermes Docker Compose startup failed."
+    dotfiles_die "Hermes Docker Compose startup failed."
   fi
   docker compose -f "$COMPOSE_FILE" ps
-  wait_for "$SERVICE_WAIT_ATTEMPTS" "Hermes API port" \
+  dotfiles_wait_for "$SERVICE_WAIT_ATTEMPTS" "Hermes API port" \
     nc -z 127.0.0.1 "${HERMES_API_PORT:-8642}"
-  wait_for "$SERVICE_WAIT_ATTEMPTS" "Hermes dashboard port" \
+  dotfiles_wait_for "$SERVICE_WAIT_ATTEMPTS" "Hermes dashboard port" \
     nc -z 127.0.0.1 "${HERMES_DASHBOARD_PORT:-9119}"
-  wait_for "$SERVICE_WAIT_ATTEMPTS" "Hermes browser viewer port" \
+  dotfiles_wait_for "$SERVICE_WAIT_ATTEMPTS" "Hermes browser viewer port" \
     nc -z 127.0.0.1 "${HERMES_BROWSER_VIEW_PORT:-6080}"
 }
 
 main() {
   preflight
-  log "Docker Desktop is subject to Docker's license terms; continuing for personal use."
-  ensure_homebrew
-  ensure_docker_desktop
+  ensure_command_line_tools
   ensure_nix
-  link_dotfiles
-  activate_home_manager
+  dotfiles_link_checkout "$ROOT"
+  apply_darwin_system
+  setup_docker_runtime
   apply_chezmoi
   start_hermes_stack
-  log "macOS setup complete."
+  "$VERIFY_ENVIRONMENT" --runtime
+  dotfiles_log "macOS setup complete."
 }
 
 main "$@"

--- a/scripts/sh/install-nixos.sh
+++ b/scripts/sh/install-nixos.sh
@@ -11,6 +11,7 @@ NIXOS_MARKER="${DOTFILES_NIXOS_MARKER:-/etc/NIXOS}"
 SERVICE_WAIT_ATTEMPTS="${DOTFILES_SERVICE_WAIT_ATTEMPTS:-60}"
 VERIFY_ENVIRONMENT="${DOTFILES_VERIFY_ENVIRONMENT:-$ROOT/scripts/sh/verify-environment.sh}"
 NIXOS_HARDWARE_CONFIG="${DOTFILES_NIXOS_HARDWARE_CONFIG:-/etc/nixos/hardware-configuration.nix}"
+NIXOS_PREBUILT_SYSTEM="${DOTFILES_NIXOS_PREBUILT_SYSTEM:-}"
 
 preflight() {
   [[ $(uname -s) == "Linux" && -e $NIXOS_MARKER ]] || dotfiles_die "NixOS is required."
@@ -21,6 +22,12 @@ preflight() {
     dotfiles_die "NixOS hardware configuration must be an absolute path: $NIXOS_HARDWARE_CONFIG"
   [[ -r $NIXOS_HARDWARE_CONFIG ]] ||
     dotfiles_die "NixOS hardware configuration is missing or unreadable: $NIXOS_HARDWARE_CONFIG"
+  if [[ -n $NIXOS_PREBUILT_SYSTEM ]]; then
+    [[ $NIXOS_PREBUILT_SYSTEM == /* ]] ||
+      dotfiles_die "Prebuilt NixOS system must be an absolute path: $NIXOS_PREBUILT_SYSTEM"
+    [[ -x $NIXOS_PREBUILT_SYSTEM/bin/switch-to-configuration ]] ||
+      dotfiles_die "Prebuilt NixOS system is invalid: $NIXOS_PREBUILT_SYSTEM"
+  fi
 
   local required
   for required in \
@@ -54,6 +61,14 @@ capture_host_identity() {
 }
 
 apply_nixos_system() {
+  if [[ -n $NIXOS_PREBUILT_SYSTEM ]]; then
+    dotfiles_log "Activating prebuilt NixOS system for E2E..."
+    sudo "$NIXOS_PREBUILT_SYSTEM/bin/switch-to-configuration" switch
+    export PATH="/run/current-system/sw/bin:/etc/profiles/per-user/$DOTFILES_USER/bin:$HOME/.nix-profile/bin:$HOME/.local/state/nix/profile/bin:$PATH"
+    hash -r
+    return
+  fi
+
   local rebuild_bin
   rebuild_bin="$(command -v nixos-rebuild)"
   dotfiles_log "Applying NixOS and Home Manager..."

--- a/scripts/sh/install-nixos.sh
+++ b/scripts/sh/install-nixos.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+export DOTFILES_LOG_PREFIX="nixos-install"
+# shellcheck source=/dev/null
+. "$ROOT/scripts/sh/install-common.sh"
+
+COMPOSE_FILE="${DOTFILES_COMPOSE_FILE:-$ROOT/docker/hermes-agent/compose.yml}"
+NIXOS_MARKER="${DOTFILES_NIXOS_MARKER:-/etc/NIXOS}"
+SERVICE_WAIT_ATTEMPTS="${DOTFILES_SERVICE_WAIT_ATTEMPTS:-60}"
+VERIFY_ENVIRONMENT="${DOTFILES_VERIFY_ENVIRONMENT:-$ROOT/scripts/sh/verify-environment.sh}"
+NIXOS_HARDWARE_CONFIG="${DOTFILES_NIXOS_HARDWARE_CONFIG:-/etc/nixos/hardware-configuration.nix}"
+
+preflight() {
+  [[ $(uname -s) == "Linux" && -e $NIXOS_MARKER ]] || dotfiles_die "NixOS is required."
+  dotfiles_have nix || dotfiles_die "Nix is required on NixOS."
+  dotfiles_have nixos-rebuild || dotfiles_die "nixos-rebuild is required on NixOS."
+
+  [[ $NIXOS_HARDWARE_CONFIG == /* ]] ||
+    dotfiles_die "NixOS hardware configuration must be an absolute path: $NIXOS_HARDWARE_CONFIG"
+  [[ -r $NIXOS_HARDWARE_CONFIG ]] ||
+    dotfiles_die "NixOS hardware configuration is missing or unreadable: $NIXOS_HARDWARE_CONFIG"
+
+  local required
+  for required in \
+    "$ROOT/flake.nix" \
+    "$ROOT/chezmoi" \
+    "$COMPOSE_FILE" \
+    "$VERIFY_ENVIRONMENT"; do
+    [[ -e $required ]] || dotfiles_die "Required repository path is missing: $required"
+  done
+}
+
+capture_host_identity() {
+  export DOTFILES_USER="${SUDO_USER:-${USER:-}}"
+  export DOTFILES_HOME="$HOME"
+  [[ -n $DOTFILES_USER && $DOTFILES_HOME == /* ]] ||
+    dotfiles_die "A current user and absolute home directory are required."
+
+  DOTFILES_UID="$(id -u "$DOTFILES_USER")"
+  DOTFILES_GID="$(id -g "$DOTFILES_USER")"
+  DOTFILES_GROUP="$(id -gn "$DOTFILES_USER")"
+  export DOTFILES_UID DOTFILES_GID DOTFILES_GROUP
+  [[ $DOTFILES_UID =~ ^[0-9]+$ && $DOTFILES_GID =~ ^[0-9]+$ && -n $DOTFILES_GROUP ]] ||
+    dotfiles_die "The existing user must have numeric UID/GID values."
+
+  export DOTFILES_SYSTEM
+  DOTFILES_SYSTEM="$(nix eval --impure --raw --expr builtins.currentSystem)"
+  case "$DOTFILES_SYSTEM" in
+  x86_64-linux | aarch64-linux) ;;
+  *) dotfiles_die "Unsupported NixOS system: $DOTFILES_SYSTEM" ;;
+  esac
+}
+
+apply_nixos_system() {
+  local rebuild_bin
+  rebuild_bin="$(command -v nixos-rebuild)"
+  dotfiles_log "Applying NixOS and Home Manager..."
+  sudo /usr/bin/env \
+    "NIX_CONFIG=extra-experimental-features = nix-command flakes" \
+    "DOTFILES_USER=$DOTFILES_USER" \
+    "DOTFILES_HOME=$DOTFILES_HOME" \
+    "DOTFILES_UID=$DOTFILES_UID" \
+    "DOTFILES_GID=$DOTFILES_GID" \
+    "DOTFILES_GROUP=$DOTFILES_GROUP" \
+    "DOTFILES_SYSTEM=$DOTFILES_SYSTEM" \
+    "DOTFILES_NIXOS_HARDWARE_CONFIG=$NIXOS_HARDWARE_CONFIG" \
+    "$rebuild_bin" switch --flake "$ROOT#linux" --impure
+
+  export PATH="/run/current-system/sw/bin:/etc/profiles/per-user/$DOTFILES_USER/bin:$HOME/.nix-profile/bin:$HOME/.local/state/nix/profile/bin:$PATH"
+  hash -r
+}
+
+apply_chezmoi() {
+  dotfiles_have chezmoi || dotfiles_die "chezmoi is unavailable after NixOS activation."
+  chezmoi init --source "$ROOT/chezmoi"
+  chezmoi apply --force
+}
+
+docker_command() {
+  dotfiles_run_in_group docker docker "$@"
+}
+
+show_compose_diagnostics() {
+  docker_command compose -f "$COMPOSE_FILE" ps || true
+  docker_command compose -f "$COMPOSE_FILE" logs --tail=100 || true
+}
+
+start_hermes_stack() {
+  dotfiles_log "Validating Hermes Docker Compose configuration..."
+  docker_command compose -f "$COMPOSE_FILE" config
+  dotfiles_log "Building Hermes images..."
+  docker_command compose -f "$COMPOSE_FILE" build --pull
+  dotfiles_log "Starting Hermes services..."
+  if ! docker_command compose -f "$COMPOSE_FILE" up -d --force-recreate --wait; then
+    show_compose_diagnostics
+    dotfiles_die "Hermes Docker Compose startup failed."
+  fi
+  docker_command compose -f "$COMPOSE_FILE" ps
+  dotfiles_wait_for "$SERVICE_WAIT_ATTEMPTS" "Hermes API port" \
+    nc -z 127.0.0.1 "${HERMES_API_PORT:-8642}"
+  dotfiles_wait_for "$SERVICE_WAIT_ATTEMPTS" "Hermes dashboard port" \
+    nc -z 127.0.0.1 "${HERMES_DASHBOARD_PORT:-9119}"
+  dotfiles_wait_for "$SERVICE_WAIT_ATTEMPTS" "Hermes browser viewer port" \
+    nc -z 127.0.0.1 "${HERMES_BROWSER_VIEW_PORT:-6080}"
+}
+
+main() {
+  preflight
+  dotfiles_link_checkout "$ROOT"
+  capture_host_identity
+  apply_nixos_system
+  apply_chezmoi
+  start_hermes_stack
+  export DOTFILES_VERIFY_SYSTEM_LAYER=nixos
+  dotfiles_run_in_group docker "$VERIFY_ENVIRONMENT" --runtime
+  dotfiles_log "NixOS setup complete."
+}
+
+main "$@"

--- a/scripts/sh/run-windows-powershell-tests.sh
+++ b/scripts/sh/run-windows-powershell-tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$(uname -s)" in
+MINGW* | MSYS* | CYGWIN*) exec pwsh.exe "$@" ;;
+*) exit 0 ;;
+esac

--- a/scripts/sh/verify-environment.sh
+++ b/scripts/sh/verify-environment.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+COMPOSE_FILE="${DOTFILES_COMPOSE_FILE:-$ROOT/docker/hermes-agent/compose.yml}"
+runtime=0
+
+fail() {
+  printf 'environment verification failed: %s\n' "$*" >&2
+  exit 1
+}
+
+while (($# > 0)); do
+  case "$1" in
+  --runtime) runtime=1 ;;
+  *) fail "unknown argument: $1" ;;
+  esac
+  shift
+done
+
+platform="${DOTFILES_VERIFY_PLATFORM:-}"
+system_layer="${DOTFILES_VERIFY_SYSTEM_LAYER:-system-manager}"
+if [[ -z $platform ]]; then
+  case "$(uname -s)" in
+  Darwin) platform="darwin" ;;
+  Linux) platform="linux" ;;
+  *) fail "unsupported platform: $(uname -s)" ;;
+  esac
+fi
+
+required=(
+  nix
+  git
+  gh
+  chezmoi
+  rg
+  fd
+  jq
+  nvim
+  node
+  python3
+  go
+  rustup
+  docker
+)
+
+case "$platform" in
+darwin) required+=(brew darwin-rebuild) ;;
+linux)
+  required+=(systemctl)
+  [[ $system_layer == "nixos" ]] && required+=(nixos-rebuild)
+  ;;
+*) fail "unsupported verification platform: $platform" ;;
+esac
+
+for command_name in "${required[@]}"; do
+  command -v "$command_name" >/dev/null 2>&1 || fail "missing command: $command_name"
+done
+
+[[ -f $COMPOSE_FILE ]] || fail "missing Compose file: $COMPOSE_FILE"
+docker compose version >/dev/null || fail "Docker Compose is unavailable"
+docker info >/dev/null || fail "Docker engine is unavailable"
+chezmoi apply --dry-run >/dev/null || fail "chezmoi dry-run failed"
+chezmoi verify >/dev/null || fail "chezmoi target state differs"
+
+if [[ $platform == "linux" ]]; then
+  case "$system_layer" in
+  system-manager)
+    systemctl is-active --quiet system-manager.target || fail "System Manager target is inactive"
+    ;;
+  nixos)
+    current_system="${DOTFILES_CURRENT_SYSTEM_PATH:-/run/current-system}"
+    [[ -e $current_system ]] || fail "NixOS current generation is missing: $current_system"
+    ;;
+  *) fail "unsupported Linux system layer: $system_layer" ;;
+  esac
+  systemctl is-active --quiet docker.service || fail "Docker service is inactive"
+  systemctl is-active --quiet docker.socket || fail "Docker socket is inactive"
+fi
+
+if ((runtime == 1)); then
+  docker run --rm hello-world >/dev/null || fail "Docker test container failed"
+  docker compose -f "$COMPOSE_FILE" config >/dev/null || fail "Compose configuration is invalid"
+  docker compose -f "$COMPOSE_FILE" ps --status running >/dev/null ||
+    fail "Compose services are not running"
+  expected_services="$(docker compose -f "$COMPOSE_FILE" config --services | LC_ALL=C sort)"
+  running_services="$(docker compose -f "$COMPOSE_FILE" ps --status running --services | LC_ALL=C sort)"
+  [[ -n $expected_services && $running_services == "$expected_services" ]] ||
+    fail "not all Compose services are running"
+fi
+
+printf 'Environment verification passed.\n'

--- a/scripts/sh/verify-environment.sh
+++ b/scripts/sh/verify-environment.sh
@@ -61,8 +61,8 @@ done
 docker compose version >/dev/null || fail "Docker Compose is unavailable"
 docker info >/dev/null || fail "Docker engine is unavailable"
 chezmoi apply --dry-run >/dev/null || fail "chezmoi dry-run failed"
-if ! chezmoi verify >/dev/null; then
-  chezmoi diff --no-pager --color=false >&2 || true
+if ! chezmoi verify --exclude=scripts >/dev/null; then
+  chezmoi diff --exclude=scripts --no-pager --color=false >&2 || true
   fail "chezmoi target state differs"
 fi
 

--- a/scripts/sh/verify-environment.sh
+++ b/scripts/sh/verify-environment.sh
@@ -61,7 +61,10 @@ done
 docker compose version >/dev/null || fail "Docker Compose is unavailable"
 docker info >/dev/null || fail "Docker engine is unavailable"
 chezmoi apply --dry-run >/dev/null || fail "chezmoi dry-run failed"
-chezmoi verify >/dev/null || fail "chezmoi target state differs"
+if ! chezmoi verify >/dev/null; then
+  chezmoi diff --no-pager --color=false >&2 || true
+  fail "chezmoi target state differs"
+fi
 
 if [[ $platform == "linux" ]]; then
   case "$system_layer" in

--- a/tests/bash/bootstrap_docs.bats
+++ b/tests/bash/bootstrap_docs.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+@test "README documents all bootstrap entrypoints and reruns" {
+	grep -q 'install.cmd' "$REPO_ROOT/README.md"
+	[ "$(grep -c './install.sh' "$REPO_ROOT/README.md")" -ge 2 ]
+	grep -q 'DOTFILES_ALLOW_USER_ONLY=1' "$REPO_ROOT/README.md"
+	grep -Eqi 're-run|rerun|再実行' "$REPO_ROOT/README.md"
+	grep -q 'self-hosted-bootstrap-runners.md' "$REPO_ROOT/README.md"
+}
+
+@test "architecture documents the four declarative layers" {
+	grep -q 'nix-darwin' "$REPO_ROOT/docs/architecture.md"
+	grep -q 'System Manager' "$REPO_ROOT/docs/architecture.md"
+	grep -q 'NixOS' "$REPO_ROOT/docs/architecture.md"
+	grep -q 'winget' "$REPO_ROOT/docs/architecture.md"
+	grep -q 'runtime acceptance' "$REPO_ROOT/docs/architecture.md"
+}
+
+@test "package and PowerShell docs describe generated coverage and acceptance" {
+	grep -q 'package-support-report' "$REPO_ROOT/docs/nix/package-management.md"
+	grep -q 'Test-Environment.ps1' "$REPO_ROOT/docs/scripts/powershell/testing.md"
+	grep -q 'hello-world' "$REPO_ROOT/docs/scripts/powershell/testing.md"
+}

--- a/tests/bash/chezmoi_script_portability.bats
+++ b/tests/bash/chezmoi_script_portability.bats
@@ -5,8 +5,10 @@ setup() {
 }
 
 @test "chezmoi shell scripts use a PATH-portable bash shebang" {
-	run rg -n '^#!/bin/bash$' "$REPO_ROOT/chezmoi/.chezmoiscripts" -g '*.sh.tmpl'
+	violations="$(
+		find "$REPO_ROOT/chezmoi/.chezmoiscripts" -type f -name '*.sh.tmpl' \
+			-exec grep -Hn '^#!/bin/bash$' {} + || true
+	)"
 
-	[ "$status" -eq 1 ]
-	[ -z "$output" ]
+	[ -z "$violations" ]
 }

--- a/tests/bash/chezmoi_script_portability.bats
+++ b/tests/bash/chezmoi_script_portability.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+@test "chezmoi shell scripts use a PATH-portable bash shebang" {
+	run rg -n '^#!/bin/bash$' "$REPO_ROOT/chezmoi/.chezmoiscripts" -g '*.sh.tmpl'
+
+	[ "$status" -eq 1 ]
+	[ -z "$output" ]
+}

--- a/tests/bash/dcnvim.bats
+++ b/tests/bash/dcnvim.bats
@@ -84,6 +84,7 @@ printf "%s\n" "$FZF_SELECTED"
 @test "explicit workspace runs plain devcontainer up then bootstraps before nvim tmux payload" {
 	workspace="$BATS_TEST_TMPDIR/project"
 	mkdir -p "$workspace/.devcontainer"
+	expected_workspace="$(_dcnvim_abs_path "$workspace")"
 	write_devcontainer_stub
 
 	run dcnvim "$workspace"
@@ -92,7 +93,7 @@ printf "%s\n" "$FZF_SELECTED"
 	log="$(cat "$DEVCONTAINER_LOG")"
 	[[ "$log" == *"arg=up"* ]]
 	[[ "$log" == *"arg=--workspace-folder"* ]]
-	[[ "$log" == *"arg=$workspace"* ]]
+	[[ "$log" == *"arg=$expected_workspace"* ]]
 	[[ "$log" != *"arg=--dotfiles-repository"* ]]
 	[[ "$log" != *"arg=--dotfiles-install-command"* ]]
 
@@ -141,6 +142,7 @@ EOF
 	ghq_root="$BATS_TEST_TMPDIR/ghq"
 	workspace="$ghq_root/github.com/foo/bar"
 	mkdir -p "$cwd" "$workspace/.devcontainer"
+	expected_workspace="$(_dcnvim_abs_path "$workspace")"
 	cd "$cwd"
 
 	export GHQ_ROOT="$ghq_root"
@@ -154,7 +156,7 @@ EOF
 
 	[ "$status" -eq 0 ]
 	log="$(cat "$DEVCONTAINER_LOG")"
-	[[ "$log" == *"arg=$workspace"* ]]
+	[[ "$log" == *"arg=$expected_workspace"* ]]
 	payload="$(cat "$DEVCONTAINER_PAYLOAD_LOG")"
 	[[ "$payload" == *"tmux new -A -s 'bar' 'nvim .'"* ]]
 }
@@ -208,12 +210,13 @@ EOF
 @test "missing devcontainer config fails before devcontainer up" {
 	workspace="$BATS_TEST_TMPDIR/project"
 	mkdir -p "$workspace"
+	expected_workspace="$(_dcnvim_abs_path "$workspace")"
 	write_devcontainer_stub
 
 	run dcnvim "$workspace"
 
 	[ "$status" -eq 1 ]
-	[[ "$output" == *"dcnvim: no .devcontainer/ or .devcontainer.json under $workspace"* ]]
+	[[ "$output" == *"dcnvim: no .devcontainer/ or .devcontainer.json under $expected_workspace"* ]]
 	[ ! -f "$DEVCONTAINER_LOG" ]
 }
 

--- a/tests/bash/flake_outputs.bats
+++ b/tests/bash/flake_outputs.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+@test "flake pins darwin homebrew and system manager inputs" {
+	run grep -E 'nix-darwin|nix-homebrew|system-manager' "$REPO_ROOT/flake.nix"
+	[ "$status" -eq 0 ]
+	[ "$(printf '%s\n' "$output" | wc -l | tr -d ' ')" -ge 3 ]
+}
+
+@test "flake imports locked platform runner apps" {
+	grep -q './apps.nix' "$REPO_ROOT/nix/flakes/default.nix"
+	grep -q 'darwin-rebuild' "$REPO_ROOT/nix/flakes/apps.nix"
+	grep -q 'system-manager' "$REPO_ROOT/nix/flakes/apps.nix"
+}
+
+@test "runner app wrappers use locked package outputs" {
+	grep -Fq 'inputs.nix-darwin.packages.${system}.darwin-rebuild' "$REPO_ROOT/nix/flakes/apps.nix"
+	grep -Fq 'inputs.system-manager.packages.${system}.default' "$REPO_ROOT/nix/flakes/apps.nix"
+	grep -Fq 'darwin-rebuild.program = lib.getExe' "$REPO_ROOT/nix/flakes/apps.nix"
+	grep -Fq 'system-manager.program =' "$REPO_ROOT/nix/flakes/apps.nix"
+	grep -Fq "lib.getExe' inputs.system-manager.packages" "$REPO_ROOT/nix/flakes/apps.nix"
+	grep -Fq '"system-manager"' "$REPO_ROOT/nix/flakes/apps.nix"
+}
+
+@test "runner apps are guarded by their target platforms" {
+	grep -Fq 'lib.optionalAttrs pkgs.stdenv.isDarwin' "$REPO_ROOT/nix/flakes/apps.nix"
+	grep -Fq 'lib.optionalAttrs pkgs.stdenv.isLinux' "$REPO_ROOT/nix/flakes/apps.nix"
+}
+
+@test "native NixOS output is unavailable without an explicit hardware profile" {
+	grep -q 'DOTFILES_NIXOS_HARDWARE_CONFIG' "$REPO_ROOT/nix/flakes/hosts.nix"
+	grep -q 'optionalAttrs.*hardwareConfig != ""' "$REPO_ROOT/nix/flakes/hosts.nix"
+}

--- a/tests/bash/install_dispatcher.bats
+++ b/tests/bash/install_dispatcher.bats
@@ -21,25 +21,90 @@ EOF
 	chmod +x "$TEST_BIN/uname"
 }
 
-write_macos_installer_stub() {
+write_dispatch_repo() {
 	mkdir -p "$BATS_TEST_TMPDIR/repo/scripts/sh"
 	cp "$REPO_ROOT/install.sh" "$BATS_TEST_TMPDIR/repo/install.sh"
-	cat >"$BATS_TEST_TMPDIR/repo/scripts/sh/install-macos.sh" <<'EOF'
+	for installer in install-macos.sh install-nixos.sh install-linux.sh install-home-manager.sh; do
+		cat >"$BATS_TEST_TMPDIR/repo/scripts/sh/$installer" <<'EOF'
 #!/usr/bin/env bash
-printf 'args=%s\n' "$*" >"$DISPATCH_LOG"
+printf 'target=%s args=%s\n' "${0##*/}" "$*" >"$DISPATCH_LOG"
 EOF
-	chmod +x "$BATS_TEST_TMPDIR/repo/scripts/sh/install-macos.sh"
+		chmod +x "$BATS_TEST_TMPDIR/repo/scripts/sh/$installer"
+	done
 }
 
 @test "Darwin arm64 dispatches to the macOS installer with arguments intact" {
 	write_uname_stub
-	write_macos_installer_stub
+	write_dispatch_repo
 	export TEST_UNAME_S=Darwin TEST_UNAME_M=arm64
 
 	run "$BATS_TEST_TMPDIR/repo/install.sh" --example
 
 	[ "$status" -eq 0 ]
-	grep -q '^args=--example$' "$DISPATCH_LOG"
+	grep -q '^target=install-macos.sh args=--example$' "$DISPATCH_LOG"
+}
+
+@test "NixOS dispatches to the native installer" {
+	write_uname_stub
+	write_dispatch_repo
+	marker="$BATS_TEST_TMPDIR/NIXOS"
+	touch "$marker"
+	export TEST_UNAME_S=Linux TEST_UNAME_M=x86_64
+	export DOTFILES_NIXOS_MARKER="$marker"
+
+	run "$BATS_TEST_TMPDIR/repo/install.sh" --example
+
+	[ "$status" -eq 0 ]
+	grep -q '^target=install-nixos.sh args=--example$' "$DISPATCH_LOG"
+}
+
+@test "Ubuntu and Debian dispatch to the System Manager installer" {
+	write_uname_stub
+	write_dispatch_repo
+	export TEST_UNAME_S=Linux TEST_UNAME_M=x86_64
+	export DOTFILES_NIXOS_MARKER="$BATS_TEST_TMPDIR/not-nixos"
+
+	for distribution in ubuntu debian; do
+		release_file="$BATS_TEST_TMPDIR/$distribution-os-release"
+		printf 'ID=%s\n' "$distribution" >"$release_file"
+		export DOTFILES_OS_RELEASE_FILE="$release_file"
+
+		run "$BATS_TEST_TMPDIR/repo/install.sh" --example
+
+		[ "$status" -eq 0 ]
+		grep -q '^target=install-linux.sh args=--example$' "$DISPATCH_LOG"
+	done
+}
+
+@test "unsupported Linux requires explicit user-only opt-in" {
+	write_uname_stub
+	write_dispatch_repo
+	release_file="$BATS_TEST_TMPDIR/fedora-os-release"
+	printf 'ID=fedora\n' >"$release_file"
+	export TEST_UNAME_S=Linux TEST_UNAME_M=x86_64
+	export DOTFILES_NIXOS_MARKER="$BATS_TEST_TMPDIR/not-nixos"
+	export DOTFILES_OS_RELEASE_FILE="$release_file"
+
+	run "$BATS_TEST_TMPDIR/repo/install.sh"
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"DOTFILES_ALLOW_USER_ONLY=1"* ]]
+}
+
+@test "unsupported Linux opt-in dispatches to Home Manager only" {
+	write_uname_stub
+	write_dispatch_repo
+	release_file="$BATS_TEST_TMPDIR/fedora-os-release"
+	printf 'ID=fedora\n' >"$release_file"
+	export TEST_UNAME_S=Linux TEST_UNAME_M=x86_64
+	export DOTFILES_NIXOS_MARKER="$BATS_TEST_TMPDIR/not-nixos"
+	export DOTFILES_OS_RELEASE_FILE="$release_file"
+	export DOTFILES_ALLOW_USER_ONLY=1
+
+	run "$BATS_TEST_TMPDIR/repo/install.sh" --example
+
+	[ "$status" -eq 0 ]
+	grep -q '^target=install-home-manager.sh args=--example$' "$DISPATCH_LOG"
 }
 
 @test "Windows-like environments direct the user to install.cmd" {

--- a/tests/bash/install_linux.bats
+++ b/tests/bash/install_linux.bats
@@ -133,7 +133,24 @@ assert_log_order() {
 		"verify-environment --runtime"
 }
 
-@test "Linux waits for systemd to leave the transient starting state" {
+@test "Linux accepts a responsive systemd manager while the global state is starting" {
+	write_nix_stub
+	write_stub systemctl '
+printf "systemctl %s\n" "$*" >>"$COMMAND_LOG"
+case "$*" in
+"is-system-running") echo starting ;;
+"show --property=Version --value") echo 255.4 ;;
+esac
+'
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 0 ]
+	[ "$(grep -c '^systemctl is-system-running$' "$COMMAND_LOG")" -eq 1 ]
+	grep -q '^systemctl show --property=Version --value$' "$COMMAND_LOG"
+}
+
+@test "Linux waits when a starting systemd manager is not yet responsive" {
 	write_nix_stub
 	state_count="$BATS_TEST_TMPDIR/systemd-state-count"
 	printf '0\n' >"$state_count"

--- a/tests/bash/install_linux.bats
+++ b/tests/bash/install_linux.bats
@@ -1,0 +1,247 @@
+#!/usr/bin/env bats
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+	INSTALLER="$REPO_ROOT/scripts/sh/install-linux.sh"
+	FALLBACK_INSTALLER="$REPO_ROOT/scripts/sh/install-home-manager.sh"
+	TEST_HOME="$BATS_TEST_TMPDIR/home"
+	STUB_BIN="$BATS_TEST_TMPDIR/bin"
+	COMMAND_LOG="$BATS_TEST_TMPDIR/commands.log"
+	FAKE_NIX_PROFILE="$BATS_TEST_TMPDIR/nix-daemon.sh"
+	FAKE_SYSTEMD_DIR="$BATS_TEST_TMPDIR/systemd/system"
+	OS_RELEASE="$BATS_TEST_TMPDIR/os-release"
+	mkdir -p "$TEST_HOME" "$STUB_BIN" "$FAKE_SYSTEMD_DIR"
+	: >"$COMMAND_LOG"
+	: >"$FAKE_NIX_PROFILE"
+	printf 'ID=ubuntu\n' >"$OS_RELEASE"
+
+	export HOME="$TEST_HOME"
+	export USER="test-user"
+	export PATH="$STUB_BIN:/usr/bin:/bin"
+	export COMMAND_LOG STUB_BIN
+	export DOTFILES_NIX_PROFILE_SCRIPT="$FAKE_NIX_PROFILE"
+	export DOTFILES_SYSTEMD_DIR="$FAKE_SYSTEMD_DIR"
+	export DOTFILES_OS_RELEASE_FILE="$OS_RELEASE"
+	export DOTFILES_WAIT_SLEEP_SECONDS=0
+	export DOTFILES_SERVICE_WAIT_ATTEMPTS=2
+	export DOTFILES_VERIFY_ENVIRONMENT="$STUB_BIN/verify-environment"
+
+	write_stub uname '
+case "${1:-}" in
+	-s) echo Linux ;;
+	-m) echo x86_64 ;;
+	*) exit 2 ;;
+esac
+'
+	write_stub systemctl '
+printf "systemctl %s\n" "$*" >>"$COMMAND_LOG"
+case "$*" in
+	"is-system-running") echo running ;;
+esac
+'
+	write_stub id '
+case "${1:-}" in
+	-u) echo 1000 ;;
+	-g) echo 1000 ;;
+	-gn) echo users ;;
+	-Gn) echo "test-user docker" ;;
+	*) /usr/bin/id "$@" ;;
+esac
+'
+	write_stub nc 'exit 0'
+	write_stub sleep 'exit 0'
+	write_stub date 'echo 20260717010203'
+	write_stub chezmoi 'printf "chezmoi %s\n" "$*" >>"$COMMAND_LOG"'
+	write_stub docker '
+printf "docker %s\n" "$*" >>"$COMMAND_LOG"
+exit 0
+'
+	write_stub verify-environment 'printf "verify-environment %s\n" "$*" >>"$COMMAND_LOG"'
+	write_stub sg '
+printf "sg %s\n" "$*" >>"$COMMAND_LOG"
+[ "${2:-}" = "-c" ]
+exec bash -c "$3"
+'
+}
+
+write_stub() {
+	local name="$1"
+	local body="$2"
+	cat >"$STUB_BIN/$name" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+$body
+EOF
+	chmod +x "$STUB_BIN/$name"
+}
+
+write_nix_stub() {
+	write_stub nix '
+printf "nix user=%s home=%s uid=%s gid=%s group=%s system=%s args=%s\n" \
+	"${DOTFILES_USER:-}" "${DOTFILES_HOME:-}" "${DOTFILES_UID:-}" \
+	"${DOTFILES_GID:-}" "${DOTFILES_GROUP:-}" "${DOTFILES_SYSTEM:-}" "$*" >>"$COMMAND_LOG"
+if [[ $* == "eval --impure --raw --expr builtins.currentSystem" ]]; then
+	printf "x86_64-linux"
+fi
+'
+}
+
+write_fresh_nix_installer_stub() {
+	write_stub curl '
+printf "curl %s\n" "$*" >>"$COMMAND_LOG"
+cat <<'"'"'SCRIPT'"'"'
+printf "nix-installer %s\n" "$*" >>"$COMMAND_LOG"
+cat >"$STUB_BIN/nix" <<'"'"'NIX'"'"'
+#!/usr/bin/env bash
+set -euo pipefail
+printf "nix user=%s home=%s uid=%s gid=%s group=%s system=%s args=%s\n" \
+	"${DOTFILES_USER:-}" "${DOTFILES_HOME:-}" "${DOTFILES_UID:-}" \
+	"${DOTFILES_GID:-}" "${DOTFILES_GROUP:-}" "${DOTFILES_SYSTEM:-}" "$*" >>"$COMMAND_LOG"
+if [[ $* == "eval --impure --raw --expr builtins.currentSystem" ]]; then
+	printf "x86_64-linux"
+fi
+NIX
+chmod +x "$STUB_BIN/nix"
+SCRIPT
+'
+}
+
+assert_log_order() {
+	local previous=0 pattern line
+	for pattern in "$@"; do
+		line="$(grep -nF "$pattern" "$COMMAND_LOG" | head -1 | cut -d: -f1)"
+		[ -n "$line" ]
+		[ "$line" -gt "$previous" ]
+		previous="$line"
+	done
+}
+
+@test "Ubuntu applies System Manager then chezmoi Compose and acceptance" {
+	write_nix_stub
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 0 ]
+	grep -q 'user=test-user home=.* uid=1000 gid=1000 group=users system=x86_64-linux args=run .#system-manager -- --nix-option pure-eval false switch --flake .#ubuntu --sudo' "$COMMAND_LOG"
+	assert_log_order \
+		"switch --flake .#ubuntu --sudo" \
+		"chezmoi init --source $REPO_ROOT/chezmoi" \
+		"chezmoi apply --force" \
+		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config" \
+		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml up -d --force-recreate --wait" \
+		"verify-environment --runtime"
+}
+
+@test "Debian selects the Debian System Manager output" {
+	printf 'ID=debian\n' >"$OS_RELEASE"
+	write_nix_stub
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 0 ]
+	grep -q 'switch --flake .#debian --sudo' "$COMMAND_LOG"
+}
+
+@test "fresh Linux setup installs Nix once and reruns idempotently" {
+	write_fresh_nix_installer_stub
+
+	run "$INSTALLER"
+	[ "$status" -eq 0 ]
+	run "$INSTALLER"
+	[ "$status" -eq 0 ]
+
+	[ "$(grep -c '^nix-installer --daemon$' "$COMMAND_LOG")" -eq 1 ]
+	[ "$(grep -c 'switch --flake .#ubuntu --sudo' "$COMMAND_LOG")" -eq 2 ]
+}
+
+@test "System Manager failure stops before user and runtime phases" {
+	write_nix_stub
+	cat >>"$STUB_BIN/nix" <<'EOF'
+if [[ $* == *"switch --flake"* ]]; then exit 42; fi
+EOF
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 42 ]
+	! grep -q '^chezmoi ' "$COMMAND_LOG"
+	! grep -q '^docker compose ' "$COMMAND_LOG"
+}
+
+@test "invalid existing user identity is rejected before System Manager" {
+	write_nix_stub
+	write_stub id '
+case "${1:-}" in
+	-u) echo not-a-number ;;
+	-g) echo 1000 ;;
+	-gn) echo users ;;
+	-Gn) echo "test-user docker" ;;
+esac
+'
+
+	run "$INSTALLER"
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"numeric UID/GID"* ]]
+	! grep -q 'switch --flake' "$COMMAND_LOG"
+}
+
+@test "a stale shell enters the declared docker group for runtime commands" {
+	write_nix_stub
+	write_stub id '
+case "${1:-}" in
+	-u) echo 1000 ;;
+	-g) echo 1000 ;;
+	-gn) echo users ;;
+	-Gn)
+		if [ "$#" -gt 1 ]; then echo "test-user docker"; else echo test-user; fi
+		;;
+	*) /usr/bin/id "$@" ;;
+esac
+'
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 0 ]
+	grep -q '^sg docker -c ' "$COMMAND_LOG"
+}
+
+@test "Home Manager fallback requires direct explicit opt-in" {
+	write_nix_stub
+
+	run "$FALLBACK_INSTALLER"
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"DOTFILES_ALLOW_USER_ONLY=1"* ]]
+}
+
+@test "Home Manager fallback activates only the user environment" {
+	export DOTFILES_ALLOW_USER_ONLY=1
+	activation="$BATS_TEST_TMPDIR/home-manager-generation"
+	mkdir -p "$activation"
+	cat >"$activation/activate" <<EOF
+#!/usr/bin/env bash
+printf 'home-manager-activate\n' >>"$COMMAND_LOG"
+EOF
+	chmod +x "$activation/activate"
+	write_stub nix "
+printf 'nix %s\\n' \"\$*\" >>\"\$COMMAND_LOG\"
+if [[ \$* == 'eval --impure --raw --expr builtins.currentSystem' ]]; then
+	printf x86_64-linux
+elif [[ \$* == *homeConfigurations*activationPackage* ]]; then
+	printf '$activation\\n'
+fi
+"
+
+	run "$FALLBACK_INSTALLER"
+
+	[ "$status" -eq 0 ]
+	grep -q 'build --impure --no-link --print-out-paths .*homeConfigurations.*x86_64-linux.*activationPackage' "$COMMAND_LOG"
+	assert_log_order \
+		"homeConfigurations" \
+		"home-manager-activate" \
+		"chezmoi init --source $REPO_ROOT/chezmoi" \
+		"chezmoi apply --force"
+	! grep -q '^docker ' "$COMMAND_LOG"
+	! grep -q '^verify-environment ' "$COMMAND_LOG"
+	[[ "$output" == *"User-only setup complete; Docker/systemd were not configured."* ]]
+}

--- a/tests/bash/install_linux.bats
+++ b/tests/bash/install_linux.bats
@@ -24,6 +24,7 @@ setup() {
 	export DOTFILES_OS_RELEASE_FILE="$OS_RELEASE"
 	export DOTFILES_WAIT_SLEEP_SECONDS=0
 	export DOTFILES_SERVICE_WAIT_ATTEMPTS=2
+	export DOTFILES_SYSTEMD_WAIT_ATTEMPTS=2
 	export DOTFILES_VERIFY_ENVIRONMENT="$STUB_BIN/verify-environment"
 
 	write_stub uname '
@@ -130,6 +131,27 @@ assert_log_order() {
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml up -d --force-recreate --wait" \
 		"verify-environment --runtime"
+}
+
+@test "Linux waits for systemd to leave the transient starting state" {
+	write_nix_stub
+	state_count="$BATS_TEST_TMPDIR/systemd-state-count"
+	printf '0\n' >"$state_count"
+	export STATE_COUNT="$state_count"
+	write_stub systemctl '
+printf "systemctl %s\n" "$*" >>"$COMMAND_LOG"
+if [[ $* == "is-system-running" ]]; then
+	count="$(cat "$STATE_COUNT")"
+	count=$((count + 1))
+	printf "%s\n" "$count" >"$STATE_COUNT"
+	if ((count == 1)); then echo starting; else echo running; fi
+fi
+'
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 0 ]
+	[ "$(grep -c '^systemctl is-system-running$' "$COMMAND_LOG")" -eq 2 ]
 }
 
 @test "Debian selects the Debian System Manager output" {

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -3,41 +3,27 @@
 setup() {
 	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
 	INSTALLER="$REPO_ROOT/scripts/sh/install-macos.sh"
+	COMMON_INSTALLER="$REPO_ROOT/scripts/sh/install-common.sh"
 	TEST_HOME="$BATS_TEST_TMPDIR/home"
 	STUB_BIN="$BATS_TEST_TMPDIR/bin"
 	COMMAND_LOG="$BATS_TEST_TMPDIR/commands.log"
 	FAKE_DOCKER_APP="$BATS_TEST_TMPDIR/Docker.app"
 	FAKE_NIX_PROFILE="$BATS_TEST_TMPDIR/nix-daemon.sh"
-	ACTIVATION="$BATS_TEST_TMPDIR/home-manager-generation"
-	mkdir -p "$TEST_HOME" "$STUB_BIN" "$ACTIVATION"
+	mkdir -p "$TEST_HOME" "$STUB_BIN"
 	: >"$COMMAND_LOG"
 	: >"$FAKE_NIX_PROFILE"
 
 	export HOME="$TEST_HOME"
 	export USER="test-user"
 	export PATH="$STUB_BIN:/usr/bin:/bin"
-	export COMMAND_LOG STUB_BIN ACTIVATION
-	export DOTFILES_BREW_BIN="$STUB_BIN/brew"
+	export COMMAND_LOG STUB_BIN
 	export DOTFILES_DOCKER_APP_PATH="$FAKE_DOCKER_APP"
 	export DOTFILES_DOCKER_SETUP_MARKER="$TEST_HOME/.config/dotfiles/docker-desktop-installed"
 	export DOTFILES_NIX_PROFILE_SCRIPT="$FAKE_NIX_PROFILE"
 	export DOTFILES_DOCKER_WAIT_ATTEMPTS=2
 	export DOTFILES_SERVICE_WAIT_ATTEMPTS=2
 	export DOTFILES_WAIT_SLEEP_SECONDS=0
-
-	cat >"$ACTIVATION/activate" <<'EOF'
-#!/usr/bin/env bash
-printf 'activate\n' >>"$COMMAND_LOG"
-mkdir -p "$HOME/.nix-profile/bin"
-if [ -n "${ACTIVATE_INSTALL_CHEZMOI:-}" ]; then
-	cat >"$HOME/.nix-profile/bin/chezmoi" <<'STUB'
-#!/usr/bin/env bash
-printf 'chezmoi %s\n' "$*" >>"$COMMAND_LOG"
-STUB
-	chmod +x "$HOME/.nix-profile/bin/chezmoi"
-fi
-EOF
-	chmod +x "$ACTIVATION/activate"
+	export DOTFILES_VERIFY_ENVIRONMENT="$STUB_BIN/verify-environment"
 
 	write_stub uname '
 case "${1:-}" in
@@ -60,6 +46,7 @@ exit 2
 printf "sudo %s\n" "$*" >>"$COMMAND_LOG"
 exec "$@"
 '
+	write_stub verify-environment 'printf "verify-environment %s\n" "$*" >>"$COMMAND_LOG"'
 }
 
 write_stub() {
@@ -73,30 +60,28 @@ EOF
 	chmod +x "$STUB_BIN/$name"
 }
 
-write_installed_stubs() {
+write_docker_app() {
 	mkdir -p "$FAKE_DOCKER_APP/Contents/MacOS" "$FAKE_DOCKER_APP/Contents/Resources/bin"
 	cat >"$FAKE_DOCKER_APP/Contents/MacOS/install" <<'EOF'
 #!/usr/bin/env bash
 printf 'docker-install %s\n' "$*" >>"$COMMAND_LOG"
 EOF
-	chmod +x "$FAKE_DOCKER_APP/Contents/MacOS/install"
+	cat >"$FAKE_DOCKER_APP/Contents/Resources/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+printf 'docker %s\n' "$*" >>"$COMMAND_LOG"
+exit 0
+EOF
+	chmod +x \
+		"$FAKE_DOCKER_APP/Contents/MacOS/install" \
+		"$FAKE_DOCKER_APP/Contents/Resources/bin/docker"
+}
+
+write_installed_stubs() {
+	write_docker_app
 	mkdir -p "$(dirname "$DOTFILES_DOCKER_SETUP_MARKER")"
 	touch "$DOTFILES_DOCKER_SETUP_MARKER"
 
-	write_stub pkgutil 'exit 0'
-	write_stub softwareupdate 'printf "softwareupdate %s\n" "$*" >>"$COMMAND_LOG"'
-	write_stub brew '
-printf "brew %s\n" "$*" >>"$COMMAND_LOG"
-if [ "${1:-}" = "shellenv" ]; then
-	printf "export PATH=%q:\$PATH\n" "$STUB_BIN"
-fi
-'
-	write_stub nix '
-printf "nix %s\n" "$*" >>"$COMMAND_LOG"
-if [ "${1:-}" = "build" ]; then
-	printf "%s\n" "$ACTIVATION"
-fi
-'
+	write_stub nix 'printf "nix %s\n" "$*" >>"$COMMAND_LOG"'
 	write_stub chezmoi 'printf "chezmoi %s\n" "$*" >>"$COMMAND_LOG"'
 	write_stub docker '
 printf "docker %s\n" "$*" >>"$COMMAND_LOG"
@@ -106,48 +91,35 @@ exit 0
 }
 
 write_fresh_install_stubs() {
-	write_stub pkgutil 'exit 1'
-	write_stub softwareupdate 'printf "softwareupdate %s\n" "$*" >>"$COMMAND_LOG"'
 	write_stub curl '
+printf "curl %s\n" "$*" >>"$COMMAND_LOG"
 case "$*" in
-	*raw.githubusercontent.com/Homebrew/install*)
-		cat <<'"'"'SCRIPT'"'"'
-mkdir -p "$(dirname "$DOTFILES_BREW_BIN")"
-cat >"$DOTFILES_BREW_BIN" <<'"'"'BREW'"'"'
-#!/usr/bin/env bash
-set -euo pipefail
-printf "brew %s\n" "$*" >>"$COMMAND_LOG"
-case "${1:-}" in
-	shellenv)
-		printf "export PATH=%q:\$PATH\n" "$(dirname "$DOTFILES_BREW_BIN")"
-		;;
-	install)
-		mkdir -p "$DOTFILES_DOCKER_APP_PATH/Contents/MacOS" "$DOTFILES_DOCKER_APP_PATH/Contents/Resources/bin"
-		cat >"$DOTFILES_DOCKER_APP_PATH/Contents/MacOS/install" <<'"'"'DOCKER_INSTALL'"'"'
-#!/usr/bin/env bash
-printf "docker-install %s\n" "$*" >>"$COMMAND_LOG"
-DOCKER_INSTALL
-		chmod +x "$DOTFILES_DOCKER_APP_PATH/Contents/MacOS/install"
-		cat >"$DOTFILES_DOCKER_APP_PATH/Contents/Resources/bin/docker" <<'"'"'DOCKER'"'"'
-#!/usr/bin/env bash
-printf "docker %s\n" "$*" >>"$COMMAND_LOG"
-exit 0
-DOCKER
-		chmod +x "$DOTFILES_DOCKER_APP_PATH/Contents/Resources/bin/docker"
-		;;
-esac
-BREW
-chmod +x "$DOTFILES_BREW_BIN"
-SCRIPT
-		;;
 	*nixos.org/nix/install*)
 		cat <<'"'"'SCRIPT'"'"'
 printf "nix-installer %s\n" "$*" >>"$COMMAND_LOG"
 cat >"$STUB_BIN/nix" <<'"'"'NIX'"'"'
 #!/usr/bin/env bash
+set -euo pipefail
 printf "nix %s\n" "$*" >>"$COMMAND_LOG"
-if [ "${1:-}" = "build" ]; then
-	printf "%s\n" "$ACTIVATION"
+if [ "${1:-}" = "run" ]; then
+	mkdir -p "$DOTFILES_DOCKER_APP_PATH/Contents/MacOS" "$DOTFILES_DOCKER_APP_PATH/Contents/Resources/bin"
+	cat >"$DOTFILES_DOCKER_APP_PATH/Contents/MacOS/install" <<'"'"'DOCKER_INSTALL'"'"'
+#!/usr/bin/env bash
+printf "docker-install %s\n" "$*" >>"$COMMAND_LOG"
+DOCKER_INSTALL
+	cat >"$DOTFILES_DOCKER_APP_PATH/Contents/Resources/bin/docker" <<'"'"'DOCKER'"'"'
+#!/usr/bin/env bash
+printf "docker %s\n" "$*" >>"$COMMAND_LOG"
+exit 0
+DOCKER
+	cat >"$STUB_BIN/chezmoi" <<'"'"'CHEZMOI'"'"'
+#!/usr/bin/env bash
+printf "chezmoi %s\n" "$*" >>"$COMMAND_LOG"
+CHEZMOI
+	chmod +x \
+		"$DOTFILES_DOCKER_APP_PATH/Contents/MacOS/install" \
+		"$DOTFILES_DOCKER_APP_PATH/Contents/Resources/bin/docker" \
+		"$STUB_BIN/chezmoi"
 fi
 NIX
 chmod +x "$STUB_BIN/nix"
@@ -156,7 +128,6 @@ SCRIPT
 	*) exit 2 ;;
 esac
 '
-	export ACTIVATE_INSTALL_CHEZMOI=1
 }
 
 assert_log_order() {
@@ -169,133 +140,62 @@ assert_log_order() {
 	done
 }
 
-@test "installed prerequisites run Home Manager, chezmoi, and Compose in order without reinstalling" {
+@test "installed prerequisites run nix-darwin chezmoi and Compose in order" {
 	write_installed_stubs
 
 	run "$INSTALLER"
 
 	[ "$status" -eq 0 ]
+	grep -q "^sudo /usr/bin/env .*DOTFILES_USER=test-user .* $STUB_BIN/nix run .#darwin-rebuild -- switch --flake .#macos --impure$" "$COMMAND_LOG"
 	assert_log_order \
-		"nix build --no-link --print-out-paths .#homeConfigurations.aarch64-darwin.activationPackage --impure" \
-		"activate" \
+		"nix run .#darwin-rebuild -- switch --flake .#macos --impure" \
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull" \
-		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml up -d --force-recreate --wait"
-	! grep -q 'brew install' "$COMMAND_LOG"
-	! grep -q 'softwareupdate' "$COMMAND_LOG"
+		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml up -d --force-recreate --wait" \
+		"verify-environment --runtime"
+	! grep -q 'brew install --cask' "$COMMAND_LOG"
+	! grep -q 'desktop.docker.com/mac' "$COMMAND_LOG"
 	! grep -q 'docker-install' "$COMMAND_LOG"
-	! grep -q 'docker desktop start' "$COMMAND_LOG"
 }
 
-@test "Home Manager build retries a transient Nix failure" {
+@test "nix-darwin switch failure stops before runtime setup" {
 	write_installed_stubs
-	export DOTFILES_NIX_BUILD_ATTEMPTS=2
-	export NIX_BUILD_COUNT_FILE="$BATS_TEST_TMPDIR/nix-build-count"
 	write_stub nix '
 printf "nix %s\n" "$*" >>"$COMMAND_LOG"
-if [ "${1:-}" = "build" ]; then
-	count=0
-	if [ -f "$NIX_BUILD_COUNT_FILE" ]; then
-		count="$(cat "$NIX_BUILD_COUNT_FILE")"
-	fi
-	count=$((count + 1))
-	printf "%s\n" "$count" >"$NIX_BUILD_COUNT_FILE"
-	if [ "$count" -eq 1 ]; then
-		printf "transient cache failure\n" >&2
-		exit 1
-	fi
-	printf "%s\n" "$ACTIVATION"
-fi
+if [ "${1:-}" = "run" ]; then exit 42; fi
 '
 
 	run "$INSTALLER"
 
-	[ "$status" -eq 0 ]
-	[ "$(cat "$NIX_BUILD_COUNT_FILE")" -eq 2 ]
+	[ "$status" -eq 42 ]
+	! grep -q '^chezmoi ' "$COMMAND_LOG"
+	! grep -q '^docker compose ' "$COMMAND_LOG"
 }
 
-@test "fresh install provisions Homebrew Docker Desktop Rosetta and Nix with required arguments" {
+@test "fresh install provisions Nix then delegates apps and Rosetta to nix-darwin" {
 	write_fresh_install_stubs
 
 	run "$INSTALLER"
 
 	[ "$status" -eq 0 ]
-	grep -q 'brew install --cask docker-desktop' "$COMMAND_LOG"
-	grep -q 'sudo .* --accept-license --user=test-user' "$COMMAND_LOG"
-	grep -q 'docker-install --accept-license --user=test-user' "$COMMAND_LOG"
-	grep -q 'softwareupdate --install-rosetta --agree-to-license' "$COMMAND_LOG"
-	grep -q 'nix-installer --daemon' "$COMMAND_LOG"
+	assert_log_order \
+		"nix-installer --daemon" \
+		"nix run .#darwin-rebuild -- switch --flake .#macos --impure" \
+		"docker-install --accept-license --user=test-user" \
+		"chezmoi init --source $REPO_ROOT/chezmoi"
+	[ "$(grep -c 'nix-installer --daemon' "$COMMAND_LOG")" -eq 1 ]
+	! grep -q 'raw.githubusercontent.com/Homebrew/install' "$COMMAND_LOG"
+	! grep -q 'brew install --cask' "$COMMAND_LOG"
+	! grep -q 'desktop.docker.com/mac' "$COMMAND_LOG"
+	! grep -q 'softwareupdate' "$COMMAND_LOG"
 }
 
-@test "Docker Desktop cask failure uses the checksum-verified DMG fallback" {
-	write_installed_stubs
-	rm -rf "$FAKE_DOCKER_APP"
-	rm -f "$DOTFILES_DOCKER_SETUP_MARKER"
-	export DOTFILES_DOCKER_FALLBACK_URL="https://example.test/Docker.dmg"
-	printf 'verified docker dmg\n' >"$BATS_TEST_TMPDIR/fallback-source.dmg"
-	export DOTFILES_DOCKER_FALLBACK_SHA256
-	DOTFILES_DOCKER_FALLBACK_SHA256="$(
-		shasum -a 256 "$BATS_TEST_TMPDIR/fallback-source.dmg" | awk '{print $1}'
-	)"
-
-	write_stub brew '
-printf "brew %s\n" "$*" >>"$COMMAND_LOG"
-if [ "${1:-}" = "shellenv" ]; then
-	printf "export PATH=%q:\$PATH\n" "$STUB_BIN"
-	exit 0
-fi
-exit 1
-'
-	write_stub curl '
-printf "curl %s\n" "$*" >>"$COMMAND_LOG"
-output=""
-while [ "$#" -gt 0 ]; do
-	if [ "$1" = "-o" ]; then
-		shift
-		output="$1"
-	fi
-	shift
-done
-cp "$BATS_TEST_TMPDIR/fallback-source.dmg" "$output"
-'
-	write_stub 7zz '
-printf "7zz %s\n" "$*" >>"$COMMAND_LOG"
-output=""
-for arg in "$@"; do
-	case "$arg" in
-		-o*) output="${arg#-o}" ;;
-	esac
-done
-app="$output/Docker/Docker.app"
-mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources/bin"
-cat >"$app/Contents/MacOS/install" <<'"'"'INSTALL'"'"'
-#!/usr/bin/env bash
-printf "docker-install %s\n" "$*" >>"$COMMAND_LOG"
-INSTALL
-cat >"$app/Contents/Resources/bin/docker" <<'"'"'DOCKER'"'"'
-#!/usr/bin/env bash
-printf "docker %s\n" "$*" >>"$COMMAND_LOG"
-exit 0
-DOCKER
-chmod +x "$app/Contents/MacOS/install" "$app/Contents/Resources/bin/docker"
-'
-	write_stub ditto '
-printf "ditto %s\n" "$*" >>"$COMMAND_LOG"
-cp -R "$1" "$2"
-'
-	write_stub codesign 'printf "codesign %s\n" "$*" >>"$COMMAND_LOG"'
-
-	run "$INSTALLER"
-
-	[ "$status" -eq 0 ]
-	grep -q '^brew install --cask docker-desktop$' "$COMMAND_LOG"
-	grep -q '^curl .*https://example.test/Docker.dmg.*-o ' "$COMMAND_LOG"
-	grep -q '^7zz x -snld20 ' "$COMMAND_LOG"
-	grep -q "^ditto .* $FAKE_DOCKER_APP$" "$COMMAND_LOG"
-	grep -q "^codesign --verify --deep --strict $FAKE_DOCKER_APP$" "$COMMAND_LOG"
-	grep -q '^docker-install --accept-license --user=test-user$' "$COMMAND_LOG"
+@test "macOS installer contains no imperative application installer fallback" {
+	grep -q 'run .#darwin-rebuild -- switch --flake .#macos --impure' "$INSTALLER"
+	! grep -q 'brew install --cask' "$INSTALLER"
+	! grep -q 'desktop.docker.com/mac' "$INSTALLER"
 }
 
 @test "a checkout already at the dotfiles target is kept in place" {
@@ -306,6 +206,7 @@ cp -R "$1" "$2"
 		"$HOME/.dotfiles/chezmoi" \
 		"$HOME/.dotfiles/docker/hermes-agent"
 	cp "$INSTALLER" "$HOME/.dotfiles/scripts/sh/install-macos.sh"
+	cp "$COMMON_INSTALLER" "$HOME/.dotfiles/scripts/sh/install-common.sh"
 	touch \
 		"$HOME/.dotfiles/flake.nix" \
 		"$HOME/.dotfiles/docker/hermes-agent/compose.yml"
@@ -336,11 +237,14 @@ cp -R "$1" "$2"
 
 @test "Docker engine readiness timeout fails after the configured attempt count" {
 	write_installed_stubs
-	write_stub docker '
+	cat >"$FAKE_DOCKER_APP/Contents/Resources/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
 printf "docker %s\n" "$*" >>"$COMMAND_LOG"
 if [ "${1:-}" = "info" ]; then exit 1; fi
 exit 0
-'
+EOF
+	chmod +x "$FAKE_DOCKER_APP/Contents/Resources/bin/docker"
 
 	run "$INSTALLER"
 

--- a/tests/bash/install_nixos.bats
+++ b/tests/bash/install_nixos.bats
@@ -107,6 +107,23 @@ line_of() {
 	! grep -q '^nixos-rebuild ' "$COMMAND_LOG"
 }
 
+@test "NixOS E2E can activate an already built system through the real installer" {
+	prebuilt="$BATS_TEST_TMPDIR/prebuilt-system"
+	mkdir -p "$prebuilt/bin"
+	cat >"$prebuilt/bin/switch-to-configuration" <<'EOF'
+#!/usr/bin/env bash
+printf 'switch-to-configuration %s\n' "$*" >>"$COMMAND_LOG"
+EOF
+	chmod +x "$prebuilt/bin/switch-to-configuration"
+	export DOTFILES_NIXOS_PREBUILT_SYSTEM="$prebuilt"
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 0 ]
+	grep -q '^switch-to-configuration switch$' "$COMMAND_LOG"
+	! grep -q '^nixos-rebuild ' "$COMMAND_LOG"
+}
+
 @test "NixOS rebuild failure stops before user configuration" {
 	write_stub nixos-rebuild '
 printf "nixos-rebuild %s\n" "$*" >>"$COMMAND_LOG"

--- a/tests/bash/install_nixos.bats
+++ b/tests/bash/install_nixos.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+	INSTALLER="$REPO_ROOT/scripts/sh/install-nixos.sh"
+	TEST_HOME="$BATS_TEST_TMPDIR/home"
+	STUB_BIN="$BATS_TEST_TMPDIR/bin"
+	COMMAND_LOG="$BATS_TEST_TMPDIR/commands.log"
+	NIXOS_MARKER="$BATS_TEST_TMPDIR/NIXOS"
+	CURRENT_SYSTEM="$BATS_TEST_TMPDIR/current-system"
+	HARDWARE_CONFIG="$BATS_TEST_TMPDIR/hardware-configuration.nix"
+	mkdir -p "$TEST_HOME" "$STUB_BIN" "$CURRENT_SYSTEM"
+	: >"$COMMAND_LOG"
+	: >"$NIXOS_MARKER"
+	printf '{ ... }: { fileSystems."/" = { device = "/dev/vda"; fsType = "ext4"; }; }\n' >"$HARDWARE_CONFIG"
+
+	export HOME="$TEST_HOME"
+	export USER="test-user"
+	export PATH="$STUB_BIN:/usr/bin:/bin"
+	export COMMAND_LOG STUB_BIN
+	export DOTFILES_NIXOS_MARKER="$NIXOS_MARKER"
+	export DOTFILES_CURRENT_SYSTEM_PATH="$CURRENT_SYSTEM"
+	export DOTFILES_NIXOS_HARDWARE_CONFIG="$HARDWARE_CONFIG"
+	export DOTFILES_WAIT_SLEEP_SECONDS=0
+	export DOTFILES_SERVICE_WAIT_ATTEMPTS=2
+	export DOTFILES_VERIFY_ENVIRONMENT="$STUB_BIN/verify-environment"
+
+	write_stub uname '
+case "${1:-}" in
+	-s) echo Linux ;;
+	-m) echo x86_64 ;;
+	*) exit 2 ;;
+esac
+'
+	write_stub id '
+case "${1:-}" in
+	-u) echo 1000 ;;
+	-g) echo 1000 ;;
+	-gn) echo users ;;
+	-Gn) echo "test-user docker" ;;
+	*) /usr/bin/id "$@" ;;
+esac
+'
+	write_stub nix '
+printf "nix %s\n" "$*" >>"$COMMAND_LOG"
+if [[ $* == "eval --impure --raw --expr builtins.currentSystem" ]]; then
+	printf x86_64-linux
+fi
+'
+	write_stub nixos-rebuild '
+printf "nixos-rebuild user=%s home=%s uid=%s gid=%s group=%s args=%s\n" \
+	"${DOTFILES_USER:-}" "${DOTFILES_HOME:-}" "${DOTFILES_UID:-}" \
+	"${DOTFILES_GID:-}" "${DOTFILES_GROUP:-}" "$*" >>"$COMMAND_LOG"
+'
+	write_stub sudo '
+printf "sudo %s\n" "$*" >>"$COMMAND_LOG"
+exec "$@"
+'
+	write_stub chezmoi 'printf "chezmoi %s\n" "$*" >>"$COMMAND_LOG"'
+	write_stub docker '
+printf "docker %s\n" "$*" >>"$COMMAND_LOG"
+exit 0
+'
+	write_stub nc 'exit 0'
+	write_stub sleep 'exit 0'
+	write_stub date 'echo 20260717010203'
+	write_stub verify-environment '
+printf "verify-environment layer=%s args=%s\n" "${DOTFILES_VERIFY_SYSTEM_LAYER:-}" "$*" >>"$COMMAND_LOG"
+'
+	ln -s "$REPO_ROOT" "$HOME/.dotfiles"
+}
+
+write_stub() {
+	local name="$1"
+	local body="$2"
+	cat >"$STUB_BIN/$name" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+$body
+EOF
+	chmod +x "$STUB_BIN/$name"
+}
+
+line_of() {
+	grep -nF "$1" "$COMMAND_LOG" | head -1 | cut -d: -f1
+}
+
+@test "NixOS rebuilds then applies chezmoi Compose and acceptance" {
+	run "$INSTALLER"
+
+	[ "$status" -eq 0 ]
+	grep -q "nixos-rebuild user=test-user home=$HOME uid=1000 gid=1000 group=users args=switch --flake $REPO_ROOT#linux --impure" "$COMMAND_LOG"
+	grep -q "DOTFILES_NIXOS_HARDWARE_CONFIG=$HARDWARE_CONFIG" "$COMMAND_LOG"
+	[ "$(line_of nixos-rebuild)" -lt "$(line_of 'chezmoi init')" ]
+	[ "$(line_of 'chezmoi apply')" -lt "$(line_of 'docker compose')" ]
+	[ "$(line_of 'docker compose')" -lt "$(line_of verify-environment)" ]
+	grep -q '^verify-environment layer=nixos args=--runtime$' "$COMMAND_LOG"
+}
+
+@test "NixOS refuses activation without a readable hardware profile" {
+	export DOTFILES_NIXOS_HARDWARE_CONFIG="$BATS_TEST_TMPDIR/missing-hardware.nix"
+
+	run "$INSTALLER"
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"NixOS hardware configuration is missing"* ]]
+	! grep -q '^nixos-rebuild ' "$COMMAND_LOG"
+}
+
+@test "NixOS rebuild failure stops before user configuration" {
+	write_stub nixos-rebuild '
+printf "nixos-rebuild %s\n" "$*" >>"$COMMAND_LOG"
+exit 42
+'
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 42 ]
+	! grep -q '^chezmoi ' "$COMMAND_LOG"
+	! grep -q '^docker ' "$COMMAND_LOG"
+}
+
+@test "NixOS Compose failure stops before acceptance" {
+	write_stub docker '
+printf "docker %s\n" "$*" >>"$COMMAND_LOG"
+if [[ $* == *" up -d --force-recreate --wait"* ]]; then exit 43; fi
+'
+
+	run "$INSTALLER"
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Hermes Docker Compose startup failed"* ]]
+	! grep -q '^verify-environment ' "$COMMAND_LOG"
+}
+
+@test "NixOS acceptance failure is propagated" {
+	write_stub verify-environment '
+printf "verify-environment %s\n" "$*" >>"$COMMAND_LOG"
+exit 44
+'
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 44 ]
+}
+
+@test "NixOS host manages current identity Docker Compose and Buildx" {
+	grep -q 'DOTFILES_USER' "$REPO_ROOT/nix/hosts/linux/configuration.nix"
+	grep -q 'DOTFILES_UID' "$REPO_ROOT/nix/hosts/linux/configuration.nix"
+	grep -q 'DOTFILES_GROUP' "$REPO_ROOT/nix/hosts/linux/configuration.nix"
+	grep -q 'virtualisation.docker.enable = true' "$REPO_ROOT/nix/hosts/linux/configuration.nix"
+	grep -q 'docker-compose' "$REPO_ROOT/nix/hosts/linux/configuration.nix"
+	grep -q 'docker-buildx' "$REPO_ROOT/nix/hosts/linux/configuration.nix"
+	! grep -q 'rootless' "$REPO_ROOT/nix/hosts/linux/configuration.nix"
+	! grep -q '/dev/sda' "$REPO_ROOT/nix/hosts/linux/configuration.nix"
+	! grep -q 'fileSystems\."/"' "$REPO_ROOT/nix/hosts/linux/configuration.nix"
+}

--- a/tests/bash/linux_config.bats
+++ b/tests/bash/linux_config.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+@test "flake exposes Ubuntu and Debian System Manager configs" {
+  grep -q 'ubuntu = mkConfig' "$REPO_ROOT/nix/flakes/system-manager.nix"
+  grep -q 'debian = mkConfig' "$REPO_ROOT/nix/flakes/system-manager.nix"
+}
+
+@test "System Manager integrates Home Manager Nix and Docker" {
+  grep -q 'home-manager.nixosModules.home-manager' "$REPO_ROOT/nix/flakes/system-manager.nix"
+  grep -q 'nix.enable = true' "$REPO_ROOT/nix/system-manager/default.nix"
+  grep -q 'services.docker' "$REPO_ROOT/nix/system-manager/docker.nix"
+  grep -q 'sockets.docker' "$REPO_ROOT/nix/system-manager/docker.nix"
+  grep -q 'docker-buildx' "$REPO_ROOT/nix/system-manager/docker.nix"
+}
+
+@test "System Manager preserves the requested existing user identity" {
+  grep -q 'mutableUsers = true' "$REPO_ROOT/nix/system-manager/default.nix"
+  grep -q 'DOTFILES_UID' "$REPO_ROOT/nix/system-manager/default.nix"
+  grep -q 'DOTFILES_GID' "$REPO_ROOT/nix/system-manager/default.nix"
+  grep -q 'DOTFILES_GROUP' "$REPO_ROOT/nix/system-manager/default.nix"
+  grep -q 'inherit uid home' "$REPO_ROOT/nix/system-manager/default.nix"
+  grep -q 'group = primaryGroup' "$REPO_ROOT/nix/system-manager/default.nix"
+}
+
+@test "Docker is activated by System Manager with a restricted group socket" {
+  grep -q 'wantedBy = \[ "system-manager.target" \]' "$REPO_ROOT/nix/system-manager/docker.nix"
+  grep -q 'SocketMode = "0660"' "$REPO_ROOT/nix/system-manager/docker.nix"
+  grep -q 'SocketGroup = "docker"' "$REPO_ROOT/nix/system-manager/docker.nix"
+}
+
+@test "native NixOS rebuild alias keeps the hardware-safe installer path" {
+	grep -q 'nrs = "~/.dotfiles/install.sh"' "$REPO_ROOT/nix/home/linux/users.nix"
+}

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -4,6 +4,27 @@ setup() {
 	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
 }
 
+@test "flake exposes a macOS nix-darwin configuration" {
+	grep -q 'darwinConfigurations.macos' "$REPO_ROOT/nix/flakes/darwin.nix"
+	grep -q './darwin.nix' "$REPO_ROOT/nix/flakes/default.nix"
+}
+
+@test "Darwin uses nix-homebrew catalog casks and Home Manager" {
+	grep -q 'nix-homebrew = {' "$REPO_ROOT/nix/darwin/default.nix"
+	grep -q 'casks = sets.darwinCasks' "$REPO_ROOT/nix/darwin/default.nix"
+	grep -q 'home-manager.darwinModules.home-manager' "$REPO_ROOT/nix/flakes/darwin.nix"
+}
+
+@test "Darwin omits the incompatible generated documentation" {
+	grep -q 'documentation.enable = false' "$REPO_ROOT/nix/darwin/default.nix"
+	grep -q 'tools.darwin-uninstaller.enable = false' "$REPO_ROOT/nix/darwin/default.nix"
+}
+
+@test "Home Manager accepts the bootstrap user and home environment" {
+	grep -q 'DOTFILES_USER' "$REPO_ROOT/nix/home/common.nix"
+	grep -q 'DOTFILES_HOME' "$REPO_ROOT/nix/home/common.nix"
+}
+
 @test "Home Manager exposes Apple Silicon package manager and Docker paths" {
 	run awk '
 		/lib\.optionals pkgs\.stdenv\.isDarwin/ { in_darwin=1 }

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+	SETS="$REPO_ROOT/nix/packages/sets.nix"
+}
+
+@test "catalog defines provider coverage outputs" {
+	grep -q 'supportReport' "$SETS"
+	grep -q 'providerErrors' "$SETS"
+	grep -q 'darwinCasks' "$SETS"
+	grep -q 'linuxSystemModules' "$SETS"
+}
+
+@test "cross-platform applications are not classified as Windows-only" {
+	windows_only="$(sed -n '/windowsOnly = {/,/^  };/p' "$SETS")"
+	for package_id in \
+		Docker.DockerDesktop \
+		dprint.dprint \
+		hadolint.hadolint \
+		Google.Chrome \
+		Microsoft.VisualStudioCode \
+		OpenAI.Codex \
+		Oven-sh.Bun \
+		zig.zig; do
+		[[ "$windows_only" != *"\"$package_id\""* ]]
+	done
+}
+
+@test "Docker declares Darwin cask and Linux system providers" {
+	run awk '
+		/docker-desktop = \{/ { in_entry=1 }
+		in_entry { print }
+		in_entry && /^    };/ { exit }
+	' "$SETS"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'winget = "Docker.DockerDesktop"'* ]]
+	[[ "$output" == *'cask = "docker-desktop"'* ]]
+	[[ "$output" == *'systemModule = "docker"'* ]]
+}
+
+@test "true Windows-only packages carry unsupported reasons" {
+	grep -q 'windowsOnlySupport' "$SETS"
+	grep -q 'Microsoft.PowerToys' "$SETS"
+	grep -q 'Windows system utility' "$SETS"
+}
+
+@test "support report derivation and CI gate are wired" {
+	grep -q 'package-support-report' "$REPO_ROOT/nix/flakes/packages.nix"
+	grep -q 'package-provider-coverage' "$REPO_ROOT/nix/flakes/packages.nix"
+	grep -q 'Verify package provider coverage' "$REPO_ROOT/.github/workflows/ci-consistency.yml"
+}
+
+@test "missing providers require an explicitly reviewed unsupported reason" {
+	grep -q 'reviewedUnsupported' "$SETS"
+	grep -q 'missing.*provider or reviewed unsupported reason' "$SETS"
+	! grep -q '{ unsupported = "No Windows provider is configured"; }' "$SETS"
+}
+
+@test "catalog Winget packages preserve ID-keyed metadata" {
+	grep -q 'attachWingetIdMetadata' "$REPO_ROOT/nix/packages/winget.nix"
+	grep -q 'attachWingetIdMetadata id' "$REPO_ROOT/nix/packages/winget.nix"
+}

--- a/tests/bash/precommit_hooks.bats
+++ b/tests/bash/precommit_hooks.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+	TEST_BIN="$BATS_TEST_TMPDIR/bin"
+	mkdir -p "$TEST_BIN"
+}
+
+write_uname_stub() {
+	local system_name="$1"
+	cat >"$TEST_BIN/uname" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' '$system_name'
+EOF
+	chmod +x "$TEST_BIN/uname"
+}
+
+write_pwsh_stub() {
+	cat >"$TEST_BIN/pwsh.exe" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"$PWSH_CALL_LOG"
+exit "${PWSH_EXIT_CODE:-0}"
+EOF
+	chmod +x "$TEST_BIN/pwsh.exe"
+}
+
+@test "PowerShell pre-commit runner skips macOS" {
+	write_uname_stub Darwin
+	write_pwsh_stub
+	export PWSH_CALL_LOG="$BATS_TEST_TMPDIR/pwsh.log"
+
+	PATH="$TEST_BIN:$PATH" run "$REPO_ROOT/scripts/sh/run-windows-powershell-tests.sh" -NoProfile -Command "exit 1"
+
+	[ "$status" -eq 0 ]
+	[ ! -e "$PWSH_CALL_LOG" ]
+}
+
+@test "PowerShell pre-commit runner delegates to pwsh.exe on Windows Git Bash" {
+	write_uname_stub MINGW64_NT-10.0
+	write_pwsh_stub
+	export PWSH_CALL_LOG="$BATS_TEST_TMPDIR/pwsh.log"
+	export PWSH_EXIT_CODE=23
+
+	PATH="$TEST_BIN:$PATH" run "$REPO_ROOT/scripts/sh/run-windows-powershell-tests.sh" -NoProfile -Command "Write-Host ok"
+
+	[ "$status" -eq 23 ]
+	grep -q -- '-NoProfile -Command Write-Host ok' "$PWSH_CALL_LOG"
+}
+
+@test "PowerShell pre-commit hooks use the platform-aware runner" {
+	run grep -c 'scripts/sh/run-windows-powershell-tests.sh' "$REPO_ROOT/.pre-commit-config.yaml"
+
+	[ "$status" -eq 0 ]
+	[ "$output" -eq 2 ]
+}

--- a/tests/bash/verify_environment.bats
+++ b/tests/bash/verify_environment.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+	VERIFIER="$REPO_ROOT/scripts/sh/verify-environment.sh"
+	STUB_BIN="$BATS_TEST_TMPDIR/bin"
+	COMMAND_LOG="$BATS_TEST_TMPDIR/commands.log"
+	mkdir -p "$STUB_BIN"
+	: >"$COMMAND_LOG"
+
+	export PATH="$STUB_BIN:/usr/bin:/bin"
+	export COMMAND_LOG
+	export DOTFILES_COMPOSE_FILE="$REPO_ROOT/docker/hermes-agent/compose.yml"
+	export DOTFILES_VERIFY_PLATFORM=darwin
+
+	for command_name in \
+		nix brew darwin-rebuild git gh chezmoi rg fd jq nvim node python3 go rustup docker; do
+		write_stub "$command_name"
+	done
+}
+
+write_stub() {
+	local command_name="$1"
+	cat >"$STUB_BIN/$command_name" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+command_name="${0##*/}"
+printf '%s %s\n' "$command_name" "$*" >>"$COMMAND_LOG"
+if [[ $command_name == "chezmoi" && ${1:-} == "verify" && -n ${CHEZMOI_VERIFY_FAIL:-} ]]; then
+	exit 1
+fi
+if [[ $command_name == "docker" ]]; then
+	case "$*" in
+		*" config --services") printf 'api\ndashboard\nbrowser\n' ;;
+		*" ps --status running --services")
+			if [[ -n ${COMPOSE_RUNNING_MISMATCH:-} ]]; then
+				printf 'api\ndashboard\n'
+			else
+				printf 'api\ndashboard\nbrowser\n'
+			fi
+			;;
+	esac
+fi
+EOF
+	chmod +x "$STUB_BIN/$command_name"
+}
+
+@test "missing required command fails verification" {
+	rm "$STUB_BIN/nvim"
+
+	run "$VERIFIER"
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"missing command: nvim"* ]]
+}
+
+@test "runtime verification exercises Docker and Compose" {
+	run "$VERIFIER" --runtime
+
+	[ "$status" -eq 0 ]
+	grep -q '^docker run --rm hello-world$' "$COMMAND_LOG"
+	grep -q "^docker compose -f $DOTFILES_COMPOSE_FILE config$" "$COMMAND_LOG"
+	grep -q "^docker compose -f $DOTFILES_COMPOSE_FILE ps --status running$" "$COMMAND_LOG"
+}
+
+@test "chezmoi drift fails verification" {
+	export CHEZMOI_VERIFY_FAIL=1
+
+	run "$VERIFIER"
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"chezmoi target state differs"* ]]
+}
+
+@test "non-runtime verification does not run a test container" {
+	run "$VERIFIER"
+
+	[ "$status" -eq 0 ]
+	! grep -q '^docker run ' "$COMMAND_LOG"
+}
+
+@test "missing running Compose service fails runtime verification" {
+	export COMPOSE_RUNNING_MISMATCH=1
+
+	run "$VERIFIER" --runtime
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"not all Compose services are running"* ]]
+}
+
+@test "Linux verification checks System Manager and Docker systemd units" {
+	export DOTFILES_VERIFY_PLATFORM=linux
+	rm "$STUB_BIN/brew" "$STUB_BIN/darwin-rebuild"
+	write_stub systemctl
+
+	run "$VERIFIER"
+
+	[ "$status" -eq 0 ]
+	grep -q '^systemctl is-active --quiet system-manager.target$' "$COMMAND_LOG"
+	grep -q '^systemctl is-active --quiet docker.service$' "$COMMAND_LOG"
+	grep -q '^systemctl is-active --quiet docker.socket$' "$COMMAND_LOG"
+}
+
+@test "NixOS verification checks the current generation and Docker units" {
+	export DOTFILES_VERIFY_PLATFORM=linux
+	export DOTFILES_VERIFY_SYSTEM_LAYER=nixos
+	export DOTFILES_CURRENT_SYSTEM_PATH="$BATS_TEST_TMPDIR/current-system"
+	mkdir -p "$DOTFILES_CURRENT_SYSTEM_PATH"
+	rm "$STUB_BIN/brew" "$STUB_BIN/darwin-rebuild"
+	write_stub systemctl
+	write_stub nixos-rebuild
+
+	run "$VERIFIER"
+
+	[ "$status" -eq 0 ]
+	! grep -q 'system-manager.target' "$COMMAND_LOG"
+	grep -q '^systemctl is-active --quiet docker.service$' "$COMMAND_LOG"
+	grep -q '^systemctl is-active --quiet docker.socket$' "$COMMAND_LOG"
+}

--- a/tests/bash/verify_environment.bats
+++ b/tests/bash/verify_environment.bats
@@ -70,7 +70,8 @@ EOF
 
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"chezmoi target state differs"* ]]
-	grep -q '^chezmoi diff --no-pager --color=false$' "$COMMAND_LOG"
+	grep -q '^chezmoi verify --exclude=scripts$' "$COMMAND_LOG"
+	grep -q '^chezmoi diff --exclude=scripts --no-pager --color=false$' "$COMMAND_LOG"
 }
 
 @test "non-runtime verification does not run a test container" {

--- a/tests/bash/verify_environment.bats
+++ b/tests/bash/verify_environment.bats
@@ -70,6 +70,7 @@ EOF
 
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"chezmoi target state differs"* ]]
+	grep -q '^chezmoi diff --no-pager --color=false$' "$COMMAND_LOG"
 }
 
 @test "non-runtime verification does not run a test container" {


### PR DESCRIPTION
## Summary

- centralize Windows, macOS, Linux, and NixOS package-provider metadata in the Nix catalog
- converge each supported OS through one command, including Docker/Compose and runtime acceptance
- add hosted build and destructive Linux/NixOS E2E coverage plus protected Windows/macOS self-hosted E2E
- require the current NixOS hardware profile instead of applying a repository-wide disk layout

## Validation

- Bats: 87/87
- focused Pester: 79/79
- nix fmt, Statix, ShellCheck, and Actionlint for the added workflows
- aarch64-darwin build and package support report build
- x86_64-linux flake checks and NixOS VM test derivation evaluation
- local tree SHA verified identical to the GitHub branch tree

## Notes

The destructive Windows and macOS jobs use the protected `destructive-e2e` environment and dedicated `dotfiles-e2e` self-hosted runners.