### PR TITLE
feat: run X MCP as a shared Hermes service

### DIFF
--- a/.github/e2e/bin/op
+++ b/.github/e2e/bin/op
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -eu
 
+if [ "$#" -eq 3 ] && [ "$1" = signin ] && [ "$2" = --account ] && \
+	[ "$3" = my.1password.com ]; then
+	printf 'acceptance-session\n'
+	exit 0
+fi
+
 if [ "$#" -ne 9 ] || [ "$1" != item ] || [ "$2" != get ] || \
 	[ "$4" != --account ] || [ "$5" != my.1password.com ] || \
 	[ "$6" != --vault ] || [ "$7" != openclaw ] || \
@@ -17,6 +23,10 @@ case "$3" in
 	"SlackBot-Hoffman" | \
 	"SlackBot-Risarisa" | \
 	"SlackBot-Nancy") ;;
+"Hermes X API MCP")
+	printf '{"id":"acceptance-Hermes X API MCP","fields":[{"label":"X_API_CLIENT_ID","value":"acceptance-x-api-client-id"},{"label":"X_API_CLIENT_SECRET","value":"acceptance-x-api-client-secret"}]}\n'
+	exit 0
+	;;
 *)
 	printf 'acceptance op fixture rejected item: %s\n' "$3" >&2
 	exit 2

--- a/.github/e2e/bootstrap-compose.yml
+++ b/.github/e2e/bootstrap-compose.yml
@@ -2,6 +2,9 @@ services:
   hermes:
     image: nginx:1.29-alpine
 
+  xapi-mcp:
+    image: nginx:1.29-alpine
+
   acceptance:
     image: nginx:1.29-alpine
     command:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -204,7 +204,33 @@ tasks:
       - sh: docker info
         msg: "Docker daemon is not running. Start Docker Desktop and try again."
     cmds:
-      - docker compose -f {{.HERMES_COMPOSE_FILE}} build --pull hermes chromium browser-mcp
+      - docker compose -f {{.HERMES_COMPOSE_FILE}} build --pull hermes chromium browser-mcp xapi-mcp
+
+  hermes:xapi:auth:
+    desc: Authenticate the X MCP bridge with the headless OAuth flow
+    interactive: true
+    preconditions:
+      - sh: docker info
+        msg: "Docker daemon is not running. Start Docker Desktop and try again."
+    cmds:
+      - docker compose -f {{.HERMES_COMPOSE_FILE}} run --rm --no-deps --entrypoint /bin/sh xapi-mcp -lc 'node_modules/.bin/xurl auth oauth2 --headless'
+
+  hermes:xapi:restart:
+    desc: Recreate the Hermes X MCP container
+    preconditions:
+      - sh: docker info
+        msg: "Docker daemon is not running. Start Docker Desktop and try again."
+    cmds:
+      - docker compose -f {{.HERMES_COMPOSE_FILE}} up -d --force-recreate xapi-mcp
+
+  hermes:xapi:logs:
+    desc: Follow Hermes X MCP logs
+    interactive: true
+    preconditions:
+      - sh: docker info
+        msg: "Docker daemon is not running. Start Docker Desktop and try again."
+    cmds:
+      - docker compose -f {{.HERMES_COMPOSE_FILE}} logs -f --tail=100 xapi-mcp
 
   hermes:up:
     desc: Start Hermes Agent gateway and dashboard in Docker

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -213,7 +213,7 @@ tasks:
       - sh: docker info
         msg: "Docker daemon is not running. Start Docker Desktop and try again."
     cmds:
-      - docker compose -f {{.HERMES_COMPOSE_FILE}} run --rm --no-deps --entrypoint /bin/sh xapi-mcp -lc 'node_modules/.bin/xurl auth oauth2 --headless'
+      - docker compose -f {{.HERMES_COMPOSE_FILE}} run --rm --no-deps --entrypoint /bin/sh xapi-mcp -lc 'CLIENT_ID="$X_API_CLIENT_ID" CLIENT_SECRET="$X_API_CLIENT_SECRET" node_modules/.bin/xurl auth oauth2 --headless'
 
   hermes:xapi:restart:
     desc: Recreate the Hermes X MCP container

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -175,6 +175,12 @@ tasks:
 
   hermes:bootstrap:
     desc: Bootstrap the Hermes runtime through the supported host adapter
+    interactive: true
+    preconditions:
+      - sh: docker info
+        msg: "Docker daemon is not running. Start Docker Desktop and try again."
+      - sh: test -f {{.HERMES_COMPOSE_FILE}}
+        msg: "Hermes compose file not found: {{.HERMES_COMPOSE_FILE}}"
     cmds:
       - cmd: bash -lc 'set -euo pipefail; source scripts/sh/install-common.sh; source scripts/sh/hermes-agent.sh; dotfiles_hermes_start_stack docker "{{.HERMES_COMPOSE_FILE}}"'
         platforms: [linux, darwin]
@@ -213,7 +219,7 @@ tasks:
       - sh: docker info
         msg: "Docker daemon is not running. Start Docker Desktop and try again."
     cmds:
-      - docker compose -f {{.HERMES_COMPOSE_FILE}} run --rm --no-deps --entrypoint /bin/sh xapi-mcp -lc 'CLIENT_ID="$X_API_CLIENT_ID" CLIENT_SECRET="$X_API_CLIENT_SECRET" node_modules/.bin/xurl auth oauth2 --headless'
+      - HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE}} bash scripts/sh/hermes-xapi.sh auth
 
   hermes:xapi:restart:
     desc: Recreate the Hermes X MCP container
@@ -221,7 +227,7 @@ tasks:
       - sh: docker info
         msg: "Docker daemon is not running. Start Docker Desktop and try again."
     cmds:
-      - docker compose -f {{.HERMES_COMPOSE_FILE}} up -d --force-recreate xapi-mcp
+      - HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE}} bash scripts/sh/hermes-xapi.sh restart
 
   hermes:xapi:logs:
     desc: Follow Hermes X MCP logs
@@ -238,7 +244,7 @@ tasks:
       - sh: docker info
         msg: "Docker daemon is not running. Start Docker Desktop and try again."
     cmds:
-      - docker compose -f {{.HERMES_COMPOSE_FILE}} up -d --force-recreate
+      - HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE}} bash scripts/sh/hermes-xapi.sh up
 
   hermes:down:
     desc: Stop Hermes Agent Docker container

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -229,7 +229,10 @@ tasks:
       - sh: docker info
         msg: "Docker daemon is not running. Start Docker Desktop and try again."
     cmds:
-      - HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE}} bash scripts/sh/hermes-xapi.sh auth
+      - cmd: HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE}} bash scripts/sh/hermes-xapi.sh auth
+        platforms: [linux, darwin]
+      - cmd: pwsh -NoProfile -File scripts/powershell/hermes-xapi.ps1 -Action auth -ComposeFile "{{.HERMES_COMPOSE_FILE}}"
+        platforms: [windows]
 
   hermes:xapi:restart:
     desc: Recreate the Hermes X MCP container
@@ -237,7 +240,10 @@ tasks:
       - sh: docker info
         msg: "Docker daemon is not running. Start Docker Desktop and try again."
     cmds:
-      - HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE}} bash scripts/sh/hermes-xapi.sh restart
+      - cmd: HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE}} bash scripts/sh/hermes-xapi.sh restart
+        platforms: [linux, darwin]
+      - cmd: pwsh -NoProfile -File scripts/powershell/hermes-xapi.ps1 -Action restart -ComposeFile "{{.HERMES_COMPOSE_FILE}}"
+        platforms: [windows]
 
   hermes:xapi:logs:
     desc: Follow Hermes X MCP logs
@@ -254,7 +260,10 @@ tasks:
       - sh: docker info
         msg: "Docker daemon is not running. Start Docker Desktop and try again."
     cmds:
-      - HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE}} bash scripts/sh/hermes-xapi.sh up
+      - cmd: HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE}} bash scripts/sh/hermes-xapi.sh up
+        platforms: [linux, darwin]
+      - cmd: pwsh -NoProfile -File scripts/powershell/hermes-xapi.ps1 -Action up -ComposeFile "{{.HERMES_COMPOSE_FILE}}"
+        platforms: [windows]
 
   hermes:down:
     desc: Stop Hermes Agent Docker container

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py
@@ -15,6 +15,10 @@ _CHROME_MCP = {
     "url": "http://browser-mcp:8080/mcp",
     "connect_timeout": 120,
 }
+_XAPI_MCP = {
+    "url": "http://xapi-mcp:8080/mcp",
+    "connect_timeout": 300,
+}
 
 
 class _UniqueKeySafeLoader(yaml.SafeLoader):
@@ -91,12 +95,26 @@ def validate_chrome_mcp_sources(staged: Sequence[StagedSource]) -> None:
             or dict(chrome) != _CHROME_MCP
         ):
             _invalid(source)
+        xapi = mcp_servers.get("xapi")
+        if (
+            not isinstance(xapi, Mapping)
+            or type(xapi.get("connect_timeout")) is not int
+            or dict(xapi) != _XAPI_MCP
+        ):
+            _invalid_xapi(source)
 
 
 def _invalid(source: StagedSource) -> NoReturn:
     name = source.declaration.name
     raise ValidationError(
         f"distribution {name!r} config.yaml has invalid Chrome MCP configuration"
+    ) from None
+
+
+def _invalid_xapi(source: StagedSource) -> NoReturn:
+    name = source.declaration.name
+    raise ValidationError(
+        f"distribution {name!r} config.yaml has invalid X API MCP configuration"
     ) from None
 
 

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py
@@ -52,7 +52,7 @@ class _UniqueKeySafeLoader(yaml.SafeLoader):
 
 
 def validate_chrome_mcp_sources(staged: Sequence[StagedSource]) -> None:
-    """Require the canonical Chrome MCP entry in every staged distribution."""
+    """Require Chrome MCP and install the canonical X API MCP entry."""
 
     for source in staged:
         try:
@@ -86,7 +86,7 @@ def validate_chrome_mcp_sources(staged: Sequence[StagedSource]) -> None:
         ):
             _invalid(source)
         mcp_servers = config.get("mcp_servers")
-        if not isinstance(mcp_servers, Mapping):
+        if not isinstance(mcp_servers, dict):
             _invalid(source)
         chrome = mcp_servers.get("chrome")
         if (
@@ -95,13 +95,31 @@ def validate_chrome_mcp_sources(staged: Sequence[StagedSource]) -> None:
             or dict(chrome) != _CHROME_MCP
         ):
             _invalid(source)
-        xapi = mcp_servers.get("xapi")
-        if (
-            not isinstance(xapi, Mapping)
-            or type(xapi.get("connect_timeout")) is not int
-            or dict(xapi) != _XAPI_MCP
-        ):
-            _invalid_xapi(source)
+        _install_xapi_mcp(source, config, mcp_servers)
+
+
+def _install_xapi_mcp(
+    source: StagedSource,
+    config: Mapping[object, object],
+    mcp_servers: dict[object, object],
+) -> None:
+    xapi = mcp_servers.get("xapi")
+    if (
+        isinstance(xapi, Mapping)
+        and type(xapi.get("connect_timeout")) is int
+        and dict(xapi) == _XAPI_MCP
+    ):
+        return
+
+    if not isinstance(config, dict):
+        _invalid_xapi(source)
+    mcp_servers["xapi"] = dict(_XAPI_MCP)
+    try:
+        (source.path / "config.yaml").write_text(
+            yaml.safe_dump(config, sort_keys=False), encoding="utf-8"
+        )
+    except (OSError, UnicodeError):
+        _invalid_xapi(source)
 
 
 def _invalid(source: StagedSource) -> NoReturn:

--- a/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
+++ b/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
@@ -92,6 +92,9 @@ def source_config(key: str, value: str) -> str:
         "  chrome:\n"
         "    url: http://browser-mcp:8080/mcp\n"
         "    connect_timeout: 120\n"
+        "  xapi:\n"
+        "    url: http://xapi-mcp:8080/mcp\n"
+        "    connect_timeout: 300\n"
     )
 
 

--- a/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
@@ -20,6 +20,16 @@ DATA_BIND = {
     "source": "${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}",
     "target": "/opt/data",
 }
+XURL_BIND = {
+    "type": "bind",
+    "source": "${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes/.xurl",
+    "target": "/root/.xurl",
+}
+EXPECTED_TCP_HEALTHCHECK = (
+    "node -e \"const net=require('node:net');const s=net.connect("
+    "{host:'127.0.0.1',port:8080},()=>{s.end();process.exit(0)});"
+    "s.on('error',()=>process.exit(1));setTimeout(()=>process.exit(1),3000);\""
+)
 
 
 class ComposeContractTests(unittest.TestCase):
@@ -78,6 +88,50 @@ class ComposeContractTests(unittest.TestCase):
                 "--browser-url=http://chromium:9222",
                 "--no-usage-statistics",
             ],
+        )
+
+    def test_xapi_mcp_is_an_internal_shared_service(self) -> None:
+        xapi = self.services.get("xapi-mcp")
+        self.assertIsNotNone(xapi)
+        assert xapi is not None
+
+        self.assertEqual(
+            xapi["build"],
+            {"context": "../hermes-xapi-mcp", "dockerfile": "Dockerfile"},
+        )
+        self.assertEqual(xapi["image"], "local/hermes-xapi-mcp:latest")
+        self.assertEqual(xapi["container_name"], "hermes-xapi-mcp")
+        self.assertEqual(xapi["networks"], ["hermes-browser"])
+        self.assertEqual(xapi["volumes"], [XURL_BIND])
+        self.assertEqual(
+            xapi["environment"],
+            {
+                "X_API_CLIENT_ID": "${X_API_CLIENT_ID:-}",
+                "X_API_CLIENT_SECRET": "${X_API_CLIENT_SECRET:-}",
+            },
+        )
+        self.assertNotIn("ports", xapi)
+        self.assertEqual(
+            xapi["healthcheck"]["test"],
+            ["CMD-SHELL", EXPECTED_TCP_HEALTHCHECK],
+        )
+        self.assertEqual(
+            xapi["command"],
+            [
+                "node_modules/.bin/mcp-proxy",
+                "--server",
+                "stream",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8080",
+                "--",
+                "/usr/local/bin/hermes-xapi-mcp",
+            ],
+        )
+        self.assertEqual(
+            self.hermes["depends_on"]["xapi-mcp"],
+            {"condition": "service_healthy"},
         )
 
     def test_dockerfile_builds_runtime_test_and_final_stages(self) -> None:

--- a/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
@@ -22,7 +22,7 @@ DATA_BIND = {
 }
 XURL_BIND = {
     "type": "bind",
-    "source": "${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes/.xurl",
+    "source": "${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.xurl",
     "target": "/root/.xurl",
 }
 EXPECTED_TCP_HEALTHCHECK = (
@@ -112,7 +112,7 @@ class ComposeContractTests(unittest.TestCase):
         )
         self.assertNotIn("ports", xapi)
         self.assertEqual(
-            xapi["healthcheck"]["test"],
+            [xapi["healthcheck"]["test"][0], xapi["healthcheck"]["test"][1].strip()],
             ["CMD-SHELL", EXPECTED_TCP_HEALTHCHECK],
         )
         self.assertEqual(

--- a/docker/hermes-agent/bootstrap/tests/test_source_contracts.py
+++ b/docker/hermes-agent/bootstrap/tests/test_source_contracts.py
@@ -25,6 +25,9 @@ mcp_servers:
   chrome:
     url: http://browser-mcp:8080/mcp
     connect_timeout: 120
+  xapi:
+    url: http://xapi-mcp:8080/mcp
+    connect_timeout: 300
   retained:
     url: https://example.invalid/mcp
 """
@@ -100,6 +103,32 @@ mcp_servers:
             "mcp-sequence": "mcp_servers: []\n",
             "missing-chrome": "mcp_servers: {}\n",
             "chrome-sequence": "mcp_servers:\n  chrome: []\n",
+            "missing-xapi": VALID_CONFIG.replace(
+                "  xapi:\n    url: http://xapi-mcp:8080/mcp\n    connect_timeout: 300\n", ""
+            ),
+            "wrong-xapi-url": VALID_CONFIG.replace(
+                "http://xapi-mcp:8080/mcp", "https://secret.invalid/mcp"
+            ),
+            "missing-xapi-timeout": VALID_CONFIG.replace(
+                "    connect_timeout: 300\n", "", 1
+            ),
+            "string-xapi-timeout": VALID_CONFIG.replace(
+                "    connect_timeout: 300", '    connect_timeout: "300"', 1
+            ),
+            "boolean-xapi-timeout": VALID_CONFIG.replace(
+                "    connect_timeout: 300", "    connect_timeout: true", 1
+            ),
+            "float-xapi-timeout": VALID_CONFIG.replace(
+                "    connect_timeout: 300", "    connect_timeout: 300.0", 1
+            ),
+            "wrong-xapi-timeout": VALID_CONFIG.replace(
+                "    connect_timeout: 300", "    connect_timeout: 60", 1
+            ),
+            "extra-xapi-key": VALID_CONFIG.replace(
+                "    connect_timeout: 300",
+                "    connect_timeout: 300\n    token: secret-marker",
+                1,
+            ),
             "wrong-url": """\
 mcp_servers:
   chrome:
@@ -148,6 +177,8 @@ mcp_servers:
         }
         for case, config in invalid.items():
             with self.subTest(case=case):
