### PR TITLE
Fix zsh delete key bindings

### DIFF
--- a/chezmoi/dot_config/shell/gh-token-switch.sh
+++ b/chezmoi/dot_config/shell/gh-token-switch.sh
@@ -1,6 +1,18 @@
 # GitHub CLI token switching for personal/work repositories.
 # Sourced by ~/.bashrc after 1Password-managed secrets are loaded.
 
+_dotfiles_bind_zsh_delete_keys() {
+  [ -n "${ZSH_VERSION:-}" ] || return 0
+
+  bindkey '^?' backward-delete-char
+  bindkey '^H' backward-delete-char
+  zmodload -F zsh/terminfo +p:terminfo 2>/dev/null || true
+  eval 'if [[ -n "${terminfo[kdch1]:-}" ]]; then bindkey "${terminfo[kdch1]}" delete-char; fi'
+  bindkey '^[[3~' delete-char
+}
+
+_dotfiles_bind_zsh_delete_keys
+
 _dotfiles_git_remote_is_work() {
   command -v git >/dev/null 2>&1 || return 1
   git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1

--- a/scripts/powershell/tests/chezmoi/ZshKeybindings.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ZshKeybindings.Tests.ps1
@@ -5,7 +5,7 @@ BeforeAll {
 }
 
 Describe 'zsh keybindings' {
-    It 'binds delete keys explicitly for terminal compatibility' {
+    It 'should bind delete keys explicitly for terminal compatibility' {
         $homeManagerZsh = Get-Content -LiteralPath (Join-Path $script:repoRoot "nix/home/common.nix") -Raw
         $zshHelper = Get-Content -LiteralPath (Join-Path $script:repoRoot "chezmoi/dot_config/shell/gh-token-switch.sh") -Raw
 

--- a/scripts/powershell/tests/chezmoi/ZshKeybindings.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ZshKeybindings.Tests.ps1
@@ -1,0 +1,19 @@
+#Requires -Module Pester
+
+BeforeAll {
+    $script:repoRoot = Join-Path $PSScriptRoot "../../../.."
+}
+
+Describe 'zsh keybindings' {
+    It 'binds delete keys explicitly for terminal compatibility' {
+        $homeManagerZsh = Get-Content -LiteralPath (Join-Path $script:repoRoot "nix/home/common.nix") -Raw
+        $zshHelper = Get-Content -LiteralPath (Join-Path $script:repoRoot "chezmoi/dot_config/shell/gh-token-switch.sh") -Raw
+
+        $homeManagerZsh | Should -Match 'gh-token-switch\.sh'
+        $zshHelper | Should -Match '\$\{ZSH_VERSION:-\}'
+        $zshHelper | Should -Match 'bindkey ''\^\?'' backward-delete-char'
+        $zshHelper | Should -Match 'bindkey ''\^H'' backward-delete-char'
+        $zshHelper | Should -Match 'terminfo\[kdch1\].*delete-char'
+        $zshHelper | Should -Match 'bindkey ''\^\[\[3~'' delete-char'
+    }
+}


### PR DESCRIPTION
## Summary
- Bind zsh Backspace/Delete escape sequences explicitly when the shared shell helper is sourced.
- Add Pester coverage for the zsh delete keybinding wiring.

## Validation
- `pwsh -NoLogo -NoProfile -Command 'Invoke-Pester -Path scripts/powershell/tests/chezmoi/ZshKeybindings.Tests.ps1 -Output Detailed'` (1 passed)
- `pwsh -NoLogo -NoProfile -Command 'Invoke-Pester -Path @("scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1", "scripts/powershell/tests/chezmoi/ZshKeybindings.Tests.ps1") -Output Detailed'` (44 passed)
- `nix fmt` (0 changed)
- `bash -n chezmoi/dot_config/shell/gh-token-switch.sh`
- `TERM=wezterm zsh -fc 'source chezmoi/dot_config/shell/gh-token-switch.sh; bindkey | sed -n "/\\^\\[\\[3~/p;/\\^?/p;/\\^H/p"'`
- `git diff --check origin/main..HEAD`