### PR TITLE
Add macOS nrs rebuild alias

### DIFF
--- a/nix/darwin/default.nix
+++ b/nix/darwin/default.nix
@@ -68,7 +68,7 @@ in
         imports = [ ../home/common.nix ];
 
         programs.zsh.shellAliases = {
-          nrs = "sudo /usr/bin/env \"NIX_CONFIG=extra-experimental-features = nix-command flakes\" \"DOTFILES_USER=$USER\" \"DOTFILES_HOME=$HOME\" nix run ~/.dotfiles#darwin-rebuild -- switch --flake ~/.dotfiles#macos --impure";
+          nrs = "nix_bin=$(command -v nix) && sudo /usr/bin/env \"NIX_CONFIG=extra-experimental-features = nix-command flakes\" \"DOTFILES_USER=$USER\" \"DOTFILES_HOME=$HOME\" \"$nix_bin\" run ~/.dotfiles#darwin-rebuild -- switch --flake ~/.dotfiles#macos --impure";
         };
       };
     extraSpecialArgs = { inherit inputs; };

--- a/nix/darwin/default.nix
+++ b/nix/darwin/default.nix
@@ -62,7 +62,15 @@ in
     useGlobalPkgs = true;
     useUserPackages = true;
     backupFileExtension = "hm-backup";
-    users.${user} = import ../home/common.nix;
+    users.${user} =
+      { ... }:
+      {
+        imports = [ ../home/common.nix ];
+
+        programs.zsh.shellAliases = {
+          nrs = "sudo /usr/bin/env \"NIX_CONFIG=extra-experimental-features = nix-command flakes\" \"DOTFILES_USER=$USER\" \"DOTFILES_HOME=$HOME\" nix run ~/.dotfiles#darwin-rebuild -- switch --flake ~/.dotfiles#macos --impure";
+        };
+      };
     extraSpecialArgs = { inherit inputs; };
   };
 }

--- a/tests/bash/linux_config.bats
+++ b/tests/bash/linux_config.bats
@@ -35,3 +35,8 @@ setup() {
 @test "native NixOS rebuild alias keeps the hardware-safe installer path" {
 	grep -q 'nrs = "~/.dotfiles/install.sh"' "$REPO_ROOT/nix/home/linux/users.nix"
 }
+
+@test "macOS rebuild alias runs nix-darwin switch" {
+	grep -q 'nrs = "sudo /usr/bin/env' "$REPO_ROOT/nix/darwin/default.nix"
+	grep -q 'nix run ~/.dotfiles#darwin-rebuild -- switch --flake ~/.dotfiles#macos --impure' "$REPO_ROOT/nix/darwin/default.nix"
+}

--- a/tests/bash/linux_config.bats
+++ b/tests/bash/linux_config.bats
@@ -37,6 +37,6 @@ setup() {
 }
 
 @test "macOS rebuild alias runs nix-darwin switch" {
-	grep -q 'nrs = "sudo /usr/bin/env' "$REPO_ROOT/nix/darwin/default.nix"
-	grep -q 'nix run ~/.dotfiles#darwin-rebuild -- switch --flake ~/.dotfiles#macos --impure' "$REPO_ROOT/nix/darwin/default.nix"
+	grep -Fq 'nrs = "nix_bin=$(command -v nix) && sudo /usr/bin/env' "$REPO_ROOT/nix/darwin/default.nix"
+	grep -Fq '\"$nix_bin\" run ~/.dotfiles#darwin-rebuild -- switch --flake ~/.dotfiles#macos --impure' "$REPO_ROOT/nix/darwin/default.nix"
 }


### PR DESCRIPTION
## Summary

- Add a macOS-only `nrs` zsh alias through the nix-darwin Home Manager user module.
- Resolve the user `nix` executable before `sudo`, then run the locked `darwin-rebuild` flake app with `switch --flake ~/.dotfiles#macos --impure`.
- Add Bats coverage for the macOS alias declaration and sudo-safe nix path usage.

## Validation

- `bats tests/bash/linux_config.bats`
- `nix fmt`
- `task commit -- Add macOS nrs rebuild alias` (`pre-commit run --all-files`)
- `task commit -- Use resolved nix path in macOS nrs alias` (`pre-commit run --all-files`)