+                if case not in {"missing-xapi"}:
+                    config = _with_valid_xapi(config)
                 staged = self.staged(case, config)
                 with self.assertRaises(ValidationError) as caught:
                     validate_chrome_mcp_sources((staged,))
@@ -185,6 +216,16 @@ distribution_owned:
             ValidationError, "future-profile.*distribution_owned.*config.yaml"
         ):
             validate_chrome_mcp_sources((staged,))
+
+
+def _with_valid_xapi(config: str | None) -> str | None:
+    if config is None or "xapi:" in config or "mcp_servers:\n" not in config:
+        return config
+    return config.replace(
+        "mcp_servers:\n",
+        "mcp_servers:\n  xapi:\n    url: http://xapi-mcp:8080/mcp\n    connect_timeout: 300\n",
+        1,
+    )
 
 
 if __name__ == "__main__":

--- a/docker/hermes-agent/bootstrap/tests/test_source_contracts.py
+++ b/docker/hermes-agent/bootstrap/tests/test_source_contracts.py
@@ -5,6 +5,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import yaml
+
 
 BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(BOOTSTRAP_ROOT))
@@ -88,6 +90,38 @@ distribution_owned:
 
         validate_chrome_mcp_sources(staged)
 
+    def test_installs_xapi_mcp_configuration_when_missing_from_source(self) -> None:
+        config = VALID_CONFIG.replace(
+            "  xapi:\n    url: http://xapi-mcp:8080/mcp\n    connect_timeout: 300\n", ""
+        )
+        staged = self.staged("default", config)
+
+        validate_chrome_mcp_sources((staged,))
+
+        updated = yaml.safe_load((staged.path / "config.yaml").read_text(encoding="utf-8"))
+        self.assertEqual(
+            updated["mcp_servers"]["xapi"],
+            {"url": "http://xapi-mcp:8080/mcp", "connect_timeout": 300},
+        )
+
+    def test_replaces_noncanonical_xapi_mcp_configuration_without_leaking_values(self) -> None:
+        config = VALID_CONFIG.replace(
+            "  xapi:\n    url: http://xapi-mcp:8080/mcp\n    connect_timeout: 300\n",
+            "  xapi:\n    url: https://secret.invalid/mcp\n    connect_timeout: 60\n    token: secret-marker\n",
+        )
+        staged = self.staged("default", config)
+
+        validate_chrome_mcp_sources((staged,))
+
+        updated_text = (staged.path / "config.yaml").read_text(encoding="utf-8")
+        updated = yaml.safe_load(updated_text)
+        self.assertEqual(
+            updated["mcp_servers"]["xapi"],
+            {"url": "http://xapi-mcp:8080/mcp", "connect_timeout": 300},
+        )
+        self.assertNotIn("secret.invalid", updated_text)
+        self.assertNotIn("secret-marker", updated_text)
+
     def test_rejects_every_noncanonical_shape_without_exposing_values(self) -> None:
         invalid = {
             "missing-file": None,
@@ -103,32 +137,6 @@ mcp_servers:
             "mcp-sequence": "mcp_servers: []\n",
             "missing-chrome": "mcp_servers: {}\n",
             "chrome-sequence": "mcp_servers:\n  chrome: []\n",
-            "missing-xapi": VALID_CONFIG.replace(
-                "  xapi:\n    url: http://xapi-mcp:8080/mcp\n    connect_timeout: 300\n", ""
-            ),
-            "wrong-xapi-url": VALID_CONFIG.replace(
-                "http://xapi-mcp:8080/mcp", "https://secret.invalid/mcp"
-            ),
-            "missing-xapi-timeout": VALID_CONFIG.replace(
-                "    connect_timeout: 300\n", "", 1
-            ),
-            "string-xapi-timeout": VALID_CONFIG.replace(
-                "    connect_timeout: 300", '    connect_timeout: "300"', 1
-            ),
-            "boolean-xapi-timeout": VALID_CONFIG.replace(
-                "    connect_timeout: 300", "    connect_timeout: true", 1
-            ),
-            "float-xapi-timeout": VALID_CONFIG.replace(
-                "    connect_timeout: 300", "    connect_timeout: 300.0", 1
-            ),
-            "wrong-xapi-timeout": VALID_CONFIG.replace(
-                "    connect_timeout: 300", "    connect_timeout: 60", 1
-            ),
-            "extra-xapi-key": VALID_CONFIG.replace(
-                "    connect_timeout: 300",
-                "    connect_timeout: 300\n    token: secret-marker",
-                1,
-            ),
             "wrong-url": """\
 mcp_servers:
   chrome:

--- a/docker/hermes-agent/bootstrap/tests/test_taskfile_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/test_taskfile_contract.py
@@ -1,0 +1,44 @@
+"""Taskfile contracts for Hermes X MCP lifecycle operations."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+TASKFILE = REPOSITORY_ROOT / "Taskfile.yml"
+
+
+class TaskfileContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tasks = yaml.safe_load(TASKFILE.read_text(encoding="utf-8"))["tasks"]
+
+    def test_xapi_tasks_are_present_in_the_hermes_lifecycle(self) -> None:
+        self.assertIn("xapi-mcp", self._command_text("hermes:pull"))
+        self.assertIn(
+            "xurl auth oauth2 --headless",
+            self._command_text("hermes:xapi:auth"),
+        )
+        self.assertIn(
+            "up -d --force-recreate xapi-mcp",
+            self._command_text("hermes:xapi:restart"),
+        )
+        self.assertIn(
+            "logs -f --tail=100 xapi-mcp",
+            self._command_text("hermes:xapi:logs"),
+        )
+
+    def _command_text(self, task_name: str) -> str:
+        task = self.tasks[task_name]
+        commands = task.get("cmds", [])
+        return "\n".join(
+            command if isinstance(command, str) else command.get("cmd", "")
+            for command in commands
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker/hermes-agent/compose.yml
+++ b/docker/hermes-agent/compose.yml
@@ -13,6 +13,8 @@ services:
     depends_on:
       browser-mcp:
         condition: service_healthy
+      xapi-mcp:
+        condition: service_healthy
     ports:
       - "127.0.0.1:${HERMES_API_PORT:-8642}:8642"
       - "127.0.0.1:${HERMES_DASHBOARD_PORT:-9119}:9119"
@@ -95,6 +97,42 @@ services:
     depends_on:
       chromium:
         condition: service_healthy
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >
+          node -e "const net=require('node:net');const s=net.connect({host:'127.0.0.1',port:8080},()=>{s.end();process.exit(0)});s.on('error',()=>process.exit(1));setTimeout(()=>process.exit(1),3000);"
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    networks:
+      - hermes-browser
+
+  xapi-mcp:
+    build:
+      context: ../hermes-xapi-mcp
+      dockerfile: Dockerfile
+    image: local/hermes-xapi-mcp:latest
+    container_name: hermes-xapi-mcp
+    restart: unless-stopped
+    command:
+      - node_modules/.bin/mcp-proxy
+      - --server
+      - stream
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8080"
+      - --
+      - /usr/local/bin/hermes-xapi-mcp
+    environment:
+      X_API_CLIENT_ID: "${X_API_CLIENT_ID:-}"
+      X_API_CLIENT_SECRET: "${X_API_CLIENT_SECRET:-}"
+    volumes:
+      - type: bind
+        source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.xurl
+        target: /root/.xurl
     healthcheck:
       test:
         - CMD-SHELL

--- a/docker/hermes-xapi-mcp/Dockerfile
+++ b/docker/hermes-xapi-mcp/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+RUN npm ci --omit=dev --ignore-scripts
+
+COPY entrypoint.sh /usr/local/bin/hermes-xapi-mcp
+
+ENV NODE_ENV=production \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
+RUN chmod 0755 /usr/local/bin/hermes-xapi-mcp
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=10s --retries=12 \
+  CMD node -e "const net=require('node:net');const s=net.connect({host:'127.0.0.1',port:8080},()=>{s.end();process.exit(0)});s.on('error',()=>process.exit(1));setTimeout(()=>process.exit(1),3000);"

--- a/docker/hermes-xapi-mcp/Dockerfile
+++ b/docker/hermes-xapi-mcp/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY package.json package-lock.json ./
 
-RUN npm ci --omit=dev --ignore-scripts
+RUN npm ci --omit=dev
 
 COPY entrypoint.sh /usr/local/bin/hermes-xapi-mcp
 

--- a/docker/hermes-xapi-mcp/Dockerfile
+++ b/docker/hermes-xapi-mcp/Dockerfile
@@ -2,6 +2,10 @@ FROM node:22-bookworm-slim
 
 WORKDIR /app
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY package.json package-lock.json ./
 
 RUN npm ci --omit=dev

--- a/docker/hermes-xapi-mcp/entrypoint.sh
+++ b/docker/hermes-xapi-mcp/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+if [ -n "${X_API_CLIENT_ID:-}" ]; then
+  export CLIENT_ID="$X_API_CLIENT_ID"
+fi
+
+if [ -n "${X_API_CLIENT_SECRET:-}" ]; then
+  export CLIENT_SECRET="$X_API_CLIENT_SECRET"
+fi
+
+exec node_modules/.bin/xurl mcp https://api.x.com/mcp

--- a/docker/hermes-xapi-mcp/package-lock.json
+++ b/docker/hermes-xapi-mcp/package-lock.json
@@ -1,0 +1,1034 @@
+{
+  "name": "hermes-xapi-mcp",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hermes-xapi-mcp",
+      "dependencies": {
+        "@xdevplatform/xurl": "1.3.1",
+        "mcp-proxy": "6.5.4"
+      }
+    },
+    "node_modules/@xdevplatform/xurl": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@xdevplatform/xurl/-/xurl-1.3.1.tgz",
+      "integrity": "sha512-XhNWx6t0LyoZqMXPeqYtbrl5BItLCK26dwnii+rxTI4mvsxkZbhPO1B2l8QKLaUMR5aQnqGw5bFQo52dJ1Jppg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "xurl": "cli.js"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/human-readable-ids": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/human-readable-ids/-/human-readable-ids-1.0.4.tgz",
+      "integrity": "sha512-h1zwThTims8A/SpqFGWyTx+jG1+WRMJaEeZgbtPGrIpj2AZjsOgy8Y+iNzJ0yAyN669Q6F02EK66WMWcst+2FA==",
+      "license": "Apache2",
+      "dependencies": {
+        "knuth-shuffle": "^1.0.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/knuth-shuffle": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/knuth-shuffle/-/knuth-shuffle-1.0.8.tgz",
+      "integrity": "sha512-IdC4Hpp+mx53zTt6VAGsAtbGM0g4BV9fP8tTcviCosSwocHcRDw9uG5Rnv6wLWckF4r72qeXFoK9NkvV1gUJCQ==",
+      "license": "(MIT OR Apache-2.0)"
+    },
+    "node_modules/koa": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.1.tgz",
+      "integrity": "sha512-e7IpWJrnanNUroVK2taAgMxoEZvHLXdQiNjeExSu/DEIWm83jaKGBgb7tLmu2rMYpA027qFB3iLR/k3AVpFRnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.8",
+        "content-disposition": "~1.0.1",
+        "content-type": "^1.0.5",
+        "cookies": "~0.9.1",
+        "delegates": "^1.0.0",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.5.0",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "license": "MIT"
+    },
+    "node_modules/koa-router": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-14.0.0.tgz",
+      "integrity": "sha512-Ue8f/PRsLLNm6b7y+eS6xkqvsG2xH11d2VB1HPcfdfW6p5736kCHf2pXaq8q9XPQ01x0Dk7V/P5Il9pe+tGTxA==",
+      "deprecated": "Please use @koa/router instead, starting from v9! ",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "path-to-regexp": "^8.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/koa/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-proxy": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.5.4.tgz",
+      "integrity": "sha512-TNEBqZ8TztuLuVGfT7TaPPN3/X6ScnOzBZot4kiatJzsohPCdpW4jOYq5tFoLCzZejCcXUs57QM8rSi1mXaCaw==",
+      "license": "MIT",
+      "dependencies": {
+        "pipenet": "^1.3.0"
+      },
+      "bin": {
+        "mcp-proxy": "dist/bin/mcp-proxy.mjs"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pipenet": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/pipenet/-/pipenet-1.4.2.tgz",
+      "integrity": "sha512-mPPqygXr7ccwImeaa8zReY9GubH/1r+kBNfqPVfKREQ1s8bKE3XlOqBMONxJAW4d3ZBNGzP9AZp9Axnhi5uOyw==",
+      "dependencies": {
+        "axios": "^1.7.3",
+        "debug": "^4.3.6",
+        "human-readable-ids": "^1.0.4",
+        "koa": "^3.1.1",
+        "koa-router": "^14.0.0",
+        "pump": "^3.0.3",
+        "tldjs": "^2.3.2",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "pipenet": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/tldjs": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.2.tgz",
+      "integrity": "sha512-EORDwFMSZKrHPUVDhejCMDeAovRS5d8jZKiqALFiPp3cjKjEldPkxBY39ZSx3c45awz3RpKwJD1cCgGxEfy8/A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    }
+  }
+}

--- a/docker/hermes-xapi-mcp/package.json
+++ b/docker/hermes-xapi-mcp/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "hermes-xapi-mcp",
+  "private": true,
+  "dependencies": {
+    "@xdevplatform/xurl": "1.3.1",
+    "mcp-proxy": "6.5.4"
+  }
+}

--- a/docs/chezmoi/secrets.md
+++ b/docs/chezmoi/secrets.md
@@ -106,6 +106,14 @@ absent after bootstrap.
 Browser lifecycle and source-owned MCP configuration are described in
 [Hermes Browser MCP](../hermes-agent/browser-mcp.md).
 
+Hermes X API MCP OAuth client credentials are centralized in account
+`my.1password.com`, vault `openclaw`, item `Hermes X API MCP`. The required
+fields are `X_API_CLIENT_ID` and `X_API_CLIENT_SECRET`. The explicit
+`task hermes:xapi:auth`, `task hermes:xapi:restart`, and `task hermes:up`
+wrappers read those fields at runtime; do not store them in `~/.hermes/.env`,
+Compose files, Git, Slack, or profile repositories. The `.xurl` OAuth cache
+remains local runtime state and must not be shared.
+
 ## パターン
 
 PowerShell deploy script で値を取得する場合:

--- a/docs/hermes-agent/bootstrap.md
+++ b/docs/hermes-agent/bootstrap.md
@@ -23,9 +23,9 @@ On Unix, the task sources `scripts/sh/hermes-agent.sh` and invokes its Docker
 adapter with the canonical Compose file. On Windows, it runs
 `pwsh -NoProfile -File scripts/powershell/hermes-bootstrap.ps1`, a focused
 Docker Desktop adapter that does not require WSL, NixOS, or a completed Nix
-rebuild. Both adapters run Compose config validation, build `hermes` and
-`hermes-bootstrap`, invoke the container bootstrap, and only then recreate the
-stack.
+rebuild. Both adapters run Compose config validation, build `hermes`,
+`hermes-bootstrap`, and `xapi-mcp`, invoke the container bootstrap, and only
+then recreate the stack.
 
 `install.cmd` remains the Windows full-machine setup entrypoint and continues
 through the PowerShell handler. The exact supported installer chains are:
@@ -200,6 +200,11 @@ pinned Docker test stage and the `gh` wrapper security suite in the
 `Hermes Bootstrap Tests` workflow, so the container transaction, payload, and
 runtime credential path are publication gates rather than optional manual
 checks.
