### PR TITLE
Fix Hermes noVNC 1Password paste

### DIFF
--- a/docker/hermes-browser/Dockerfile
+++ b/docker/hermes-browser/Dockerfile
@@ -18,7 +18,7 @@ RUN test "$(dpkg --print-architecture)" = "amd64" \
   && groupadd --system --gid 997 hermes-browser \
   && useradd --system --uid 997 --create-home --gid hermes-browser hermes-browser \
   && install -d -o hermes-browser -g hermes-browser /data \
-  && sed -i 's#</body>#  <script type="module" src="app/clipboard-paste.js?v=2"></script>\n</body>#' /usr/share/novnc/vnc.html \
+  && sed -i 's#</body>#  <script type="module" src="app/clipboard-paste.js?v=5"></script>\n</body>#' /usr/share/novnc/vnc.html \
   && ln -sf vnc.html /usr/share/novnc/index.html
 
 ENV LANG=ja_JP.UTF-8 \

--- a/docker/hermes-browser/clipboard-paste.js
+++ b/docker/hermes-browser/clipboard-paste.js
@@ -3,8 +3,16 @@ import RFB from "../core/rfb.js";
 import UI from "./ui.js";
 
 let clipboardRfb;
+let hostPasteTarget;
+let hostPasteAttempt = 0;
+let hostPasteHandledAttempt = 0;
 let hostClipboardWritePending = false;
 let legacyHostCopyInProgress = false;
