### PR TITLE
Improve direnv dev shell logs

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,4 +3,5 @@ watch_file flake.lock
 
 if has nix; then
   use flake .
+  log_status "dotfiles dev shell ready: treefmt, statix, deadnix"
 fi

--- a/.envrc
+++ b/.envrc
@@ -2,6 +2,5 @@ watch_file flake.nix
 watch_file flake.lock
 
 if has nix; then
-  use flake .
-  log_status "dotfiles dev shell ready: treefmt, statix, deadnix"
+  use flake . && log_status "dotfiles dev shell ready: treefmt, statix, deadnix"
 fi

--- a/chezmoi/dot_config/direnv/direnv.toml
+++ b/chezmoi/dot_config/direnv/direnv.toml
@@ -1,0 +1,2 @@
+[global]
+hide_env_diff = true

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -229,6 +229,26 @@ Describe 'chezmoi テンプレート バリデーション' {
         }
     }
 
+    Context 'direnv user config' {
+        It 'should hide low-level environment diff noise while keeping status logs' {
+            $configPath = Join-Path $script:chezmoiRoot "dot_config/direnv/direnv.toml"
+
+            Test-Path -LiteralPath $configPath | Should -BeTrue
+            $content = Get-Content -LiteralPath $configPath -Raw
+
+            $content | Should -Match '(?m)^\[global\]\s*$'
+            $content | Should -Match '(?m)^hide_env_diff\s*=\s*true\s*$'
+            $content | Should -Not -Match '(?m)^log_format\s*=\s*"-"\s*$' -Because "status logs should still explain when direnv loads nix-direnv"
+        }
+
+        It 'should print a human-readable dev shell summary for this repository' {
+            $envrcPath = Join-Path $script:repoRoot ".envrc"
+            $content = Get-Content -LiteralPath $envrcPath -Raw
+
+            $content | Should -Match 'log_status "dotfiles dev shell ready: treefmt, statix, deadnix"'
+        }
+    }
+
     Context 'Docker MCP SDK サーバーの設定整合性' {
         BeforeAll {
             $script:mcpServersPath = Join-Path $script:chezmoiRoot ".chezmoidata/mcp_servers.yaml"

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -246,6 +246,7 @@ Describe 'chezmoi テンプレート バリデーション' {
             $content = Get-Content -LiteralPath $envrcPath -Raw
 
             $content | Should -Match 'log_status "dotfiles dev shell ready: treefmt, statix, deadnix"'
+            $content | Should -Match 'use flake \. && log_status' -Because "direnv must preserve use flake failure status"
         }
     }
 


### PR DESCRIPTION
## Summary
- Hide direnv's low-level environment diff noise via managed `~/.config/direnv/direnv.toml`
- Add a short `.envrc` status line that explains the dotfiles dev shell contents
- Cover the direnv config and repository status message in the chezmoi template tests

## Why
The Nix dev shell exports many implementation-detail variables such as compiler and Darwin SDK settings. direnv was showing that raw diff, which made a successful shell load look like an error. This keeps the useful load/cache status while replacing the noisy diff with a small human-readable summary.

## Validation
- `nix fmt -- scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1 chezmoi/dot_config/direnv/direnv.toml`
- `pwsh -NoProfile -File ./Invoke-Tests.ps1 -Path ./chezmoi/ChezmoiTemplate.Tests.ps1 -MinimumCoverage 0`
- `direnv exec . sh -c 'printf "loaded=%s\n" "$IN_NIX_SHELL"'`
- `task skills:sync && task fmt && task lint`
- `task commit -- "improve direnv dev shell logs"`