+
+The same source validation requires every root and managed profile distribution
+to declare `mcp_servers.xapi` with URL `http://xapi-mcp:8080/mcp` and
+`connect_timeout: 300`. The declaration stays in the source repository; the
+bootstrap process validates it but does not mutate or synthesize it.
 
 The four source repositories use the same `fast` and `full` validator. Local
 validator exits are `0` pass, `1` validation failure, `2` prerequisite blocked,

--- a/docs/hermes-agent/bootstrap.md
+++ b/docs/hermes-agent/bootstrap.md
@@ -26,7 +26,10 @@ adapter with the canonical Compose file. On Windows, it runs
 Docker Desktop adapter that does not require WSL, NixOS, or a completed Nix
 rebuild. Both adapters validate Compose, build `hermes`, `hermes-bootstrap`,
 and `xapi-mcp`, run the container bootstrap, and recreate the stack only after
-success. The full installer chains remain:
+success. The final recreate is wrapped with the host X API credential adapter
+on both Unix and Windows, so `X_API_CLIENT_*` values are read from the
+configured 1Password item instead of being exported or stored locally. The full
+installer chains remain:
 
 ```text
 install.sh -> OS installer -> shell adapter (scripts/sh/hermes-agent.sh) -> hermes-bootstrap container -> compose up

--- a/docs/hermes-agent/bootstrap.md
+++ b/docs/hermes-agent/bootstrap.md
@@ -202,9 +202,10 @@ runtime credential path are publication gates rather than optional manual
 checks.
 
 The same source validation requires every root and managed profile distribution
-to declare `mcp_servers.xapi` with URL `http://xapi-mcp:8080/mcp` and
-`connect_timeout: 300`. The declaration stays in the source repository; the
-bootstrap process validates it but does not mutate or synthesize it.
+to own `config.yaml`. Bootstrap validates the Chrome MCP guardrails, then
+synthesizes the non-secret `mcp_servers.xapi` entry in the staged runtime copy
+with URL `http://xapi-mcp:8080/mcp` and `connect_timeout: 300`. The generated
+entry is not written back to source repositories.
 
 The four source repositories use the same `fast` and `full` validator. Local
 validator exits are `0` pass, `1` validation failure, `2` prerequisite blocked,

--- a/docs/hermes-agent/profile-home-layout.md
+++ b/docs/hermes-agent/profile-home-layout.md
@@ -39,6 +39,10 @@ host ~/.hermes/                    container /opt/data/
   cron, scripts, and MCP declarations. The bootstrap stages those sources and
   applies them transactionally without turning runtime homes into Git working
   trees.
+- Every managed distribution declares the shared X API MCP endpoint as
+  `mcp_servers.xapi.url: http://xapi-mcp:8080/mcp` with
+  `connect_timeout: 300`. The endpoint is served by the separate Compose
+  `xapi-mcp` container and uses the shared root `.xurl` OAuth cache.
 
 Do not run a second Hermes gateway container against this runtime root or a
 managed profile while the main Hermes container can see it. Do not initialize a

--- a/docs/hermes-agent/profile-home-layout.md
+++ b/docs/hermes-agent/profile-home-layout.md
@@ -39,8 +39,8 @@ host ~/.hermes/                    container /opt/data/
   cron, scripts, and MCP declarations. The bootstrap stages those sources and
   applies them transactionally without turning runtime homes into Git working
   trees.
-- Every managed distribution declares the shared X API MCP endpoint as
-  `mcp_servers.xapi.url: http://xapi-mcp:8080/mcp` with
+- Bootstrap installs the shared X API MCP endpoint into every staged managed
+  distribution as `mcp_servers.xapi.url: http://xapi-mcp:8080/mcp` with
   `connect_timeout: 300`. The endpoint is served by the separate Compose
   `xapi-mcp` container and uses the shared root `.xurl` OAuth cache.
 

--- a/docs/hermes-agent/xapi-mcp.md
+++ b/docs/hermes-agent/xapi-mcp.md
@@ -1,0 +1,77 @@
+# Hermes X API MCP
+
+Hermes connects to X's official hosted MCP server through an isolated Compose
+service. The service runs the official `@xdevplatform/xurl` bridge and exposes
+it as Streamable HTTP inside the Compose network.
+
+## Services
+
+```text
+Hermes profile config
+  -> http://xapi-mcp:8080/mcp
+  -> xapi-mcp container
+  -> xurl mcp https://api.x.com/mcp
+```
+
+The `xapi-mcp` service uses the existing `hermes-browser` network and does not
+publish port 8080 to the host. Its OAuth cache is the host runtime directory
+`${HERMES_DATA_DIR:-~/.hermes}/.xurl`, mounted at `/root/.xurl`.
+
+Every managed distribution must own this non-secret configuration in its
+`config.yaml`:
+
+```yaml
+mcp_servers:
+  xapi:
+    url: http://xapi-mcp:8080/mcp
+    connect_timeout: 300
+```
+
+The bootstrap source contract validates this exact entry in the root
+distribution and every managed profile. Bootstrap does not inject or merge it
+into source repositories.
+
+## First authentication
+
+Set the X OAuth application credentials in the host environment. Do not put
+them in Compose files, Git, or profile configuration:
+
+```bash
+export X_API_CLIENT_ID='...'
+export X_API_CLIENT_SECRET='...'
+task hermes:xapi:auth
+```
+
+The command runs X's documented headless OAuth flow. Complete the displayed
+browser/code exchange once; subsequent service restarts reuse and refresh the
+cache under `~/.hermes/.xurl`.
+
+Start or recreate the stack after authentication:
+
+```bash
+task hermes:up
+task hermes:xapi:logs
+```
+
+The normal bootstrap path also builds and starts `xapi-mcp`:
+
+```bash
+task hermes:bootstrap
+```
+
+## Verification
+
+Check the service and test the same MCP endpoint from each profile:
+
+```bash
+docker compose -f docker/hermes-agent/compose.yml ps xapi-mcp hermes
+docker exec hermes hermes -p rick mcp test xapi
+docker exec hermes hermes -p hoffman mcp test xapi
+docker exec hermes hermes -p risarisa mcp test xapi
+docker exec hermes hermes -p nancy mcp test xapi
+```
+
+If authentication is missing, inspect `task hermes:xapi:logs` and rerun
+`task hermes:xapi:auth`. Never expose the internal MCP port or copy the
+`.xurl` cache into a profile repository.
+

--- a/docs/hermes-agent/xapi-mcp.md
+++ b/docs/hermes-agent/xapi-mcp.md
@@ -49,7 +49,9 @@ task hermes:xapi:auth
 
 The command runs X's documented headless OAuth flow. Complete the displayed
 browser/code exchange once; subsequent service restarts reuse and refresh the
-cache under `~/.hermes/.xurl`.
+cache under `~/.hermes/.xurl`. Unix hosts run the bash adapter; Windows hosts
+run `scripts/powershell/hermes-xapi.ps1` and read the same 1Password item
+through native `op.exe`.
 
 Start or recreate the stack after authentication:
 
@@ -65,8 +67,8 @@ task hermes:bootstrap
 ```
 
 This path uses the same 1Password-backed credential wrapper as
-`task hermes:up`, so no `X_API_CLIENT_*` values need to be exported before
-bootstrap.
+`task hermes:up` on Unix and Windows, so no `X_API_CLIENT_*` values need to be
+exported before bootstrap.
 
 ## Verification
 

--- a/docs/hermes-agent/xapi-mcp.md
+++ b/docs/hermes-agent/xapi-mcp.md
@@ -36,9 +36,9 @@ does not write the generated entry back to source repositories.
 Create or update the X OAuth application credentials in 1Password. Do not put
 them in Compose files, Git, profile configuration, Slack, or local env files:
 
-| Account              | Vault      | Item               | Fields                                      |
-| -------------------- | ---------- | ------------------ | ------------------------------------------- |
-| `my.1password.com`   | `openclaw` | `Hermes X API MCP` | `X_API_CLIENT_ID`, `X_API_CLIENT_SECRET`    |
+| Account            | Vault      | Item               | Fields                                   |
+| ------------------ | ---------- | ------------------ | ---------------------------------------- |
+| `my.1password.com` | `openclaw` | `Hermes X API MCP` | `X_API_CLIENT_ID`, `X_API_CLIENT_SECRET` |
 
 Then run the headless OAuth flow. The task reads those fields from 1Password
 only for this explicit command:

--- a/docs/hermes-agent/xapi-mcp.md
+++ b/docs/hermes-agent/xapi-mcp.md
@@ -17,8 +17,8 @@ The `xapi-mcp` service uses the existing `hermes-browser` network and does not
 publish port 8080 to the host. Its OAuth cache is the host runtime directory
 `${HERMES_DATA_DIR:-~/.hermes}/.xurl`, mounted at `/root/.xurl`.
 
-Every managed distribution must own this non-secret configuration in its
-`config.yaml`:
+Every managed distribution must own `config.yaml`. During bootstrap, Hermes
+installs this non-secret MCP entry into the staged runtime copy:
 
 ```yaml
 mcp_servers:
@@ -27,18 +27,23 @@ mcp_servers:
     connect_timeout: 300
 ```
 
-The bootstrap source contract validates this exact entry in the root
-distribution and every managed profile. Bootstrap does not inject or merge it
-into source repositories.
+The bootstrap source contract still validates the source-owned Chrome MCP
+guardrails, but X API MCP is synthesized in the staged runtime copy. Bootstrap
+does not write the generated entry back to source repositories.
 
 ## First authentication
 
-Set the X OAuth application credentials in the host environment. Do not put
-them in Compose files, Git, or profile configuration:
+Create or update the X OAuth application credentials in 1Password. Do not put
+them in Compose files, Git, profile configuration, Slack, or local env files:
+
+| Account              | Vault      | Item               | Fields                                      |
+| -------------------- | ---------- | ------------------ | ------------------------------------------- |
+| `my.1password.com`   | `openclaw` | `Hermes X API MCP` | `X_API_CLIENT_ID`, `X_API_CLIENT_SECRET`    |
+
+Then run the headless OAuth flow. The task reads those fields from 1Password
+only for this explicit command:
 
 ```bash
-export X_API_CLIENT_ID='...'
-export X_API_CLIENT_SECRET='...'
 task hermes:xapi:auth
 ```
 
@@ -59,6 +64,10 @@ The normal bootstrap path also builds and starts `xapi-mcp`:
 task hermes:bootstrap
 ```
 
+This path uses the same 1Password-backed credential wrapper as
+`task hermes:up`, so no `X_API_CLIENT_*` values need to be exported before
+bootstrap.
+
 ## Verification
 
 Check the service and test the same MCP endpoint from each profile:
@@ -74,4 +83,3 @@ docker exec hermes hermes -p nancy mcp test xapi
 If authentication is missing, inspect `task hermes:xapi:logs` and rerun
 `task hermes:xapi:auth`. Never expose the internal MCP port or copy the
 `.xurl` cache into a profile repository.
-

--- a/docs/superpowers/plans/2026-07-24-hermes-x-mcp.md
+++ b/docs/superpowers/plans/2026-07-24-hermes-x-mcp.md
@@ -23,7 +23,7 @@
 
 **Files:**
 - Modify: `docker/hermes-agent/bootstrap/tests/test_compose_contract.py`
-- Create: `docker/hermes-agent/bootstrap/tests/test_taskfile_contract.py`
+- Create: `tests/python/test_taskfile_contract.py`
 
 **Interfaces:**
 - Consumes: current `docker/hermes-agent/compose.yml` and `Taskfile.yml`.
@@ -67,7 +67,7 @@ Run:
 
 ```bash
 python -m unittest docker/hermes-agent/bootstrap/tests/test_compose_contract.py
-python -m unittest docker/hermes-agent/bootstrap/tests/test_taskfile_contract.py
+python -m unittest tests/python/test_taskfile_contract.py
 ```
 
 Expected: failures identify the missing `xapi-mcp` service and task entries;
@@ -76,7 +76,7 @@ there must be no YAML import or test syntax error.
 - [ ] **Step 4: Commit the red tests**
 
 ```bash
-git add docker/hermes-agent/bootstrap/tests/test_compose_contract.py docker/hermes-agent/bootstrap/tests/test_taskfile_contract.py
+git add docker/hermes-agent/bootstrap/tests/test_compose_contract.py tests/python/test_taskfile_contract.py
 git commit -m "test: define Hermes X MCP compose contracts"
 ```
 
@@ -250,7 +250,7 @@ Run:
 
 ```bash
 python -m unittest docker/hermes-agent/bootstrap/tests/test_compose_contract.py
-python -m unittest docker/hermes-agent/bootstrap/tests/test_taskfile_contract.py
+python -m unittest tests/python/test_taskfile_contract.py
 docker compose -f docker/hermes-agent/compose.yml config --quiet
 ```
 

