### PR TITLE
feat(codex): add global work mode instructions

### DIFF
--- a/chezmoi/.chezmoiscripts/deploy/llms/run_onchange_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/llms/run_onchange_deploy.ps1.tmpl
@@ -1,6 +1,6 @@
 {{ if eq .chezmoi.os "windows" -}}
 # Deploy LLM tool configurations for Windows
-# hash: {{ include "dot_claude/settings.json.tmpl" | sha256sum }}{{ include "dot_claude/dot_claude.json.tmpl" | sha256sum }}{{ include "dot_claude/CLAUDE.md" | sha256sum }}{{ include "dot_codex/config.toml.tmpl" | sha256sum }}{{ include "dot_cursor/rules" | sha256sum }}{{ include "dot_cursor/cli-config.json.tmpl" | sha256sum }}{{ include "dot_gemini/settings.json.tmpl" | sha256sum }}
+# hash: {{ include "dot_claude/settings.json.tmpl" | sha256sum }}{{ include "dot_claude/dot_claude.json.tmpl" | sha256sum }}{{ include "dot_claude/CLAUDE.md" | sha256sum }}{{ include "dot_codex/config.toml.tmpl" | sha256sum }}{{ include "dot_codex/AGENTS.override.md" | sha256sum }}{{ include "dot_cursor/rules" | sha256sum }}{{ include "dot_cursor/cli-config.json.tmpl" | sha256sum }}{{ include "dot_gemini/settings.json.tmpl" | sha256sum }}
 
 $ErrorActionPreference = "Stop"
 
@@ -43,6 +43,7 @@ Deploy-Template "$ChezmoiSource\dot_claude\settings.json.tmpl" "$HomeDir\.claude
 Deploy-Template "$ChezmoiSource\dot_claude\dot_claude.json.tmpl" "$HomeDir\.claude\.claude.json"
 Deploy-File "$ChezmoiSource\dot_claude\CLAUDE.md" "$HomeDir\.claude\CLAUDE.md"
 Deploy-Template "$ChezmoiSource\dot_codex\config.toml.tmpl" "$HomeDir\.codex\config.toml"
+Deploy-File "$ChezmoiSource\dot_codex\AGENTS.override.md" "$HomeDir\.codex\AGENTS.override.md"
 Deploy-File "$ChezmoiSource\dot_cursor\rules" "$HomeDir\.cursor\rules"
 Deploy-Template "$ChezmoiSource\dot_cursor\cli-config.json.tmpl" "$HomeDir\.cursor\cli-config.json"
 Deploy-Template "$ChezmoiSource\dot_gemini\settings.json.tmpl" "$HomeDir\.gemini\settings.json"

--- a/chezmoi/.chezmoiscripts/deploy/llms/run_onchange_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/llms/run_onchange_deploy.sh.tmpl
@@ -1,7 +1,7 @@
 {{ if ne .chezmoi.os "windows" -}}
 #!/usr/bin/env bash
 # Deploy LLM tool configurations for Linux/macOS
-# hash: {{ include "dot_claude/settings.json.tmpl" | sha256sum }}{{ include "dot_claude/dot_claude.json.tmpl" | sha256sum }}{{ include "dot_claude/CLAUDE.md" | sha256sum }}{{ include "dot_codex/config.toml.tmpl" | sha256sum }}{{ include "dot_cursor/rules" | sha256sum }}{{ include "dot_cursor/cli-config.json.tmpl" | sha256sum }}{{ include "dot_gemini/settings.json.tmpl" | sha256sum }}
+# hash: {{ include "dot_claude/settings.json.tmpl" | sha256sum }}{{ include "dot_claude/dot_claude.json.tmpl" | sha256sum }}{{ include "dot_claude/CLAUDE.md" | sha256sum }}{{ include "dot_codex/config.toml.tmpl" | sha256sum }}{{ include "dot_codex/AGENTS.override.md" | sha256sum }}{{ include "dot_cursor/rules" | sha256sum }}{{ include "dot_cursor/cli-config.json.tmpl" | sha256sum }}{{ include "dot_gemini/settings.json.tmpl" | sha256sum }}
 
 set -euo pipefail
 
@@ -34,6 +34,7 @@ deploy_template "$CHEZMOI_SOURCE/dot_claude/settings.json.tmpl" "$HOME_DIR/.clau
 deploy_template "$CHEZMOI_SOURCE/dot_claude/dot_claude.json.tmpl" "$HOME_DIR/.claude/.claude.json"
 deploy_file "$CHEZMOI_SOURCE/dot_claude/CLAUDE.md" "$HOME_DIR/.claude/CLAUDE.md"
 deploy_template "$CHEZMOI_SOURCE/dot_codex/config.toml.tmpl" "$HOME_DIR/.codex/config.toml"
