### PR TITLE
Fix noVNC clipboard synchronization

### DIFF
--- a/docker/hermes-browser/Dockerfile
+++ b/docker/hermes-browser/Dockerfile
@@ -18,7 +18,7 @@ RUN test "$(dpkg --print-architecture)" = "amd64" \
   && groupadd --system --gid 997 hermes-browser \
   && useradd --system --uid 997 --create-home --gid hermes-browser hermes-browser \
   && install -d -o hermes-browser -g hermes-browser /data \
-  && sed -i 's#</body>#  <script type="module" src="app/clipboard-paste.js"></script>\n</body>#' /usr/share/novnc/vnc.html \
+  && sed -i 's#</body>#  <script type="module" src="app/clipboard-paste.js?v=2"></script>\n</body>#' /usr/share/novnc/vnc.html \
   && ln -sf vnc.html /usr/share/novnc/index.html
 
 ENV LANG=ja_JP.UTF-8 \

--- a/docker/hermes-browser/clipboard-paste.js
+++ b/docker/hermes-browser/clipboard-paste.js
@@ -2,6 +2,10 @@ import KeyTable from "../core/input/keysym.js";
 import RFB from "../core/rfb.js";
 import UI from "./ui.js";
 
+let clipboardRfb;
+let hostClipboardWritePending = false;
+let legacyHostCopyInProgress = false;
+
 function isClipboardPanelTarget(target) {
   return target instanceof Element && target.closest("#noVNC_clipboard") !== null;
 }
@@ -10,15 +14,126 @@ function isPasteShortcut(event) {
   return (event.ctrlKey || event.metaKey) && !event.altKey && event.code === "KeyV";
 }
 
+function isRemoteClipboardShortcut(event) {
+  return (
+    (event.ctrlKey || event.metaKey) &&
+    !event.altKey &&
+    (event.code === "KeyC" || event.code === "KeyX")
+  );
+}
+
 function sendClipboardText(text) {
   // noVNC 1.3 truncates the fallback clipboard payload to Latin-1.
   RFB.messages.clientCutText(UI.rfb._sock, new TextEncoder().encode(text));
 }
 