--- a/docs/superpowers/plans/2026-07-24-hermes-x-mcp.md
+++ b/docs/superpowers/plans/2026-07-24-hermes-x-mcp.md
@@ -1,0 +1,389 @@
+# Hermes X MCP Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run X's official hosted MCP bridge as an isolated Compose service and make the same `xapi` MCP endpoint available to every managed Hermes distribution.
+
+**Architecture:** Add a Node 22 `xapi-mcp` image with pinned `@xdevplatform/xurl@1.3.1` and `mcp-proxy@6.5.4`. The service mounts the existing `.xurl` cache, exposes only an internal Streamable HTTP endpoint, and receives OAuth client credentials through Compose environment interpolation. Hermes distributions declare `http://xapi-mcp:8080/mcp`, while bootstrap source validation guarantees the URL exists in the root and every managed profile.
+
+**Tech Stack:** Docker Compose, Node.js 22, `@xdevplatform/xurl`, `mcp-proxy`, Python `unittest`/PyYAML contract tests, Bash Bats, go-task.
+
+## Global Constraints
+
+- Use the X hosted endpoint `https://api.x.com/mcp` through the official `xurl mcp` bridge.
+- Do not publish the X MCP port to the host.
+- Do not commit `CLIENT_ID`, `CLIENT_SECRET`, bearer tokens, or `.xurl` contents.
+- Keep the existing `hermes-browser` network and `.hermes/.xurl` runtime path.
+- Preserve the distribution-owned profile configuration model; validate, do not inject, `xapi` configuration during bootstrap.
+- Run tests first in the failing state, then implement the minimum behavior required by each test.
+
+---
+
+### Task 1: Add failing Compose and Taskfile contract tests
+
+**Files:**
+- Modify: `docker/hermes-agent/bootstrap/tests/test_compose_contract.py`
+- Create: `docker/hermes-agent/bootstrap/tests/test_taskfile_contract.py`
+
+**Interfaces:**
+- Consumes: current `docker/hermes-agent/compose.yml` and `Taskfile.yml`.
+- Produces: executable contracts for the `xapi-mcp` service and its task entry points.
+
+- [ ] **Step 1: Write the failing Compose service test**
+
+Add a test that requires an `xapi-mcp` service with:
+
+```python
+self.assertEqual(xapi["container_name"], "hermes-xapi-mcp")
+self.assertEqual(xapi["image"], "local/hermes-xapi-mcp:latest")
+self.assertEqual(xapi["networks"], ["hermes-browser"])
+self.assertEqual(xapi["volumes"], [XURL_BIND])
+self.assertNotIn("ports", xapi)
+self.assertEqual(xapi["environment"], {
+    "X_API_CLIENT_ID": "${X_API_CLIENT_ID:-}",
+    "X_API_CLIENT_SECRET": "${X_API_CLIENT_SECRET:-}",
+})
+self.assertEqual(xapi["healthcheck"]["test"], ["CMD-SHELL", EXPECTED_TCP_HEALTHCHECK])
+self.assertIn("xapi-mcp", self.services["hermes"]["depends_on"])
+```
+
+Also assert the service command contains `mcp-proxy`, `--server`, `stream`,
+`--host`, `0.0.0.0`, `--port`, `8080`, and `hermes-xapi-mcp`.
+
+- [ ] **Step 2: Write the failing Taskfile contract test**
+
+Parse `Taskfile.yml` with PyYAML and require these commands:
+
+```python
+assert_command_contains("hermes:pull", "xapi-mcp")
+assert_command_contains("hermes:xapi:auth", "xurl auth oauth2 --headless")
+assert_command_contains("hermes:xapi:restart", "up -d --force-recreate xapi-mcp")
+assert_command_contains("hermes:xapi:logs", "logs -f --tail=100 xapi-mcp")
+```
+
+- [ ] **Step 3: Run the focused tests and verify the expected failure**
+
+Run:
+
+```bash
+python -m unittest docker/hermes-agent/bootstrap/tests/test_compose_contract.py
+python -m unittest docker/hermes-agent/bootstrap/tests/test_taskfile_contract.py
+```
+
+Expected: failures identify the missing `xapi-mcp` service and task entries;
+there must be no YAML import or test syntax error.
+
+- [ ] **Step 4: Commit the red tests**
+
+```bash
+git add docker/hermes-agent/bootstrap/tests/test_compose_contract.py docker/hermes-agent/bootstrap/tests/test_taskfile_contract.py
+git commit -m "test: define Hermes X MCP compose contracts"
+```
+
+### Task 2: Build the isolated X MCP image
+
+**Files:**
+- Create: `docker/hermes-xapi-mcp/Dockerfile`
+- Create: `docker/hermes-xapi-mcp/package.json`
+- Create: `docker/hermes-xapi-mcp/package-lock.json`
+- Create: `docker/hermes-xapi-mcp/entrypoint.sh`
+
+**Interfaces:**
+- Consumes: `CLIENT_ID`, `CLIENT_SECRET`, and `/root/.xurl` at runtime.
+- Produces: a stdio `xurl mcp https://api.x.com/mcp` bridge wrapped as a
+  Streamable HTTP server on port 8080.
+
+- [ ] **Step 1: Add the pinned package manifest**
+
+Create `package.json` with production dependencies:
+
+```json
+{
+  "name": "hermes-xapi-mcp",
+  "private": true,
+  "dependencies": {
+    "@xdevplatform/xurl": "1.3.1",
+    "mcp-proxy": "6.5.4"
+  }
+}
+```
+
+Generate the lockfile with `npm install --package-lock-only --ignore-scripts`
+from `docker/hermes-xapi-mcp` and verify both exact versions are present.
+
+- [ ] **Step 2: Add the bridge entrypoint**
+
+Create `entrypoint.sh` that maps optional Compose names to the names expected
+by xurl and then replaces the shell with the bridge:
+
+```sh
+#!/bin/sh
+set -eu
+
+if [ -n "${X_API_CLIENT_ID:-}" ]; then
+  export CLIENT_ID="$X_API_CLIENT_ID"
+fi
+if [ -n "${X_API_CLIENT_SECRET:-}" ]; then
+  export CLIENT_SECRET="$X_API_CLIENT_SECRET"
+fi
+
+exec node_modules/.bin/xurl mcp https://api.x.com/mcp
+```
+
+The production command will invoke this script as the child command of
+`mcp-proxy`; it must keep stdout reserved for JSON-RPC and send diagnostics to
+stderr through xurl.
+
+- [ ] **Step 3: Add the Dockerfile**
+
+Use `node:22-bookworm-slim`, copy the package manifests, run
+`npm ci --omit=dev --ignore-scripts`, copy the entrypoint, set it executable,
+set `NODE_ENV=production`, expose 8080 for the internal service, and add a
+TCP healthcheck against `127.0.0.1:8080`.
+
+- [ ] **Step 4: Build the image and run the image contract checks**
+
+Run:
+
+```bash
+docker build -t local/hermes-xapi-mcp:test docker/hermes-xapi-mcp
+docker run --rm local/hermes-xapi-mcp:test node --version
+```
+
+Expected: the image builds without running an OAuth flow during build, and
+Node reports major version 22.
+
+- [ ] **Step 5: Commit the image**
+
+```bash
+git add docker/hermes-xapi-mcp
+git commit -m "feat: add isolated X MCP bridge image"
+```
+
+### Task 3: Wire `xapi-mcp` into Compose and Taskfile
+
+**Files:**
+- Modify: `docker/hermes-agent/compose.yml`
+- Modify: `Taskfile.yml`
+- Modify: `scripts/sh/hermes-agent.sh`
+- Modify: `scripts/powershell/hermes-bootstrap.ps1`
+
+**Interfaces:**
+- Consumes: `local/hermes-xapi-mcp:latest`, host `${HERMES_DATA_DIR}/.xurl`,
+  `X_API_CLIENT_ID`, and `X_API_CLIENT_SECRET`.
+- Produces: a healthy internal `xapi-mcp` service available at
+  `http://xapi-mcp:8080/mcp`; all bootstrap and update paths build/start it.
+
+- [ ] **Step 1: Add the Compose service**
+
+Add `xapi-mcp` with the following contract:
+
+```yaml
+xapi-mcp:
+  build:
+    context: ../hermes-xapi-mcp
+    dockerfile: Dockerfile
+  image: local/hermes-xapi-mcp:latest
+  container_name: hermes-xapi-mcp
+  restart: unless-stopped
+  command:
+    - node_modules/.bin/mcp-proxy
+    - --server
+    - stream
+    - --host
+    - 0.0.0.0
+    - --port
+    - "8080"
+    - --
+    - /usr/local/bin/hermes-xapi-mcp
+  environment:
+    X_API_CLIENT_ID: "${X_API_CLIENT_ID:-}"
+    X_API_CLIENT_SECRET: "${X_API_CLIENT_SECRET:-}"
+  volumes:
+    - type: bind
+      source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.xurl
+      target: /root/.xurl
+  healthcheck:
+    test: ["CMD-SHELL", "node -e \"const net=require('node:net');const s=net.connect({host:'127.0.0.1',port:8080},()=>{s.end();process.exit(0)});s.on('error',()=>process.exit(1));setTimeout(()=>process.exit(1),3000);\""]
+    interval: 10s
+    timeout: 5s
+    retries: 12
+    start_period: 10s
+  networks:
+    - hermes-browser
+```
+
+Add `xapi-mcp` to the Hermes `depends_on` map with
+`condition: service_healthy`. Keep the X service free of host ports.
+
+- [ ] **Step 2: Update stack build and auth operations**
+
+Update every cross-platform Hermes build path to include `xapi-mcp`, including
+the Unix and PowerShell bootstrap adapters. Add these Taskfile tasks with the
+same Docker precondition style as existing Hermes tasks:
+
+```yaml
+hermes:xapi:auth:
+  desc: Authenticate the X MCP bridge with the headless OAuth flow
+  interactive: true
+  cmds:
+    - docker compose -f {{.HERMES_COMPOSE_FILE}} run --rm --no-deps --entrypoint /bin/sh xapi-mcp -lc 'node_modules/.bin/xurl auth oauth2 --headless'
+
+hermes:xapi:restart:
+  desc: Recreate the Hermes X MCP container
+  cmds:
+    - docker compose -f {{.HERMES_COMPOSE_FILE}} up -d --force-recreate xapi-mcp
+
+hermes:xapi:logs:
+  desc: Follow Hermes X MCP logs
+  interactive: true
+  cmds:
+    - docker compose -f {{.HERMES_COMPOSE_FILE}} logs -f --tail=100 xapi-mcp
+```
+
+Use the service's mounted `.xurl` directory for the headless flow and never
+place client credentials in the command arguments.
+
+- [ ] **Step 3: Run Compose and Taskfile tests to verify they pass**
+
+Run:
+
+```bash
+python -m unittest docker/hermes-agent/bootstrap/tests/test_compose_contract.py
+python -m unittest docker/hermes-agent/bootstrap/tests/test_taskfile_contract.py
+docker compose -f docker/hermes-agent/compose.yml config --quiet
+```
+
+Expected: all focused tests pass and Compose exits successfully.
+
+- [ ] **Step 4: Commit the runtime wiring**
+
+```bash
+git add docker/hermes-agent/compose.yml Taskfile.yml scripts/sh/hermes-agent.sh scripts/powershell/hermes-bootstrap.ps1
+git commit -m "feat: run X MCP as a Hermes compose service"
+```
+
+### Task 4: Enforce and document the all-profile MCP contract
+
+**Files:**
+- Modify: `docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py`
+- Modify: `docker/hermes-agent/bootstrap/tests/test_source_contracts.py`
+- Create: `docs/hermes-agent/xapi-mcp.md`
+- Modify: `docs/hermes-agent/bootstrap.md`
+- Modify: `docs/hermes-agent/profile-home-layout.md`
+
+**Interfaces:**
+- Consumes: staged root/profile `config.yaml` files.
+- Produces: a validation error when any managed distribution lacks the
+  canonical `xapi` MCP entry.
+
+- [ ] **Step 1: Write failing source-contract tests**
+
+Extend the valid fixture with:
+
+```yaml
+xapi:
+  url: http://xapi-mcp:8080/mcp
+  connect_timeout: 300
+```
+
+Add cases for missing `xapi`, wrong URL, missing timeout, non-integer timeout,
+and extra keys. Assert the error identifies the distribution and
+`config.yaml` without echoing secret values.
+
+- [ ] **Step 2: Run the source-contract tests and verify RED**
+
+Run:
+
+```bash
+python -m unittest docker/hermes-agent/bootstrap/tests/test_source_contracts.py
+```
+
+Expected: the updated valid fixture fails because the validator does not yet
+require `xapi`.
+
+- [ ] **Step 3: Implement the canonical xapi validator**
+
+Add:
+
+```python
+_XAPI_MCP = {
+    "url": "http://xapi-mcp:8080/mcp",
+    "connect_timeout": 300,
+}
+```
+
+Validate `mcp_servers.xapi` with the same strict mapping checks as Chrome,
+while preserving all unrelated MCP entries. Invoke the validator for every
+staged root/profile source already covered by the existing function.
+
+- [ ] **Step 4: Run the source-contract tests and verify GREEN**
+
+Run the same unittest command and expect all tests to pass.
+
+- [ ] **Step 5: Document first login, runtime access, and recovery**
+
+Document that `task hermes:xapi:auth` is required once with
+`X_API_CLIENT_ID` and `X_API_CLIENT_SECRET` set, that the cache is shared at
+`~/.hermes/.xurl`, and that each profile uses the internal URL. Include the
+verification commands:
+
+```bash
+docker compose -f docker/hermes-agent/compose.yml ps xapi-mcp hermes
+docker exec hermes hermes -p rick mcp test xapi
+docker exec hermes hermes -p hoffman mcp test xapi
+docker exec hermes hermes -p risarisa mcp test xapi
+docker exec hermes hermes -p nancy mcp test xapi
+```
+
+- [ ] **Step 6: Commit the profile contract and docs**
+
+```bash
+git add docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py docker/hermes-agent/bootstrap/tests/test_source_contracts.py docs/hermes-agent/xapi-mcp.md docs/hermes-agent/bootstrap.md docs/hermes-agent/profile-home-layout.md
+git commit -m "feat: require X MCP in every Hermes profile"
+```
+
+### Task 5: Verify the complete change
+
+**Files:**
+- Modify: none
+
+- [ ] **Step 1: Run focused Python and shell tests**
+
+```bash
+python -m unittest discover -s docker/hermes-agent/bootstrap/tests
+bats tests/bash/hermes_agent.bats
+```
+
+Expected: all tests pass with no new warnings or failures.
+
+- [ ] **Step 2: Validate formatting and Compose contracts**
+
+```bash
+git diff --check
+docker compose -f docker/hermes-agent/compose.yml config --quiet
+task hermes:bootstrap:config
+```
+
+Expected: all commands exit 0. If Docker is unavailable, report that runtime
+validation is environment-blocked while retaining the completed static tests.
+
+- [ ] **Step 3: Build the production images**
+
+```bash
+task hermes:pull
+```
+
+Expected: `hermes`, `chromium`, `browser-mcp`, and `xapi-mcp` build
+successfully without exposing credentials.
+
+- [ ] **Step 4: Review the final diff and status**
+
+```bash
+git diff HEAD~4..HEAD --stat
+git status --short --branch
+```
+
+Confirm the branch is `feat/hermes-x-mcp`, no `.xurl` files are tracked, and
+only the intended Compose, Taskfile, bootstrap contract, image, tests, and
+documentation files changed.

--- a/docs/superpowers/plans/2026-07-24-hermes-x-mcp.md
+++ b/docs/superpowers/plans/2026-07-24-hermes-x-mcp.md
@@ -22,10 +22,12 @@
 ### Task 1: Add failing Compose and Taskfile contract tests
 
 **Files:**
+
 - Modify: `docker/hermes-agent/bootstrap/tests/test_compose_contract.py`
 - Create: `tests/python/test_taskfile_contract.py`
 
 **Interfaces:**
+
 - Consumes: current `docker/hermes-agent/compose.yml` and `Taskfile.yml`.
 - Produces: executable contracts for the `xapi-mcp` service and its task entry points.
 
@@ -83,12 +85,14 @@ git commit -m "test: define Hermes X MCP compose contracts"
 ### Task 2: Build the isolated X MCP image
 
 **Files:**
+
 - Create: `docker/hermes-xapi-mcp/Dockerfile`
 - Create: `docker/hermes-xapi-mcp/package.json`
 - Create: `docker/hermes-xapi-mcp/package-lock.json`
 - Create: `docker/hermes-xapi-mcp/entrypoint.sh`
 
 **Interfaces:**
+
 - Consumes: `CLIENT_ID`, `CLIENT_SECRET`, and `/root/.xurl` at runtime.
 - Produces: a stdio `xurl mcp https://api.x.com/mcp` bridge wrapped as a
   Streamable HTTP server on port 8080.
@@ -163,12 +167,14 @@ git commit -m "feat: add isolated X MCP bridge image"
 ### Task 3: Wire `xapi-mcp` into Compose and Taskfile
 
 **Files:**
+
 - Modify: `docker/hermes-agent/compose.yml`
 - Modify: `Taskfile.yml`
 - Modify: `scripts/sh/hermes-agent.sh`
 - Modify: `scripts/powershell/hermes-bootstrap.ps1`
 
 **Interfaces:**
+
 - Consumes: `local/hermes-xapi-mcp:latest`, host `${HERMES_DATA_DIR}/.xurl`,
   `X_API_CLIENT_ID`, and `X_API_CLIENT_SECRET`.
 - Produces: a healthy internal `xapi-mcp` service available at
@@ -204,7 +210,11 @@ xapi-mcp:
       source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.xurl
       target: /root/.xurl
   healthcheck:
-    test: ["CMD-SHELL", "node -e \"const net=require('node:net');const s=net.connect({host:'127.0.0.1',port:8080},()=>{s.end();process.exit(0)});s.on('error',()=>process.exit(1));setTimeout(()=>process.exit(1),3000);\""]
+    test:
+      [
+        "CMD-SHELL",
+        'node -e "const net=require(''node:net'');const s=net.connect({host:''127.0.0.1'',port:8080},()=>{s.end();process.exit(0)});s.on(''error'',()=>process.exit(1));setTimeout(()=>process.exit(1),3000);"',
+      ]
     interval: 10s
     timeout: 5s
     retries: 12
@@ -266,6 +276,7 @@ git commit -m "feat: run X MCP as a Hermes compose service"
 ### Task 4: Enforce and document the all-profile MCP contract
 
 **Files:**
+
 - Modify: `docker/hermes-agent/bootstrap/hermes_bootstrap/source_contracts.py`
 - Modify: `docker/hermes-agent/bootstrap/tests/test_source_contracts.py`
 - Create: `docs/hermes-agent/xapi-mcp.md`
@@ -273,6 +284,7 @@ git commit -m "feat: run X MCP as a Hermes compose service"
 - Modify: `docs/hermes-agent/profile-home-layout.md`
 
 **Interfaces:**
+
 - Consumes: staged root/profile `config.yaml` files.
 - Produces: a validation error when any managed distribution lacks the
   canonical `xapi` MCP entry.
@@ -346,6 +358,7 @@ git commit -m "feat: require X MCP in every Hermes profile"
 ### Task 5: Verify the complete change
 
 **Files:**
+
 - Modify: none
 
 - [ ] **Step 1: Run focused Python and shell tests**

