### PR TITLE
Update flake inputs and macOS GUI applications

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -68,6 +68,24 @@
       }
     },
     "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
       "inputs": {
         "nixpkgs-lib": [
           "system-manager",
@@ -86,24 +104,6 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782134359,
-        "narHash": "sha256-dh0RDcJ17Rubgk3hGTugYmTu6rnUPfRu5vA7MA1Pdo0=",
+        "lastModified": 1784489491,
+        "narHash": "sha256-j9maqjx1T8+ljAVntAdSI5hSGCm77QNZz64JF1rJNu0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "979bfee6e1a7996fc395270d54c9b59e88762494",
+        "rev": "3139deb8cafbe73b39b24451255b2fdd3426077e",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784123936,
-        "narHash": "sha256-IOWwQMJhUxcojm0MRvuKs1fKLH727u4+hHeEOPhdUyA=",
+        "lastModified": 1784500460,
+        "narHash": "sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "a4cf1d10853b0d2be19b9eca35d749e201d70b55",
+        "rev": "57a3171f94705599a2499248ca5758d5eb47c0e0",
         "type": "github"
       },
       "original": {
@@ -191,15 +191,14 @@
     },
     "nixos-vscode-server": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "flake-parts": "flake-parts_2"
       },
       "locked": {
-        "lastModified": 1770124655,
-        "narHash": "sha256-yHmd2B13EtBUPLJ+x0EaBwNkQr9LTne1arLVxT6hSnY=",
+        "lastModified": 1784312229,
+        "narHash": "sha256-2uHCSUw341o3my1R0U0YCfbnMEazylxb58evWsjGL50=",
         "owner": "nix-community",
         "repo": "nixos-vscode-server",
-        "rev": "92ce71c3ba5a94f854e02d57b14af4997ab54ef0",
+        "rev": "2f984dfbe7e5271b5c413d3e734374cc1306c921",
         "type": "github"
       },
       "original": {
@@ -211,14 +210,16 @@
     "nixos-wsl": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1781182279,
-        "narHash": "sha256-V5EQQbDnmdiXGQXrEF1PEL7QYsFqfH8N1E89Z5ONwFk=",
+        "lastModified": 1784058842,
+        "narHash": "sha256-3u3tvbCIAid3Mv7RrJx13jusIEQC/HeKYhO/SUSxR3A=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "5675822ba756e6e56f8f6a5a76e90e0da2ece94d",
+        "rev": "24c8dc8e0f2170e1a377be24dfadc7d9d21dc1ad",
         "type": "github"
       },
       "original": {
@@ -228,51 +229,6 @@
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1682134069,
-        "narHash": "sha256-TnI/ZXSmRxQDt2sjRYK/8j8iha4B4zP2cnQCZZ3vp7k=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fd901ef4bf93499374c5af385b2943f5801c0833",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
       "locked": {
         "lastModified": 1784356753,
         "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
@@ -288,19 +244,33 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1768305791,
-        "narHash": "sha256-AIdl6WAn9aymeaH/NvBj0H9qM+XuAuYbGMZaP0zcXAQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1412caf7bf9e660f2f962917c14b1ea1c3bc695e",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
         "type": "github"
       }
     },
@@ -340,9 +310,9 @@
         "nix-homebrew": "nix-homebrew",
         "nixos-vscode-server": "nixos-vscode-server",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs",
         "system-manager": "system-manager",
-        "systems": "systems_3",
+        "systems": "systems_2",
         "treefmt-nix": "treefmt-nix",
         "workmux": "workmux"
       }
@@ -399,21 +369,6 @@
         "type": "github"
       }
     },
-    "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
@@ -421,11 +376,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "lastModified": 1784369104,
+        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
         "type": "github"
       },
       "original": {
@@ -440,13 +395,13 @@
           "system-manager",
           "flake-compat"
         ],
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "nixpkgs": [
           "system-manager",
           "nixpkgs"
         ],
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
-        "systems": "systems_2"
+        "systems": "systems"
       },
       "locked": {
         "lastModified": 1770377964,
@@ -465,14 +420,16 @@
     },
     "workmux": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1781294686,
-        "narHash": "sha256-KpL8s32cKatXOU0KpjwzYBXaE/HAY40v7010BdmQcFA=",
+        "lastModified": 1784375035,
+        "narHash": "sha256-HnqP0wvVk3q5nTXzGmFQ96cDqnCQ2zjs4TtO1ZxU80g=",
         "owner": "raine",
         "repo": "workmux",