+function sendRemoteControlShortcut(code) {
+  const keysym = code === "KeyC" ? KeyTable.XK_c : KeyTable.XK_x;
+
+  UI.rfb.sendKey(KeyTable.XK_Control_L, "ControlLeft", true);
+  UI.rfb.sendKey(keysym, code, true);
+  UI.rfb.sendKey(keysym, code, false);
+  UI.rfb.sendKey(KeyTable.XK_Control_L, "ControlLeft", false);
+}
+
+function decodeVncClipboardText(text) {
+  if (Array.from(text).some((character) => character.charCodeAt(0) > 0xff)) {
+    return text;
+  }
+
+  try {
+    const bytes = Uint8Array.from(text, (character) => character.charCodeAt(0));
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return text;
+  }
+}
+
+function copyTextWithDocument(text) {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  legacyHostCopyInProgress = true;
+
+  try {
+    document.body.append(textarea);
+    textarea.select();
+    document.execCommand("copy");
+  } finally {
+    textarea.remove();
+    legacyHostCopyInProgress = false;
+    UI.rfb.focus();
+  }
+}
+
+function writeHostClipboard(text) {
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(text).catch(() => copyTextWithDocument(text));
+    return;
+  }
+
+  copyTextWithDocument(text);
+}
+
+function receiveRemoteClipboard(event) {
+  const rawText = event.detail?.text;
+  if (typeof rawText !== "string") {
+    return;
+  }
+
+  const text = decodeVncClipboardText(rawText);
+  document.querySelector("#noVNC_clipboard_text").value = text;
+  if (!hostClipboardWritePending) {
+    return;
+  }
+
+  hostClipboardWritePending = false;
+  writeHostClipboard(text);
+}
+
+function ensureClipboardReceiver() {
+  if (clipboardRfb === UI.rfb) {
+    return;
+  }
+
+  clipboardRfb?.removeEventListener("clipboard", receiveRemoteClipboard);
+  clipboardRfb = UI.rfb;
+  clipboardRfb.addEventListener("clipboard", receiveRemoteClipboard);
+}
+
+function beginRemoteClipboardTransfer(code) {
+  ensureClipboardReceiver();
+  hostClipboardWritePending = true;
+  sendRemoteControlShortcut(code);
+  UI.rfb.focus();
+}
+
+function handleRemoteClipboardCommand(event, code) {
+  if (!UI.rfb || legacyHostCopyInProgress || isClipboardPanelTarget(event.target)) {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  beginRemoteClipboardTransfer(code);
+}
+
 document.addEventListener(
   "keydown",
   (event) => {
-    if (!UI.rfb || isClipboardPanelTarget(event.target) || !isPasteShortcut(event)) {
+    if (!UI.rfb || isClipboardPanelTarget(event.target)) {
+      return;
+    }
+
+    if (isRemoteClipboardShortcut(event)) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      beginRemoteClipboardTransfer(event.code);
+      return;
+    }
+
+    if (!isPasteShortcut(event)) {
       return;
     }
 
@@ -27,6 +142,10 @@ document.addEventListener(
   },
   true
 );
+
+document.addEventListener("copy", (event) => handleRemoteClipboardCommand(event, "KeyC"), true);
+
+document.addEventListener("cut", (event) => handleRemoteClipboardCommand(event, "KeyX"), true);
 
 document.addEventListener(
   "paste",

--- a/docs/hermes-agent/browser-mcp.md
+++ b/docs/hermes-agent/browser-mcp.md
@@ -11,6 +11,7 @@ host 側の Chrome/Chromium/Brave 実行ファイル、host CDP endpoint、host 
 - `hermes`: `browser-mcp` service 名で Browser MCP に接続する。
 
 Google Chrome container は `ja_JP.UTF-8` locale と `--lang=ja` で起動し、Chrome UI と日本語入力内容を表示できるようにする。
+noVNC viewer は通常の `Cmd/Ctrl+C`、`Cmd/Ctrl+X`、`Cmd/Ctrl+V` を Google Chrome 側のショートカットへ変換し、プレーンテキストの clipboard をホストと双方向に同期する。
 
 Hermes から接続する内部 URL は次の固定値にする。
 

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -240,7 +240,7 @@ Describe 'HermesAgentHandler' {
             $dockerfileContent | Should -Match "hermes-browser"
             $dockerfileContent | Should -Match "COPY entrypoint\.sh"
             $dockerfileContent | Should -Match "COPY clipboard-paste\.js /usr/share/novnc/app/clipboard-paste\.js"
-            $dockerfileContent | Should -Match ([regex]::Escape('<script type="module" src="app/clipboard-paste.js"></script>'))
+            $dockerfileContent | Should -Match ([regex]::Escape('<script type="module" src="app/clipboard-paste.js?v=2"></script>'))
             $dockerfileContent | Should -Match ([regex]::Escape('ln -sf vnc.html /usr/share/novnc/index.html'))
             $dockerfileContent | Should -Match "COPY healthcheck\.sh"
             $dockerfileContent | Should -Match "chmod \+x"
@@ -302,12 +302,18 @@ Describe 'HermesAgentHandler' {
 
             $clipboardPasteContent = Get-Content -LiteralPath $clipboardPastePath -Raw
             $clipboardPasteContent | Should -Match 'document\.addEventListener\(\s*"keydown"'
+            $clipboardPasteContent | Should -Match 'document\.addEventListener\(\s*"copy"'
+            $clipboardPasteContent | Should -Match 'document\.addEventListener\(\s*"cut"'
             $clipboardPasteContent | Should -Match 'document\.addEventListener\(\s*"paste"'
+            $clipboardPasteContent | Should -Match 'addEventListener\(\s*"clipboard"'
             $clipboardPasteContent | Should -Match ([regex]::Escape('clipboardData?.getData("text/plain")'))
+            $clipboardPasteContent | Should -Match ([regex]::Escape('navigator.clipboard.writeText'))
             $clipboardPasteContent | Should -Match ([regex]::Escape('new TextEncoder().encode(text)'))
             $clipboardPasteContent | Should -Match ([regex]::Escape('RFB.messages.clientCutText'))
             $clipboardPasteContent | Should -Match "XK_Control_L"
+            $clipboardPasteContent | Should -Match "XK_c"
             $clipboardPasteContent | Should -Match "XK_v"
+            $clipboardPasteContent | Should -Match "XK_x"
             $clipboardPasteContent | Should -Match ([regex]::Escape('#noVNC_clipboard'))
 
             $imageEntrypointContent = "$dockerfileContent`n$entrypointContent"


### PR DESCRIPTION
## Summary

- synchronize plain-text clipboard data bidirectionally between the noVNC viewer and containerized Chrome
- map host Cmd/Ctrl+C and Cmd/Ctrl+X to Linux Chrome shortcuts and decode UTF-8 VNC clipboard payloads
- cache-bust the injected clipboard bridge and document the supported shortcuts
- extend Hermes browser contract tests for copy, cut, paste, and remote clipboard handling

## Root cause

The existing bridge handled only host-to-Chrome paste. Remote clipboard events stayed inside noVNC, macOS Cmd+C was not translated to Linux Ctrl+C, and Japanese ServerCutText payloads were interpreted as Latin-1.

## Validation

- `pre-commit run --all-files`
- Hermes Agent Pester tests: 57 passed, 0 failed
- `docker compose -f docker/hermes-agent/compose.yml config --quiet`
- `docker compose -f docker/hermes-agent/compose.yml build chromium`
- manual Japanese clipboard round-trip through the running noVNC viewer