--- a/docs/superpowers/specs/2026-07-23-hermes-x-mcp-design.md
+++ b/docs/superpowers/specs/2026-07-23-hermes-x-mcp-design.md
@@ -1,0 +1,94 @@
+# Hermes X MCP Integration Design
+
+## Goal
+
+Expose X's official hosted MCP server to every managed Hermes profile through a
+dedicated Docker Compose service, while keeping X OAuth state and the Hermes
+gateway lifecycle separate.
+
+## Context and constraints
+
+- The upstream MCP endpoint is `https://api.x.com/mcp`.
+- The supported full-access connection is the `@xdevplatform/xurl` bridge,
+  which handles OAuth 2.0 login, bearer-token injection, and token refresh.
+- The Hermes gateway already runs in Docker and the Compose network is the
+  correct private communication boundary for MCP services.
+- Managed profiles own their declarative MCP configuration. The dotfiles
+  bootstrap must not silently inject or merge profile configuration.
+- X client credentials and the OAuth cache are runtime secrets. They must not
+  be committed, embedded in images, or published as host ports.
+
+## Decision
+
+Add an `xapi-mcp` service to `docker/hermes-agent/compose.yml`. The service
+will use a small Node image containing pinned `@xdevplatform/xurl` and
+`mcp-proxy` dependencies. Its command will expose the xurl stdio bridge as
+Streamable HTTP on `0.0.0.0:8080`; the service will not publish that port to
+the host. Hermes will connect to `http://xapi-mcp:8080/mcp` over the existing
+Compose network.
+
+The service will bind-mount the existing host cache directory
+`${HERMES_DATA_DIR}/.xurl` at `/root/.xurl` and receive `CLIENT_ID` and
+`CLIENT_SECRET` from host environment variables via Compose interpolation.
+The image will contain no credentials. A dedicated `task hermes:xapi:auth`
+operation will provide the documented headless first-login flow; normal stack
+startup will reuse the shared cache.
+
+Every managed distribution (`default`, `rick`, `hoffman`, `risarisa`, and
+`nancy`) will declare the same `mcp_servers.xapi` URL and a generous connection
+timeout. The bootstrap source contract will validate this invariant so a
+profile cannot silently lose X MCP access during a distribution update. The
+actual profile repositories remain the owners of their `config.yaml` files.
+
+## Alternatives considered
+
+### Install xurl directly in the Hermes image
+
+This avoids the HTTP proxy and is smaller initially, but every profile would
+spawn its own bridge process inside the gateway container. It couples X
+authentication and process lifecycle to Hermes image updates and makes the
+shared-account behavior less explicit. It also conflicts with the requested
+independent service boundary.
+
+### Connect each profile directly to `https://api.x.com/mcp`
+
+This can use a static app-only bearer header, but it is read-only and does not
+provide the OAuth user-context capabilities needed for bookmarks, Articles,
+or other account-scoped operations. It also duplicates credential wiring in
+every profile.
+
+## Runtime flow
+
+```text
+task hermes:xapi:auth (first run only)
+  -> xapi-mcp container runs xurl OAuth2 headless flow
+  -> ~/.hermes/.xurl receives the refreshed credential cache
+
+task hermes:bootstrap / task hermes:up
+  -> xapi-mcp starts independently
+  -> xurl bridge connects to https://api.x.com/mcp
+  -> mcp-proxy exposes http://xapi-mcp:8080/mcp
+  -> every Hermes profile discovers the same X MCP tool set
+```
+
+## Error handling and security
+
+- `xapi-mcp` has a TCP healthcheck and Hermes depends on it being healthy.
+- Missing client credentials or an empty OAuth cache produce a clear service
+  error; they do not fall back to an unauthenticated endpoint.
+- The service is reachable only on the internal `hermes-browser` network.
+- `.xurl` remains outside Git and is created by the existing Hermes runtime
+  preparation helper.
+- Compose and source-contract tests must reject host port publishing, secret
+  values in committed configuration, and noncanonical profile URLs.
+
+## Verification
+
+- Unit/contract tests cover the Compose service, dependency, mount, healthcheck,
+  command, and all-profile source contract.
+- `docker compose -f docker/hermes-agent/compose.yml config --quiet` validates
+  interpolation and Compose syntax.
+- The pinned bootstrap test stage remains green.
+- With Docker and valid X credentials available, `task hermes:xapi:auth`,
+  `task hermes:up`, and `hermes mcp test xapi` are the runtime smoke path.
+

--- a/docs/superpowers/specs/2026-07-23-hermes-x-mcp-design.md
+++ b/docs/superpowers/specs/2026-07-23-hermes-x-mcp-design.md
@@ -91,4 +91,3 @@ task hermes:bootstrap / task hermes:up
 - The pinned bootstrap test stage remains green.
 - With Docker and valid X credentials available, `task hermes:xapi:auth`,
   `task hermes:up`, and `hermes mcp test xapi` are the runtime smoke path.
-

--- a/scripts/powershell/handlers/Handler.HermesAgent.ps1
+++ b/scripts/powershell/handlers/Handler.HermesAgent.ps1
@@ -6,6 +6,7 @@
 $libPath = Split-Path -Parent $PSScriptRoot
 . (Join-Path $libPath 'lib\Invoke-ExternalCommand.ps1')
 . (Join-Path $libPath 'lib\HermesBootstrap.ps1')
+. (Join-Path $libPath 'lib\HermesXApi.ps1')
 
 class HermesAgentHandler : SetupHandlerBase {
     [int]$DockerCheckTimeoutSeconds = 15
@@ -76,7 +77,18 @@ class HermesAgentHandler : SetupHandlerBase {
                 return $this.CreateFailureResult("Hermes bootstrap failed: $($bootstrap.Message)")
             }
 
-            $start = $this.InvokeCompose($composeFile, @('up', '-d', '--force-recreate'))
+            try {
+                $handler = $this
+                $start = Invoke-HermesXApiCredentialScope -Action {
+                    $handler.InvokeCompose($composeFile, @('up', '-d', '--force-recreate'))
+                }
+            }
+            catch {
+                if ($_.Exception.Message -ne 'Hermes X API credential retrieval failed.') {
+                    throw
+                }
+                return $this.CreateFailureResult('Hermes X API credential retrieval failed.')
+            }
             if (-not $start.Success) {
                 return $this.CreateFailureResult("Hermes Agent startup failed: $($start.Message)")
             }

--- a/scripts/powershell/handlers/Handler.HermesAgent.ps1
+++ b/scripts/powershell/handlers/Handler.HermesAgent.ps1
@@ -61,7 +61,7 @@ class HermesAgentHandler : SetupHandlerBase {
                 return $this.CreateFailureResult("Hermes Compose validation failed: $($validation.Message)")
             }
 
-            $build = $this.InvokeCompose($composeFile, @('build', 'hermes', 'hermes-bootstrap'))
+            $build = $this.InvokeCompose($composeFile, @('build', 'hermes', 'hermes-bootstrap', 'xapi-mcp'))
             if (-not $build.Success) {
                 return $this.CreateFailureResult("Hermes image build failed: $($build.Message)")
             }

--- a/scripts/powershell/hermes-bootstrap.ps1
+++ b/scripts/powershell/hermes-bootstrap.ps1
@@ -252,7 +252,7 @@ function Invoke-HermesBootstrapEntrypoint {
             if ($config.ExitCode -ne 0) { return $config }
 
             $build = Invoke-HermesBootstrapDockerPhase `
-                -Arguments @('compose', '-f', $paths.ComposeFile, 'build', 'hermes', 'hermes-bootstrap') `
+                -Arguments @('compose', '-f', $paths.ComposeFile, 'build', 'hermes', 'hermes-bootstrap', 'xapi-mcp') `
                 -FailureMessage 'Hermes image build failed.'
             if ($build.ExitCode -ne 0) { return $build }
 

--- a/scripts/powershell/hermes-bootstrap.ps1
+++ b/scripts/powershell/hermes-bootstrap.ps1
@@ -15,6 +15,7 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'lib/Invoke-ExternalCommand.ps1')
 . (Join-Path $PSScriptRoot 'lib/HermesBootstrap.ps1')
+. (Join-Path $PSScriptRoot 'lib/HermesXApi.ps1')
 
 function New-HermesBootstrapEntrypointResult {
     [CmdletBinding()]
@@ -280,9 +281,21 @@ function Invoke-HermesBootstrapEntrypoint {
                     -Message $message
             }
 
-            $startup = Invoke-HermesBootstrapDockerPhase `
-                -Arguments @('compose', '-f', $paths.ComposeFile, 'up', '-d', '--force-recreate') `
-                -FailureMessage 'Hermes Compose startup failed.'
+            try {
+                $startup = Invoke-HermesXApiCredentialScope -Action {
+                    Invoke-HermesBootstrapDockerPhase `
+                        -Arguments @('compose', '-f', $paths.ComposeFile, 'up', '-d', '--force-recreate') `
+                        -FailureMessage 'Hermes Compose startup failed.'
+                }
+            }
+            catch {
+                if ($_.Exception.Message -ne 'Hermes X API credential retrieval failed.') {
+                    throw
+                }
+                return New-HermesBootstrapEntrypointResult `
+                    -ExitCode 1 `
+                    -Message 'Hermes X API credential retrieval failed.'
+            }
             if ($startup.ExitCode -ne 0) { return $startup }
 
             if (-not (Wait-HermesBootstrapApi)) {

--- a/scripts/powershell/hermes-xapi.ps1
+++ b/scripts/powershell/hermes-xapi.ps1
@@ -77,10 +77,11 @@ function Invoke-HermesXApiDocker {
 
 try {
     $resolvedComposeFile = Get-HermesXApiComposeFile -ComposeFile $ComposeFile
+    $commandName = $Action
     Initialize-HermesXApiRuntimeHome
 
     $exitCode = Invoke-HermesXApiCredentialScope -Action {
-        switch ($Action) {
+        switch ($commandName) {
             'auth' {
                 Invoke-HermesXApiDocker -Arguments @(
                     'compose', '-f', $resolvedComposeFile,

--- a/scripts/powershell/hermes-xapi.ps1
+++ b/scripts/powershell/hermes-xapi.ps1
@@ -1,0 +1,110 @@
+<#
+.SYNOPSIS
+    Runs Hermes X API MCP lifecycle commands through native Windows Docker.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('auth', 'restart', 'up')]
+    [string]$Action,
+    [string]$ComposeFile = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'lib/Invoke-ExternalCommand.ps1')
+. (Join-Path $PSScriptRoot 'lib/HermesXApi.ps1')
+
+function Get-HermesXApiComposeFile {
+    [CmdletBinding()]
+    param([string]$ComposeFile = '')
+
+    if (-not [string]::IsNullOrWhiteSpace($ComposeFile)) {
+        return [System.IO.Path]::GetFullPath($ComposeFile)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:HERMES_COMPOSE_FILE)) {
+        return [System.IO.Path]::GetFullPath($env:HERMES_COMPOSE_FILE)
+    }
+
+    $repositoryRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
+    return [System.IO.Path]::GetFullPath((Join-Path $repositoryRoot 'docker/hermes-agent/compose.yml'))
+}
+
+function Get-HermesXApiDataDir {
+    [CmdletBinding()]
+    param()
+
+    if (-not [string]::IsNullOrWhiteSpace($env:HERMES_DATA_DIR)) {
+        return [System.IO.Path]::GetFullPath($env:HERMES_DATA_DIR)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:USERPROFILE)) {
+        return [System.IO.Path]::GetFullPath((Join-Path $env:USERPROFILE '.hermes'))
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:HOME)) {
+        return [System.IO.Path]::GetFullPath((Join-Path $env:HOME '.hermes'))
+    }
+
+    $userProfile = [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
+    if ([string]::IsNullOrWhiteSpace($userProfile)) {
+        throw [System.InvalidOperationException]::new('Unable to resolve the current user profile.')
+    }
+    return [System.IO.Path]::GetFullPath((Join-Path $userProfile '.hermes'))
+}
+
+function Initialize-HermesXApiRuntimeHome {
+    [CmdletBinding()]
+    param()
+
+    $dataDir = Get-HermesXApiDataDir
+    foreach ($directory in @($dataDir, (Join-Path $dataDir '.xurl'))) {
+        $null = New-Item -ItemType Directory -Path $directory -Force
+    }
+}
+
+function Invoke-HermesXApiDocker {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Arguments
+    )
+
+    $global:LASTEXITCODE = 0
+    Invoke-Docker -Arguments $Arguments | Out-Host
+    return $global:LASTEXITCODE
+}
+
+try {
+    $resolvedComposeFile = Get-HermesXApiComposeFile -ComposeFile $ComposeFile
+    Initialize-HermesXApiRuntimeHome
+
+    $exitCode = Invoke-HermesXApiCredentialScope -Action {
+        switch ($Action) {
+            'auth' {
+                Invoke-HermesXApiDocker -Arguments @(
+                    'compose', '-f', $resolvedComposeFile,
+                    'run', '--rm', '--no-deps', '--entrypoint', '/bin/sh', 'xapi-mcp',
+                    '-lc', 'CLIENT_ID="$X_API_CLIENT_ID" CLIENT_SECRET="$X_API_CLIENT_SECRET" node_modules/.bin/xurl auth oauth2 --headless'
+                )
+            }
+            'restart' {
+                Invoke-HermesXApiDocker -Arguments @(
+                    'compose', '-f', $resolvedComposeFile,
+                    'up', '-d', '--force-recreate', 'xapi-mcp'
+                )
+            }
+            'up' {
+                Invoke-HermesXApiDocker -Arguments @(
+                    'compose', '-f', $resolvedComposeFile,
+                    'up', '-d', '--force-recreate'
+                )
+            }
+        }
+    }
+    exit $exitCode
+}
+catch {
+    [Console]::Error.WriteLine('Hermes X API lifecycle command failed.')
+    exit 1
+}

--- a/scripts/powershell/lib/HermesXApi.ps1
+++ b/scripts/powershell/lib/HermesXApi.ps1
@@ -1,0 +1,175 @@
+<#
+.SYNOPSIS
+    Reads Hermes X API OAuth credentials from 1Password for PowerShell callers.
+#>
+
+$script:DefaultHermesXApiOnePasswordInvoker = {
+    param(
+        [Parameter(ValueFromRemainingArguments)]
+        [string[]]$Arguments
+    )
+
+    $output = @(& op @Arguments 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        throw [System.InvalidOperationException]::new('Hermes X API 1Password retrieval failed.')
+    }
+    return $output
+}
+
+function ConvertFrom-HermesXApiJson {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Json,
+        [Parameter(Mandatory)]
+        [int]$Depth
+    )
+
+    $command = Get-Command -Name ConvertFrom-Json -CommandType Cmdlet -ErrorAction Stop
+    if ($command.Parameters.ContainsKey('Depth')) {
+        return ($Json | ConvertFrom-Json -Depth $Depth -ErrorAction Stop)
+    }
+    return ($Json | ConvertFrom-Json -ErrorAction Stop)
+}
+
+function ConvertTo-HermesXApiItemObject {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object[]]$Output
+    )
+
+    if ($Output.Count -eq 1 -and $Output[0] -isnot [string]) {
+        return $Output[0]
+    }
+
+    $json = @($Output | ForEach-Object { [string]$_ }) -join "`n"
+    try {
+        return ConvertFrom-HermesXApiJson -Json $json -Depth 64
+    }
+    catch {
+        throw [System.InvalidOperationException]::new('Hermes X API 1Password retrieval failed.')
+    }
+}
+
+function Get-HermesXApiOnePasswordAccount {
+    [CmdletBinding()]
+    param()
+
+    if (-not [string]::IsNullOrWhiteSpace($env:DOTFILES_HERMES_XAPI_1PASSWORD_ACCOUNT)) {
+        return $env:DOTFILES_HERMES_XAPI_1PASSWORD_ACCOUNT
+    }
+    return 'my.1password.com'
+}
+
+function Get-HermesXApiOnePasswordVault {
+    [CmdletBinding()]
+    param()
+
+    if (-not [string]::IsNullOrWhiteSpace($env:DOTFILES_HERMES_XAPI_1PASSWORD_VAULT)) {
+        return $env:DOTFILES_HERMES_XAPI_1PASSWORD_VAULT
+    }
+    return 'openclaw'
+}
+
+function Get-HermesXApiOnePasswordItem {
+    [CmdletBinding()]
+    param()
+
+    if (-not [string]::IsNullOrWhiteSpace($env:DOTFILES_HERMES_XAPI_1PASSWORD_ITEM)) {
+        return $env:DOTFILES_HERMES_XAPI_1PASSWORD_ITEM
+    }
+    return 'Hermes X API MCP'
+}
+
+function Get-HermesXApiItemFieldValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object]$Item,
+        [Parameter(Mandatory)]
+        [string[]]$Labels
+    )
+
+    if ($null -eq $Item -or $null -eq $Item.fields) {
+        throw [System.InvalidOperationException]::new('Hermes X API credential field is missing.')
+    }
+
+    $fields = @($Item.fields | Where-Object {
+            $null -ne $_ -and
+            $_.PSObject.Properties.Name -contains 'label' -and
+            $_.PSObject.Properties.Name -contains 'value' -and
+            $_.label -in $Labels -and
+            $_.value -is [string] -and
+            $_.value.Length -gt 0
+        })
+    if ($fields.Count -ne 1) {
+        throw [System.InvalidOperationException]::new('Hermes X API credential field is missing.')
+    }
+
+    return [string]$fields[0].value
+}
+
+function Get-HermesXApiCredential {
+    [CmdletBinding()]
+    param(
+        [scriptblock]$InvokeOnePassword = $script:DefaultHermesXApiOnePasswordInvoker
+    )
+
+    $account = Get-HermesXApiOnePasswordAccount
+    $vault = Get-HermesXApiOnePasswordVault
+    $itemName = Get-HermesXApiOnePasswordItem
+
+    [void](& $InvokeOnePassword 'signin' '--account' $account)
+    $itemOutput = @(& $InvokeOnePassword 'item' 'get' $itemName '--account' $account '--vault' $vault '--format' 'json')
+    $item = ConvertTo-HermesXApiItemObject -Output $itemOutput
+
+    return [PSCustomObject]@{
+        ClientId     = Get-HermesXApiItemFieldValue -Item $item -Labels @('X_API_CLIENT_ID', 'client_id', 'Client ID')
+        ClientSecret = Get-HermesXApiItemFieldValue -Item $item -Labels @('X_API_CLIENT_SECRET', 'client_secret', 'Client Secret')
+    }
+}
+
+function Invoke-HermesXApiCredentialScope {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [scriptblock]$Action,
+        [scriptblock]$InvokeOnePassword = $script:DefaultHermesXApiOnePasswordInvoker
+    )
+
+    $clientIdPath = 'Env:\X_API_CLIENT_ID'
+    $clientSecretPath = 'Env:\X_API_CLIENT_SECRET'
+    $clientIdExists = Test-Path -LiteralPath $clientIdPath
+    $clientSecretExists = Test-Path -LiteralPath $clientSecretPath
+    $clientIdValue = if ($clientIdExists) { (Get-Item -LiteralPath $clientIdPath).Value } else { $null }
+    $clientSecretValue = if ($clientSecretExists) { (Get-Item -LiteralPath $clientSecretPath).Value } else { $null }
+
+    try {
+        $credential = Get-HermesXApiCredential -InvokeOnePassword $InvokeOnePassword
+    }
+    catch {
+        throw [System.InvalidOperationException]::new('Hermes X API credential retrieval failed.')
+    }
+
+    try {
+        Set-Item -LiteralPath $clientIdPath -Value $credential.ClientId
+        Set-Item -LiteralPath $clientSecretPath -Value $credential.ClientSecret
+        return & $Action
+    }
+    finally {
+        $credential = $null
+        if ($clientIdExists) {
+            Set-Item -LiteralPath $clientIdPath -Value $clientIdValue
+        }
+        else {
+            Remove-Item -LiteralPath $clientIdPath -ErrorAction SilentlyContinue
+        }
+        if ($clientSecretExists) {
+            Set-Item -LiteralPath $clientSecretPath -Value $clientSecretValue
+        }
+        else {
+            Remove-Item -LiteralPath $clientSecretPath -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
+++ b/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
@@ -95,6 +95,11 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             }
         }
 
