### PR TITLE
fix: allow secure Hermes profile config mode

### DIFF
--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/distributions.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/distributions.py
@@ -642,7 +642,7 @@ def _profile_is_current(
         payload = tuple(entry for entry in sanitized.iterdir() if entry.name != "distribution.yaml")
         for source in payload:
             destination = target / (".env.EXAMPLE" if source.name == ".env.template" else source.name)
-            if not _same_path(source, destination):
+            if not _same_profile_payload_path(source, destination):
                 return False
         if getattr(manifest, "env_requires", None) and not _is_regular_file(target / ".env.EXAMPLE"):
             return False
@@ -773,6 +773,25 @@ def _same_path(source: Path, destination: Path) -> bool:
         destination_entries = sorted(entry.name for entry in os.scandir(destination))
         return source_entries == destination_entries and all(
             _same_path(source / name, destination / name) for name in source_entries
+        )
+    except OSError:
+        return False
+
+
+def _same_profile_payload_path(source: Path, destination: Path) -> bool:
+    if _same_path(source, destination):
+        return True
+    if source.name != "config.yaml" or not _lexists(destination):
+        return False
+    try:
+        source_mode = source.lstat().st_mode
+        destination_mode = destination.lstat().st_mode
+        return (
+            stat.S_ISREG(source_mode)
+            and stat.S_ISREG(destination_mode)
+            and stat.S_IMODE(source_mode) == 0o644
+            and stat.S_IMODE(destination_mode) == 0o600
+            and source.read_bytes() == destination.read_bytes()
         )
     except OSError:
         return False

--- a/docker/hermes-agent/bootstrap/tests/test_distributions.py
+++ b/docker/hermes-agent/bootstrap/tests/test_distributions.py
@@ -960,6 +960,39 @@ class DistributionTests(unittest.TestCase):
         self.assertEqual(tx.snapshots, [])
         install.assert_not_called()
 
+    def test_profile_no_overwrite_allows_owner_only_config_mode(
+        self,
+    ) -> None:
+        config = self.stage_root / "config.yaml"
+        config.write_text("config\n", encoding="utf-8")
+        config.chmod(0o644)
+        self.write_profile_manifest("rick", ["config.yaml"])
+        apply_profile_distribution(
+            self.source("rick"),
+            self.data_root,
+            RecordingTransaction(),
+        )
+        target = self.data_root / "profiles" / "rick"
+        installed_config = target / "config.yaml"
+        installed_config.chmod(0o600)
+        tx = RecordingTransaction()
+
+        with mock.patch(
+            "hermes_bootstrap.distributions.profile_distribution.install_distribution"
+        ) as install:
+            changed = apply_profile_distribution(
+                self.source("rick"),
+                self.data_root,
+                tx,
+                replace_existing=False,
+                expected_missing=False,
+            )
+
+        self.assertEqual(changed, ChangeSet(()))
+        self.assertEqual(stat.S_IMODE(installed_config.stat().st_mode), 0o600)
+        self.assertEqual(tx.snapshots, [])
+        install.assert_not_called()
+
     def test_profile_no_overwrite_rejects_differing_and_malformed_existing_targets_without_mutation(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- allow an installed Hermes profile's top-level `config.yaml` to remain owner-only (`0600`) when its published source is `0644` and the file contents are identical
- keep strict content and permission comparison for every other profile payload path
- add a regression test covering no-overwrite profile synchronization with an owner-only config

## Root cause

Hermes hardens installed profile configs to `0600`, while the profile repositories publish the same files as `0644`. Bootstrap required an exact mode match, so every profile was incorrectly treated as changed and no-overwrite synchronization failed.

## Validation

- focused regression test: failed before the fix and passed after it
- distribution tests: 52 passed
- full bootstrap suite: 548 passed, 3 skipped
- `nix fmt`: 414 files checked, 0 changed
- pre-commit checks: passed
- live `task hermes:bootstrap` with all four profile configs at `0600`: passed
- default, Rick, Hoffman, RisaRisa, and Nancy gateways: running
- Chrome, X API, X Docs, and Google Calendar MCPs for all five profiles: connected
- Google Calendar exposes 13 tools including create, update, and delete event operations