+let hostPastePrimeReleaseTimer;
+
+const HOST_CLIPBOARD_READ_FALLBACK_DELAY_MS = 100;
+const HOST_PASTE_PRIMING_TIMEOUT_MS = 1000;
+const REMOTE_PASTE_SHORTCUT_DELAY_MS = 100;
 
 function isClipboardPanelTarget(target) {
   return target instanceof Element && target.closest("#noVNC_clipboard") !== null;
@@ -12,6 +20,10 @@ function isClipboardPanelTarget(target) {
 
 function isPasteShortcut(event) {
   return (event.ctrlKey || event.metaKey) && !event.altKey && event.code === "KeyV";
+}
+
+function isHostPastePrimingKey(event) {
+  return event.code === "MetaLeft" || event.code === "MetaRight";
 }
 
 function isRemoteClipboardShortcut(event) {
@@ -27,6 +39,54 @@ function sendClipboardText(text) {
   RFB.messages.clientCutText(UI.rfb._sock, new TextEncoder().encode(text));
 }
 
+function getHostPasteTarget() {
+  if (hostPasteTarget?.isConnected) {
+    return hostPasteTarget;
+  }
+
+  hostPasteTarget = document.createElement("textarea");
+  hostPasteTarget.id = "noVNC_host_paste_target";
+  hostPasteTarget.setAttribute("aria-hidden", "true");
+  hostPasteTarget.autocomplete = "off";
+  hostPasteTarget.autocapitalize = "off";
+  hostPasteTarget.spellcheck = false;
+  hostPasteTarget.style.position = "fixed";
+  hostPasteTarget.style.left = "-1000px";
+  hostPasteTarget.style.top = "0";
+  hostPasteTarget.style.width = "1px";
+  hostPasteTarget.style.height = "1px";
+  hostPasteTarget.style.opacity = "0";
+
+  document.body.append(hostPasteTarget);
+  return hostPasteTarget;
+}
+
+function focusHostPasteTarget() {
+  const hostPasteTarget = getHostPasteTarget();
+  hostPasteTarget.value = "";
+  hostPasteTarget.focus();
+  hostPasteTarget.select();
+}
+
+function clearHostPastePrimeRelease() {
+  if (hostPastePrimeReleaseTimer === undefined) {
+    return;
+  }
+
+  window.clearTimeout(hostPastePrimeReleaseTimer);
+  hostPastePrimeReleaseTimer = undefined;
+}
+
+function scheduleHostPastePrimeRelease() {
+  clearHostPastePrimeRelease();
+  hostPastePrimeReleaseTimer = window.setTimeout(() => {
+    hostPastePrimeReleaseTimer = undefined;
+    if (UI.rfb && document.activeElement === hostPasteTarget) {
+      UI.rfb.focus();
+    }
+  }, HOST_PASTE_PRIMING_TIMEOUT_MS);
+}
+
 function sendRemoteControlShortcut(code) {
   const keysym = code === "KeyC" ? KeyTable.XK_c : KeyTable.XK_x;
 
@@ -34,6 +94,83 @@ function sendRemoteControlShortcut(code) {
   UI.rfb.sendKey(keysym, code, true);
   UI.rfb.sendKey(keysym, code, false);
   UI.rfb.sendKey(KeyTable.XK_Control_L, "ControlLeft", false);
+}
+
+function sendRemotePasteShortcut() {
+  UI.rfb.sendKey(KeyTable.XK_Control_L, "ControlLeft", true);
+  UI.rfb.sendKey(KeyTable.XK_v, "KeyV", true);
+  UI.rfb.sendKey(KeyTable.XK_v, "KeyV", false);
+  UI.rfb.sendKey(KeyTable.XK_Control_L, "ControlLeft", false);
+  UI.rfb.focus();
+}
+
+function getTypeableKeysym(character) {
+  if (character === "\n" || character === "\r") {
+    return KeyTable.XK_Return;
+  }
+
+  if (character === "\t") {
+    return KeyTable.XK_Tab;
+  }
+
+  const codePoint = character.codePointAt(0);
+  if (codePoint >= 0x20 && codePoint <= 0x7e) {
+    return codePoint;
+  }
+
+  return null;
+}
+
+function getTypeableKeysyms(text) {
+  return Array.from(text.replace(/\r\n/g, "\n").replace(/\r/g, "\n"), getTypeableKeysym);
+}
+
+function typeTextToRemote(text) {
+  const keysyms = getTypeableKeysyms(text);
+  if (keysyms.some((keysym) => keysym === null)) {
+    return false;
+  }
+
+  for (const keysym of keysyms) {
+    UI.rfb.sendKey(keysym, "", true);
+    UI.rfb.sendKey(keysym, "", false);
+  }
+
+  UI.rfb.focus();
+  return true;
+}
+
+function scheduleRemotePasteShortcut() {
+  window.setTimeout(sendRemotePasteShortcut, REMOTE_PASTE_SHORTCUT_DELAY_MS);
+}
+
+function pasteTextToRemote(text) {
+  if (typeTextToRemote(text)) {
+    return;
+  }
+
+  sendClipboardText(text);
+  scheduleRemotePasteShortcut();
+}
+
+function scheduleHostClipboardReadFallback(pasteAttempt) {
+  if (!navigator.clipboard?.readText) {
+    return;
+  }
+
+  navigator.clipboard
+    .readText()
+    .then((text) => {
+      window.setTimeout(() => {
+        if (hostPasteHandledAttempt >= pasteAttempt || typeof text !== "string") {
+          return;
+        }
+
+        hostPasteHandledAttempt = pasteAttempt;
+        pasteTextToRemote(text);
+      }, HOST_CLIPBOARD_READ_FALLBACK_DELAY_MS);
+    })
+    .catch(() => {});
 }
 
 function decodeVncClipboardText(text) {
@@ -104,6 +241,7 @@ function ensureClipboardReceiver() {
 
 function beginRemoteClipboardTransfer(code) {
   ensureClipboardReceiver();
+  clearHostPastePrimeRelease();
   hostClipboardWritePending = true;
   sendRemoteControlShortcut(code);
   UI.rfb.focus();
@@ -126,6 +264,13 @@ document.addEventListener(
       return;
     }
 
+    if (isHostPastePrimingKey(event)) {
+      event.stopImmediatePropagation();
+      focusHostPasteTarget();
+      scheduleHostPastePrimeRelease();
+      return;
+    }
+
     if (isRemoteClipboardShortcut(event)) {
       event.preventDefault();
       event.stopImmediatePropagation();
@@ -138,7 +283,10 @@ document.addEventListener(
     }
 
     event.stopImmediatePropagation();
-    UI.rfb.blur();
+    clearHostPastePrimeRelease();
+    hostPasteAttempt += 1;
+    focusHostPasteTarget();
+    scheduleHostClipboardReadFallback(hostPasteAttempt);
   },
   true
 );
@@ -161,12 +309,9 @@ document.addEventListener(
     }
 
     event.preventDefault();
-    sendClipboardText(text);
-    UI.rfb.sendKey(KeyTable.XK_Control_L, "ControlLeft", true);
-    UI.rfb.sendKey(KeyTable.XK_v, "KeyV", true);
-    UI.rfb.sendKey(KeyTable.XK_v, "KeyV", false);
-    UI.rfb.sendKey(KeyTable.XK_Control_L, "ControlLeft", false);
-    UI.rfb.focus();
+    clearHostPastePrimeRelease();
+    hostPasteHandledAttempt = hostPasteAttempt;
+    pasteTextToRemote(text);
   },
   true
 );

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -240,7 +240,7 @@ Describe 'HermesAgentHandler' {
             $dockerfileContent | Should -Match "hermes-browser"
             $dockerfileContent | Should -Match "COPY entrypoint\.sh"
             $dockerfileContent | Should -Match "COPY clipboard-paste\.js /usr/share/novnc/app/clipboard-paste\.js"
-            $dockerfileContent | Should -Match ([regex]::Escape('<script type="module" src="app/clipboard-paste.js?v=2"></script>'))
+            $dockerfileContent | Should -Match ([regex]::Escape('<script type="module" src="app/clipboard-paste.js?v=5"></script>'))
             $dockerfileContent | Should -Match ([regex]::Escape('ln -sf vnc.html /usr/share/novnc/index.html'))
             $dockerfileContent | Should -Match "COPY healthcheck\.sh"
             $dockerfileContent | Should -Match "chmod \+x"
@@ -307,6 +307,27 @@ Describe 'HermesAgentHandler' {
             $clipboardPasteContent | Should -Match 'document\.addEventListener\(\s*"paste"'
             $clipboardPasteContent | Should -Match 'addEventListener\(\s*"clipboard"'
             $clipboardPasteContent | Should -Match ([regex]::Escape('clipboardData?.getData("text/plain")'))
+            $clipboardPasteContent | Should -Match "getHostPasteTarget"
+            $clipboardPasteContent | Should -Match ([regex]::Escape('hostPasteTarget.focus()'))
+            $clipboardPasteContent | Should -Match ([regex]::Escape('hostPasteTarget.select()'))
+            $clipboardPasteContent | Should -Match "isHostPastePrimingKey"
+            $clipboardPasteContent | Should -Match ([regex]::Escape('event.code === "MetaLeft"'))
+            $clipboardPasteContent | Should -Match ([regex]::Escape('event.code === "MetaRight"'))
+            $clipboardPasteContent | Should -Match "HOST_PASTE_PRIMING_TIMEOUT_MS"
+            $clipboardPasteContent | Should -Match "hostPastePrimeReleaseTimer"
+            $clipboardPasteContent | Should -Match "scheduleHostPastePrimeRelease"
+            $clipboardPasteContent | Should -Match "clearHostPastePrimeRelease"
+            $clipboardPasteContent | Should -Match ([regex]::Escape('window.clearTimeout(hostPastePrimeReleaseTimer)'))
+            $clipboardPasteContent | Should -Match ([regex]::Escape('document.activeElement === hostPasteTarget'))
+            $clipboardPasteContent | Should -Match ([regex]::Escape('.readText()'))
+            $clipboardPasteContent | Should -Match "scheduleRemotePasteShortcut"
+            $clipboardPasteContent | Should -Match ([regex]::Escape('window.setTimeout'))
+            $clipboardPasteContent | Should -Match "typeTextToRemote"
+            $clipboardPasteContent | Should -Match "getTypeableKeysyms"
+            $clipboardPasteContent | Should -Match ([regex]::Escape('text.replace(/\r\n/g, "\n").replace(/\r/g, "\n")'))
+            $clipboardPasteContent | Should -Match ([regex]::Escape('character.codePointAt(0)'))
+            $clipboardPasteContent | Should -Match ([regex]::Escape('KeyTable.XK_Return'))
+            $clipboardPasteContent | Should -Match ([regex]::Escape('UI.rfb.sendKey(keysym, "", true)'))
             $clipboardPasteContent | Should -Match ([regex]::Escape('navigator.clipboard.writeText'))
             $clipboardPasteContent | Should -Match ([regex]::Escape('new TextEncoder().encode(text)'))
             $clipboardPasteContent | Should -Match ([regex]::Escape('RFB.messages.clientCutText'))


### PR DESCRIPTION
## Summary
- prime a hidden noVNC paste target as soon as the macOS Command key is pressed
- paste ASCII password text directly through RFB key events instead of relying on x11vnc clipboard propagation
- keep the clipboard path as a fallback for non-typeable text and bump the noVNC script cache key to v5

## Root cause
1Password paste was still missing in the real noVNC browser because the paste target could be selected too late when handling only `Cmd+V`, and browsers could keep the previous `v=4` clipboard helper cached. x11vnc clipboard propagation was also not reliable enough for the password paste path, so ASCII password text now uses direct RFB key input.

## Validation
- `node --input-type=module --check < docker/hermes-browser/clipboard-paste.js`
- `pwsh -NoProfile -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1` (57 passed)
- `git diff --cached --check`
- `pre-commit run --files docker/hermes-browser/Dockerfile docker/hermes-browser/clipboard-paste.js scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1`
- rebuilt and recreated `hermes-chromium` / `hermes-browser-mcp`
- verified noVNC `v=5` Cmd-primed paste E2E with an ASCII/symbol 1Password-like probe string