+        Mock Invoke-HermesXApiCredentialScope {
+            $script:eventLog.Add('xapi-credentials')
+            & $Action
+        }
+
         Mock Invoke-WebRequest {
             [PSCustomObject]@{ StatusCode = 200 }
         }
@@ -126,7 +131,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             -BrowserDataDir $script:browserDir
 
         $result.ExitCode | Should -Be 0
-        $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'up')
+        $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'xapi-credentials', 'up')
         $script:dockerCalls | Should -Be @(
             'info',
             'compose version',
@@ -160,6 +165,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
         Should -Invoke Invoke-HermesBootstrap -Times 1 -Exactly -ParameterFilter {
             $ComposeFile -eq $script:composeFile -and $DataDir -eq $script:dataDir
         }
+        Should -Invoke Invoke-HermesXApiCredentialScope -Times 1 -Exactly
         Should -Invoke Invoke-WebRequest -Times 1 -Exactly -ParameterFilter {
             $Uri -eq 'http://127.0.0.1:8642/health' -and
             $Method -eq 'Get' -and
@@ -427,7 +433,24 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             -BrowserDataDir $script:browserDir
 
         $result.ExitCode | Should -Be 29
-        $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'up')
+        $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'xapi-credentials', 'up')
         $script:dockerCalls[-1] | Should -Be "compose -f $script:composeFile up -d --force-recreate"
+    }
+
+    It 'should fail without exposing X API credentials when credential retrieval fails' {
+        Mock Invoke-HermesXApiCredentialScope {
+            $script:eventLog.Add('xapi-credentials')
+            throw [System.InvalidOperationException]::new('Hermes X API credential retrieval failed.')
+        }
+
+        $result = Invoke-HermesBootstrapEntrypoint `
+            -ComposeFile $script:composeFile `
+            -DataDir $script:dataDir `
+            -BrowserDataDir $script:browserDir
+
+        $result.ExitCode | Should -Be 1
+        $result.Message | Should -Be 'Hermes X API credential retrieval failed.'
+        $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'xapi-credentials')
+        ($script:dockerCalls -join "`n") | Should -Not -Match 'force-recreate'
     }
 }

--- a/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
+++ b/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
@@ -131,7 +131,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             'info',
             'compose version',
             "compose -f $script:composeFile config --quiet",