-        "rev": "366a19f72ac6eb628fe502ecee7da56718c05bbc",
+        "rev": "de98e3162fa7caa31332ba6f3fc8dfe5df007e5e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,10 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     systems.url = "github:nix-systems/default";
-    nixos-wsl.url = "github:nix-community/NixOS-WSL";
+    nixos-wsl = {
+      url = "github:nix-community/NixOS-WSL";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     nixos-vscode-server.url = "github:nix-community/nixos-vscode-server";
     nix-darwin = {
       url = "github:nix-darwin/nix-darwin/master";
@@ -22,7 +25,10 @@
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    workmux.url = "github:raine/workmux";
+    workmux = {
+      url = "github:raine/workmux";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/nix/darwin/default.nix
+++ b/nix/darwin/default.nix
@@ -49,9 +49,10 @@ in
   homebrew = {
     enable = true;
     casks = sets.darwinCasks;
+    greedyCasks = true;
     onActivation = {
-      autoUpdate = false;
-      upgrade = false;
+      autoUpdate = true;
+      upgrade = true;
       cleanup = "none";
     };
   };
@@ -68,7 +69,7 @@ in
         imports = [ ../home/common.nix ];
 
         programs.zsh.shellAliases = {
-          nrs = "nix_bin=$(command -v nix) && sudo /usr/bin/env \"NIX_CONFIG=extra-experimental-features = nix-command flakes\" \"DOTFILES_USER=$USER\" \"DOTFILES_HOME=$HOME\" \"$nix_bin\" run ~/.dotfiles#darwin-rebuild -- switch --flake ~/.dotfiles#macos --impure";
+          nrs = "~/.dotfiles/install.sh";
         };
       };
     extraSpecialArgs = { inherit inputs; };

--- a/nix/flakes/darwin.nix
+++ b/nix/flakes/darwin.nix
@@ -1,11 +1,8 @@
 { inputs, ... }:
 let
   system = "aarch64-darwin";
-  workmuxOverlay = _: _: {
-    workmux = inputs.workmux.packages.${system}.default.overrideAttrs (_: {
-      doCheck = false;
-    });
-  };
+  Workmux = import ./lib/workmux.nix { inherit inputs; };
+  workmuxOverlay = Workmux.mkOverlay (_: inputs.workmux.packages.${system}.default);
 in
 {
   flake.darwinConfigurations.macos = inputs.nix-darwin.lib.darwinSystem {

--- a/nix/flakes/home.nix
+++ b/nix/flakes/home.nix
@@ -5,11 +5,8 @@
 #   home-manager switch --flake .#aarch64-linux
 { inputs, ... }:
 let
-  workmuxOverlay = final: prev: {
-    workmux = inputs.workmux.packages.${prev.stdenv.hostPlatform.system}.default.overrideAttrs (_: {
-      doCheck = false;
-    });
-  };
+  Workmux = import ./lib/workmux.nix { inherit inputs; };
+  workmuxOverlay = Workmux.mkOverlay (system: inputs.workmux.packages.${system}.default);
   mkHome =
     system:
     inputs.home-manager.lib.homeManagerConfiguration {

--- a/nix/flakes/hosts.nix
+++ b/nix/flakes/hosts.nix
@@ -5,11 +5,8 @@
 }:
 let
   Hosts = import ./lib/hosts.nix { inherit inputs; };
-  workmuxOverlay = final: prev: {
-    workmux = inputs.workmux.packages.${prev.stdenv.hostPlatform.system}.default.overrideAttrs (_: {
-      doCheck = false;
-    });
-  };
+  Workmux = import ./lib/workmux.nix { inherit inputs; };
+  workmuxOverlay = Workmux.mkOverlay (system: inputs.workmux.packages.${system}.default);
   hardwareConfig = builtins.getEnv "DOTFILES_NIXOS_HARDWARE_CONFIG";
   requestedSystem = builtins.getEnv "DOTFILES_SYSTEM";
   nativeLinuxSystem = if requestedSystem == "" then "x86_64-linux" else requestedSystem;

--- a/nix/flakes/lib/workmux.nix
+++ b/nix/flakes/lib/workmux.nix
@@ -1,0 +1,36 @@
+{ inputs }:
+let
+  lib = inputs.nixpkgs.lib;
+
+  withoutAuditableCargo =
+    nativeBuildInputs:
+    lib.filter (input: !(lib.hasPrefix "auditable-cargo" (input.name or ""))) nativeBuildInputs;
+
+  overrideWorkmux =
+    pkgs: package:
+    package.overrideAttrs (
+      old:
+      {
+        doCheck = false;
+      }
+      // lib.optionalAttrs (pkgs.stdenv.hostPlatform.isDarwin && pkgs.stdenv.hostPlatform.isAarch64) {
+        nativeBuildInputs = withoutAuditableCargo (old.nativeBuildInputs or [ ]) ++ [
+          pkgs.llvmPackages_21.lld
+        ];
+        buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.libiconv ];
+        RUSTFLAGS = lib.concatStringsSep " " (
+          lib.filter (flag: flag != "") [
+            (old.RUSTFLAGS or "")
+            "-C linker=${pkgs.llvmPackages_21.lld}/bin/ld64.lld"
+            "-C linker-flavor=ld64.lld"
+            "-C link-arg=-L${pkgs.libiconv}/lib"
+          ]
+        );
+      }
+    );
+in
+{
+  mkOverlay = workmuxPackageFor: final: prev: {
+    workmux = overrideWorkmux final (workmuxPackageFor prev.stdenv.hostPlatform.system);
+  };
+}

--- a/nix/flakes/packages.nix
+++ b/nix/flakes/packages.nix
@@ -15,11 +15,8 @@
       ...
     }:
     let
-      workmuxOverlay = _: _: {
-        workmux = inputs'.workmux.packages.default.overrideAttrs (_: {
-          doCheck = false;
-        });
-      };
+      Workmux = import ./lib/workmux.nix { inherit inputs; };
+      workmuxOverlay = Workmux.mkOverlay (_: inputs'.workmux.packages.default);
       unfreePkgs =
         (import pkgs.path {
           system = pkgs.stdenv.hostPlatform.system;

--- a/nix/flakes/system-manager.nix
+++ b/nix/flakes/system-manager.nix
@@ -2,11 +2,8 @@
 let
   requestedSystem = builtins.getEnv "DOTFILES_SYSTEM";
   system = if requestedSystem == "" then "x86_64-linux" else requestedSystem;
-  workmuxOverlay = _: _: {
-    workmux = inputs.workmux.packages.${system}.default.overrideAttrs (_: {
-      doCheck = false;
-    });
-  };
+  Workmux = import ./lib/workmux.nix { inherit inputs; };
+  workmuxOverlay = Workmux.mkOverlay (_: inputs.workmux.packages.${system}.default);
   mkConfig =
     distro:
     inputs.system-manager.lib.makeSystemConfig {

--- a/scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/GhTokenSwitch.Tests.ps1
@@ -811,30 +811,30 @@ Describe 'Codex login preflight helper' {
         Set-Content -LiteralPath (Join-Path $runtimeHome 'config.toml') -Encoding ascii -Value 'model = "gpt-5.5"'
         Set-Content -LiteralPath (Join-Path $runtimeHome 'hooks.json') -Encoding ascii -Value '{}'
         Set-Content -LiteralPath (Join-Path $runtimeHome 'auth.json') -Encoding ascii -Value (@{
-                auth_mode = 'chatgpt'
+                auth_mode      = 'chatgpt'
                 OPENAI_API_KEY = $null
-                tokens = @{
-                    id_token = New-TestJwt @{
-                        email = 'kohei@example.com'
+                tokens         = @{
+                    id_token      = New-TestJwt @{
+                        email                         = 'kohei@example.com'
                         'https://api.openai.com/auth' = @{
-                            chatgpt_account_id = 'acct_123'
-                            workspace_name = 'ai-mate'
+                            chatgpt_account_id   = 'acct_123'
+                            workspace_name       = 'ai-mate'
                             workspace_account_id = 'ws_456'
                         }
                     }
-                    access_token = 'test-access-token'
+                    access_token  = 'test-access-token'
                     refresh_token = 'test-refresh-token'
-                    account_id = 'acct_123'
+                    account_id    = 'acct_123'
                 }
-                last_refresh = '2026-07-10T00:00:00Z'
+                last_refresh   = '2026-07-10T00:00:00Z'
             } | ConvertTo-Json -Depth 10)
         Set-Content -LiteralPath (Join-Path $orcaRoot 'orca-data.json') -Encoding ascii -Value (@{
                 settings = @{
-                    codexManagedAccounts = @()
-                    activeCodexManagedAccountId = $null
+                    codexManagedAccounts                  = @()
+                    activeCodexManagedAccountId           = $null
                     activeCodexManagedAccountIdsByRuntime = @{
                         host = $null
-                        wsl = @{}
+                        wsl  = @{}
                     }
                 }
             } | ConvertTo-Json -Depth 10)
@@ -879,7 +879,7 @@ Describe 'Codex login preflight helper' {
         Set-Content -LiteralPath (Join-Path $runtimeHome 'config.toml') -Encoding ascii -Value 'model = "gpt-5.5"'
         Set-Content -LiteralPath (Join-Path $runtimeHome 'auth.json') -Encoding ascii -Value (@{
                 auth_mode = 'chatgpt'
-                tokens = @{
+                tokens    = @{
                     id_token = New-TestJwt @{
                         email = 'kohei@example.com'
                     }

--- a/tests/bash/linux_config.bats
+++ b/tests/bash/linux_config.bats
@@ -36,7 +36,6 @@ setup() {
 	grep -q 'nrs = "~/.dotfiles/install.sh"' "$REPO_ROOT/nix/home/linux/users.nix"
 }
 
-@test "macOS rebuild alias runs nix-darwin switch" {
-	grep -Fq 'nrs = "nix_bin=$(command -v nix) && sudo /usr/bin/env' "$REPO_ROOT/nix/darwin/default.nix"
-	grep -Fq '\"$nix_bin\" run ~/.dotfiles#darwin-rebuild -- switch --flake ~/.dotfiles#macos --impure' "$REPO_ROOT/nix/darwin/default.nix"
+@test "macOS rebuild alias keeps the application-safe installer path" {
+  grep -q 'nrs = "~/.dotfiles/install.sh"' "$REPO_ROOT/nix/darwin/default.nix"
 }

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -17,9 +17,16 @@ setup() {
 }
 
 @test "Darwin uses nix-homebrew catalog casks and Home Manager" {
-	grep -q 'nix-homebrew = {' "$REPO_ROOT/nix/darwin/default.nix"
-	grep -q 'casks = sets.darwinCasks' "$REPO_ROOT/nix/darwin/default.nix"
-	grep -q 'home-manager.darwinModules.home-manager' "$REPO_ROOT/nix/flakes/darwin.nix"
+  grep -q 'nix-homebrew = {' "$REPO_ROOT/nix/darwin/default.nix"
+  grep -q 'casks = sets.darwinCasks' "$REPO_ROOT/nix/darwin/default.nix"
+  grep -q 'home-manager.darwinModules.home-manager' "$REPO_ROOT/nix/flakes/darwin.nix"
+}
+
+@test "Darwin activation updates and upgrades every managed cask" {
+  grep -q 'greedyCasks = true' "$REPO_ROOT/nix/darwin/default.nix"
+  grep -q 'autoUpdate = true' "$REPO_ROOT/nix/darwin/default.nix"
+  grep -q 'upgrade = true' "$REPO_ROOT/nix/darwin/default.nix"
+  grep -q 'cleanup = "none"' "$REPO_ROOT/nix/darwin/default.nix"
 }
 
 @test "Darwin omits the incompatible generated documentation" {


### PR DESCRIPTION
## Summary

- update the locked flake inputs and make NixOS-WSL and workmux follow the root nixpkgs input
- add an Apple Silicon Darwin linker compatibility override for the updated workmux package
- refresh and greedily upgrade catalog-managed Homebrew casks during macOS activation
- route the macOS `nrs` alias through `install.sh` so GUI upgrades use the existing Docker shutdown and runtime acceptance flow

## Impact

Running `./install.sh` or `nrs` now upgrades managed macOS GUI applications. Nix-managed applications such as WezTerm and Warp continue to follow the versions pinned by `flake.lock`.

## Validation

- `nix flake check --all-systems --no-build`
- `env DOTFILES_USER="$(id -un)" DOTFILES_HOME="$HOME" nix build .#darwinConfigurations.macos.system --impure --no-link`
- focused macOS and alias Bats tests (16 passing)
- every Bats file run independently
- `pre-commit run --all-files`

Local directory-wide Bats execution has a pre-existing cross-file isolation failure that reproduces on the unchanged base commit; each test file passes independently.