### PR TITLE
feat: enforce visible Chrome MCP for all Hermes profiles

### DIFF
--- a/.superpowers/sdd/final-fix-report.md
+++ b/.superpowers/sdd/final-fix-report.md
@@ -67,23 +67,23 @@ CRLF. The mixed-ending file was not normalized.
 
 ### Source Unit Suites
 
-| Repository | Result |
-| --- | --- |
-| hermes-home | 49 tests passed |
-| hermes-profile-rick | 38 tests passed |
-| hermes-profile-hoffman | 38 tests passed |
+| Repository              | Result          |
+| ----------------------- | --------------- |
+| hermes-home             | 49 tests passed |
+| hermes-profile-rick     | 38 tests passed |
+| hermes-profile-hoffman  | 38 tests passed |
 | hermes-profile-risarisa | 39 tests passed |
-| hermes-profile-nancy | 38 tests passed |
+| hermes-profile-nancy    | 38 tests passed |
 
 ### Full Source Validators
 
-| Repository | Result |
-| --- | --- |
-| hermes-home | pass, 9/9 checks |
-| hermes-profile-rick | pass, 8/8 checks |
-| hermes-profile-hoffman | pass, 8/8 checks |
+| Repository              | Result           |
+| ----------------------- | ---------------- |
+| hermes-home             | pass, 9/9 checks |
+| hermes-profile-rick     | pass, 8/8 checks |
+| hermes-profile-hoffman  | pass, 8/8 checks |
 | hermes-profile-risarisa | pass, 8/8 checks |
-| hermes-profile-nancy | pass, 8/8 checks |
+| hermes-profile-nancy    | pass, 8/8 checks |
 
 ### Dotfiles Bootstrap Suite
 
@@ -97,13 +97,13 @@ deprecation warning during the container suite. It did not affect the result.
 
 ## Source Commits
 
-| Repository | Commit |
-| --- | --- |
-| hermes-home | `48bfcca` |
-| hermes-profile-rick | `bd39023` |
-| hermes-profile-hoffman | `331241a` |
+| Repository              | Commit    |
+| ----------------------- | --------- |
+| hermes-home             | `48bfcca` |
+| hermes-profile-rick     | `bd39023` |
+| hermes-profile-hoffman  | `331241a` |
 | hermes-profile-risarisa | `8c2139c` |
-| hermes-profile-nancy | `c397cd6` |
+| hermes-profile-nancy    | `c397cd6` |
 
 The dotfiles commit SHA is reported in the completion response because this
 report is contained in that commit.

--- a/.superpowers/sdd/final-fix-report.md
+++ b/.superpowers/sdd/final-fix-report.md
@@ -1,0 +1,130 @@
+# Hermes Chrome MCP Final Fix Report
+
+## Status
+
+DONE
+
+All final-review findings were addressed in the six assigned worktrees. No
+branches were pushed and no pull requests were created.
+
+## Source Validator Hardening
+
+Each of the five source validators now:
+
+- Parses `config.yaml` with a `yaml.SafeLoader` subclass that rejects duplicate
+  mapping keys recursively at every mapping level.
+- Requires
+  `type(config["mcp_servers"]["chrome"]["connect_timeout"]) is int`.
+- Retains the repository's existing exact `mcp_servers` map equality contract.
+- Leaves the source Chrome MCP configuration unchanged.
+
+Each source test suite now runs two negative checks in the pinned Hermes image:
+
+- `connect_timeout: 120.0` must fail the `config-contract` check.
+- A duplicate Chrome `url` whose final value is canonical must fail the
+  `config-contract` check.
+
+### TDD Evidence
+
+Before the validator changes, both new tests failed independently in every
+source repository because each validator returned exit code `0` instead of the
+expected validation failure. After the safe loader and exact-type check were
+added, all ten targeted regression tests passed.
+
+## Bootstrap Integration Coverage
+
+The bootstrap integration fixture now creates a `future` profile Git
+distribution, appends a corresponding `DistributionSource` and Slack
+credential declaration to the fixture manifest, and gives the staged source a
+floating Chrome timeout.
+
+The test runs through `_patched_runtime`, whose local source adapter calls the
+real `stage_distribution`. It does not mock `validate_chrome_mcp_sources`. The
+test proves:
+
+- `ValidationError` is raised for the future profile.
+- `synchronize_remote` is never called.
+- `Transaction.begin` is never called.
+- The managed runtime tree remains byte-for-byte unchanged.
+- The future profile target is not created.
+
+The production bootstrap ordering already enforced this behavior for every
+staged source, so the final-review change in dotfiles is regression coverage
+rather than a production-code modification.
+
+## Hoffman Line Endings
+
+Only the three added Chrome lines in `config.yaml` were converted from LF to
+CRLF. The mixed-ending file was not normalized.
+
+- Before: `CRLF=172`, lone `LF=20`
+- After: `CRLF=175`, lone `LF=17`
+- `git diff --ignore-space-at-eol --exit-code -- config.yaml`: pass
+- `git -c core.whitespace=cr-at-eol diff --check`: pass
+- Working-tree diff for `config.yaml`: 3 additions, 3 deletions
+
+## Verification
+
+### Source Unit Suites
+
+| Repository | Result |
+| --- | --- |
+| hermes-home | 49 tests passed |
+| hermes-profile-rick | 38 tests passed |
+| hermes-profile-hoffman | 38 tests passed |
+| hermes-profile-risarisa | 39 tests passed |
+| hermes-profile-nancy | 38 tests passed |
+
+### Full Source Validators
+
+| Repository | Result |
+| --- | --- |
+| hermes-home | pass, 9/9 checks |
+| hermes-profile-rick | pass, 8/8 checks |
+| hermes-profile-hoffman | pass, 8/8 checks |
+| hermes-profile-risarisa | pass, 8/8 checks |
+| hermes-profile-nancy | pass, 8/8 checks |
+
+### Dotfiles Bootstrap Suite
+
+`task hermes:bootstrap:test` passed:
+
+- Containerized Python suite: 330 tests passed, 1 existing skip.
+- `test_gh_wrapper.sh`: PASS.
+
+The pinned Hermes dependency emitted its existing `re.split(..., maxsplit)`
+deprecation warning during the container suite. It did not affect the result.
+
+## Source Commits
+
+| Repository | Commit |
+| --- | --- |
+| hermes-home | `48bfcca` |
+| hermes-profile-rick | `bd39023` |
+| hermes-profile-hoffman | `331241a` |
+| hermes-profile-risarisa | `8c2139c` |
+| hermes-profile-nancy | `c397cd6` |
+
+The dotfiles commit SHA is reported in the completion response because this
+report is contained in that commit.
+
+## Changed Paths
+
+- `/Users/ktome1995/Program/.worktrees/hermes-home-chrome-mcp/scripts/validate_distribution.py`
+- `/Users/ktome1995/Program/.worktrees/hermes-home-chrome-mcp/tests/test_validate_distribution.py`
+- `/Users/ktome1995/Program/.worktrees/hermes-profile-rick-chrome-mcp/scripts/validate_distribution.py`
+- `/Users/ktome1995/Program/.worktrees/hermes-profile-rick-chrome-mcp/tests/test_validate_distribution.py`
+- `/Users/ktome1995/Program/.worktrees/hermes-profile-hoffman-chrome-mcp/config.yaml`
+- `/Users/ktome1995/Program/.worktrees/hermes-profile-hoffman-chrome-mcp/scripts/validate_distribution.py`
+- `/Users/ktome1995/Program/.worktrees/hermes-profile-hoffman-chrome-mcp/tests/test_validate_distribution.py`
+- `/Users/ktome1995/Program/.worktrees/hermes-profile-risarisa-chrome-mcp/scripts/validate_distribution.py`
+- `/Users/ktome1995/Program/.worktrees/hermes-profile-risarisa-chrome-mcp/tests/test_validate_distribution.py`
+- `/Users/ktome1995/Program/.worktrees/hermes-profile-nancy-chrome-mcp/scripts/validate_distribution.py`
+- `/Users/ktome1995/Program/.worktrees/hermes-profile-nancy-chrome-mcp/tests/test_validate_distribution.py`
+- `/Users/ktome1995/Program/dotfiles/.worktrees/hermes-chrome-all-profiles/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py`
+- `/Users/ktome1995/Program/dotfiles/.worktrees/hermes-chrome-all-profiles/.superpowers/sdd/final-fix-report.md`
+
+## Concerns
+
+No rollout-blocking concerns remain. The single bootstrap-suite skip and the
+pinned dependency deprecation warning are pre-existing and are recorded above.

--- a/docker/hermes-agent/Dockerfile
+++ b/docker/hermes-agent/Dockerfile
@@ -13,13 +13,46 @@ COPY hermes-bootstrap /usr/local/bin/hermes-bootstrap
 RUN python3 - <<'PY'
 from pathlib import Path
 
-path = Path("/opt/hermes/gateway/channel_directory.py")
-text = path.read_text(encoding="utf-8")
-old = 'types="public_channel,private_channel",'
-new = 'types="public_channel",'
-if old not in text:
-    raise SystemExit(f"expected Slack channel directory call not found in {path}")
-path.write_text(text.replace(old, new), encoding="utf-8")
+def replace_once(path: Path, old: str, new: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    if text.count(old) != 1:
+        raise SystemExit(f"expected exactly one pinned source match in {path}")
+    path.write_text(text.replace(old, new), encoding="utf-8")
+
+
+replace_once(
+    Path("/opt/hermes/gateway/channel_directory.py"),
+    'types="public_channel,private_channel",',
+    'types="public_channel",',
+)
+replace_once(
+    Path("/opt/hermes/toolsets.py"),
+    '"browser_dialog", "web_search"',
+    '"browser_dialog"',
+)
+replace_once(
+    Path("/opt/hermes/hermes_cli/profile_distribution.py"),
+    """\
+    target.mkdir(parents=True, exist_ok=True)
+
+    for entry in staged.iterdir():
+        name = entry.name
+""",
+    """\
+    target.mkdir(parents=True, exist_ok=True)
+
+    owned_roots = {
+        Path(path).parts[0]
+        for path in manifest.owned_paths()
+        if Path(path).parts
+    }
+    for entry in staged.iterdir():
+        name = entry.name
+
+        if name not in owned_roots and name != ENV_TEMPLATE_FILENAME:
+            continue
+""",
+)
 PY
 
 RUN apt-get update \

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/app.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/app.py
@@ -47,6 +47,7 @@ from .repositories import (
     synchronize_named_repository,
     synchronize_remote,
 )
+from .source_contracts import validate_chrome_mcp_sources
 from .transaction import Transaction
 
 
@@ -128,7 +129,11 @@ def _apply_sensitive(
         )
 
         scratch = _private_scratch(manifest.data_root)
-        staged = [stage_distribution(source, scratch, auth) for source in _distributions(manifest)]
+        staged = [
+            stage_distribution(source, scratch, auth)
+            for source in _distributions(manifest)
+        ]
+        validate_chrome_mcp_sources(staged)
         for repo in manifest.shared_repositories:
             remote_results.append((repo, synchronize_remote(repo, auth)))
 

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py
@@ -52,12 +52,34 @@ def validate_chrome_mcp_sources(staged: Sequence[StagedSource]) -> None:
 
     for source in staged:
         try:
+            with (
+                source.path / source.declaration.manifest_name
+            ).open(encoding="utf-8") as handle:
+                manifest = yaml.load(handle, Loader=_UniqueKeySafeLoader)
             with (source.path / "config.yaml").open(encoding="utf-8") as handle:
                 config = yaml.load(handle, Loader=_UniqueKeySafeLoader)
         except (OSError, UnicodeError, yaml.YAMLError):
             _invalid(source)
 
+        if not isinstance(manifest, Mapping):
+            _invalid_ownership(source)
+        distribution_owned = manifest.get("distribution_owned")
+        if (
+            not isinstance(distribution_owned, list)
+            or "config.yaml" not in distribution_owned
+        ):
+            _invalid_ownership(source)
         if not isinstance(config, Mapping):
+            _invalid(source)
+        agent = config.get("agent")
+        if not isinstance(agent, Mapping):
+            _invalid(source)
+        disabled_toolsets = agent.get("disabled_toolsets")
+        if (
+            not isinstance(disabled_toolsets, list)
+            or any(not isinstance(toolset, str) for toolset in disabled_toolsets)
+            or "browser" not in disabled_toolsets
+        ):
             _invalid(source)
         mcp_servers = config.get("mcp_servers")
         if not isinstance(mcp_servers, Mapping):
@@ -75,4 +97,11 @@ def _invalid(source: StagedSource) -> NoReturn:
     name = source.declaration.name
     raise ValidationError(
         f"distribution {name!r} config.yaml has invalid Chrome MCP configuration"
+    ) from None
+
+
+def _invalid_ownership(source: StagedSource) -> NoReturn:
+    name = source.declaration.name
+    raise ValidationError(
+        f"distribution {name!r} distribution_owned must include config.yaml"
     ) from None

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py
@@ -63,7 +63,11 @@ def validate_chrome_mcp_sources(staged: Sequence[StagedSource]) -> None:
         if not isinstance(mcp_servers, Mapping):
             _invalid(source)
         chrome = mcp_servers.get("chrome")
-        if not isinstance(chrome, Mapping) or dict(chrome) != _CHROME_MCP:
+        if (
+            not isinstance(chrome, Mapping)
+            or type(chrome.get("connect_timeout")) is not int
+            or dict(chrome) != _CHROME_MCP
+        ):
             _invalid(source)
 
 

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py
@@ -1,0 +1,74 @@
+"""Non-secret contracts for staged Hermes source distributions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import NoReturn
+
+import yaml
+
+from .errors import ValidationError
+from .git import StagedSource
+
+
+_CHROME_MCP = {
+    "url": "http://browser-mcp:8080/mcp",
+    "connect_timeout": 120,
+}
+
+
+class _UniqueKeySafeLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects duplicate keys in every mapping."""
+
+    def construct_mapping(
+        self, node: yaml.MappingNode, deep: bool = False
+    ) -> dict[object, object]:
+        self.flatten_mapping(node)
+        mapping: dict[object, object] = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            try:
+                duplicate = key in mapping
+            except TypeError as error:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    "found unacceptable key",
+                    key_node.start_mark,
+                ) from error
+            if duplicate:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    "found duplicate key",
+                    key_node.start_mark,
+                )
+            mapping[key] = self.construct_object(value_node, deep=deep)
+        return mapping
+
+
+def validate_chrome_mcp_sources(staged: Sequence[StagedSource]) -> None:
+    """Require the canonical Chrome MCP entry in every staged distribution."""
+
+    for source in staged:
+        try:
+            with (source.path / "config.yaml").open(encoding="utf-8") as handle:
+                config = yaml.load(handle, Loader=_UniqueKeySafeLoader)
+        except (OSError, UnicodeError, yaml.YAMLError):
+            _invalid(source)
+
+        if not isinstance(config, Mapping):
+            _invalid(source)
+        mcp_servers = config.get("mcp_servers")
+        if not isinstance(mcp_servers, Mapping):
+            _invalid(source)
+        chrome = mcp_servers.get("chrome")
+        if not isinstance(chrome, Mapping) or dict(chrome) != _CHROME_MCP:
+            _invalid(source)
+
+
+def _invalid(source: StagedSource) -> NoReturn:
+    name = source.declaration.name
+    raise ValidationError(
+        f"distribution {name!r} config.yaml has invalid Chrome MCP configuration"
+    ) from None