+deploy_file "$CHEZMOI_SOURCE/dot_codex/AGENTS.override.md" "$HOME_DIR/.codex/AGENTS.override.md"
 deploy_file "$CHEZMOI_SOURCE/dot_cursor/rules" "$HOME_DIR/.cursor/rules"
 deploy_template "$CHEZMOI_SOURCE/dot_cursor/cli-config.json.tmpl" "$HOME_DIR/.cursor/cli-config.json"
 deploy_template "$CHEZMOI_SOURCE/dot_gemini/settings.json.tmpl" "$HOME_DIR/.gemini/settings.json"

--- a/chezmoi/dot_codex/AGENTS.override.md
+++ b/chezmoi/dot_codex/AGENTS.override.md
@@ -33,3 +33,41 @@ These instructions are intended to be the **highest priority** global rules for 
 - Execute clear requests immediately without asking for confirmation.
 - Confirm only when the action is destructive, the specification is ambiguous, or information is insufficient.
 - Apply minor changes in bulk and report what was changed concisely after the fact.
+
+## Work Modes
+
+Use a work mode for every coding task. The user may select one explicitly with
+`[mode=fast]`, `[mode=normal]`, or `[mode=deep]`; otherwise select the mode
+without an extra clarification turn using these rules:
+
+- Use `fast` for a small, unambiguous change in one or two files.
+- Use `normal` for a routine implementation spanning several related files.
+- Use `deep` for design changes, unknown bugs, migrations, authentication,
+  data, security, or any task with a material regression risk.
+- If any `deep` condition applies, use `deep`. Otherwise, if two or more
+  `normal` conditions apply, use `normal`; use `fast` for the remaining tasks.
+
+### Fast
+
+- Inspect only the target files and their direct references.
+- Make the smallest change that satisfies the request.
+- Run only directly relevant formatting or validation.
+- Stop when the completion criteria are met; do not perform broad review.
+
+### Normal
+
+- Inspect related files and relevant tests.
+- Run the relevant format, lint, and test checks after the change.
+- Investigate further only when a check fails.
+- Review the final diff before stopping.
+
+### Deep
+
+- Start with a short implementation plan.
+- Investigate impact, existing patterns, and likely failure cases.
+- Run relevant tests and review the final diff for regressions.
+- Stop when the completion criteria are met; do not continue with unbounded
+  exploration.
+
+For every mode, report only the changed files, validation results, and unresolved
+issues. Do not include exploratory logs or hidden reasoning.

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -17,6 +17,18 @@ BeforeAll {
 }
 
 Describe 'chezmoi テンプレート バリデーション' {
+    Context 'Codex global instructions deployment' {
+        It 'should deploy AGENTS.override.md and include it in the change hash for both OSes' {
+            $unixScript = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot '.chezmoiscripts/deploy/llms/run_onchange_deploy.sh.tmpl') -Raw
+            $windowsScript = Get-Content -LiteralPath (Join-Path $script:chezmoiRoot '.chezmoiscripts/deploy/llms/run_onchange_deploy.ps1.tmpl') -Raw
+
+            $unixScript | Should -Match 'include "dot_codex/AGENTS\.override\.md" \| sha256sum'
+            $unixScript | Should -Match 'deploy_file "\$CHEZMOI_SOURCE/dot_codex/AGENTS\.override\.md" "\$HOME_DIR/\.codex/AGENTS\.override\.md"'
+            $windowsScript | Should -Match 'include "dot_codex/AGENTS\.override\.md" \| sha256sum'
+            $windowsScript | Should -Match 'Deploy-File "\$ChezmoiSource\\dot_codex\\AGENTS\.override\.md" "\$HomeDir\\\.codex\\AGENTS\.override\.md"'
+        }
+    }
+
     Context 'onepasswordRead はテンプレート展開中に呼ばない' {
         It 'すべての .tmpl ファイルで onepasswordRead を呼ばないこと' {
             $violations = @()


### PR DESCRIPTION
## Summary
- add global `fast` / `normal` / `deep` Codex work-mode rules
- deploy `AGENTS.override.md` to `~/.codex/` on Unix and Windows
- include the instruction file in the chezmoi change-detection hash
- add a Pester regression test for both deployment scripts

## Validation
- `Invoke-Pester` for `scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1`: 45 passed
- `pre-commit run --files ...`: passed
- `git diff --check`: passed