-            "compose -f $script:composeFile build hermes hermes-bootstrap",
+            "compose -f $script:composeFile build hermes hermes-bootstrap xapi-mcp",
             "compose -f $script:composeFile stop hermes",
             "compose -f $script:composeFile up -d --force-recreate"
         )

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -151,7 +151,7 @@ Describe 'HermesAgentHandler' {
             $browserDir | Should -Exist
             $script:dockerCalls | Should -Be @(
                 "compose -f $script:composeFile config --quiet",
-                "compose -f $script:composeFile build hermes hermes-bootstrap",
+                "compose -f $script:composeFile build hermes hermes-bootstrap xapi-mcp",
                 "compose -f $script:composeFile stop hermes",
                 "compose -f $script:composeFile up -d --force-recreate"
             )
@@ -184,7 +184,7 @@ Describe 'HermesAgentHandler' {
         It 'does not request secrets or recreate services when image build fails' {
             Mock Invoke-Docker {
                 $script:dockerCalls.Add(($Arguments -join ' '))
-                if ($Arguments[-1] -eq 'hermes-bootstrap') {
+                if ($Arguments[-1] -eq 'xapi-mcp') {
                     $global:LASTEXITCODE = 18
                     return 'build failure'
                 }

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -4,6 +4,7 @@ BeforeAll {
     . $PSScriptRoot/../../lib/SetupHandler.ps1
     . $PSScriptRoot/../../lib/Invoke-ExternalCommand.ps1
     . $PSScriptRoot/../../lib/HermesBootstrap.ps1
+    . $PSScriptRoot/../../lib/HermesXApi.ps1
     . $PSScriptRoot/../../handlers/Handler.NixOSWSL.ps1
     . $PSScriptRoot/../../handlers/Handler.NixRebuild.ps1
     . $PSScriptRoot/../../handlers/Handler.HermesAgent.ps1
@@ -56,6 +57,10 @@ Describe 'HermesAgentHandler' {
         Mock Invoke-HermesBootstrap {
             $script:eventLog.Add('bootstrap')
             [PSCustomObject]@{ Success = $true; Changed = $true; Message = 'Hermes bootstrap completed.' }
+        }
+        Mock Invoke-HermesXApiCredentialScope {
+            $script:eventLog.Add('xapi-credentials')
+            & $Action
         }
         Mock Invoke-WebRequest {
             $script:readinessAttempts++
@@ -155,7 +160,7 @@ Describe 'HermesAgentHandler' {
                 "compose -f $script:composeFile stop hermes",
                 "compose -f $script:composeFile up -d --force-recreate"
             )
-            $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'up', 'health')
+            $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'xapi-credentials', 'up', 'health')
             Should -Invoke Invoke-WebRequest -Times 1 -Exactly -ParameterFilter {
                 $Uri -eq 'http://127.0.0.1:8642/health' -and
                 $Method -eq 'Get' -and
@@ -164,6 +169,7 @@ Describe 'HermesAgentHandler' {
             Should -Invoke Invoke-HermesBootstrap -Times 1 -Exactly -ParameterFilter {
                 $ComposeFile -eq $script:composeFile -and $DataDir -eq $dataDir
             }
+            Should -Invoke Invoke-HermesXApiCredentialScope -Times 1 -Exactly
         }
 
         It 'does not bootstrap or recreate services when compose validation fails' {
@@ -253,6 +259,20 @@ Describe 'HermesAgentHandler' {
             $result.Message | Should -Match 'startup failure'
             $script:dockerCalls[-1] | Should -Be "compose -f $script:composeFile up -d --force-recreate"
             $script:dockerCalls | Should -Contain "compose -f $script:composeFile stop hermes"
+        }
+
+        It 'fails without exposing X API credentials when credential retrieval fails' {
+            Mock Invoke-HermesXApiCredentialScope {
+                $script:eventLog.Add('xapi-credentials')
+                throw [System.InvalidOperationException]::new('Hermes X API credential retrieval failed.')
+            }
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -BeFalse
+            $result.Message | Should -Be 'Hermes X API credential retrieval failed.'
+            $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'xapi-credentials')
+            $script:dockerCalls | Should -Not -Contain "compose -f $script:composeFile up -d --force-recreate"
         }
 
         It 'waits through transient API failures before reporting startup success' {
@@ -348,7 +368,7 @@ Describe 'HermesAgentHandler' {
 
             $result.Success | Should -BeFalse
             $result.Message | Should -Be 'Hermes Agent setup failed.'
-            $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'up')
+            $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'xapi-credentials', 'up')
         }
 
         It 'propagates migration exit code 5 without starting services or writing host content' {
@@ -396,6 +416,7 @@ $libPath = Join-Path $RepositoryRoot 'scripts/powershell/lib'
 . (Join-Path $libPath 'SetupHandler.ps1')
 . (Join-Path $libPath 'Invoke-ExternalCommand.ps1')
 . (Join-Path $libPath 'HermesBootstrap.ps1')
+. (Join-Path $libPath 'HermesXApi.ps1')
 
 $handlersPath = Join-Path $RepositoryRoot 'scripts/powershell/handlers'
 $handlers = Get-SetupHandler -HandlersPath $handlersPath
@@ -403,8 +424,11 @@ $hermes = @($handlers | Where-Object { $_.Name -eq 'HermesAgent' })
 if ($hermes.Count -ne 1) { throw "Expected one Hermes handler, found $($hermes.Count)." }
 
 $adapter = Get-Command Invoke-HermesBootstrap -CommandType Function -ErrorAction Stop
+$xapiAdapter = Get-Command Invoke-HermesXApiCredentialScope -CommandType Function -ErrorAction Stop
 $expectedAdapterPath = (Resolve-Path -LiteralPath (Join-Path $libPath 'HermesBootstrap.ps1')).Path
+$expectedXApiAdapterPath = (Resolve-Path -LiteralPath (Join-Path $libPath 'HermesXApi.ps1')).Path
 $actualAdapterPath = (Resolve-Path -LiteralPath $adapter.ScriptBlock.File).Path
+$actualXApiAdapterPath = (Resolve-Path -LiteralPath $xapiAdapter.ScriptBlock.File).Path
 $types = @(
     ('HermesBootstrapBoundedDrain' -as [type]),
     ('HermesBootstrapErrorHistory' -as [type])
@@ -416,6 +440,7 @@ $types = @(
     Phase = $hermes[0].Phase
     Order = $hermes[0].Order
     AdapterIsActual = $actualAdapterPath -eq $expectedAdapterPath
+    XApiAdapterIsActual = $actualXApiAdapterPath -eq $expectedXApiAdapterPath
     BootstrapTypeCount = @($types | Where-Object { $null -ne $_ }).Count
 } | ConvertTo-Json -Compress
 '@
@@ -432,6 +457,7 @@ $types = @(
             $loaded.Phase | Should -Be 2
             $loaded.Order | Should -Be 56
             $loaded.AdapterIsActual | Should -BeTrue
+            $loaded.XApiAdapterIsActual | Should -BeTrue
             $loaded.BootstrapTypeCount | Should -Be 2
         }
 

--- a/scripts/powershell/tests/lib/HermesXApi.Tests.ps1
+++ b/scripts/powershell/tests/lib/HermesXApi.Tests.ps1
@@ -1,0 +1,137 @@
+BeforeAll {
+    . $PSScriptRoot/../../lib/HermesXApi.ps1
+
+    function Get-HermesXApiTestEnvironmentVariableState {
+        param([Parameter(Mandatory)][string]$Name)
+
+        $path = "Env:\$Name"
+        return [PSCustomObject]@{
+            Exists = Test-Path -LiteralPath $path
+            Value  = [Environment]::GetEnvironmentVariable($Name, 'Process')
+        }
+    }
+
+    function Restore-HermesXApiTestEnvironmentVariable {
+        param(
+            [Parameter(Mandatory)][string]$Name,
+            [Parameter(Mandatory)][PSCustomObject]$State
+        )
+
+        $path = "Env:\$Name"
+        if ($State.Exists) {
+            Set-Item -LiteralPath $path -Value $State.Value
+        }
+        else {
+            Remove-Item -LiteralPath $path -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Describe 'Hermes X API PowerShell credentials' {
+    BeforeEach {
+        $script:opCalls = [System.Collections.Generic.List[string]]::new()
+        $script:originalClientId = Get-HermesXApiTestEnvironmentVariableState -Name 'X_API_CLIENT_ID'
+        $script:originalClientSecret = Get-HermesXApiTestEnvironmentVariableState -Name 'X_API_CLIENT_SECRET'
+        $script:originalAccount = Get-HermesXApiTestEnvironmentVariableState -Name 'DOTFILES_HERMES_XAPI_1PASSWORD_ACCOUNT'
+        $script:originalVault = Get-HermesXApiTestEnvironmentVariableState -Name 'DOTFILES_HERMES_XAPI_1PASSWORD_VAULT'
+        $script:originalItem = Get-HermesXApiTestEnvironmentVariableState -Name 'DOTFILES_HERMES_XAPI_1PASSWORD_ITEM'
+        foreach ($name in @(
+                'X_API_CLIENT_ID',
+                'X_API_CLIENT_SECRET',
+                'DOTFILES_HERMES_XAPI_1PASSWORD_ACCOUNT',
+                'DOTFILES_HERMES_XAPI_1PASSWORD_VAULT',
+                'DOTFILES_HERMES_XAPI_1PASSWORD_ITEM'
+            )) {
+            Remove-Item -LiteralPath "Env:\$name" -ErrorAction SilentlyContinue
+        }
+    }
+
+    AfterEach {
+        Restore-HermesXApiTestEnvironmentVariable -Name 'X_API_CLIENT_ID' -State $script:originalClientId
+        Restore-HermesXApiTestEnvironmentVariable -Name 'X_API_CLIENT_SECRET' -State $script:originalClientSecret
+        Restore-HermesXApiTestEnvironmentVariable `
+            -Name 'DOTFILES_HERMES_XAPI_1PASSWORD_ACCOUNT' `
+            -State $script:originalAccount
+        Restore-HermesXApiTestEnvironmentVariable `
+            -Name 'DOTFILES_HERMES_XAPI_1PASSWORD_VAULT' `
+            -State $script:originalVault
+        Restore-HermesXApiTestEnvironmentVariable `
+            -Name 'DOTFILES_HERMES_XAPI_1PASSWORD_ITEM' `
+            -State $script:originalItem
+    }
+
+    It 'loads the canonical 1Password item and restores existing process credentials' {
+        Set-Item -LiteralPath Env:\X_API_CLIENT_ID -Value 'original-client-id'
+        Set-Item -LiteralPath Env:\X_API_CLIENT_SECRET -Value 'original-client-secret'
+        $invoker = {
+            param([Parameter(ValueFromRemainingArguments)][string[]]$Arguments)
+
+            $script:opCalls.Add(($Arguments -join '|'))
+            if ($Arguments[0] -eq 'signin') {
+                return @('signed in')
+            }
+            return @(
+                '{"fields":[',
+                '{"label":"X_API_CLIENT_ID","value":"xapi-client-id-marker"},',
+                '{"label":"X_API_CLIENT_SECRET","value":"xapi-client-secret-marker"}',
+                ']}'
+            )
+        }
+
+        $inside = Invoke-HermesXApiCredentialScope -InvokeOnePassword $invoker -Action {
+            [PSCustomObject]@{
+                ClientId     = $env:X_API_CLIENT_ID
+                ClientSecret = $env:X_API_CLIENT_SECRET
+            }
+        }
+
+        $inside.ClientId | Should -Be 'xapi-client-id-marker'
+        $inside.ClientSecret | Should -Be 'xapi-client-secret-marker'
+        $env:X_API_CLIENT_ID | Should -Be 'original-client-id'
+        $env:X_API_CLIENT_SECRET | Should -Be 'original-client-secret'
+        $script:opCalls | Should -Be @(
+            'signin|--account|my.1password.com',
+            'item|get|Hermes X API MCP|--account|my.1password.com|--vault|openclaw|--format|json'
+        )
+    }
+
+    It 'accepts configured item coordinates and alternate field labels' {
+        $env:DOTFILES_HERMES_XAPI_1PASSWORD_ACCOUNT = 'team.1password.com'
+        $env:DOTFILES_HERMES_XAPI_1PASSWORD_VAULT = 'ops'
+        $env:DOTFILES_HERMES_XAPI_1PASSWORD_ITEM = 'custom x item'
+        $invoker = {
+            param([Parameter(ValueFromRemainingArguments)][string[]]$Arguments)
+
+            $script:opCalls.Add(($Arguments -join '|'))
+            if ($Arguments[0] -eq 'signin') {
+                return @('signed in')
+            }
+            return @('{"fields":[{"label":"Client ID","value":"custom-id"},{"label":"client_secret","value":"custom-secret"}]}')
+        }
+
+        $credential = Get-HermesXApiCredential -InvokeOnePassword $invoker
+
+        $credential.ClientId | Should -Be 'custom-id'
+        $credential.ClientSecret | Should -Be 'custom-secret'
+        $script:opCalls | Should -Be @(
+            'signin|--account|team.1password.com',
+            'item|get|custom x item|--account|team.1password.com|--vault|ops|--format|json'
+        )
+    }
+
+    It 'fails closed when a required field is missing and leaves env unset' {
+        $invoker = {
+            param([Parameter(ValueFromRemainingArguments)][string[]]$Arguments)
+
+            if ($Arguments[0] -eq 'signin') {
+                return @('signed in')
+            }
+            return @('{"fields":[{"label":"X_API_CLIENT_ID","value":"client-only"}]}')
+        }
+
+        { Invoke-HermesXApiCredentialScope -InvokeOnePassword $invoker -Action { 'should not run' } } |
+            Should -Throw
+        (Test-Path -LiteralPath Env:\X_API_CLIENT_ID) | Should -BeFalse
+        (Test-Path -LiteralPath Env:\X_API_CLIENT_SECRET) | Should -BeFalse
+    }
+}

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -215,7 +215,7 @@ dotfiles_hermes_start_stack() {
     dotfiles_hermes_show_compose_diagnostics "$docker_runner" "$compose_file"
     return "$status"
   fi
-  if "$docker_runner" compose -f "$compose_file" build hermes hermes-bootstrap; then
+  if "$docker_runner" compose -f "$compose_file" build hermes hermes-bootstrap xapi-mcp; then
     :
   else
     status=$?

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -46,6 +46,71 @@ dotfiles_hermes_require_secret_tools() {
   dotfiles_have curl || dotfiles_die "curl is required for Hermes readiness checks."
 }
 
+dotfiles_hermes_xapi_secret_item() {
+  printf '%s\n' "${DOTFILES_HERMES_XAPI_1PASSWORD_ITEM:-Hermes X API MCP}"
+}
+
+dotfiles_hermes_xapi_secret_account() {
+  printf '%s\n' "${DOTFILES_HERMES_XAPI_1PASSWORD_ACCOUNT:-my.1password.com}"
+}
+
+dotfiles_hermes_xapi_secret_vault() {
+  printf '%s\n' "${DOTFILES_HERMES_XAPI_1PASSWORD_VAULT:-openclaw}"
+}
+
+dotfiles_hermes_extract_xapi_credentials() {
+  jq -e -c '
+    def field($labels):
+      .fields
+      | map(select((.label // "") as $label | $labels | index($label)))
+      | if length == 1 and (.[0].value | type == "string" and length > 0)
+        then .[0].value
+        else error("missing required X API OAuth field")
+        end;
+    {
+      client_id: field(["X_API_CLIENT_ID", "client_id", "Client ID"]),
+      client_secret: field(["X_API_CLIENT_SECRET", "client_secret", "Client Secret"])
+    }
+  '
+}
+
+dotfiles_hermes_read_xapi_credentials() {
+  local op_command account vault item
+  op_command="$(dotfiles_hermes_op_command)" || return 1
+  account="$(dotfiles_hermes_xapi_secret_account)"
+  vault="$(dotfiles_hermes_xapi_secret_vault)"
+  item="$(dotfiles_hermes_xapi_secret_item)"
+
+  "$op_command" signin --account "$account" >/dev/null
+  "$op_command" item get "$item" --account "$account" --vault "$vault" --format json |
+    dotfiles_hermes_extract_xapi_credentials
+}
+
+dotfiles_hermes_with_xapi_credentials() {
+  local credentials client_id client_secret status=0 xtrace_enabled=0
+
+  dotfiles_hermes_op_command >/dev/null ||
+    dotfiles_die "1Password CLI (op) is required for Hermes X API credentials."
+  dotfiles_have jq || dotfiles_die "jq is required for Hermes X API credentials."
+
+  if [[ $- == *x* ]]; then
+    xtrace_enabled=1
+    set +x
+  fi
+  if credentials="$(dotfiles_hermes_read_xapi_credentials)" &&
+    client_id="$(printf '%s\n' "$credentials" | jq -r '.client_id')" &&
+    client_secret="$(printf '%s\n' "$credentials" | jq -r '.client_secret')"; then
+    X_API_CLIENT_ID="$client_id" X_API_CLIENT_SECRET="$client_secret" "$@" || status=$?
+  else
+    status=1
+  fi
+  unset credentials client_id client_secret
+  if ((xtrace_enabled)); then
+    set -x
+  fi
+  return "$status"
+}
+
 dotfiles_hermes_validate_secret_plan() {
   jq -Ssce '
     if length == 1 and (.[0] | type == "object") then .[0] else false end
@@ -236,7 +301,7 @@ dotfiles_hermes_start_stack() {
     dotfiles_hermes_show_compose_diagnostics "$docker_runner" "$compose_file"
     return "$status"
   fi
-  if "$docker_runner" compose -f "$compose_file" up -d --force-recreate; then
+  if dotfiles_hermes_with_xapi_credentials "$docker_runner" compose -f "$compose_file" up -d --force-recreate; then
     :
   else
     status=$?

--- a/scripts/sh/hermes-xapi.sh
+++ b/scripts/sh/hermes-xapi.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd -P)"
+
+. "$SCRIPT_DIR/install-common.sh"
+. "$SCRIPT_DIR/hermes-agent.sh"
+
+compose_file="${HERMES_COMPOSE_FILE:-$REPO_ROOT/docker/hermes-agent/compose.yml}"
+command_name="${1:-}"
+
+case "$command_name" in
+auth)
+  dotfiles_hermes_prepare_runtime_home
+  dotfiles_hermes_with_xapi_credentials \
+    docker compose -f "$compose_file" run --rm --no-deps --entrypoint /bin/sh xapi-mcp \
+    -lc 'CLIENT_ID="$X_API_CLIENT_ID" CLIENT_SECRET="$X_API_CLIENT_SECRET" node_modules/.bin/xurl auth oauth2 --headless'
+  ;;
+restart)
+  dotfiles_hermes_prepare_runtime_home
+  dotfiles_hermes_with_xapi_credentials \
+    docker compose -f "$compose_file" up -d --force-recreate xapi-mcp
+  ;;
+up)
+  dotfiles_hermes_prepare_runtime_home
+  dotfiles_hermes_with_xapi_credentials \
+    docker compose -f "$compose_file" up -d --force-recreate
+  ;;
+*)
+  printf 'Usage: %s {auth|restart|up}\n' "$0" >&2
+  exit 64
+  ;;
+esac

--- a/tests/bash/bootstrap_acceptance.bats
+++ b/tests/bash/bootstrap_acceptance.bats
@@ -76,6 +76,17 @@ EOF
 	[ "$status" -eq 0 ]
 	[[ "$output" == *'"id":"acceptance-SlackBot-Nancy"'* ]]
 
+	run "$op" signin --account my.1password.com
+	[ "$status" -eq 0 ]
+	[[ "$output" == 'acceptance-session' ]]
+
+	run "$op" item get "Hermes X API MCP" \
+		--account my.1password.com --vault openclaw --format json
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'"id":"acceptance-Hermes X API MCP"'* ]]
+	[[ "$output" == *'"label":"X_API_CLIENT_ID"'* ]]
+	[[ "$output" == *'"label":"X_API_CLIENT_SECRET"'* ]]
+
 	run "$op" item get "Unapproved Item" \
 		--account my.1password.com --vault openclaw --format json
 	[ "$status" -ne 0 ]
@@ -86,6 +97,7 @@ EOF
 
 	grep -Fq 'exec /bin/httpd -f -p 80 -h /www' "$compose"
 	grep -Fq "exec nginx -g 'daemon off;'" "$compose"
+	grep -Fq 'xapi-mcp:' "$compose"
 	grep -Fq './hermes-bootstrap-fixture.sh:/usr/share/nginx/html/health:ro' "$compose"
 	grep -Fq './hermes-bootstrap-fixture.sh:/www/health:ro' "$compose"
 }

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -526,7 +526,7 @@ dotfiles_hermes_start_stack docker "$COMPOSE_FILE"
 	run_start_stack
 
 	[ "$status" -eq 0 ]
-	assert_log_order '<config> <--quiet>' '<build> <hermes> <hermes-bootstrap>' '<stop> <hermes>' '<secret-plan>' '<apply>' '<Hermes Agent Dashboard>' '<GitHubUsedOpenClawPAT>' '<SlackBot-OpenClaw>' '<SlackBot-Rick>' '<SlackBot-Hoffman>' '<SlackBot-Risarisa>' '<SlackBot-Nancy>' '<Hermes X API MCP>' '<up> <-d> <--force-recreate>'
+	assert_log_order '<config> <--quiet>' '<build> <hermes> <hermes-bootstrap> <xapi-mcp>' '<stop> <hermes>' '<secret-plan>' '<apply>' '<Hermes Agent Dashboard>' '<GitHubUsedOpenClawPAT>' '<SlackBot-OpenClaw>' '<SlackBot-Rick>' '<SlackBot-Hoffman>' '<SlackBot-Risarisa>' '<SlackBot-Nancy>' '<Hermes X API MCP>' '<up> <-d> <--force-recreate>'
 	[ "$(grep -c '^op ' "$COMMAND_LOG")" -eq 9 ]
 	mapfile -t records < <("$REAL_JQ" -r '.type + ":" + (.key // "")' "$PAYLOAD_CAPTURE")
 	[ "${records[*]}" = 'header: item:dashboard item:github item:slack_default item:slack_rick item:slack_hoffman item:slack_risarisa item:slack_nancy end:' ]

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -20,6 +20,7 @@ setup() {
 	export COMMAND_LOG PAYLOAD_CAPTURE READY_ATTEMPT_FILE COMPOSE_FILE REAL_JQ SECRET_MARKER
 	export PLAN_JSON="$(valid_secret_plan)"
 	export OP_ITEM_JSON='{"id":"item-id","fields":[{"label":"credential","value":"adapter-secret-marker"}]}'
+	export XAPI_OP_ITEM_JSON='{"id":"xapi-item","fields":[{"label":"X_API_CLIENT_ID","value":"xapi-client-id-marker"},{"label":"X_API_CLIENT_SECRET","value":"xapi-client-secret-marker"}]}'
 	export BOOTSTRAP_STATUS=0
 	export OP_FAIL_ITEM=""
 	export OP_DELAY_SECONDS=0
@@ -42,7 +43,11 @@ fi
 if [[ $OP_DELAY_SECONDS != 0 ]]; then
 	/bin/sleep "$OP_DELAY_SECONDS"
 fi
-printf "%s\n" "$OP_ITEM_JSON"
+if [ "${3:-}" = "Hermes X API MCP" ]; then
+	printf "%s\n" "$XAPI_OP_ITEM_JSON"
+else
+	printf "%s\n" "$OP_ITEM_JSON"
+fi
 '
 	write_stub docker '
 printf "docker" >>"$COMMAND_LOG"
@@ -389,6 +394,22 @@ dotfiles_hermes_browser_data_dir
 	[ "$output" = "$TEST_HOME/custom-data/.browser" ]
 }
 
+@test "injects X API OAuth credentials from 1Password for explicit wrapper commands" {
+	export XAPI_OP_ITEM_JSON='{"id":"xapi-item","fields":[{"label":"X_API_CLIENT_ID","value":"xapi-client-id-marker"},{"label":"X_API_CLIENT_SECRET","value":"xapi-client-secret-marker"}]}'
+
+	run bash -c '
+set -euo pipefail
+. "$REPO_ROOT/scripts/sh/install-common.sh"
+. "$REPO_ROOT/scripts/sh/hermes-agent.sh"
+dotfiles_hermes_with_xapi_credentials bash -c '"'"'printf "%s:%s\n" "$X_API_CLIENT_ID" "$X_API_CLIENT_SECRET"'"'"'
+'
+
+	[ "$status" -eq 0 ]
+	[ "$output" = "xapi-client-id-marker:xapi-client-secret-marker" ]
+	grep -q '^op <item> <get> <Hermes X API MCP> <--account> <my.1password.com> <--vault> <openclaw> <--format> <json>$' "$COMMAND_LOG"
+	! grep -q 'xapi-client-secret-marker' "$COMMAND_LOG"
+}
+
 @test "fails preflight before Compose when op is unavailable" {
 	run_start_stack op
 
@@ -505,8 +526,8 @@ dotfiles_hermes_start_stack docker "$COMPOSE_FILE"
 	run_start_stack
 
 	[ "$status" -eq 0 ]
-	assert_log_order '<config> <--quiet>' '<build> <hermes> <hermes-bootstrap>' '<stop> <hermes>' '<secret-plan>' '<apply>' '<Hermes Agent Dashboard>' '<GitHubUsedOpenClawPAT>' '<SlackBot-OpenClaw>' '<SlackBot-Rick>' '<SlackBot-Hoffman>' '<SlackBot-Risarisa>' '<SlackBot-Nancy>' '<up> <-d> <--force-recreate>'
-	[ "$(grep -c '^op ' "$COMMAND_LOG")" -eq 7 ]
+	assert_log_order '<config> <--quiet>' '<build> <hermes> <hermes-bootstrap>' '<stop> <hermes>' '<secret-plan>' '<apply>' '<Hermes Agent Dashboard>' '<GitHubUsedOpenClawPAT>' '<SlackBot-OpenClaw>' '<SlackBot-Rick>' '<SlackBot-Hoffman>' '<SlackBot-Risarisa>' '<SlackBot-Nancy>' '<Hermes X API MCP>' '<up> <-d> <--force-recreate>'
+	[ "$(grep -c '^op ' "$COMMAND_LOG")" -eq 9 ]
 	mapfile -t records < <("$REAL_JQ" -r '.type + ":" + (.key // "")' "$PAYLOAD_CAPTURE")
 	[ "${records[*]}" = 'header: item:dashboard item:github item:slack_default item:slack_rick item:slack_hoffman item:slack_risarisa item:slack_nancy end:' ]
 	"$REAL_JQ" -e -c 'select(.type == "item") | .item.id == "item-id"' "$PAYLOAD_CAPTURE" >/dev/null

--- a/tests/bash/install_linux.bats
+++ b/tests/bash/install_linux.bats
@@ -160,7 +160,7 @@ assert_log_order() {
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet" \
-		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build hermes hermes-bootstrap" \
+		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build hermes hermes-bootstrap xapi-mcp" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap secret-plan" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap apply" \

--- a/tests/bash/install_linux.bats
+++ b/tests/bash/install_linux.bats
@@ -24,6 +24,7 @@ setup() {
 	export COMMAND_LOG STUB_BIN PAYLOAD_CAPTURE REAL_JQ
 	export HERMES_SECRET_PLAN="$(valid_secret_plan)"
 	export HERMES_ITEM_JSON='{"id":"fixture-item","fields":[]}'
+	export HERMES_XAPI_ITEM_JSON='{"id":"xapi-item","fields":[{"label":"X_API_CLIENT_ID","value":"xapi-client-id-marker"},{"label":"X_API_CLIENT_SECRET","value":"xapi-client-secret-marker"}]}'
 	export HERMES_BOOTSTRAP_STATUS=0
 	export DOTFILES_NIX_PROFILE_SCRIPT="$FAKE_NIX_PROFILE"
 	export DOTFILES_SYSTEMD_DIR="$FAKE_SYSTEMD_DIR"
@@ -65,7 +66,11 @@ exit 0
 	write_stub jq 'exec "$REAL_JQ" "$@"'
 	write_stub op '
 printf "op %s\n" "$*" >>"$COMMAND_LOG"
-printf "%s\n" "$HERMES_ITEM_JSON"
+if [ "${3:-}" = "Hermes X API MCP" ]; then
+	printf "%s\n" "$HERMES_XAPI_ITEM_JSON"
+else
+	printf "%s\n" "$HERMES_ITEM_JSON"
+fi
 '
 	write_stub docker '
 printf "docker %s\n" "$*" >>"$COMMAND_LOG"
@@ -161,7 +166,8 @@ assert_log_order() {
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap apply" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml up -d --force-recreate" \
 		"verify-environment --runtime"
-	[ "$(grep -c '^op item get ' "$COMMAND_LOG")" -eq 7 ]
+	[ "$(grep -c '^op item get ' "$COMMAND_LOG")" -eq 8 ]
+	[ "$(grep -c '^op signin --account my.1password.com$' "$COMMAND_LOG")" -eq 1 ]
 	[ -s "$PAYLOAD_CAPTURE" ]
 }
 

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -198,7 +198,7 @@ assert_log_order() {
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet" \
-		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build hermes hermes-bootstrap" \
+		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build hermes hermes-bootstrap xapi-mcp" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap secret-plan" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap apply" \

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -26,6 +26,7 @@ setup() {
 	export COMMAND_LOG STUB_BIN PAYLOAD_CAPTURE REAL_JQ
 	export HERMES_SECRET_PLAN="$(valid_secret_plan)"
 	export HERMES_ITEM_JSON='{"id":"fixture-item","fields":[]}'
+	export HERMES_XAPI_ITEM_JSON='{"id":"xapi-item","fields":[{"label":"X_API_CLIENT_ID","value":"xapi-client-id-marker"},{"label":"X_API_CLIENT_SECRET","value":"xapi-client-secret-marker"}]}'
 	export HERMES_BOOTSTRAP_STATUS=0
 	export DOTFILES_DOCKER_APP_PATH="$FAKE_DOCKER_APP"
 	export DOTFILES_DOCKER_SETUP_MARKER="$TEST_HOME/.config/dotfiles/docker-desktop-installed"
@@ -70,7 +71,11 @@ exec "$@"
 	write_stub jq 'exec "$REAL_JQ" "$@"'
 	write_stub op '
 printf "op %s\n" "$*" >>"$COMMAND_LOG"
-printf "%s\n" "$HERMES_ITEM_JSON"
+if [ "${3:-}" = "Hermes X API MCP" ]; then
+	printf "%s\n" "$HERMES_XAPI_ITEM_JSON"
+else
+	printf "%s\n" "$HERMES_ITEM_JSON"
+fi
 '
 }
 
@@ -199,7 +204,8 @@ assert_log_order() {
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap apply" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml up -d --force-recreate" \
 		"verify-environment --runtime"
-	[ "$(grep -c '^op item get ' "$COMMAND_LOG")" -eq 7 ]
+	[ "$(grep -c '^op item get ' "$COMMAND_LOG")" -eq 8 ]
+	[ "$(grep -c '^op signin --account my.1password.com$' "$COMMAND_LOG")" -eq 1 ]
 	[ -s "$PAYLOAD_CAPTURE" ]
 	! grep -q 'brew install --cask' "$COMMAND_LOG"
 	! grep -q 'desktop.docker.com/mac' "$COMMAND_LOG"

--- a/tests/bash/install_nixos.bats
+++ b/tests/bash/install_nixos.bats
@@ -121,8 +121,8 @@ line_of() {
 	grep -q "DOTFILES_NIXOS_HARDWARE_CONFIG=$HARDWARE_CONFIG" "$COMMAND_LOG"
 	[ "$(line_of nixos-rebuild)" -lt "$(line_of 'chezmoi init')" ]
 	[ "$(line_of 'chezmoi apply')" -lt "$(line_of 'docker compose')" ]
-	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build hermes hermes-bootstrap")" ]
-	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build hermes hermes-bootstrap")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes")" ]
+	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build hermes hermes-bootstrap xapi-mcp")" ]
+	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build hermes hermes-bootstrap xapi-mcp")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes")" ]
 	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes")" -lt "$(line_of 'hermes-bootstrap secret-plan')" ]
 	[ "$(line_of 'hermes-bootstrap secret-plan')" -lt "$(line_of 'hermes-bootstrap apply')" ]
 	[ "$(line_of 'hermes-bootstrap apply')" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml up -d --force-recreate")" ]

--- a/tests/bash/install_nixos.bats
+++ b/tests/bash/install_nixos.bats
@@ -23,6 +23,7 @@ setup() {
 	export COMMAND_LOG STUB_BIN PAYLOAD_CAPTURE REAL_JQ
 	export HERMES_SECRET_PLAN="$(valid_secret_plan)"
 	export HERMES_ITEM_JSON='{"id":"fixture-item","fields":[]}'
+	export HERMES_XAPI_ITEM_JSON='{"id":"xapi-item","fields":[{"label":"X_API_CLIENT_ID","value":"xapi-client-id-marker"},{"label":"X_API_CLIENT_SECRET","value":"xapi-client-secret-marker"}]}'
 	export HERMES_BOOTSTRAP_STATUS=0
 	export DOTFILES_NIXOS_MARKER="$NIXOS_MARKER"
 	export DOTFILES_CURRENT_SYSTEM_PATH="$CURRENT_SYSTEM"
@@ -65,7 +66,11 @@ exec "$@"
 	write_stub jq 'exec "$REAL_JQ" "$@"'
 	write_stub op '
 printf "op %s\n" "$*" >>"$COMMAND_LOG"
-printf "%s\n" "$HERMES_ITEM_JSON"
+if [ "${3:-}" = "Hermes X API MCP" ]; then
+	printf "%s\n" "$HERMES_XAPI_ITEM_JSON"
+else
+	printf "%s\n" "$HERMES_ITEM_JSON"
+fi
 '
 	write_stub docker '
 printf "docker %s\n" "$*" >>"$COMMAND_LOG"
@@ -123,7 +128,8 @@ line_of() {
 	[ "$(line_of 'hermes-bootstrap apply')" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml up -d --force-recreate")" ]
 	[ "$(line_of 'docker compose')" -lt "$(line_of verify-environment)" ]
 	grep -q '^verify-environment layer=nixos args=--runtime$' "$COMMAND_LOG"
-	[ "$(grep -c '^op item get ' "$COMMAND_LOG")" -eq 7 ]
+	[ "$(grep -c '^op item get ' "$COMMAND_LOG")" -eq 8 ]
+	[ "$(grep -c '^op signin --account my.1password.com$' "$COMMAND_LOG")" -eq 1 ]
 	[ -s "$PAYLOAD_CAPTURE" ]
 }
 

--- a/tests/python/test_taskfile_contract.py
+++ b/tests/python/test_taskfile_contract.py
@@ -23,6 +23,10 @@ class TaskfileContractTests(unittest.TestCase):
             self._command_text("hermes:xapi:auth"),
         )
         self.assertIn(
+            'CLIENT_ID="$X_API_CLIENT_ID" CLIENT_SECRET="$X_API_CLIENT_SECRET"',
+            self._command_text("hermes:xapi:auth"),
+        )
+        self.assertIn(
             "up -d --force-recreate xapi-mcp",
             self._command_text("hermes:xapi:restart"),
         )

--- a/tests/python/test_taskfile_contract.py
+++ b/tests/python/test_taskfile_contract.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import yaml
 
 
-REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 TASKFILE = REPOSITORY_ROOT / "Taskfile.yml"
 
 

--- a/tests/python/test_taskfile_contract.py
+++ b/tests/python/test_taskfile_contract.py
@@ -12,6 +12,7 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 TASKFILE = REPOSITORY_ROOT / "Taskfile.yml"
 HERMES_AGENT = REPOSITORY_ROOT / "scripts" / "sh" / "hermes-agent.sh"
 XAPI_WRAPPER = REPOSITORY_ROOT / "scripts" / "sh" / "hermes-xapi.sh"
+XAPI_WINDOWS_WRAPPER = REPOSITORY_ROOT / "scripts" / "powershell" / "hermes-xapi.ps1"
 
 
 class TaskfileContractTests(unittest.TestCase):
@@ -25,11 +26,23 @@ class TaskfileContractTests(unittest.TestCase):
             self._command_text("hermes:xapi:auth"),
         )
         self.assertIn(
+            "scripts/powershell/hermes-xapi.ps1 -Action auth",
+            self._command_text("hermes:xapi:auth"),
+        )
+        self.assertIn(
             "scripts/sh/hermes-xapi.sh restart",
             self._command_text("hermes:xapi:restart"),
         )
         self.assertIn(
+            "scripts/powershell/hermes-xapi.ps1 -Action restart",
+            self._command_text("hermes:xapi:restart"),
+        )
+        self.assertIn(
             "scripts/sh/hermes-xapi.sh up",
+            self._command_text("hermes:up"),
+        )
+        self.assertIn(
+            "scripts/powershell/hermes-xapi.ps1 -Action up",
             self._command_text("hermes:up"),
         )
         self.assertIn(
@@ -53,12 +66,19 @@ class TaskfileContractTests(unittest.TestCase):
 
     def test_xapi_lifecycle_reads_oauth_credentials_from_1password(self) -> None:
         wrapper = XAPI_WRAPPER.read_text(encoding="utf-8")
+        windows_wrapper = XAPI_WINDOWS_WRAPPER.read_text(encoding="utf-8")
         adapter = HERMES_AGENT.read_text(encoding="utf-8")
 
         self.assertIn("dotfiles_hermes_with_xapi_credentials", wrapper)
         self.assertIn("xurl auth oauth2 --headless", wrapper)
         self.assertIn("up -d --force-recreate xapi-mcp", wrapper)
         self.assertIn("up -d --force-recreate", wrapper)
+        self.assertIn("Invoke-HermesXApiCredentialScope", windows_wrapper)
+        self.assertIn("xurl auth oauth2 --headless", windows_wrapper)
+        self.assertIn("'up', '-d', '--force-recreate', 'xapi-mcp'", windows_wrapper)
+        self.assertIn("'up', '-d', '--force-recreate'", windows_wrapper)
+        self.assertIn("X_API_CLIENT_ID", windows_wrapper)
+        self.assertIn("X_API_CLIENT_SECRET", windows_wrapper)
 
         self.assertIn("Hermes X API MCP", adapter)
         self.assertIn("X_API_CLIENT_ID", adapter)

--- a/tests/python/test_taskfile_contract.py
+++ b/tests/python/test_taskfile_contract.py
@@ -10,6 +10,8 @@ import yaml
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 TASKFILE = REPOSITORY_ROOT / "Taskfile.yml"
+HERMES_AGENT = REPOSITORY_ROOT / "scripts" / "sh" / "hermes-agent.sh"
+XAPI_WRAPPER = REPOSITORY_ROOT / "scripts" / "sh" / "hermes-xapi.sh"
 
 
 class TaskfileContractTests(unittest.TestCase):
@@ -19,21 +21,53 @@ class TaskfileContractTests(unittest.TestCase):
     def test_xapi_tasks_are_present_in_the_hermes_lifecycle(self) -> None:
         self.assertIn("xapi-mcp", self._command_text("hermes:pull"))
         self.assertIn(
-            "xurl auth oauth2 --headless",
+            "scripts/sh/hermes-xapi.sh auth",
             self._command_text("hermes:xapi:auth"),
         )
         self.assertIn(
-            'CLIENT_ID="$X_API_CLIENT_ID" CLIENT_SECRET="$X_API_CLIENT_SECRET"',
-            self._command_text("hermes:xapi:auth"),
-        )
-        self.assertIn(
-            "up -d --force-recreate xapi-mcp",
+            "scripts/sh/hermes-xapi.sh restart",
             self._command_text("hermes:xapi:restart"),
+        )
+        self.assertIn(
+            "scripts/sh/hermes-xapi.sh up",
+            self._command_text("hermes:up"),
         )
         self.assertIn(
             "logs -f --tail=100 xapi-mcp",
             self._command_text("hermes:xapi:logs"),
         )
+
+    def test_bootstrap_uses_the_same_container_startup_guardrails(self) -> None:
+        task = self.tasks["hermes:bootstrap"]
+        precondition_text = "\n".join(
+            precondition.get("sh", "") for precondition in task.get("preconditions", [])
+        )
+
+        self.assertIs(task.get("interactive"), True)
+        self.assertIn("docker info", precondition_text)
+        self.assertIn("test -f {{.HERMES_COMPOSE_FILE}}", precondition_text)
+        self.assertIn(
+            'dotfiles_hermes_start_stack docker "{{.HERMES_COMPOSE_FILE}}"',
+            self._command_text("hermes:bootstrap"),
+        )
+
+    def test_xapi_lifecycle_reads_oauth_credentials_from_1password(self) -> None:
+        wrapper = XAPI_WRAPPER.read_text(encoding="utf-8")
+        adapter = HERMES_AGENT.read_text(encoding="utf-8")
+
+        self.assertIn("dotfiles_hermes_with_xapi_credentials", wrapper)
+        self.assertIn("xurl auth oauth2 --headless", wrapper)
+        self.assertIn("up -d --force-recreate xapi-mcp", wrapper)
+        self.assertIn("up -d --force-recreate", wrapper)
+
+        self.assertIn("Hermes X API MCP", adapter)
+        self.assertIn("X_API_CLIENT_ID", adapter)
+        self.assertIn("X_API_CLIENT_SECRET", adapter)
+        self.assertIn('signin --account "$account"', adapter)
+        self.assertIn('item get "$item"', adapter)
+        self.assertIn("jq -e -c", adapter)
+        self.assertNotIn("jq -erce", adapter)
+        self.assertNotIn("X_API_CLIENT_SECRET='", wrapper)
 
     def _command_text(self, task_name: str) -> str:
         task = self.tasks[task_name]

--- a/tests/python/test_xapi_image_contract.py
+++ b/tests/python/test_xapi_image_contract.py
@@ -1,0 +1,23 @@
+"""Build contract for the isolated Hermes X MCP image."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+DOCKERFILE = (
+    Path(__file__).resolve().parents[2] / "docker" / "hermes-xapi-mcp" / "Dockerfile"
+)
+
+
+class XapiImageContractTests(unittest.TestCase):
+    def test_xurl_postinstall_is_enabled_so_the_native_binary_is_installed(self) -> None:
+        dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+        self.assertIn("npm ci --omit=dev", dockerfile)
+        self.assertNotIn("npm ci --omit=dev --ignore-scripts", dockerfile)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_xapi_image_contract.py
+++ b/tests/python/test_xapi_image_contract.py
@@ -18,6 +18,11 @@ class XapiImageContractTests(unittest.TestCase):
         self.assertIn("npm ci --omit=dev", dockerfile)
         self.assertNotIn("npm ci --omit=dev --ignore-scripts", dockerfile)
 
+    def test_image_has_system_certificate_roots_for_x_api_tls(self) -> None:
+        dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+        self.assertIn("ca-certificates", dockerfile)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add a dedicated `xapi-mcp` Compose service using X's official xurl MCP bridge.
- Expose the shared Streamable HTTP endpoint to every managed Hermes profile.
- Add Taskfile authentication, restart, and log commands.
- Validate the canonical X MCP declaration during Hermes bootstrap.
- Add setup documentation and container/test coverage.

## Local verification

- Compose, Taskfile, and source contract tests: 12 tests, 1 skipped
- Bats: 19 tests
- Hermes bootstrap Docker test image: 336 tests, 1 skipped
- X MCP image build and dependency smoke test

Profile configuration updates are tracked in the five linked draft PRs for the managed profile repositories.