--- a/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
+++ b/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
@@ -85,6 +85,9 @@ _CHILD_PROCESSES: list[subprocess.Popen[object]] = []
 def source_config(key: str, value: str) -> str:
     return (
         f"{key}: {value}\n"
+        "agent:\n"
+        "  disabled_toolsets:\n"
+        "    - browser\n"
         "mcp_servers:\n"
         "  chrome:\n"
         "    url: http://browser-mcp:8080/mcp\n"
@@ -979,6 +982,67 @@ class BootstrapFlowTests(unittest.TestCase):
                     "    connect_timeout: 120\n",
                     "    connect_timeout: 120.0\n",
                 ),
+                "SOUL.md": "future initial\n",
+            },
+        )
+        future_source = DistributionSource(
+            name=future,
+            source="https://github.com/rurusasu/hermes-profile-future.git",
+            ref="main",
+            target=self.data_root / "profiles" / future,
+            manifest_name="distribution.yaml",
+        )
+        future_slack_item = replace(
+            next(
+                item
+                for item in self.manifest.onepassword_items
+                if item.key == "slack_rick"
+            ),
+            key="slack_future",
+            item="Hermes Slack future",
+        )
+        self.manifest = replace(
+            self.manifest,
+            profiles=(*self.manifest.profiles, future_source),
+            onepassword_items=(
+                *self.manifest.onepassword_items,
+                future_slack_item,
+            ),
+        )
+        before = self._snapshot_managed_tree()
+
+        with (
+            self._patched_runtime(),
+            mock.patch.object(
+                app,
+                "synchronize_remote",
+                wraps=app.synchronize_remote,
+            ) as synchronize_remote,
+            mock.patch.object(
+                app.Transaction,
+                "begin",
+                wraps=app.Transaction.begin,
+            ) as transaction_begin,
+        ):
+            with self.assertRaises(ValidationError):
+                app.apply(PRODUCTION_MANIFEST, self._payload())
+
+        synchronize_remote.assert_not_called()
+        transaction_begin.assert_not_called()
+        self.assertEqual(self._snapshot_managed_tree(), before)
+        self.assertFalse(future_source.target.exists())
+
+    def test_future_profile_must_distribute_its_valid_chrome_config_before_mutation(
+        self,
+    ) -> None:
+        future = "future"
+        self._create_distribution(
+            future,
+            {
+                "distribution.yaml": self._profile_manifest(future).replace(
+                    "  - config.yaml\n", ""
+                ),
+                "config.yaml": source_config("profile", "future-valid"),
                 "SOUL.md": "future initial\n",
             },
         )

--- a/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
+++ b/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
@@ -28,7 +28,12 @@ BOOTSTRAP_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(BOOTSTRAP_ROOT))
 
 from hermes_bootstrap import app, cli
-from hermes_bootstrap.errors import ApplyError, CredentialError, RepositoryError
+from hermes_bootstrap.errors import (
+    ApplyError,
+    CredentialError,
+    RepositoryError,
+    ValidationError,
+)
 from hermes_bootstrap.envfiles import GITHUB_KEYS, read_environment_values
 from hermes_bootstrap.git import StagedSource, stage_distribution
 from hermes_bootstrap.github import GitHubClient
@@ -458,6 +463,11 @@ class BootstrapFlowTests(unittest.TestCase):
                 "bot_token": "xoxb-nancy-bot",
                 "app_token": "xapp-nancy-app",
                 "allowed_users": "UNANCY",
+            },
+            "slack_future": {
+                "bot_token": "xoxb-future-bot",
+                "app_token": "xapp-future-app",
+                "allowed_users": "UFUTURE",
             },
         }
         for item in self.manifest.onepassword_items:
@@ -956,6 +966,68 @@ class BootstrapFlowTests(unittest.TestCase):
         self.assertEqual(after, before)
         journal = self.data_root / ".bootstrap" / "transactions"
         self.assertFalse(journal.exists() and any(path.name != ".lock" for path in journal.iterdir()))
+
+    def test_future_profile_chrome_validation_precedes_remote_and_transaction_mutation(
+        self,
+    ) -> None:
+        future = "future"
+        self._create_distribution(
+            future,
+            {
+                "distribution.yaml": self._profile_manifest(future),
+                "config.yaml": source_config("profile", "future-invalid").replace(
+                    "    connect_timeout: 120\n",
+                    "    connect_timeout: 120.0\n",
+                ),
+                "SOUL.md": "future initial\n",
+            },
+        )
+        future_source = DistributionSource(
+            name=future,
+            source="https://github.com/rurusasu/hermes-profile-future.git",
+            ref="main",
+            target=self.data_root / "profiles" / future,
+            manifest_name="distribution.yaml",
+        )
+        future_slack_item = replace(
+            next(
+                item
+                for item in self.manifest.onepassword_items
+                if item.key == "slack_rick"
+            ),
+            key="slack_future",
+            item="Hermes Slack future",
+        )
+        self.manifest = replace(
+            self.manifest,
+            profiles=(*self.manifest.profiles, future_source),
+            onepassword_items=(
+                *self.manifest.onepassword_items,
+                future_slack_item,
+            ),
+        )
+        before = self._snapshot_managed_tree()
+
+        with (
+            self._patched_runtime(),
+            mock.patch.object(
+                app,
+                "synchronize_remote",
+                wraps=app.synchronize_remote,
+            ) as synchronize_remote,
+            mock.patch.object(
+                app.Transaction,
+                "begin",
+                wraps=app.Transaction.begin,
+            ) as transaction_begin,
+        ):
+            with self.assertRaises(ValidationError):
+                app.apply(PRODUCTION_MANIFEST, self._payload())
+
+        synchronize_remote.assert_not_called()
+        transaction_begin.assert_not_called()
+        self.assertEqual(self._snapshot_managed_tree(), before)
+        self.assertFalse(future_source.target.exists())
 
     def test_runtime_failpoints_rollback_each_mutation_phase_without_reversing_remote_pushes(self) -> None:
         self._initial_apply()

--- a/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
+++ b/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
@@ -77,6 +77,16 @@ _REAL_POPEN = subprocess.Popen
 _CHILD_PROCESSES: list[subprocess.Popen[object]] = []
 
 
+def source_config(key: str, value: str) -> str:
+    return (
+        f"{key}: {value}\n"
+        "mcp_servers:\n"
+        "  chrome:\n"
+        "    url: http://browser-mcp:8080/mcp\n"
+        "    connect_timeout: 120\n"
+    )
+
+
 @dataclass(frozen=True)
 class TreeEntry:
     kind: str
@@ -297,7 +307,7 @@ class BootstrapFlowTests(unittest.TestCase):
             "root",
             {
                 "root-distribution.yaml": self._root_manifest(["config.yaml", "retired.md"]),
-                "config.yaml": "root: initial\n",
+                "config.yaml": source_config("root", "initial"),
                 "retired.md": "retire me\n",
             },
         )
@@ -306,7 +316,7 @@ class BootstrapFlowTests(unittest.TestCase):
                 profile,
                 {
                     "distribution.yaml": self._profile_manifest(profile),
-                    "config.yaml": f"profile: {profile}-initial\n",
+                    "config.yaml": source_config("profile", f"{profile}-initial"),
                     "SOUL.md": f"{profile} initial\n",
                 },
             )
@@ -626,10 +636,16 @@ class BootstrapFlowTests(unittest.TestCase):
     def test_initial_install_stages_distributions_and_preserves_runtime(self) -> None:
         self._initial_apply()
 
-        self.assertEqual((self.data_root / "config.yaml").read_text(encoding="utf-8"), "root: initial\n")
+        self.assertEqual(
+            (self.data_root / "config.yaml").read_text(encoding="utf-8"),
+            source_config("root", "initial"),
+        )
         for profile in PROFILE_NAMES:
             target = self.data_root / "profiles" / profile
-            self.assertEqual((target / "config.yaml").read_text(encoding="utf-8"), f"profile: {profile}-initial\n")
+            self.assertEqual(
+                (target / "config.yaml").read_text(encoding="utf-8"),
+                source_config("profile", f"{profile}-initial"),
+            )
             self.assertEqual((target / "memories" / "runtime.txt").read_text(encoding="utf-8"), f"{profile} memory\n")
             self.assertEqual(self._mode(target / ".env"), 0o600)
         self.assertEqual((self.data_root / "memories" / "root.txt").read_text(encoding="utf-8"), "root memory\n")
@@ -766,7 +782,7 @@ class BootstrapFlowTests(unittest.TestCase):
             "rick",
             {
                 "distribution.yaml": self._profile_manifest("rick", "0.2.0"),
-                "config.yaml": "profile: rick-updated\n",
+                "config.yaml": source_config("profile", "rick-updated"),
             },
             "update rick",
         )
@@ -781,7 +797,10 @@ class BootstrapFlowTests(unittest.TestCase):
             installed.source,
             next(source.source for source in self.manifest.profiles if source.name == "rick"),
         )
-        self.assertEqual((target / "config.yaml").read_text(encoding="utf-8"), "profile: rick-updated\n")
+        self.assertEqual(
+            (target / "config.yaml").read_text(encoding="utf-8"),
+            source_config("profile", "rick-updated"),
+        )
         self.assertEqual(
             (runtime.stat().st_ino, runtime.read_bytes(), self._mode(runtime)),
             runtime_before,
@@ -1002,9 +1021,11 @@ class BootstrapFlowTests(unittest.TestCase):
             with self.subTest(phase=phase):
                 try:
                     version = f"0.{revision}.0"
-                    desired_root = f"root: rollback-{revision}\n"
+                    desired_root = source_config("root", f"rollback-{revision}")
                     desired_profiles = {
-                        profile: f"profile: {profile}-rollback-{revision}\n"
+                        profile: source_config(
+                            "profile", f"{profile}-rollback-{revision}"
+                        )
                         for profile in PROFILE_NAMES
                     }
                     self._commit(

--- a/docker/hermes-agent/bootstrap/tests/test_app.py
+++ b/docker/hermes-agent/bootstrap/tests/test_app.py
@@ -73,11 +73,18 @@ class FakeTransaction:
 
 class AppTests(unittest.TestCase):
     def setUp(self) -> None:
+        from hermes_bootstrap import app
+
         self.temp = tempfile.TemporaryDirectory()
         self.addCleanup(self.temp.cleanup)
         self.root = Path(self.temp.name) / "data"
         self.root.mkdir()
         self.manifest = manifest(self.root)
+        source_contract_patcher = mock.patch.object(
+            app, "validate_chrome_mcp_sources"
+        )
+        self.validate_chrome_mcp_sources = source_contract_patcher.start()
+        self.addCleanup(source_contract_patcher.stop)
 
     def write_installed_profile(
         self,
@@ -201,6 +208,13 @@ class AppTests(unittest.TestCase):
             events.append("validate")
             return {"profiles": ["rick"], "repositories": ["lifelog"]}
 
+        self.validate_chrome_mcp_sources.side_effect = (
+            lambda staged: events.append(
+                "source-contract:"
+                + ",".join(stage.declaration.name for stage in staged)
+            )
+        )
+
         with (
             mock.patch.object(app, "load_manifest", return_value=self.manifest),
             mock.patch.object(app.Transaction, "recover_if_needed", side_effect=recover),
@@ -223,12 +237,57 @@ class AppTests(unittest.TestCase):
         self.assertEqual(
             events,
             [
-                "recover", "payload", "stage:default", "stage:rick", "sync:lifelog",
-                "root", "profile:rick", "shared:lifelog", "env:data", "env:rick", "validate", "commit",
+                "recover",
+                "payload",
+                "stage:default",
+                "stage:rick",
+                "source-contract:default,rick",
+                "sync:lifelog",
+                "root",
+                "profile:rick",
+                "shared:lifelog",
+                "env:data",
+                "env:rick",
+                "validate",
+                "commit",
             ],
         )
         self.assertEqual(client.authenticated_login.call_count, 3)
         self.assertEqual(client.assert_repository_access.call_count, 3)
+
+    def test_source_contract_failure_precedes_remote_sync_and_transaction(self) -> None:
+        from hermes_bootstrap import app
+
+        secrets = mock.Mock(
+            github_token="token",
+            redactor=SecretRedactor(("token",)),
+        )
+        staged = mock.Mock()
+        self.validate_chrome_mcp_sources.side_effect = ValidationError(
+            "distribution 'future-profile' config.yaml has invalid Chrome MCP configuration"
+        )
+
+        with (
+            mock.patch.object(app, "load_manifest", return_value=self.manifest),
+            mock.patch.object(app.Transaction, "recover_if_needed"),
+            mock.patch.object(app, "read_secret_payload", return_value=secrets),
+            mock.patch.object(app, "_validate_remote_credentials"),
+            mock.patch.object(app, "_validate_profile_credentials"),
+            mock.patch.object(app, "stage_distribution", return_value=staged),
+            mock.patch.object(app, "synchronize_remote") as synchronize,
+            mock.patch.object(app.Transaction, "begin") as begin,
+        ):
+            with self.assertRaisesRegex(
+                ValidationError, "future-profile.*config.yaml"
+            ):
+                app.apply(Path("manifest.yaml"), io.StringIO("payload"))
+
+        self.assertEqual(
+            self.validate_chrome_mcp_sources.call_args.args[0],
+            [staged, staged],
+        )
+        synchronize.assert_not_called()
+        begin.assert_not_called()
 
     def test_apply_rolls_back_after_transaction_and_rollback_error_wins(self) -> None:
         from hermes_bootstrap import app

--- a/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
@@ -51,6 +51,35 @@ class ComposeContractTests(unittest.TestCase):
         self.assertIn("127.0.0.1:${HERMES_API_PORT:-8642}:8642", self.hermes["ports"])
         self.assertNotIn("API_SERVER_KEY", self.hermes["environment"])
 
+    def test_browser_mcp_and_novnc_share_the_compose_chromium_process(self) -> None:
+        chromium = self.services["chromium"]
+        browser_mcp = self.services["browser-mcp"]
+        self.assertEqual(
+            browser_mcp["depends_on"],
+            {"chromium": {"condition": "service_healthy"}},
+        )
+        self.assertEqual(browser_mcp["networks"], chromium["networks"])
+        self.assertIn(
+            "127.0.0.1:${HERMES_BROWSER_VIEW_PORT:-6080}:6080",
+            chromium["ports"],
+        )
+        self.assertEqual(
+            browser_mcp["command"],
+            [
+                "node_modules/.bin/mcp-proxy",
+                "--server",
+                "stream",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8080",
+                "--",
+                "node_modules/.bin/chrome-devtools-mcp",
+                "--browser-url=http://chromium:9222",
+                "--no-usage-statistics",
+            ],
+        )
+
     def test_dockerfile_builds_runtime_test_and_final_stages(self) -> None:
         dockerfile = DOCKERFILE.read_text(encoding="utf-8")
         pinned_base = (

--- a/docker/hermes-agent/bootstrap/tests/test_distribution_filter.py
+++ b/docker/hermes-agent/bootstrap/tests/test_distribution_filter.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+HERMES_ROOT = Path("/opt/hermes")
+
+
+class DistributionFilterContractTests(unittest.TestCase):
+    def test_installer_copies_only_manifest_owned_roots(self) -> None:
+        if not (HERMES_ROOT / "hermes_cli/profile_distribution.py").is_file():
+            self.skipTest("Hermes runtime source is only available in the image")
+
+        sys.path.insert(0, str(HERMES_ROOT))
+        from hermes_cli.profile_distribution import (
+            _copy_dist_payload,
+            read_manifest,
+        )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            staged = root / "staged"
+            target = root / "target"
+            staged.mkdir()
+            (staged / "distribution.yaml").write_text(
+                """\
+name: fixture
+version: 0.1.0
+distribution_owned:
+  - SOUL.md
+  - config.yaml
+  - assets/
+""",
+                encoding="utf-8",
+            )
+            (staged / "SOUL.md").write_text("fixture\n", encoding="utf-8")
+            (staged / "config.yaml").write_text("{}\n", encoding="utf-8")
+            (staged / "assets").mkdir()
+            (staged / "assets/avatar.txt").write_text("fixture\n", encoding="utf-8")
+            (staged / ".github").mkdir()
+            (staged / ".github/workflow.yml").write_text("unowned\n", encoding="utf-8")
+            (staged / "tests").mkdir()
+            (staged / "tests/test_fixture.py").write_text("unowned\n", encoding="utf-8")
+
+            manifest = read_manifest(staged)
+            self.assertIsNotNone(manifest)
+            assert manifest is not None
+            _copy_dist_payload(staged, target, manifest, preserve_config=False)
+
+            self.assertTrue((target / "SOUL.md").is_file())
+            self.assertTrue((target / "config.yaml").is_file())
+            self.assertTrue((target / "assets/avatar.txt").is_file())
+            self.assertTrue((target / "distribution.yaml").is_file())
+            self.assertFalse((target / ".github").exists())
+            self.assertFalse((target / "tests").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker/hermes-agent/bootstrap/tests/test_source_contracts.py
+++ b/docker/hermes-agent/bootstrap/tests/test_source_contracts.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BOOTSTRAP_ROOT))
+
+from hermes_bootstrap.errors import ValidationError
+from hermes_bootstrap.git import StagedSource
+from hermes_bootstrap.models import DistributionSource
+from hermes_bootstrap.source_contracts import validate_chrome_mcp_sources
+
+
+VALID_CONFIG = """\
+model:
+  provider: openai-codex
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: 120
+  retained:
+    url: https://example.invalid/mcp
+"""
+
+
+class SourceContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+
+    def staged(self, name: str, config: str | None) -> StagedSource:
+        path = self.root / name
+        path.mkdir()
+        if config is not None:
+            (path / "config.yaml").write_text(config, encoding="utf-8")
+        declaration = DistributionSource(
+            name=name,
+            source=f"https://github.com/example/{name}.git",
+            ref="main",
+            target=(
+                Path("/opt/data")
+                if name == "default"
+                else Path("/opt/data/profiles") / name
+            ),
+            manifest_name=(
+                "root-distribution.yaml"
+                if name == "default"
+                else "distribution.yaml"
+            ),
+        )
+        return StagedSource(declaration=declaration, path=path, commit="a" * 40)
+
+    def test_accepts_root_and_profiles_while_preserving_other_servers(self) -> None:
+        staged = (
+            self.staged("default", VALID_CONFIG),
+            self.staged("rick", VALID_CONFIG),
+        )
+
+        validate_chrome_mcp_sources(staged)
+
+    def test_rejects_every_noncanonical_shape_without_exposing_values(self) -> None:
+        invalid = {
+            "missing-file": None,
+            "malformed-yaml": "mcp_servers: [\n",
+            "duplicate-key": """\
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    url: https://secret.invalid/mcp
+    connect_timeout: 120
+""",
+            "top-level-sequence": "- mcp_servers\n",
+            "mcp-sequence": "mcp_servers: []\n",
+            "missing-chrome": "mcp_servers: {}\n",
+            "chrome-sequence": "mcp_servers:\n  chrome: []\n",
+            "wrong-url": """\
+mcp_servers:
+  chrome:
+    url: https://secret.invalid/mcp
+    connect_timeout: 120
+""",
+            "missing-timeout": """\
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+""",
+            "string-timeout": """\
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: "120"
+""",
+            "boolean-timeout": """\
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: true
+""",
+            "wrong-timeout": """\
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: 60
+""",
+            "extra-chrome-key": """\
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: 120
+    token: secret-marker
+""",
+        }
+        for case, config in invalid.items():
+            with self.subTest(case=case):
+                staged = self.staged(case, config)
+                with self.assertRaises(ValidationError) as caught:
+                    validate_chrome_mcp_sources((staged,))
+                message = str(caught.exception)
+                self.assertIn(case, message)
+                self.assertIn("config.yaml", message)
+                self.assertNotIn("secret-marker", message)
+                self.assertNotIn("secret.invalid", message)
+                self.assertIsNone(caught.exception.__cause__)
+
+    def test_manifest_additions_are_covered_without_a_profile_allowlist(self) -> None:
+        stages = (
+            self.staged("default", VALID_CONFIG),
+            self.staged("rick", VALID_CONFIG),
+            self.staged("future-profile", "mcp_servers: {}\n"),
+        )
+
+        with self.assertRaisesRegex(ValidationError, "future-profile.*config.yaml"):
+            validate_chrome_mcp_sources(stages)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker/hermes-agent/bootstrap/tests/test_source_contracts.py
+++ b/docker/hermes-agent/bootstrap/tests/test_source_contracts.py
@@ -101,6 +101,12 @@ mcp_servers:
     url: http://browser-mcp:8080/mcp
     connect_timeout: true
 """,
+            "float-timeout": """\
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: 120.0
+""",
             "wrong-timeout": """\
 mcp_servers:
   chrome:

--- a/docker/hermes-agent/bootstrap/tests/test_source_contracts.py
+++ b/docker/hermes-agent/bootstrap/tests/test_source_contracts.py
@@ -18,6 +18,9 @@ from hermes_bootstrap.source_contracts import validate_chrome_mcp_sources
 VALID_CONFIG = """\
 model:
   provider: openai-codex
+agent:
+  disabled_toolsets:
+    - browser
 mcp_servers:
   chrome:
     url: http://browser-mcp:8080/mcp
@@ -53,6 +56,25 @@ class SourceContractTests(unittest.TestCase):
                 else "distribution.yaml"
             ),
         )
+        manifest = (
+            """\
+schema_version: 1
+name: default
+version: 0.1.0
+hermes_requires: ">=0.18.2"
+distribution_owned:
+  - config.yaml
+"""
+            if name == "default"
+            else f"""\
+name: {name}
+version: 0.1.0
+hermes_requires: ">=0.18.2"
+distribution_owned:
+  - config.yaml
+"""
+        )
+        (path / declaration.manifest_name).write_text(manifest, encoding="utf-8")
         return StagedSource(declaration=declaration, path=path, commit="a" * 40)
 
     def test_accepts_root_and_profiles_while_preserving_other_servers(self) -> None:
@@ -120,6 +142,9 @@ mcp_servers:
     connect_timeout: 120
     token: secret-marker
 """,
+            "enabled-built-in-browser": VALID_CONFIG.replace(
+                "agent:\n  disabled_toolsets:\n    - browser\n", ""
+            ),
         }
         for case, config in invalid.items():
             with self.subTest(case=case):
@@ -142,6 +167,24 @@ mcp_servers:
 
         with self.assertRaisesRegex(ValidationError, "future-profile.*config.yaml"):
             validate_chrome_mcp_sources(stages)
+
+    def test_rejects_config_that_is_not_owned_by_its_distribution(self) -> None:
+        staged = self.staged("future-profile", VALID_CONFIG)
+        (staged.path / staged.declaration.manifest_name).write_text(
+            """\
+name: future-profile
+version: 0.1.0
+hermes_requires: ">=0.18.2"
+distribution_owned:
+  - SOUL.md
+""",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(
+            ValidationError, "future-profile.*distribution_owned.*config.yaml"
+        ):
+            validate_chrome_mcp_sources((staged,))
 
 
 if __name__ == "__main__":

--- a/docker/hermes-agent/bootstrap/tests/test_toolsets.py
+++ b/docker/hermes-agent/bootstrap/tests/test_toolsets.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+HERMES_ROOT = Path("/opt/hermes")
+BROWSER_AUTOMATION_TOOLS = {
+    "browser_navigate",
+    "browser_snapshot",
+    "browser_click",
+    "browser_type",
+    "browser_scroll",
+    "browser_back",
+    "browser_press",
+    "browser_get_images",
+    "browser_vision",
+    "browser_console",
+    "browser_cdp",
+    "browser_dialog",
+}
+
+
+class ToolsetContractTests(unittest.TestCase):
+    def test_browser_toolset_excludes_web_search_without_losing_automation_tools(
+        self,
+    ) -> None:
+        if not (HERMES_ROOT / "toolsets.py").is_file():
+            self.skipTest("Hermes runtime source is only available in the image")
+
+        sys.path.insert(0, str(HERMES_ROOT))
+        from toolsets import resolve_toolset
+
+        browser_tools = set(resolve_toolset("browser"))
+        self.assertEqual(browser_tools, BROWSER_AUTOMATION_TOOLS)
+        self.assertNotIn("web_search", browser_tools)
+        self.assertIn("web_search", resolve_toolset("web"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker/hermes-agent/compose.yml
+++ b/docker/hermes-agent/compose.yml
@@ -80,6 +80,18 @@ services:
     image: local/hermes-browser-mcp:latest
     container_name: hermes-browser-mcp
     restart: unless-stopped
+    command:
+      - node_modules/.bin/mcp-proxy
+      - --server
+      - stream
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8080"
+      - --
+      - node_modules/.bin/chrome-devtools-mcp
+      - --browser-url=http://chromium:9222
+      - --no-usage-statistics
     depends_on:
       chromium:
         condition: service_healthy

--- a/docs/hermes-agent/bootstrap-design.md
+++ b/docs/hermes-agent/bootstrap-design.md
@@ -294,7 +294,10 @@ browser data, X credentials, and other runtime paths do not move.
 - Existing root declarative files are backed up, then replaced only if listed
   by `root-distribution.yaml`.
 - Existing named profiles without `distribution.yaml` are converted with
-  `hermes profile install --force`; Hermes preserves user-owned paths.
+  `hermes profile install --force`; Hermes preserves user-owned paths. The
+  pinned runtime also restricts a direct profile install to the manifest's
+  top-level `distribution_owned` roots, so repository workflows, tests, and
+  validator tooling are not copied into the profile.
 - An existing `/opt/data/core/lifelog` checkout is copied to a private sibling,
   validated, and atomically published at `/opt/data/shared/lifelog`. The legacy
   path is snapshotted before removal and is absent after success.

--- a/docs/hermes-agent/browser-mcp.md
+++ b/docs/hermes-agent/browser-mcp.md
@@ -28,7 +28,9 @@ mcp_servers:
 この URL は Compose network 内専用で、host に `8080` や `9222` を publish しない。
 サーバー名は Hermes 組み込みの `browser` toolset と衝突しないよう `chrome` にする。
 全 managed profile は `agent.disabled_toolsets` で組み込みの `browser` toolset を
-無効化し、別の local browser session を選択できないようにする。
+無効化し、別の local browser session を選択できないようにする。固定した Hermes
+runtime では `web_search` を `browser` toolset から除外して `web` toolset にだけ
+所属させるため、この設定で Web 検索は無効にならない。
 
 ## Distribution source contract
 
@@ -91,5 +93,5 @@ docker exec -e HERMES_HOME=/opt/data/profiles/nancy hermes hermes mcp test chrom
 
 全コマンドで接続が成功し、`navigate_page` と `take_snapshot` を含む同じ tool set
 が表示されることを確認する。`hermes tools list --platform slack` では built-in
-`browser` が disabled と表示されることも確認する。host noVNC は
+`browser` が disabled、`web` が enabled と表示されることも確認する。host noVNC は
 `http://127.0.0.1:6080/` で開く。

--- a/docs/hermes-agent/browser-mcp.md
+++ b/docs/hermes-agent/browser-mcp.md
@@ -16,6 +16,9 @@ noVNC viewer は通常の `Cmd/Ctrl+C`、`Cmd/Ctrl+X`、`Cmd/Ctrl+V` を Google 
 Hermes から接続する内部 URL は次の固定値にする。
 
 ```yaml
+agent:
+  disabled_toolsets:
+    - browser
 mcp_servers:
   chrome:
     url: http://browser-mcp:8080/mcp
@@ -24,20 +27,25 @@ mcp_servers:
 
 この URL は Compose network 内専用で、host に `8080` や `9222` を publish しない。
 サーバー名は Hermes 組み込みの `browser` toolset と衝突しないよう `chrome` にする。
+全 managed profile は `agent.disabled_toolsets` で組み込みの `browser` toolset を
+無効化し、別の local browser session を選択できないようにする。
 
 ## Distribution source contract
 
 root distribution と `docker/hermes-agent/bootstrap-manifest.yaml` に宣言された
 全 profile は、source repository の `config.yaml` で上記の
-`mcp_servers.chrome` を所有する。他の MCP server は `chrome` と共存できる。
+`mcp_servers.chrome` と built-in `browser` の無効化を所有する。各 distribution
+manifest の `distribution_owned` は `config.yaml` を明示的に含める。他の MCP
+server は `chrome` と共存できる。
 
 Bootstrap は全 distribution を stage した後、shared repository の同期や local
-transaction の開始前に、この URL と timeout を検証する。設定の注入、merge、
-修復は行わない。新しい profile を manifest に追加すると、同じ検証へ自動的に
-含まれる。manifest 外で手動作成した profile は管理対象外のままにする。
+transaction の開始前に、配布所有権、built-in `browser` の無効化、URL、timeout
+を検証する。設定の注入、merge、修復は行わない。新しい profile を manifest に
+追加すると、同じ検証へ自動的に含まれる。manifest 外で手動作成した profile は
+管理対象外のままにする。
 
 Hermes 組み込みの `browser_*` tool は、noVNC が表示する Chrome とは別の local
-browser session を起動する。host から操作を確認する必要がある場合、agent は
+browser session を起動するため、managed profile では無効である。agent は
 `mcp_servers.chrome` から discover された tool を使う。
 
 ## Browser profile
@@ -82,4 +90,6 @@ docker exec -e HERMES_HOME=/opt/data/profiles/nancy hermes hermes mcp test chrom
 ```
 
 全コマンドで接続が成功し、`navigate_page` と `take_snapshot` を含む同じ tool set
-が表示されることを確認する。host noVNC は `http://127.0.0.1:6080/` で開く。
+が表示されることを確認する。`hermes tools list --platform slack` では built-in
+`browser` が disabled と表示されることも確認する。host noVNC は
+`http://127.0.0.1:6080/` で開く。

--- a/docs/hermes-agent/browser-mcp.md
+++ b/docs/hermes-agent/browser-mcp.md
@@ -25,6 +25,21 @@ mcp_servers:
 この URL は Compose network 内専用で、host に `8080` や `9222` を publish しない。
 サーバー名は Hermes 組み込みの `browser` toolset と衝突しないよう `chrome` にする。
 
+## Distribution source contract
+
+root distribution と `docker/hermes-agent/bootstrap-manifest.yaml` に宣言された
+全 profile は、source repository の `config.yaml` で上記の
+`mcp_servers.chrome` を所有する。他の MCP server は `chrome` と共存できる。
+
+Bootstrap は全 distribution を stage した後、shared repository の同期や local
+transaction の開始前に、この URL と timeout を検証する。設定の注入、merge、
+修復は行わない。新しい profile を manifest に追加すると、同じ検証へ自動的に
+含まれる。manifest 外で手動作成した profile は管理対象外のままにする。
+
+Hermes 組み込みの `browser_*` tool は、noVNC が表示する Chrome とは別の local
+browser session を起動する。host から操作を確認する必要がある場合、agent は
+`mcp_servers.chrome` から discover された tool を使う。
+
 ## Browser profile
 
 Google Chrome の profile は専用 data directory に保存する。
@@ -52,3 +67,19 @@ task hermes:browser:restart
 Browser が lifelog を参照する場合も canonical path は
 `/opt/data/shared/lifelog` である。migration-only の
 `/opt/data/core/lifelog` を runtime 設定へ追加しない。
+
+## Runtime verification
+
+各 profile home を明示して、同じ Chrome MCP tool set を discover できることを
+確認する。
+
+```text
+docker exec -e HERMES_HOME=/opt/data hermes hermes mcp test chrome
+docker exec -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp test chrome
+docker exec -e HERMES_HOME=/opt/data/profiles/hoffman hermes hermes mcp test chrome
+docker exec -e HERMES_HOME=/opt/data/profiles/risarisa hermes hermes mcp test chrome
+docker exec -e HERMES_HOME=/opt/data/profiles/nancy hermes hermes mcp test chrome
+```
+
+全コマンドで接続が成功し、`navigate_page` と `take_snapshot` を含む同じ tool set
+が表示されることを確認する。host noVNC は `http://127.0.0.1:6080/` で開く。

--- a/docs/superpowers/plans/2026-07-23-hermes-chrome-all-profiles.md
+++ b/docs/superpowers/plans/2026-07-23-hermes-chrome-all-profiles.md
@@ -101,12 +101,14 @@ Expected after each `worktree add`: `Preparing worktree (new branch 'codex/chrom
 **Repository:** `rurusasu/dotfiles`
 
 **Files:**
+
 - Create: `docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py`
 - Create: `docker/hermes-agent/bootstrap/tests/test_source_contracts.py`
 - Modify: `docker/hermes-agent/bootstrap/hermes_bootstrap/app.py:37-40,131-135`
 - Modify: `docker/hermes-agent/bootstrap/tests/test_app.py:61-70,167-231`
 
 **Interfaces:**
+
 - Consumes: `StagedSource(declaration: DistributionSource, path: Path, commit: str)` from `hermes_bootstrap.git`.
 - Produces: `validate_chrome_mcp_sources(staged: Sequence[StagedSource]) -> None`.
 - Raises: `ValidationError` with the distribution name and `config.yaml`, without chained parser/file exceptions.
@@ -464,11 +466,13 @@ git commit -m "feat: enforce Chrome MCP in Hermes distributions"
 **Repository:** `rurusasu/hermes-profile-rick`
 
 **Files:**
+
 - Modify: `config.yaml`
 - Modify: `scripts/validate_distribution.py`
 - Modify: `tests/test_validate_distribution.py`
 
 **Interfaces:**
+
 - Consumes: the repository's `config-contract` validator check.
 - Produces: a Rick distribution whose `mcp_servers` retains `xapi` and `x-docs` and adds canonical `chrome`.
 
@@ -477,11 +481,11 @@ git commit -m "feat: enforce Chrome MCP in Hermes distributions"
 In the fixture `config.yaml` string in `tests/test_validate_distribution.py`, make `mcp_servers` begin with:
 
 ```yaml
-            mcp_servers:
-              chrome:
-                url: http://browser-mcp:8080/mcp
-                connect_timeout: 120
-              xapi:
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: 120
+  xapi:
 ```
 
 Add these tests to `DistributionValidatorTests`:
@@ -591,11 +595,13 @@ git commit -m "feat: add Chrome MCP to Rick"
 **Repository:** `rurusasu/hermes-profile-hoffman`
 
 **Files:**
+
 - Modify: `config.yaml`
 - Modify: `scripts/validate_distribution.py`
 - Modify: `tests/test_validate_distribution.py`
 
 **Interfaces:**
+
 - Consumes: the repository's `config-contract` validator check.
 - Produces: a Hoffman distribution whose `mcp_servers` retains `xapi` and `x-docs` and adds canonical `chrome`.
 
@@ -604,11 +610,11 @@ git commit -m "feat: add Chrome MCP to Rick"
 Insert the canonical `chrome` mapping before `xapi` in the fixture `config.yaml`:
 
 ```yaml
-            mcp_servers:
-              chrome:
-                url: http://browser-mcp:8080/mcp
-                connect_timeout: 120
-              xapi:
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: 120
+  xapi:
 ```
 
 Add the following complete test methods:
@@ -718,11 +724,13 @@ git commit -m "feat: add Chrome MCP to Hoffman"
 **Repository:** `rurusasu/hermes-profile-risarisa`
 
 **Files:**
+
 - Modify: `config.yaml`
 - Modify: `scripts/validate_distribution.py`
 - Modify: `tests/test_validate_distribution.py`
 
 **Interfaces:**
+
 - Consumes: the repository's `config-contract` validator check.
 - Produces: a Risarisa distribution whose `mcp_servers` retains `xapi` and `x-docs` and adds canonical `chrome`.
 
@@ -731,11 +739,11 @@ git commit -m "feat: add Chrome MCP to Hoffman"
 Insert:
 
 ```yaml
-            mcp_servers:
-              chrome:
-                url: http://browser-mcp:8080/mcp
-                connect_timeout: 120
-              xapi:
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: 120
+  xapi:
 ```
 
 Add:
@@ -845,6 +853,7 @@ git commit -m "feat: add Chrome MCP to Risarisa"
 **Repository:** `rurusasu/hermes-profile-nancy`
 
 **Files:**
+
 - Create: `distribution.yaml`
 - Create: `scripts/validate_distribution.py`
 - Create: `tests/test_validate_distribution.py`
@@ -854,6 +863,7 @@ git commit -m "feat: add Chrome MCP to Risarisa"
 - Modify: `config.yaml`
 
 **Interfaces:**
+
 - Consumes: Hermes profile distribution schema `>=0.18.2`.
 - Produces: a `name: nancy`, `version: 0.1.0` distribution with no profile-specific environment requirements and a complete independent validation workflow.
 
@@ -1127,7 +1137,7 @@ repos:
 
 Keep `.github/workflows/distribution.yml` on the established pinned images:
 
-```yaml
+````yaml
 name: Distribution validation
 
 on:
@@ -1173,7 +1183,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           exit "$validator_status"
-```
+````
 
 - [ ] **Step 8: Prove no Rick/X API contract remains in Nancy's tooling**
 
@@ -1210,9 +1220,11 @@ git commit -m "feat: formalize Nancy with Chrome MCP"
 **Repository:** `rurusasu/dotfiles`
 
 **Files:**
+
 - Modify: `docs/hermes-agent/browser-mcp.md`
 
 **Interfaces:**
+
 - Consumes: `validate_chrome_mcp_sources(...)` and the canonical source config.
 - Produces: operator guidance that distinguishes Hermes built-in `browser_*` tools from `mcp_servers.chrome`.
 
@@ -1288,9 +1300,11 @@ git commit -m "docs: explain Chrome MCP profile contract"
 **Repositories:** all five source distributions plus `rurusasu/dotfiles`
 
 **Files:**
+
 - Verify only; no source edits are expected.
 
 **Interfaces:**
+
 - Consumes: the commits from Tasks 1-6.
 - Produces: a reproducible local verification record and, only after approval, publishable branches.
 
@@ -1344,9 +1358,11 @@ Report the five commit SHAs, test results, and the fact that production still re
 **Repositories:** `rurusasu/hermes-profile-rick`, `rurusasu/hermes-profile-hoffman`, `rurusasu/hermes-profile-risarisa`, `rurusasu/hermes-profile-nancy`, then `rurusasu/dotfiles`.
 
 **Files:**
+
 - No additional edits unless CI reveals a defect.
 
 **Interfaces:**
+
 - Consumes: green local commits and source repositories whose `main` branches are referenced by `bootstrap-manifest.yaml`.
 - Produces: merged source distributions, merged bootstrap enforcement, applied runtime state, successful MCP discovery for all profiles, and a noVNC-visible navigation proof.
 

--- a/docs/superpowers/plans/2026-07-23-hermes-chrome-all-profiles.md
+++ b/docs/superpowers/plans/2026-07-23-hermes-chrome-all-profiles.md
@@ -1,0 +1,1455 @@
+# Hermes Chrome MCP For All Profiles Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure the Hermes root distribution and every manifest-declared profile distribution configure the canonical `chrome` MCP server, reject source drift before bootstrap mutation, and prove that profile-driven navigation appears in the noVNC Chrome session.
+
+**Architecture:** Each source distribution remains the owner of its complete `config.yaml`; bootstrap never injects or merges MCP configuration. A focused source-contract validator checks every staged distribution before shared-repository synchronization or transaction creation, so current and future manifest profiles fail closed when the canonical Chrome MCP entry is absent or malformed.
+
+**Tech Stack:** Python 3.11, PyYAML, `unittest`, Hermes distribution manifests, Docker Compose, Model Context Protocol over HTTP, Git worktrees, GitHub Actions.
+
+## Global Constraints
+
+- The canonical entry is exactly:
+
+  ```yaml
+  mcp_servers:
+    chrome:
+      url: http://browser-mcp:8080/mcp
+      connect_timeout: 120
+  ```
+
+- Preserve additional profile MCP servers such as `xapi` and `x-docs`.
+- Cover the root distribution, every profile in `bootstrap-manifest.yaml`, and profiles added to that manifest later.
+- Do not scan or mutate manually created profiles that are absent from the bootstrap manifest.
+- Validate all staged `config.yaml` files before `synchronize_remote(...)` and before `Transaction.begin(...)`.
+- Reject missing files, malformed or duplicate-key YAML, non-mapping nodes, the wrong URL, a missing/wrong/non-integer timeout, and extra keys under `mcp_servers.chrome`.
+- Validation errors may identify the distribution name and `config.yaml`, but must not include file contents, staging paths, source URLs, credentials, or parser details.
+- Source distributions own complete configuration files; bootstrap must not inject, merge, or repair MCP settings.
+- Use branch `codex/chrome-mcp-all-profiles` in every repository with edits and isolate all edits in Git worktrees.
+- Do not push branches, create pull requests, merge, or run the production bootstrap until the user explicitly approves publication.
+
+---
+
+## File Map
+
+### `rurusasu/dotfiles`
+
+- Create `docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py`: strict, non-secret validation for staged distribution configuration.
+- Create `docker/hermes-agent/bootstrap/tests/test_source_contracts.py`: table-driven source-contract unit tests.
+- Modify `docker/hermes-agent/bootstrap/hermes_bootstrap/app.py`: call the validator after all distributions are staged and before remote synchronization.
+- Modify `docker/hermes-agent/bootstrap/tests/test_app.py`: preserve orchestration isolation and assert fail-before-mutation ordering.
+- Modify `docs/hermes-agent/browser-mcp.md`: document ownership, bootstrap enforcement, and runtime verification.
+
+### `rurusasu/hermes-profile-rick`
+
+- Modify `config.yaml`: add the canonical `chrome` entry without removing `xapi` or `x-docs`.
+- Modify `scripts/validate_distribution.py`: require the canonical entry.
+- Modify `tests/test_validate_distribution.py`: exercise accepted and rejected Chrome MCP contracts against the pinned Hermes image.
+
+### `rurusasu/hermes-profile-hoffman`
+
+- Modify `config.yaml`: add the canonical `chrome` entry without removing `xapi` or `x-docs`.
+- Modify `scripts/validate_distribution.py`: require the canonical entry.
+- Modify `tests/test_validate_distribution.py`: exercise accepted and rejected Chrome MCP contracts against the pinned Hermes image.
+
+### `rurusasu/hermes-profile-risarisa`
+
+- Modify `config.yaml`: add the canonical `chrome` entry without removing `xapi` or `x-docs`.
+- Modify `scripts/validate_distribution.py`: require the canonical entry.
+- Modify `tests/test_validate_distribution.py`: exercise accepted and rejected Chrome MCP contracts against the pinned Hermes image.
+
+### `rurusasu/hermes-profile-nancy`
+
+- Create `distribution.yaml`: make Nancy a valid bootstrap distribution.
+- Create `scripts/validate_distribution.py`: provide the same fail-closed distribution validation surface as the established profiles, with Nancy-specific contracts.
+- Create `tests/test_validate_distribution.py`: verify manifest, config, payload, policy, secret scanning, parser compatibility, and user-data preservation behavior.
+- Create `.github/workflows/distribution.yml`: run full validation for pull requests.
+- Create `.pre-commit-config.yaml`: run fast validation on commit and full validation on push.
+- Modify `.gitignore`: ignore generated validation reports.
+- Modify `config.yaml`: add the canonical `chrome` MCP entry.
+
+## Worktree Layout
+
+The dotfiles worktree already exists:
+
+```text
+/Users/ktome1995/Program/dotfiles/.worktrees/hermes-chrome-all-profiles
+```
+
+Create source-repository worktrees from current `origin/main` before their tasks:
+
+```bash
+git -C /Users/ktome1995/Program/hermes-profile-rick fetch origin main
+git -C /Users/ktome1995/Program/hermes-profile-rick worktree add -b codex/chrome-mcp-all-profiles /Users/ktome1995/Program/.worktrees/hermes-profile-rick-chrome-mcp origin/main
+
+git -C /Users/ktome1995/Program/hermes-profile-hoffman fetch origin main
+git -C /Users/ktome1995/Program/hermes-profile-hoffman worktree add -b codex/chrome-mcp-all-profiles /Users/ktome1995/Program/.worktrees/hermes-profile-hoffman-chrome-mcp origin/main
+
+git -C /Users/ktome1995/Program/hermes-profile-risarisa fetch origin main
+git -C /Users/ktome1995/Program/hermes-profile-risarisa worktree add -b codex/chrome-mcp-all-profiles /Users/ktome1995/Program/.worktrees/hermes-profile-risarisa-chrome-mcp origin/main
+
+gh repo clone rurusasu/hermes-profile-nancy /Users/ktome1995/Program/hermes-profile-nancy
+git -C /Users/ktome1995/Program/hermes-profile-nancy fetch origin main
+git -C /Users/ktome1995/Program/hermes-profile-nancy worktree add -b codex/chrome-mcp-all-profiles /Users/ktome1995/Program/.worktrees/hermes-profile-nancy-chrome-mcp origin/main
+```
+
+Expected after each `worktree add`: `Preparing worktree (new branch 'codex/chrome-mcp-all-profiles')`.
+
+### Task 1: Enforce The Chrome MCP Source Contract In Bootstrap
+
+**Repository:** `rurusasu/dotfiles`
+
+**Files:**
+- Create: `docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py`
+- Create: `docker/hermes-agent/bootstrap/tests/test_source_contracts.py`
+- Modify: `docker/hermes-agent/bootstrap/hermes_bootstrap/app.py:37-40,131-135`
+- Modify: `docker/hermes-agent/bootstrap/tests/test_app.py:61-70,167-231`
+
+**Interfaces:**
+- Consumes: `StagedSource(declaration: DistributionSource, path: Path, commit: str)` from `hermes_bootstrap.git`.
+- Produces: `validate_chrome_mcp_sources(staged: Sequence[StagedSource]) -> None`.
+- Raises: `ValidationError` with the distribution name and `config.yaml`, without chained parser/file exceptions.
+
+- [ ] **Step 1: Write table-driven failing source-contract tests**
+
+Create `docker/hermes-agent/bootstrap/tests/test_source_contracts.py` with helpers that build immutable staged sources:
+
+```python
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BOOTSTRAP_ROOT))
+
+from hermes_bootstrap.errors import ValidationError
+from hermes_bootstrap.git import StagedSource
+from hermes_bootstrap.models import DistributionSource
+from hermes_bootstrap.source_contracts import validate_chrome_mcp_sources
+
+
+VALID_CONFIG = """\
+model:
+  provider: openai-codex
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: 120
+  retained:
+    url: https://example.invalid/mcp
+"""
+
+
+class SourceContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+
+    def staged(self, name: str, config: str | None) -> StagedSource:
+        path = self.root / name
+        path.mkdir()
+        if config is not None:
+            (path / "config.yaml").write_text(config, encoding="utf-8")
+        declaration = DistributionSource(
+            name=name,
+            source=f"https://github.com/example/{name}.git",
+            ref="main",
+            target=Path("/opt/data") if name == "default" else Path("/opt/data/profiles") / name,
+            manifest_name="root-distribution.yaml" if name == "default" else "distribution.yaml",
+        )
+        return StagedSource(declaration=declaration, path=path, commit="a" * 40)
+
+    def test_accepts_root_and_profiles_while_preserving_other_servers(self) -> None:
+        staged = (
+            self.staged("default", VALID_CONFIG),
+            self.staged("rick", VALID_CONFIG),
+        )
+
+        validate_chrome_mcp_sources(staged)
+
+    def test_rejects_every_noncanonical_shape_without_exposing_values(self) -> None:
+        invalid = {
+            "missing-file": None,
+            "malformed-yaml": "mcp_servers: [\n",
+            "duplicate-key": """\
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    url: https://secret.invalid/mcp
+    connect_timeout: 120
+""",
+            "top-level-sequence": "- mcp_servers\n",
+            "mcp-sequence": "mcp_servers: []\n",
+            "missing-chrome": "mcp_servers: {}\n",
+            "chrome-sequence": "mcp_servers:\n  chrome: []\n",
+            "wrong-url": """\
+mcp_servers:
+  chrome:
+    url: https://secret.invalid/mcp
+    connect_timeout: 120
+""",
+            "missing-timeout": """\
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+""",
+            "string-timeout": """\
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: "120"
+""",
+            "boolean-timeout": """\
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: true
+""",
+            "wrong-timeout": """\
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: 60
+""",
+            "extra-chrome-key": """\
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: 120
+    token: secret-marker
+""",
+        }
+        for case, config in invalid.items():
+            with self.subTest(case=case):
+                staged = self.staged(case, config)
+                with self.assertRaises(ValidationError) as caught:
+                    validate_chrome_mcp_sources((staged,))
+                message = str(caught.exception)
+                self.assertIn(case, message)
+                self.assertIn("config.yaml", message)
+                self.assertNotIn("secret-marker", message)
+                self.assertNotIn("secret.invalid", message)
+                self.assertIsNone(caught.exception.__cause__)
+
+    def test_manifest_additions_are_covered_without_a_profile_allowlist(self) -> None:
+        stages = (
+            self.staged("default", VALID_CONFIG),
+            self.staged("rick", VALID_CONFIG),
+            self.staged("future-profile", "mcp_servers: {}\n"),
+        )
+
+        with self.assertRaisesRegex(ValidationError, "future-profile.*config.yaml"):
+            validate_chrome_mcp_sources(stages)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run the bootstrap suite and verify the new test is red**
+
+Run:
+
+```bash
+task hermes:bootstrap:test
+```
+
+Expected: non-zero exit while building `hermes-bootstrap-test`, with `ModuleNotFoundError: No module named 'hermes_bootstrap.source_contracts'`.
+
+- [ ] **Step 3: Implement strict staged-source validation**
+
+Create `docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py`:
+
+```python
+"""Non-secret contracts for staged Hermes source distributions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import NoReturn
+
+import yaml
+
+from .errors import ValidationError
+from .git import StagedSource
+
+
+_CHROME_MCP = {
+    "url": "http://browser-mcp:8080/mcp",
+    "connect_timeout": 120,
+}
+
+
+class _UniqueKeySafeLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects duplicate keys in every mapping."""
+
+    def construct_mapping(
+        self, node: yaml.MappingNode, deep: bool = False
+    ) -> dict[object, object]:
+        self.flatten_mapping(node)
+        mapping: dict[object, object] = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            try:
+                duplicate = key in mapping
+            except TypeError as error:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    "found unacceptable key",
+                    key_node.start_mark,
+                ) from error
+            if duplicate:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    "found duplicate key",
+                    key_node.start_mark,
+                )
+            mapping[key] = self.construct_object(value_node, deep=deep)
+        return mapping
+
+
+def validate_chrome_mcp_sources(staged: Sequence[StagedSource]) -> None:
+    """Require the canonical Chrome MCP entry in every staged distribution."""
+
+    for source in staged:
+        try:
+            with (source.path / "config.yaml").open(encoding="utf-8") as handle:
+                config = yaml.load(handle, Loader=_UniqueKeySafeLoader)
+        except (OSError, UnicodeError, yaml.YAMLError):
+            _invalid(source)
+
+        if not isinstance(config, Mapping):
+            _invalid(source)
+        mcp_servers = config.get("mcp_servers")
+        if not isinstance(mcp_servers, Mapping):
+            _invalid(source)
+        chrome = mcp_servers.get("chrome")
+        if not isinstance(chrome, Mapping) or dict(chrome) != _CHROME_MCP:
+            _invalid(source)
+
+
+def _invalid(source: StagedSource) -> NoReturn:
+    name = source.declaration.name
+    raise ValidationError(
+        f"distribution {name!r} config.yaml has invalid Chrome MCP configuration"
+    ) from None
+```
+
+- [ ] **Step 4: Insert validation before all synchronization and mutation**
+
+In `app.py`, import the new function:
+
+```python
+from .source_contracts import validate_chrome_mcp_sources
+```
+
+Then change the staged-source section of `_apply_sensitive(...)` to:
+
+```python
+        scratch = _private_scratch(manifest.data_root)
+        staged = [
+            stage_distribution(source, scratch, auth)
+            for source in _distributions(manifest)
+        ]
+        validate_chrome_mcp_sources(staged)
+        for repo in manifest.shared_repositories:
+            remote_results.append((repo, synchronize_remote(repo, auth)))
+
+        tx = Transaction.begin(manifest.data_root)
+```
+
+- [ ] **Step 5: Add orchestration tests for ordering and fail-before-mutation**
+
+In `AppTests.setUp`, install a default no-op patch so existing orchestration tests remain focused:
+
+```python
+        from hermes_bootstrap import app
+
+        source_contract_patcher = mock.patch.object(
+            app, "validate_chrome_mcp_sources"
+        )
+        self.validate_chrome_mcp_sources = source_contract_patcher.start()
+        self.addCleanup(source_contract_patcher.stop)
+```
+
+In `test_apply_recovers_before_reading_secrets_and_network_before_transaction`, set:
+
+```python
+        self.validate_chrome_mcp_sources.side_effect = (
+            lambda staged: events.append(
+                "source-contract:" + ",".join(
+                    stage.declaration.name for stage in staged
+                )
+            )
+        )
+```
+
+and require this event between `stage:rick` and `sync:lifelog`:
+
+```python
+                "stage:default",
+                "stage:rick",
+                "source-contract:default,rick",
+                "sync:lifelog",
+```
+
+Add a second test:
+
+```python
+    def test_source_contract_failure_precedes_remote_sync_and_transaction(self) -> None:
+        from hermes_bootstrap import app
+
+        secrets = mock.Mock(
+            github_token="token",
+            redactor=SecretRedactor(("token",)),
+        )
+        staged = mock.Mock()
+        self.validate_chrome_mcp_sources.side_effect = ValidationError(
+            "distribution 'future-profile' config.yaml has invalid Chrome MCP configuration"
+        )
+
+        with (
+            mock.patch.object(app, "load_manifest", return_value=self.manifest),
+            mock.patch.object(app.Transaction, "recover_if_needed"),
+            mock.patch.object(app, "read_secret_payload", return_value=secrets),
+            mock.patch.object(app, "_validate_remote_credentials"),
+            mock.patch.object(app, "_validate_profile_credentials"),
+            mock.patch.object(app, "stage_distribution", return_value=staged),
+            mock.patch.object(app, "synchronize_remote") as synchronize,
+            mock.patch.object(app.Transaction, "begin") as begin,
+        ):
+            with self.assertRaisesRegex(
+                ValidationError, "future-profile.*config.yaml"
+            ):
+                app.apply(Path("manifest.yaml"), io.StringIO("payload"))
+
+        self.assertEqual(
+            self.validate_chrome_mcp_sources.call_args.args[0],
+            [staged, staged],
+        )
+        synchronize.assert_not_called()
+        begin.assert_not_called()
+```
+
+- [ ] **Step 6: Run the full bootstrap test suite**
+
+Run:
+
+```bash
+task hermes:bootstrap:test
+```
+
+Expected: Docker test stage completes with all Python tests passing, followed by `test_gh_wrapper: PASS`.
+
+- [ ] **Step 7: Commit the bootstrap enforcement**
+
+```bash
+git add docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py
+git add docker/hermes-agent/bootstrap/hermes_bootstrap/app.py
+git add docker/hermes-agent/bootstrap/tests/test_source_contracts.py
+git add docker/hermes-agent/bootstrap/tests/test_app.py
+git commit -m "feat: enforce Chrome MCP in Hermes distributions"
+```
+
+### Task 2: Add Chrome MCP To Rick
+
+**Repository:** `rurusasu/hermes-profile-rick`
+
+**Files:**
+- Modify: `config.yaml`
+- Modify: `scripts/validate_distribution.py`
+- Modify: `tests/test_validate_distribution.py`
+
+**Interfaces:**
+- Consumes: the repository's `config-contract` validator check.
+- Produces: a Rick distribution whose `mcp_servers` retains `xapi` and `x-docs` and adds canonical `chrome`.
+
+- [ ] **Step 1: Make the fixture describe the desired contract and add real-image tests**
+
+In the fixture `config.yaml` string in `tests/test_validate_distribution.py`, make `mcp_servers` begin with:
+
+```yaml
+            mcp_servers:
+              chrome:
+                url: http://browser-mcp:8080/mcp
+                connect_timeout: 120
+              xapi:
+```
+
+Add these tests to `DistributionValidatorTests`:
+
+```python
+    def test_real_config_contract_accepts_canonical_chrome_mcp(self) -> None:
+        self.require_real_docker()
+
+        completed = self.run_validator(
+            "fast", "--json", environment=os.environ.copy()
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stdout)
+
+    def test_real_config_contract_rejects_wrong_chrome_endpoint(self) -> None:
+        self.require_real_docker()
+        config_path = self.fixture.root / "config.yaml"
+        config_path.write_text(
+            config_path.read_text(encoding="utf-8").replace(
+                "http://browser-mcp:8080/mcp",
+                "https://wrong.invalid/mcp",
+            ),
+            encoding="utf-8",
+        )
+
+        completed = self.run_validator(
+            "fast", "--json", environment=os.environ.copy()
+        )
+
+        self.assertEqual(completed.returncode, 1)
+        result = self.parse_json(completed)
+        contract = next(
+            check for check in result["checks"] if check["id"] == "config-contract"
+        )
+        self.assertEqual(contract["status"], "fail")
+```
+
+- [ ] **Step 2: Run the focused test and verify the desired config is rejected**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_validate_distribution.DistributionValidatorTests.test_real_config_contract_accepts_canonical_chrome_mcp -v
+```
+
+Expected: `FAIL`; the current validator still expects only `xapi` and `x-docs`.
+
+- [ ] **Step 3: Update the validator's complete MCP expectation**
+
+Make `CONFIG_CONTRACT_CODE` assert:
+
+```python
+assert config["mcp_servers"] == {
+    "chrome": {
+        "url": "http://browser-mcp:8080/mcp",
+        "connect_timeout": 120,
+    },
+    "xapi": {
+        "command": "/usr/local/bin/hermes-xapi-mcp",
+        "connect_timeout": 300,
+        "env": {
+            "X_API_CLIENT_ID": "${X_API_CLIENT_ID}",
+            "X_API_CLIENT_SECRET": "${X_API_CLIENT_SECRET}",
+        },
+    },
+    "x-docs": {
+        "url": "https://docs.x.com/mcp",
+        "connect_timeout": 60,
+    },
+}
+```
+
+- [ ] **Step 4: Add Chrome to Rick's source configuration**
+
+Make the real `config.yaml` `mcp_servers` section begin with:
+
+```yaml
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: 120
+  xapi:
+```
+
+Leave the complete existing `xapi` and `x-docs` mappings unchanged.
+
+- [ ] **Step 5: Run Rick's unit and full distribution validation**
+
+Run:
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 scripts/validate_distribution.py full --json
+```
+
+Expected: all unit tests pass; the JSON report has `"status":"pass"` and `"exit_code":0`.
+
+- [ ] **Step 6: Commit Rick's source contract**
+
+```bash
+git add config.yaml scripts/validate_distribution.py tests/test_validate_distribution.py
+git commit -m "feat: add Chrome MCP to Rick"
+```
+
+### Task 3: Add Chrome MCP To Hoffman
+
+**Repository:** `rurusasu/hermes-profile-hoffman`
+
+**Files:**
+- Modify: `config.yaml`
+- Modify: `scripts/validate_distribution.py`
+- Modify: `tests/test_validate_distribution.py`
+
+**Interfaces:**
+- Consumes: the repository's `config-contract` validator check.
+- Produces: a Hoffman distribution whose `mcp_servers` retains `xapi` and `x-docs` and adds canonical `chrome`.
+
+- [ ] **Step 1: Make Hoffman's fixture and real-image tests require Chrome**
+
+Insert the canonical `chrome` mapping before `xapi` in the fixture `config.yaml`:
+
+```yaml
+            mcp_servers:
+              chrome:
+                url: http://browser-mcp:8080/mcp
+                connect_timeout: 120
+              xapi:
+```
+
+Add the following complete test methods:
+
+```python
+    def test_real_config_contract_accepts_canonical_chrome_mcp(self) -> None:
+        self.require_real_docker()
+
+        completed = self.run_validator(
+            "fast", "--json", environment=os.environ.copy()
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stdout)
+
+    def test_real_config_contract_rejects_wrong_chrome_endpoint(self) -> None:
+        self.require_real_docker()
+        config_path = self.fixture.root / "config.yaml"
+        config_path.write_text(
+            config_path.read_text(encoding="utf-8").replace(
+                "http://browser-mcp:8080/mcp",
+                "https://wrong.invalid/mcp",
+            ),
+            encoding="utf-8",
+        )
+
+        completed = self.run_validator(
+            "fast", "--json", environment=os.environ.copy()
+        )
+
+        self.assertEqual(completed.returncode, 1)
+        result = self.parse_json(completed)
+        contract = next(
+            check for check in result["checks"] if check["id"] == "config-contract"
+        )
+        self.assertEqual(contract["status"], "fail")
+```
+
+- [ ] **Step 2: Confirm the current validator rejects the desired fixture**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_validate_distribution.DistributionValidatorTests.test_real_config_contract_accepts_canonical_chrome_mcp -v
+```
+
+Expected: `FAIL`; `config-contract` has not yet admitted Chrome.
+
+- [ ] **Step 3: Require Chrome while retaining Hoffman's existing servers**
+
+Replace the validator's `assert config["mcp_servers"] == ...` block with:
+
+```python
+assert config["mcp_servers"] == {
+    "chrome": {
+        "url": "http://browser-mcp:8080/mcp",
+        "connect_timeout": 120,
+    },
+    "xapi": {
+        "command": "/usr/local/bin/hermes-xapi-mcp",
+        "connect_timeout": 300,
+        "env": {
+            "X_API_CLIENT_ID": "${X_API_CLIENT_ID}",
+            "X_API_CLIENT_SECRET": "${X_API_CLIENT_SECRET}",
+        },
+    },
+    "x-docs": {
+        "url": "https://docs.x.com/mcp",
+        "connect_timeout": 60,
+    },
+}
+```
+
+- [ ] **Step 4: Add Chrome to Hoffman's real config**
+
+Insert exactly:
+
+```yaml
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: 120
+  xapi:
+```
+
+Keep the existing `xapi` and `x-docs` mappings byte-for-byte except for indentation required by the insertion.
+
+- [ ] **Step 5: Run Hoffman's complete validation**
+
+Run:
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 scripts/validate_distribution.py full --json
+```
+
+Expected: all unit tests pass; the full report contains `"status":"pass"`.
+
+- [ ] **Step 6: Commit Hoffman's source contract**
+
+```bash
+git add config.yaml scripts/validate_distribution.py tests/test_validate_distribution.py
+git commit -m "feat: add Chrome MCP to Hoffman"
+```
+
+### Task 4: Add Chrome MCP To Risarisa
+
+**Repository:** `rurusasu/hermes-profile-risarisa`
+
+**Files:**
+- Modify: `config.yaml`
+- Modify: `scripts/validate_distribution.py`
+- Modify: `tests/test_validate_distribution.py`
+
+**Interfaces:**
+- Consumes: the repository's `config-contract` validator check.
+- Produces: a Risarisa distribution whose `mcp_servers` retains `xapi` and `x-docs` and adds canonical `chrome`.
+
+- [ ] **Step 1: Add the desired mapping to the fixture and cover it with real Docker**
+
+Insert:
+
+```yaml
+            mcp_servers:
+              chrome:
+                url: http://browser-mcp:8080/mcp
+                connect_timeout: 120
+              xapi:
+```
+
+Add:
+
+```python
+    def test_real_config_contract_accepts_canonical_chrome_mcp(self) -> None:
+        self.require_real_docker()
+
+        completed = self.run_validator(
+            "fast", "--json", environment=os.environ.copy()
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stdout)
+
+    def test_real_config_contract_rejects_wrong_chrome_endpoint(self) -> None:
+        self.require_real_docker()
+        config_path = self.fixture.root / "config.yaml"
+        config_path.write_text(
+            config_path.read_text(encoding="utf-8").replace(
+                "http://browser-mcp:8080/mcp",
+                "https://wrong.invalid/mcp",
+            ),
+            encoding="utf-8",
+        )
+
+        completed = self.run_validator(
+            "fast", "--json", environment=os.environ.copy()
+        )
+
+        self.assertEqual(completed.returncode, 1)
+        result = self.parse_json(completed)
+        contract = next(
+            check for check in result["checks"] if check["id"] == "config-contract"
+        )
+        self.assertEqual(contract["status"], "fail")
+```
+
+- [ ] **Step 2: Prove the test is red before changing the validator**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_validate_distribution.DistributionValidatorTests.test_real_config_contract_accepts_canonical_chrome_mcp -v
+```
+
+Expected: `FAIL` from the current `config-contract`.
+
+- [ ] **Step 3: Set Risarisa's exact validator expectation**
+
+Use:
+
+```python
+assert config["mcp_servers"] == {
+    "chrome": {
+        "url": "http://browser-mcp:8080/mcp",
+        "connect_timeout": 120,
+    },
+    "xapi": {
+        "command": "/usr/local/bin/hermes-xapi-mcp",
+        "connect_timeout": 300,
+        "env": {
+            "X_API_CLIENT_ID": "${X_API_CLIENT_ID}",
+            "X_API_CLIENT_SECRET": "${X_API_CLIENT_SECRET}",
+        },
+    },
+    "x-docs": {
+        "url": "https://docs.x.com/mcp",
+        "connect_timeout": 60,
+    },
+}
+```
+
+- [ ] **Step 4: Add the canonical entry to Risarisa's real config**
+
+Use:
+
+```yaml
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: 120
+  xapi:
+```
+
+Retain the existing complete `xapi` and `x-docs` values.
+
+- [ ] **Step 5: Run Risarisa's complete validation**
+
+Run:
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 scripts/validate_distribution.py full --json
+```
+
+Expected: all tests pass and the full report has `"exit_code":0`.
+
+- [ ] **Step 6: Commit Risarisa's source contract**
+
+```bash
+git add config.yaml scripts/validate_distribution.py tests/test_validate_distribution.py
+git commit -m "feat: add Chrome MCP to Risarisa"
+```
+
+### Task 5: Formalize Nancy And Add Chrome MCP
+
+**Repository:** `rurusasu/hermes-profile-nancy`
+
+**Files:**
+- Create: `distribution.yaml`
+- Create: `scripts/validate_distribution.py`
+- Create: `tests/test_validate_distribution.py`
+- Create: `.github/workflows/distribution.yml`
+- Create: `.pre-commit-config.yaml`
+- Modify: `.gitignore`
+- Modify: `config.yaml`
+
+**Interfaces:**
+- Consumes: Hermes profile distribution schema `>=0.18.2`.
+- Produces: a `name: nancy`, `version: 0.1.0` distribution with no profile-specific environment requirements and a complete independent validation workflow.
+
+- [ ] **Step 1: Seed Nancy's validator harness from the already-tested Rick worktree**
+
+Copy the robust validator and test harness after Task 2 has passed:
+
+```bash
+mkdir -p scripts tests .github/workflows
+cp /Users/ktome1995/Program/.worktrees/hermes-profile-rick-chrome-mcp/scripts/validate_distribution.py scripts/validate_distribution.py
+cp /Users/ktome1995/Program/.worktrees/hermes-profile-rick-chrome-mcp/tests/test_validate_distribution.py tests/test_validate_distribution.py
+cp /Users/ktome1995/Program/.worktrees/hermes-profile-rick-chrome-mcp/.github/workflows/distribution.yml .github/workflows/distribution.yml
+cp /Users/ktome1995/Program/.worktrees/hermes-profile-rick-chrome-mcp/.pre-commit-config.yaml .pre-commit-config.yaml
+```
+
+This mechanical seed preserves the tested fail-closed Git enumeration, redaction, parser, preservation, and report behavior. The following steps replace every profile-specific contract before the files are committed.
+
+- [ ] **Step 2: Write Nancy's exact distribution manifest**
+
+Create `distribution.yaml`:
+
+```yaml
+name: nancy
+version: 0.1.0
+description: Research and communications strategist profile
+hermes_requires: ">=0.18.2"
+author: rurusasu
+license: private
+distribution_owned:
+  - .no-bundled-skills
+  - SOUL.md
+  - config.yaml
+  - profile.yaml
+  - slack-manifest.json
+  - assets/
+```
+
+- [ ] **Step 3: Rewrite the validator's Nancy-specific constants and contracts**
+
+Set:
+
+```python
+REPOSITORY_NAME = "hermes-profile-nancy"
+PROFILE_NAME = "nancy"
+```
+
+Replace `MANIFEST_SCHEMA_CODE` with:
+
+```python
+MANIFEST_SCHEMA_CODE = r"""
+from pathlib import Path
+import yaml
+
+expected = {
+    "name": "nancy",
+    "version": "0.1.0",
+    "description": "Research and communications strategist profile",
+    "hermes_requires": ">=0.18.2",
+    "author": "rurusasu",
+    "license": "private",
+    "distribution_owned": [
+        ".no-bundled-skills",
+        "SOUL.md",
+        "config.yaml",
+        "profile.yaml",
+        "slack-manifest.json",
+        "assets/",
+    ],
+}
+actual = yaml.safe_load(Path("/repository/distribution.yaml").read_text(encoding="utf-8"))
+assert actual == expected
+""".strip()
+```
+
+Replace `CONFIG_CONTRACT_CODE` with:
+
+```python
+CONFIG_CONTRACT_CODE = r"""
+from pathlib import Path
+import yaml
+
+config = yaml.safe_load(Path("/repository/config.yaml").read_text(encoding="utf-8"))
+assert config["model"] == {
+    "provider": "openai-codex",
+    "default": "gpt-5.6-luna",
+}
+assert config["terminal"] == {
+    "backend": "local",
+    "cwd": ".",
+    "timeout": 180,
+}
+assert config["slack"] == {
+    "require_mention": True,
+    "strict_mention": False,
+    "allow_bots": "mentions",
+}
+assert config["mcp_servers"] == {
+    "chrome": {
+        "url": "http://browser-mcp:8080/mcp",
+        "connect_timeout": 120,
+    },
+}
+for forbidden in ("github", "dashboard"):
+    assert forbidden not in config
+""".strip()
+```
+
+Replace `HERMES_PARSER_CODE` with:
+
+```python
+HERMES_PARSER_CODE = r"""
+from pathlib import Path
+from hermes_cli.profile_distribution import plan_install
+
+p = plan_install("/distribution", Path("/tmp/stage"))
+assert p.manifest.name == "nancy"
+assert p.manifest.version == "0.1.0"
+assert list(p.manifest.env_requires) == []
+""".strip()
+```
+
+In `PRESERVATION_SCRIPT`, use:
+
+```sh
+profile=/tmp/hermes/profiles/nancy
+hermes profile install /distribution --name nancy --force -y >/tmp/install.log
+```
+
+Set policy requirements in `check_repository_policy(...)` to:
+
+```python
+    requirements = [
+        "/opt/data/docs/profile-home-layout.md",
+        "Keep Hermes' standard filesystem layout intact",
+        "/opt/data/core/lifelog/AGENTS.md",
+        "do not use profile memories/",
+    ]
+```
+
+Use Nancy in all pass/fail messages and use:
+
+```python
+parser = argparse.ArgumentParser(description="Validate the Nancy Hermes distribution")
+```
+
+- [ ] **Step 4: Rewrite the test fixture and identity assertions before running it**
+
+In `tests/test_validate_distribution.py`:
+
+- Set fixture manifest fields exactly to the `distribution.yaml` from Step 2 and remove Rick's `env_requires`.
+- Set fixture `SOUL.md` to include all four Nancy policy strings from Step 3.
+- Set fixture `config.yaml` to Nancy's model, terminal, slack, and canonical Chrome MCP contract.
+- Replace every repository assertion with `hermes-profile-nancy`.
+- Replace every manifest/profile identity with `nancy`.
+- Replace every runtime path with `/tmp/hermes/profiles/nancy`.
+- Remove `test_manifest_schema_requires_xapi_env_requirements`.
+- Add this manifest test:
+
+```python
+    def test_manifest_schema_rejects_unexpected_environment_requirements(self) -> None:
+        self.require_real_docker()
+        manifest_path = self.fixture.root / "distribution.yaml"
+        manifest_path.write_text(
+            manifest_path.read_text(encoding="utf-8")
+            + "env_requires:\n"
+            + "  - name: UNEXPECTED_SECRET\n"
+            + "    description: must be rejected\n",
+            encoding="utf-8",
+        )
+
+        completed = self.run_validator(
+            "fast", "--json", environment=os.environ.copy()
+        )
+
+        self.assertEqual(completed.returncode, 1)
+        result = self.parse_json(completed)
+        manifest = next(
+            check for check in result["checks"] if check["id"] == "manifest-schema"
+        )
+        self.assertEqual(manifest["status"], "fail")
+```
+
+Add the canonical/wrong endpoint tests:
+
+```python
+    def test_real_config_contract_accepts_canonical_chrome_mcp(self) -> None:
+        self.require_real_docker()
+
+        completed = self.run_validator(
+            "fast", "--json", environment=os.environ.copy()
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stdout)
+
+    def test_real_config_contract_rejects_wrong_chrome_endpoint(self) -> None:
+        self.require_real_docker()
+        config_path = self.fixture.root / "config.yaml"
+        config_path.write_text(
+            config_path.read_text(encoding="utf-8").replace(
+                "http://browser-mcp:8080/mcp",
+                "https://wrong.invalid/mcp",
+            ),
+            encoding="utf-8",
+        )
+
+        completed = self.run_validator(
+            "fast", "--json", environment=os.environ.copy()
+        )
+
+        self.assertEqual(completed.returncode, 1)
+        result = self.parse_json(completed)
+        contract = next(
+            check for check in result["checks"] if check["id"] == "config-contract"
+        )
+        self.assertEqual(contract["status"], "fail")
+```
+
+- [ ] **Step 5: Run the rewritten tests and verify Nancy's real config is still red**
+
+Run:
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 scripts/validate_distribution.py fast --json
+```
+
+Expected: unit fixtures pass, while validation of the repository root exits `1` because the real `config.yaml` does not yet contain `mcp_servers.chrome`.
+
+- [ ] **Step 6: Add Chrome to Nancy's real configuration**
+
+Insert after `terminal` and before `memory`:
+
+```yaml
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: 120
+```
+
+Do not add `xapi` or `x-docs` to Nancy.
+
+- [ ] **Step 7: Finish repository-local validation wiring**
+
+Append to `.gitignore`:
+
+```gitignore
+
+# Distribution validation reports
+.hermes-validation/
+```
+
+Keep `.pre-commit-config.yaml` exactly:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: hermes-distribution-fast
+        name: Hermes distribution fast validation
+        entry: python3 scripts/validate_distribution.py fast
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+      - id: hermes-distribution-full
+        name: Hermes distribution full validation
+        entry: python3 scripts/validate_distribution.py full
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+```
+
+Keep `.github/workflows/distribution.yml` on the established pinned images:
+
+```yaml
+name: Distribution validation
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: distribution-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out pull request head
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Pull pinned validator images
+        run: |
+          docker pull docker.io/nousresearch/hermes-agent@sha256:dbd5484b4e822307e78bb68d5bf17a57eece7c5e278ca38b8670df9499f14731
+          docker pull zricethezav/gitleaks@sha256:691af3c7c5a48b16f187ce3446d5f194838f91238f27270ed36eef6359a574d9
+
+      - name: Run full distribution validation
+        shell: bash
+        run: |
+          set +e
+          python3 scripts/validate_distribution.py full --json --output .hermes-validation/full.json
+          validator_status=$?
+          set -e
+
+          cat .hermes-validation/full.json
+          {
+            echo '## Hermes distribution validation'
+            echo '```json'
+            cat .hermes-validation/full.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit "$validator_status"
+```
+
+- [ ] **Step 8: Prove no Rick/X API contract remains in Nancy's tooling**
+
+Run:
+
+```bash
+rg -n "rick|Rick|X_API_CLIENT_ID|X_API_CLIENT_SECRET|xapi|x-docs" distribution.yaml scripts tests config.yaml
+```
+
+Expected: no output and exit code `1`.
+
+- [ ] **Step 9: Run Nancy's complete validation**
+
+Run:
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 scripts/validate_distribution.py full --json
+```
+
+Expected: all unit tests pass; full JSON has `"repository":"hermes-profile-nancy"`, `"status":"pass"`, and `"exit_code":0`.
+
+- [ ] **Step 10: Commit Nancy's distribution**
+
+```bash
+git add distribution.yaml config.yaml .gitignore .pre-commit-config.yaml
+git add .github/workflows/distribution.yml scripts/validate_distribution.py
+git add tests/test_validate_distribution.py
+git commit -m "feat: formalize Nancy with Chrome MCP"
+```
+
+### Task 6: Document The Ownership And Enforcement Boundary
+
+**Repository:** `rurusasu/dotfiles`
+
+**Files:**
+- Modify: `docs/hermes-agent/browser-mcp.md`
+
+**Interfaces:**
+- Consumes: `validate_chrome_mcp_sources(...)` and the canonical source config.
+- Produces: operator guidance that distinguishes Hermes built-in `browser_*` tools from `mcp_servers.chrome`.
+
+- [ ] **Step 1: Add the source contract section**
+
+Add:
+
+````markdown
+## Distribution source contract
+
+The root distribution and every profile declared in
+`docker/hermes-agent/bootstrap-manifest.yaml` must own this exact entry in
+their source `config.yaml`:
+
+```yaml
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: 120
+```
+
+Other MCP servers may coexist with `chrome`. Bootstrap stages every declared
+distribution and validates this entry before synchronizing shared repositories
+or opening a local transaction. It does not inject or repair configuration.
+
+Hermes' built-in `browser_*` tools launch a separate local browser session.
+For activity that must be visible through the host noVNC page, the agent must
+use the tools discovered from `mcp_servers.chrome`.
+````
+
+- [ ] **Step 2: Add runtime checks**
+
+Add:
+
+````markdown
+## Runtime verification
+
+Use each profile home explicitly:
+
+```bash
+docker exec -e HERMES_HOME=/opt/data hermes hermes mcp test chrome
+docker exec -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp test chrome
+docker exec -e HERMES_HOME=/opt/data/profiles/hoffman hermes hermes mcp test chrome
+docker exec -e HERMES_HOME=/opt/data/profiles/risarisa hermes hermes mcp test chrome
+docker exec -e HERMES_HOME=/opt/data/profiles/nancy hermes hermes mcp test chrome
+```
+
+Every command must report a successful connection and the same discovered
+Chrome tool set, including `navigate_page` and `take_snapshot`. The host noVNC
+page is `http://127.0.0.1:6080/`.
+````
+
+- [ ] **Step 3: Run documentation and bootstrap checks**
+
+Run:
+
+```bash
+task lint:all
+task hermes:bootstrap:test
+```
+
+Expected: lint succeeds; bootstrap tests end with `test_gh_wrapper: PASS`.
+
+- [ ] **Step 4: Commit the operator documentation**
+
+```bash
+git add docs/hermes-agent/browser-mcp.md
+git commit -m "docs: explain Chrome MCP profile contract"
+```
+
+### Task 7: Cross-Repository Verification And Publication Gate
+
+**Repositories:** all five source distributions plus `rurusasu/dotfiles`
+
+**Files:**
+- Verify only; no source edits are expected.
+
+**Interfaces:**
+- Consumes: the commits from Tasks 1-6.
+- Produces: a reproducible local verification record and, only after approval, publishable branches.
+
+- [ ] **Step 1: Confirm every worktree is clean and on the intended branch**
+
+Run `git status --short --branch` in each worktree:
+
+```text
+/Users/ktome1995/Program/dotfiles/.worktrees/hermes-chrome-all-profiles
+/Users/ktome1995/Program/.worktrees/hermes-profile-rick-chrome-mcp
+/Users/ktome1995/Program/.worktrees/hermes-profile-hoffman-chrome-mcp
+/Users/ktome1995/Program/.worktrees/hermes-profile-risarisa-chrome-mcp
+/Users/ktome1995/Program/.worktrees/hermes-profile-nancy-chrome-mcp
+```
+
+Expected: branch `codex/chrome-mcp-all-profiles` and no modified/untracked files in every worktree.
+
+- [ ] **Step 2: Re-run every source validator**
+
+Run in `hermes-home`:
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 scripts/validate_distribution.py full --json
+```
+
+Run the same two commands in the Rick, Hoffman, Risarisa, and Nancy worktrees.
+
+Expected: all tests pass and all five full reports contain `"status":"pass"`.
+
+- [ ] **Step 3: Re-run dotfiles verification**
+
+Run:
+
+```bash
+task hermes:bootstrap:test
+task hermes:bootstrap:config
+task lint:all
+```
+
+Expected: bootstrap tests, Compose validation, and repository lint all pass.
+
+- [ ] **Step 4: Stop for explicit publication approval**
+
+Report the five commit SHAs, test results, and the fact that production still reads `main` from the source repositories. Do not continue to the publication and runtime tasks until the user explicitly approves push/PR/merge.
+
+### Task 8: Publish, Apply, And Prove The Shared noVNC Session
+
+**Precondition:** the user has explicitly approved publication.
+
+**Repositories:** `rurusasu/hermes-profile-rick`, `rurusasu/hermes-profile-hoffman`, `rurusasu/hermes-profile-risarisa`, `rurusasu/hermes-profile-nancy`, then `rurusasu/dotfiles`.
+
+**Files:**
+- No additional edits unless CI reveals a defect.
+
+**Interfaces:**
+- Consumes: green local commits and source repositories whose `main` branches are referenced by `bootstrap-manifest.yaml`.
+- Produces: merged source distributions, merged bootstrap enforcement, applied runtime state, successful MCP discovery for all profiles, and a noVNC-visible navigation proof.
+
+- [ ] **Step 1: Push source branches and create pull requests**
+
+For each source worktree:
+
+```bash
+git push -u origin codex/chrome-mcp-all-profiles
+gh pr create --base main --head codex/chrome-mcp-all-profiles --fill
+```
+
+Expected: one pull-request URL per repository.
+
+- [ ] **Step 2: Wait for source Actions and merge in dependency order**
+
+For each source PR:
+
+```bash
+gh pr checks --watch
+gh pr merge --squash --delete-branch
+```
+
+Expected: all checks pass and Rick, Hoffman, Risarisa, and Nancy merge before dotfiles is applied.
+
+- [ ] **Step 3: Push, check, and merge dotfiles**
+
+From the dotfiles worktree:
+
+```bash
+git push -u origin codex/hermes-chrome-all-profiles
+gh pr create --base main --head codex/hermes-chrome-all-profiles --fill
+gh pr checks --watch
+gh pr merge --squash --delete-branch
+```
+
+Expected: dotfiles Actions pass and the PR merges.
+
+- [ ] **Step 4: Update the local main checkout and apply bootstrap**
+
+From `/Users/ktome1995/Program/dotfiles`:
+
+```bash
+git pull --ff-only origin main
+task hermes:bootstrap
+```
+
+Expected: bootstrap reports `status: applied`; root plus profiles `rick`, `hoffman`, `risarisa`, and `nancy` are installed without validation errors.
+
+- [ ] **Step 5: Test Chrome MCP from every runtime home**
+
+Run:
+
+```bash
+docker exec -e HERMES_HOME=/opt/data hermes hermes mcp test chrome
+docker exec -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp test chrome
+docker exec -e HERMES_HOME=/opt/data/profiles/hoffman hermes hermes mcp test chrome
+docker exec -e HERMES_HOME=/opt/data/profiles/risarisa hermes hermes mcp test chrome
+docker exec -e HERMES_HOME=/opt/data/profiles/nancy hermes hermes mcp test chrome
+```
+
+Expected: each command connects to `http://browser-mcp:8080/mcp` and discovers the same Chrome MCP tools, including `navigate_page` and `take_snapshot`.
+
+- [ ] **Step 6: Trigger a Nancy-only MCP navigation proof**
+
+Record the start time in the shell that will run Steps 6 and 7:
+
+```bash
+export START_EPOCH="$(date +%s)"
+printf '%s\n' "$START_EPOCH"
+```
+
+Then run:
+
+```bash
+docker exec -e HERMES_HOME=/opt/data/profiles/nancy hermes hermes -z "Use the Chrome MCP navigate_page tool, not any built-in browser_* tool, to open https://example.com/?profile=nancy. Report only the final page title."
+```
+
+Expected: final response `Example Domain`.
+
+- [ ] **Step 7: Verify the recorded tool call came from Chrome MCP**
+
+Run in the same shell:
+
+```bash
+docker exec -e START_EPOCH="$START_EPOCH" hermes python -c "import os, sqlite3; db=sqlite3.connect('/opt/data/profiles/nancy/state.db'); print(list(db.execute(\"select tool_name from messages where timestamp >= ? and role = 'tool' order by id\", (float(os.environ['START_EPOCH']),))))"
+```
+
+Expected: the output contains the Chrome MCP navigation tool name and contains neither `browser_navigate` nor `browser_snapshot`.
+
+- [ ] **Step 8: Verify the same navigation in noVNC**
+
+Open `http://127.0.0.1:6080/` in the connected Browser plugin.
+
+Expected: the visible Chromium session shows `Example Domain` at `https://example.com/?profile=nancy`, proving Nancy used the shared `hermes-chromium` session rather than a separate built-in headless browser.
+
+- [ ] **Step 9: Report final evidence**
+
+Report:
+
+- Source and dotfiles PR URLs.
+- Green Actions status.
+- Bootstrap apply result.
+- Five successful `mcp test chrome` results.
+- Nancy's recorded MCP tool name.
+- noVNC page title and URL.

--- a/docs/superpowers/plans/2026-07-23-hermes-chrome-all-profiles.md
+++ b/docs/superpowers/plans/2026-07-23-hermes-chrome-all-profiles.md
@@ -20,10 +20,12 @@
   ```
 
 - Preserve additional profile MCP servers such as `xapi` and `x-docs`.
+- Require `agent.disabled_toolsets` to contain `browser` so the separate built-in browser session cannot be selected.
+- Require every distribution manifest to include `config.yaml` in `distribution_owned`.
 - Cover the root distribution, every profile in `bootstrap-manifest.yaml`, and profiles added to that manifest later.
 - Do not scan or mutate manually created profiles that are absent from the bootstrap manifest.
 - Validate all staged `config.yaml` files before `synchronize_remote(...)` and before `Transaction.begin(...)`.
-- Reject missing files, malformed or duplicate-key YAML, non-mapping nodes, the wrong URL, a missing/wrong/non-integer timeout, and extra keys under `mcp_servers.chrome`.
+- Reject missing or unowned files, malformed or duplicate-key YAML, non-mapping nodes, an enabled built-in browser, the wrong URL, a missing/wrong/non-integer timeout, and extra keys under `mcp_servers.chrome`.
 - Validation errors may identify the distribution name and `config.yaml`, but must not include file contents, staging paths, source URLs, credentials, or parser details.
 - Source distributions own complete configuration files; bootstrap must not inject, merge, or repair MCP settings.
 - Use branch `codex/chrome-mcp-all-profiles` in every repository with edits and isolate all edits in Git worktrees.

--- a/docs/superpowers/specs/2026-07-23-hermes-chrome-all-profiles-design.md
+++ b/docs/superpowers/specs/2026-07-23-hermes-chrome-all-profiles-design.md
@@ -7,6 +7,9 @@ must configure the visible container browser through the canonical Chrome MCP
 endpoint:
 
 ```yaml
+agent:
+  disabled_toolsets:
+    - browser
 mcp_servers:
   chrome:
     url: http://browser-mcp:8080/mcp
@@ -26,14 +29,17 @@ Each named profile's `config.yaml` remains owned by its corresponding
 The dotfiles bootstrap validates this contract but does not inject, merge, or
 rewrite MCP settings after applying a distribution. This preserves the existing
 distribution ownership boundary and makes the responsible source repository
-clear when validation fails.
+clear when validation fails. Every distribution manifest must list
+`config.yaml` in `distribution_owned`, so the validated file is also the file
+that bootstrap installs.
 
 ## Data Flow
 
 1. Bootstrap reads the root and profile declarations from the manifest.
 2. It fetches, verifies, and stages each declared source distribution.
 3. Before starting the local transaction, it parses each staged `config.yaml`.
-4. It verifies the canonical `mcp_servers.chrome` URL and timeout.
+4. It verifies `config.yaml` ownership, the global built-in `browser`
+   suppression, and the canonical `mcp_servers.chrome` URL and timeout.
 5. Only after every declared source passes does bootstrap begin local writes.
 6. The existing stack recreation flow restarts each gateway with the installed
    source-owned configuration.
@@ -46,7 +52,9 @@ the same validation path.
 Bootstrap rejects a declared source before local writes when:
 
 - `config.yaml` is missing;
+- `config.yaml` is absent from `distribution_owned`;
 - the file is not valid YAML;
+- `agent.disabled_toolsets` does not include `browser`;
 - `mcp_servers` or `mcp_servers.chrome` is not a mapping;
 - `mcp_servers.chrome.url` is not
   `http://browser-mcp:8080/mcp`; or
@@ -81,7 +89,11 @@ Focused bootstrap tests cover:
 - an incorrect Chrome MCP URL;
 - an incorrect or non-integer timeout;
 - validation before any local write; and
-- automatic coverage of an additional manifest-declared profile.
+- automatic coverage of an additional manifest-declared profile;
+- rejection when that future profile validates a file it does not distribute;
+  and
+- the static Compose contract connecting Browser MCP and noVNC to the same
+  Chromium service and CDP process.
 
 The full Hermes bootstrap and GitHub wrapper suites must remain green. Each
 source repository must pass its own validator.
@@ -92,9 +104,11 @@ After the source changes are available and bootstrap is applied locally:
 
 1. The root profile and every manifest-declared named profile list `chrome` as
    an enabled MCP server.
-2. The Chrome MCP connection discovers the expected tools, including
+2. Hermes reports the built-in `browser` toolset as disabled for every managed
+   profile.
+3. The Chrome MCP connection discovers the expected tools, including
    `navigate_page` and `take_snapshot`.
-3. Nancy uses the Chrome MCP toolset rather than Hermes' built-in
+4. Nancy uses the Chrome MCP toolset rather than Hermes' built-in
    `browser_navigate` toolset.
-4. A page opened by Nancy appears in the same Google Chrome session shown at
+5. A page opened by Nancy appears in the same Google Chrome session shown at
    `http://127.0.0.1:6080/`.

--- a/docs/superpowers/specs/2026-07-23-hermes-chrome-all-profiles-design.md
+++ b/docs/superpowers/specs/2026-07-23-hermes-chrome-all-profiles-design.md
@@ -1,0 +1,100 @@
+# Hermes Chrome MCP For All Profiles
+
+## Goal
+
+Every Hermes source declared by `docker/hermes-agent/bootstrap-manifest.yaml`
+must configure the visible container browser through the canonical Chrome MCP
+endpoint:
+
+```yaml
+mcp_servers:
+  chrome:
+    url: http://browser-mcp:8080/mcp
+    connect_timeout: 120
+```
+
+The requirement applies to the root distribution, every currently declared
+named profile, and every profile added to the bootstrap manifest later. Hermes
+profiles outside the manifest remain unmanaged and unchanged.
+
+## Ownership
+
+The root `config.yaml` remains owned by the `hermes-home` source distribution.
+Each named profile's `config.yaml` remains owned by its corresponding
+`hermes-profile-*` source distribution.
+
+The dotfiles bootstrap validates this contract but does not inject, merge, or
+rewrite MCP settings after applying a distribution. This preserves the existing
+distribution ownership boundary and makes the responsible source repository
+clear when validation fails.
+
+## Data Flow
+
+1. Bootstrap reads the root and profile declarations from the manifest.
+2. It fetches, verifies, and stages each declared source distribution.
+3. Before starting the local transaction, it parses each staged `config.yaml`.
+4. It verifies the canonical `mcp_servers.chrome` URL and timeout.
+5. Only after every declared source passes does bootstrap begin local writes.
+6. The existing stack recreation flow restarts each gateway with the installed
+   source-owned configuration.
+
+Adding a profile to the manifest automatically adds its staged `config.yaml` to
+the same validation path.
+
+## Validation And Errors
+
+Bootstrap rejects a declared source before local writes when:
+
+- `config.yaml` is missing;
+- the file is not valid YAML;
+- `mcp_servers` or `mcp_servers.chrome` is not a mapping;
+- `mcp_servers.chrome.url` is not
+  `http://browser-mcp:8080/mcp`; or
+- `mcp_servers.chrome.connect_timeout` is not the integer `120`.
+
+The error identifies the source and file without printing the full
+configuration or any secret value. A failure prevents the transaction from
+starting, so the root and every profile keep their previously installed state.
+
+## Source Changes
+
+The root source and every profile source declared by the current manifest must
+carry the canonical block. At the time of this design, that covers:
+
+- `rurusasu/hermes-home`;
+- `rurusasu/hermes-profile-rick`;
+- `rurusasu/hermes-profile-hoffman`;
+- `rurusasu/hermes-profile-risarisa`; and
+- `rurusasu/hermes-profile-nancy`.
+
+Source changes must pass each repository's existing distribution validator
+before bootstrap consumes them.
+
+## Testing
+
+Focused bootstrap tests cover:
+
+- valid root and profile configurations;
+- a missing `config.yaml`;
+- malformed YAML;
+- missing or non-mapping MCP sections;
+- an incorrect Chrome MCP URL;
+- an incorrect or non-integer timeout;
+- validation before any local write; and
+- automatic coverage of an additional manifest-declared profile.
+
+The full Hermes bootstrap and GitHub wrapper suites must remain green. Each
+source repository must pass its own validator.
+
+## Completion Criteria
+
+After the source changes are available and bootstrap is applied locally:
+
+1. The root profile and every manifest-declared named profile list `chrome` as
+   an enabled MCP server.
+2. The Chrome MCP connection discovers the expected tools, including
+   `navigate_page` and `take_snapshot`.
+3. Nancy uses the Chrome MCP toolset rather than Hermes' built-in
+   `browser_navigate` toolset.
+4. A page opened by Nancy appears in the same Google Chrome session shown at
+   `http://127.0.0.1:6080/`.


### PR DESCRIPTION
## Summary

- validate the canonical Chrome MCP contract in every staged root/profile distribution
- require each distribution to install its validated `config.yaml` and disable the built-in browser toolset
- fail before shared-repository synchronization or local transaction creation
- cover malformed, duplicate, missing, incorrectly typed, and future-profile configurations
- lock the noVNC and Browser MCP wiring to the same Compose Chromium service
- document source ownership, built-in browser separation, and runtime/noVNC verification

## Root cause

Hermes' built-in `browser_*` tools create a separate browser session, while
noVNC displays the Compose-managed Chrome session. Profile source
distributions did not consistently declare `mcp_servers.chrome`, and bootstrap
did not reject that drift.

## Validation

- bootstrap test image: 333 tests passed (1 existing skip)
- `test_gh_wrapper: PASS`
- `pre-commit run --all-files`: all hooks passed
- root distribution: 50 unit tests and 9/9 full checks passed
- Rick/Hoffman/Risarisa/Nancy: all unit suites and 8/8 full checks passed
