### PR TITLE
Automate Hermes 1Password bootstrap and Slack secret references

### DIFF
--- a/.github/e2e/bin/op
+++ b/.github/e2e/bin/op
@@ -7,6 +7,16 @@ if [ "$#" -eq 3 ] && [ "$1" = signin ] && [ "$2" = --account ] && \
 	exit 0
 fi
 
+if [ "$#" -eq 4 ] && [ "$1" = --account ] && \
+	[ "$2" = my.1password.com ] && [ "$3" = read ]; then
+	if [ "$4" = 'op://openclaw/3bgd5qtytxuvuauauyqr2p4iki/credential' ]; then
+		printf 'acceptance-hermes-service-account-token\n'
+		exit 0
+	fi
+	printf 'acceptance op fixture rejected reference: %s\n' "$4" >&2
+	exit 2
+fi
+
 if [ "$#" -ne 9 ] || [ "$1" != item ] || [ "$2" != get ] || \
 	[ "$4" != --account ] || [ "$5" != my.1password.com ] || \
 	[ "$6" != --vault ] || \

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ scripts/powershell/test-results.xml
 
 # Docker env files
 docker/**/.env
+**/.op.env
 
 # WSL config (machine-specific)
 windows/.wslconfig

--- a/docker/hermes-agent/Dockerfile
+++ b/docker/hermes-agent/Dockerfile
@@ -57,12 +57,22 @@ replace_once(
 PY
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl gh \
+  && apt-get install -y --no-install-recommends ca-certificates curl gh gnupg \
   && arch="$(dpkg --print-architecture)" \
+  && case "$arch" in \
+    amd64|arm64) ;; \
+    *) echo "unsupported architecture for 1Password CLI: $arch" >&2; exit 1 ;; \
+  esac \
+  && install -d -m 0755 /usr/share/keyrings /etc/apt/sources.list.d \
+  && curl -fsSL https://downloads.1password.com/linux/keys/1password.asc | \
+    gpg --dearmor --batch --yes -o /usr/share/keyrings/1password-archive-keyring.gpg \
+  && printf 'deb [arch=%s signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/%s stable main\n' "$arch" "$arch" > /etc/apt/sources.list.d/1password.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends 1password-cli \
+  && op --version \
   && case "$arch" in \
     amd64) article_collector_asset="article-collector-linux-amd64" ;; \
     arm64) article_collector_asset="article-collector-linux-arm64" ;; \
-    *) echo "unsupported architecture for article-collector: $arch" >&2; exit 1 ;; \
   esac \
   && curl -fsSL \
     "https://github.com/rurusasu/article-collector/releases/download/${ARTICLE_COLLECTOR_VERSION}/${article_collector_asset}" \

--- a/docker/hermes-agent/bootstrap-manifest.yaml
+++ b/docker/hermes-agent/bootstrap-manifest.yaml
@@ -34,8 +34,10 @@ onepassword_items:
       - canonical_name: bot_token
         labels: [SLACK_BOT_TOKEN, bot_token, bot token]
       - canonical_name: app_token
+        reference: app_level_token
         labels: [SLACK_APP_TOKEN, app_level_token, app token, app-level token]
       - canonical_name: allowed_users
+        reference: SLACK_ALLOWED_USERS
         labels: [SLACK_ALLOWED_USERS, allowed_users, allowed users, allowFrom, allow_from]
   - key: slack_rick
     account: my.1password.com

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/app.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/app.py
@@ -53,6 +53,7 @@ from .google_calendar import (
     install_google_calendar_credentials,
     validate_google_calendar_installation,
 )
+from .configfiles import reconcile_onepassword_configurations
 from .github import GitAuth, GitHubClient
 from .manifest import load_manifest
 from .models import BootstrapManifest, DistributionSource, SharedRepository
@@ -274,6 +275,12 @@ def _apply_sensitive(
         install_google_calendar_credentials(
             manifest.data_root,
             secrets.google_calendar,
+            tx,
+        )
+
+        reconcile_onepassword_configurations(
+            manifest,
+            _environment_targets(manifest),
             tx,
         )
 

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/configfiles.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/configfiles.py
@@ -1,0 +1,101 @@
+"""Transactional reconciliation of managed Hermes configuration sections."""
+
+from __future__ import annotations
+
+import stat
+from collections.abc import Sequence
+from pathlib import Path
+
+import yaml
+
+from .distributions import _atomic_write
+from .errors import ApplyError
+from .models import BootstrapManifest
+from .onepassword import build_onepassword_config
+from .transaction import Transaction
+
+
+def reconcile_onepassword_configurations(
+    manifest: BootstrapManifest,
+    targets: Sequence[tuple[str, Path]],
+    transaction: Transaction,
+) -> None:
+    """Merge managed onepassword settings into each Hermes config atomically."""
+
+    if not manifest.onepassword_items:
+        return
+
+    try:
+        for profile, target in targets:
+            path = target / "config.yaml"
+            try:
+                metadata = path.lstat()
+            except OSError:
+                continue
+            if (
+                stat.S_ISLNK(metadata.st_mode)
+                or not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+            ):
+                continue
+            try:
+                original_content = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeError):
+                continue
+            try:
+                config = yaml.safe_load(original_content)
+            except (OSError, UnicodeError, yaml.YAMLError):
+                continue
+            if not isinstance(config, dict):
+                continue
+
+            secrets = config.get("secrets")
+            if secrets is None:
+                secrets = {}
+            if not isinstance(secrets, dict):
+                continue
+            onepassword = secrets.get("onepassword")
+            if onepassword is None:
+                onepassword = {}
+            if not isinstance(onepassword, dict):
+                continue
+            existing_env = onepassword.get("env")
+            if existing_env is None:
+                existing_env = {}
+            if not isinstance(existing_env, dict):
+                continue
+
+            managed = build_onepassword_config(manifest, profile)
+            if "secrets" not in config:
+                content = (
+                    original_content.rstrip("\n")
+                    + "\n"
+                    + yaml.safe_dump(
+                        {"secrets": {"onepassword": managed}},
+                        sort_keys=False,
+                    )
+                ).encode("utf-8")
+                if path.read_bytes() == content:
+                    continue
+                transaction.snapshot(path)
+                _atomic_write(path, content, stat.S_IMODE(metadata.st_mode))
+                continue
+            if onepassword == managed and existing_env == managed["env"]:
+                continue
+            merged_onepassword = dict(onepassword)
+            merged_onepassword.update(managed)
+            merged_onepassword["env"] = {
+                **existing_env,
+                **managed["env"],
+            }
+            merged_secrets = dict(secrets)
+            merged_secrets["onepassword"] = merged_onepassword
+            candidate = dict(config)
+            candidate["secrets"] = merged_secrets
+            content = yaml.safe_dump(candidate, sort_keys=False).encode("utf-8")
+            if path.read_bytes() == content:
+                continue
+            transaction.snapshot(path)
+            _atomic_write(path, content, stat.S_IMODE(metadata.st_mode))
+    except (OSError, TypeError, UnicodeError, ValueError, yaml.YAMLError):
+        raise ApplyError("could not reconcile Hermes 1Password configuration") from None

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/distributions.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/distributions.py
@@ -303,7 +303,7 @@ def _apply_root_boundary(stage: StagedSource, data_root: Path, tx: Transaction) 
             _require_safe_managed_path(data_root, destination)
             if owned in next_set:
                 source = stage.path.joinpath(*owned.parts)
-                if _same_path(source, destination):
+                if _same_distribution_path(source, destination):
                     continue
                 _ensure_destination_parent(destination.parent, snapshots)
                 _snapshot(snapshots, destination)
@@ -642,7 +642,7 @@ def _profile_is_current(
         payload = tuple(entry for entry in sanitized.iterdir() if entry.name != "distribution.yaml")
         for source in payload:
             destination = target / (".env.EXAMPLE" if source.name == ".env.template" else source.name)
-            if not _same_path(source, destination):
+            if not _same_distribution_path(source, destination):
                 return False
         if getattr(manifest, "env_requires", None) and not _is_regular_file(target / ".env.EXAMPLE"):
             return False
@@ -778,6 +778,35 @@ def _same_path(source: Path, destination: Path) -> bool:
         return False
 
 
+def _same_distribution_path(source: Path, destination: Path) -> bool:
+    """Compare distribution files while ignoring bootstrap-owned onepassword config."""
+
+    if source.name != "config.yaml" or destination.name != "config.yaml":
+        return _same_path(source, destination)
+    try:
+        source_config = yaml.safe_load(source.read_text(encoding="utf-8"))
+        destination_config = yaml.safe_load(destination.read_text(encoding="utf-8"))
+        if not isinstance(source_config, dict) or not isinstance(destination_config, dict):
+            return _same_path(source, destination)
+        source_config = _without_bootstrap_onepassword(source_config)
+        destination_config = _without_bootstrap_onepassword(destination_config)
+        return source_config == destination_config
+    except (OSError, UnicodeError, TypeError, ValueError, yaml.YAMLError):
+        return _same_path(source, destination)
+
+
+def _without_bootstrap_onepassword(config: dict[object, object]) -> dict[object, object]:
+    result = dict(config)
+    secrets = result.get("secrets")
+    if not isinstance(secrets, dict):
+        return result
+    remaining_secrets = dict(secrets)
+    remaining_secrets.pop("onepassword", None)
+    if remaining_secrets:
+        result["secrets"] = remaining_secrets
+    else:
+        result.pop("secrets", None)
+    return result
 def _replace_from_source(source: Path, destination: Path, snapshots: _SnapshotTracker) -> None:
     _validate_source_path(source)
     _ensure_destination_parent(destination.parent, snapshots)

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/manifest.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/manifest.py
@@ -149,15 +149,26 @@ def _onepassword_items(value: object) -> tuple[OnePasswordItem, ...]:
         for field_index, raw_field in enumerate(_sequence(item["fields"], f"{context}.fields")):
             field_context = f"{context}.fields[{field_index}]"
             field = _mapping(raw_field, field_context)
-            _keys(field, {"canonical_name", "labels"}, field_context)
+            _keys(field, {"canonical_name", "labels"}, field_context, optional={"reference"})
             canonical_name = _text(field["canonical_name"], f"{field_context}.canonical_name")
+            reference_name = (
+                _text(field["reference"], f"{field_context}.reference")
+                if "reference" in field
+                else None
+            )
             labels = tuple(
                 _text(label, f"{field_context}.labels[{label_index}]")
                 for label_index, label in enumerate(_sequence(field["labels"], f"{field_context}.labels"))
             )
             if not labels:
                 _invalid(f"{field_context}.labels must not be empty")
-            fields.append(OnePasswordField(canonical_name=canonical_name, labels=labels))
+            fields.append(
+                OnePasswordField(
+                    canonical_name=canonical_name,
+                    labels=labels,
+                    reference_name=reference_name,
+                )
+            )
         if not fields:
             _invalid(f"{context}.fields must not be empty")
         _unique((field.canonical_name for field in fields), f"{context} field names")

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/models.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/models.py
@@ -11,6 +11,7 @@ from typing import Literal
 class OnePasswordField:
     canonical_name: str
     labels: tuple[str, ...]
+    reference_name: str | None = None
 
 
 @dataclass(frozen=True)

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/onepassword.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/onepassword.py
@@ -1,0 +1,66 @@
+"""Build the managed Hermes 1Password configuration without secret values."""
+
+from __future__ import annotations
+
+from .errors import ValidationError
+from .models import BootstrapManifest, OnePasswordItem
+
+
+_SERVICE_ACCOUNT_ENV = "OP_SERVICE_ACCOUNT_TOKEN"
+_OP_BINARY = "/usr/bin/op"
+_MANAGED_ENV_FIELDS: tuple[tuple[str, str, str], ...] = (
+    ("HERMES_DASHBOARD_BASIC_AUTH_USERNAME", "dashboard", "username"),
+    ("GITHUB_PERSONAL_ACCESS_TOKEN", "github", "credential"),
+    ("GH_TOKEN", "github", "credential"),
+    ("GITHUB_TOKEN", "github", "credential"),
+)
+_SLACK_ENV_FIELDS: tuple[tuple[str, str], ...] = (
+    ("SLACK_BOT_TOKEN", "bot_token"),
+    ("SLACK_APP_TOKEN", "app_token"),
+    ("SLACK_ALLOWED_USERS", "allowed_users"),
+)
+
+
+def build_onepassword_config(
+    manifest: BootstrapManifest, profile: str
+) -> dict[str, object]:
+    """Return the non-secret onepassword block for one Hermes home."""
+
+    items = {item.key: item for item in manifest.onepassword_items}
+    slack_key = "slack_default" if profile == "default" else f"slack_{profile}"
+    required = {key for _env, key, _field in _MANAGED_ENV_FIELDS}
+    required.update({"dashboard", "github", slack_key})
+    missing = sorted(key for key in required if key not in items)
+    if missing:
+        raise ValidationError("1Password manifest is missing managed items")
+
+    managed_items = [items[key] for key in ("dashboard", "github", slack_key)]
+    accounts = {item.account for item in managed_items}
+    if len(accounts) != 1:
+        raise ValidationError("managed 1Password items use different accounts")
+    account = next(iter(accounts))
+
+    environment: dict[str, str] = {}
+    for env_name, item_key, field_name in _MANAGED_ENV_FIELDS:
+        environment[env_name] = _reference(items[item_key], field_name)
+    for env_name, field_name in _SLACK_ENV_FIELDS:
+        environment[env_name] = _reference(items[slack_key], field_name)
+
+    return {
+        "enabled": True,
+        "env": environment,
+        "account": account,
+        "service_account_token_env": _SERVICE_ACCOUNT_ENV,
+        "binary_path": _OP_BINARY,
+        "cache_ttl_seconds": 300,
+        "override_existing": True,
+    }
+
+
+def _reference(item: OnePasswordItem, canonical_name: str) -> str:
+    fields = [field for field in item.fields if field.canonical_name == canonical_name]
+    if len(fields) != 1:
+        raise ValidationError("1Password manifest has an invalid managed field")
+    field = fields[0]
+    reference_name = field.reference_name or canonical_name
+    return f"op://{item.vault}/{item.item}/{reference_name}"

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/payload.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/payload.py
@@ -122,6 +122,11 @@ def build_secret_plan(manifest: BootstrapManifest) -> dict[str, object]:
                     {
                         "canonical_name": field.canonical_name,
                         "labels": list(field.labels),
+                        **(
+                            {"reference": field.reference_name}
+                            if field.reference_name is not None
+                            else {}
+                        ),
                     }
                     for field in item.fields
                 ],

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_snapshot.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_snapshot.py
@@ -1046,6 +1046,8 @@ def _public_profile_config(content: bytes) -> bytes:
     secrets_indent = -1
     for index, line in enumerate(lines):
         stripped = line.lstrip(" ")
+        if len(line) - len(stripped) != 0:
+            continue
         if stripped == "secrets:\n" or stripped == "secrets:\r\n" or stripped == "secrets:":
             secrets_index = index
             secrets_indent = len(line) - len(stripped)

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_snapshot.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_snapshot.py
@@ -988,13 +988,22 @@ def _copy_regular(
         digest = hashlib.sha256()
         size = 0
         scanner = _SensitiveStreamScanner()
+        source_chunks: list[bytes] | None = [] if relative == PurePosixPath("config.yaml") else None
         for chunk in _read_bounded_chunks(source_fd, before.st_size):
             _reject_sensitive_bytes(chunk, final=False, scanner=scanner)
-            _write_descriptor(destination_fd, chunk)
-            digest.update(chunk)
-            size += len(chunk)
+            if source_chunks is None:
+                _write_descriptor(destination_fd, chunk)
+                digest.update(chunk)
+                size += len(chunk)
+            else:
+                source_chunks.append(chunk)
         _reject_sensitive_bytes(b"", scanner=scanner)
-        _verify_regular(parent_fd, name, source_fd, before, size)
+        _verify_regular(parent_fd, name, source_fd, before, before.st_size)
+        if source_chunks is not None:
+            content = _public_profile_config(b"".join(source_chunks))
+            _write_descriptor(destination_fd, content)
+            digest.update(content)
+            size = len(content)
         mode = _git_mode(before.st_mode)
         os.fchmod(destination_fd, mode)
         os.fsync(destination_fd)
@@ -1020,6 +1029,73 @@ def _copy_regular(
         if destination_fd is not None and not destination_registered:
             os.close(destination_fd)
     entries.append(SnapshotEntry(relative, mode, size, sha256))
+
+
+def _public_profile_config(content: bytes) -> bytes:
+    try:
+        config = yaml.safe_load(content)
+    except yaml.YAMLError:
+        return content
+    if not isinstance(config, dict):
+        return content
+    secrets = config.get("secrets")
+    if not isinstance(secrets, dict) or "onepassword" not in secrets:
+        return content
+    lines = content.decode("utf-8").splitlines(keepends=True)
+    secrets_index: int | None = None
+    secrets_indent = -1
+    for index, line in enumerate(lines):
+        stripped = line.lstrip(" ")
+        if stripped == "secrets:\n" or stripped == "secrets:\r\n" or stripped == "secrets:":
+            secrets_index = index
+            secrets_indent = len(line) - len(stripped)
+            break
+    if secrets_index is None:
+        return yaml.safe_dump(
+            {key: value for key, value in config.items() if key != "secrets"},
+            sort_keys=False,
+        ).encode("utf-8")
+    onepassword_index: int | None = None
+    onepassword_indent = -1
+    for index in range(secrets_index + 1, len(lines)):
+        line = lines[index]
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        if indent <= secrets_indent:
+            break
+        if line.strip() == "onepassword:" or line.lstrip(" ").startswith("onepassword:"):
+            onepassword_index = index
+            onepassword_indent = indent
+            break
+    if onepassword_index is None:
+        return content
+    end = onepassword_index + 1
+    while end < len(lines):
+        line = lines[end]
+        if line.strip() and len(line) - len(line.lstrip(" ")) <= onepassword_indent:
+            break
+        end += 1
+    secrets_end = secrets_index + 1
+    while secrets_end < len(lines):
+        line = lines[secrets_end]
+        if line.strip() and len(line) - len(line.lstrip(" ")) <= secrets_indent:
+            break
+        secrets_end += 1
+    remaining_secret_children = any(
+        line.strip()
+        and len(line) - len(line.lstrip(" ")) > secrets_indent
+        for line in lines[secrets_index + 1:onepassword_index]
+    ) or any(
+        line.strip()
+        and len(line) - len(line.lstrip(" ")) > secrets_indent
+        for line in lines[end:secrets_end]
+    )
+    if remaining_secret_children:
+        return "".join(
+            (*lines[:onepassword_index], *lines[end:])
+        ).encode("utf-8")
+    return "".join((*lines[:secrets_index], *lines[end:])).encode("utf-8")
 
 
 def _read_regular(parent_fd: int, name: str) -> tuple[bytes, os.stat_result]:

--- a/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
+++ b/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
@@ -21,6 +21,8 @@ from pathlib import Path
 from typing import Iterator
 from unittest import mock
 
+import yaml
+
 from hermes_cli import profile_distribution
 
 
@@ -39,6 +41,7 @@ from hermes_bootstrap.git import StagedSource, stage_distribution
 from hermes_bootstrap.github import GitHubClient
 from hermes_bootstrap.manifest import load_manifest
 from hermes_bootstrap.models import BootstrapManifest, DistributionSource, SharedRepository
+from hermes_bootstrap.onepassword import build_onepassword_config
 from hermes_bootstrap.payload import SCHEMA_VERSION
 
 
@@ -95,6 +98,17 @@ def source_config(key: str, value: str) -> str:
         "    env:\n"
         "      GOOGLE_OAUTH_CREDENTIALS: /opt/data/google-calendar-mcp/gcp-oauth.keys.json\n"
         "      GOOGLE_CALENDAR_MCP_TOKEN_PATH: /opt/data/google-calendar-mcp/tokens.json\n"
+    )
+
+
+def managed_source_config(
+    manifest: BootstrapManifest, profile: str, key: str, value: str
+) -> str:
+    managed = build_onepassword_config(manifest, profile)
+    return (
+        source_config(key, value).rstrip("\n")
+        + "\n"
+        + yaml.safe_dump({"secrets": {"onepassword": managed}}, sort_keys=False)
     )
 
 
@@ -762,7 +776,7 @@ class BootstrapFlowTests(unittest.TestCase):
                 for path, entry in self._snapshot_tree(
                     self.data_root / "profiles" / profile
                 ).items()
-                if path != ".env"
+                if path not in {".env", "config.yaml"}
             }
             for profile in PROFILE_NAMES
         }
@@ -771,19 +785,21 @@ class BootstrapFlowTests(unittest.TestCase):
 
         self.assertEqual(
             (self.data_root / "config.yaml").read_text(encoding="utf-8"),
-            source_config("root", "initial"),
+            managed_source_config(self.manifest, "default", "root", "initial"),
         )
         for profile in PROFILE_NAMES:
             target = self.data_root / "profiles" / profile
             self.assertEqual(
                 (target / "config.yaml").read_text(encoding="utf-8"),
-                source_config("profile", f"{profile}-initial"),
+                managed_source_config(
+                    self.manifest, profile, "profile", f"{profile}-initial"
+                ),
             )
             self.assertEqual(
                 {
                     path: (entry.kind, entry.mode, entry.payload)
                     for path, entry in self._snapshot_tree(target).items()
-                    if path != ".env"
+                    if path not in {".env", "config.yaml"}
                 },
                 profiles_before[profile],
             )
@@ -1011,7 +1027,9 @@ class BootstrapFlowTests(unittest.TestCase):
         )
         self.assertEqual(
             (target / "config.yaml").read_text(encoding="utf-8"),
-            source_config("profile", "rick-updated"),
+            managed_source_config(
+                self.manifest, "rick", "profile", "rick-updated"
+            ),
         )
         self.assertEqual(
             (runtime.stat().st_ino, runtime.read_bytes(), self._mode(runtime)),
@@ -1401,10 +1419,18 @@ class BootstrapFlowTests(unittest.TestCase):
             with self.subTest(phase=phase):
                 try:
                     version = f"0.{revision}.0"
-                    desired_root = source_config("root", f"rollback-{revision}")
+                    desired_root = managed_source_config(
+                        self.manifest,
+                        "default",
+                        "root",
+                        f"rollback-{revision}",
+                    )
                     desired_profiles = {
-                        profile: source_config(
-                            "profile", f"{profile}-rollback-{revision}"
+                        profile: managed_source_config(
+                            self.manifest,
+                            profile,
+                            "profile",
+                            f"{profile}-rollback-{revision}",
                         )
                         for profile in PROFILE_NAMES
                     }

--- a/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
@@ -56,6 +56,16 @@ class ComposeContractTests(unittest.TestCase):
     def test_gateway_uses_the_canonical_shared_lifelog_path(self) -> None:
         self.assertEqual(self.hermes["environment"]["LIFELOG_ROOT"], "/opt/data/shared/lifelog")
 
+    def test_hermes_services_load_the_private_service_account_environment_file(self) -> None:
+        expected = [
+            {
+                "path": "${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.op.env",
+                "required": False,
+            }
+        ]
+        self.assertEqual(self.hermes["env_file"], expected)
+        self.assertEqual(self.bootstrap["env_file"], expected)
+
     def test_gateway_exposes_the_authenticated_api_on_the_container_interface(self) -> None:
         self.assertEqual(self.hermes["environment"]["API_SERVER_HOST"], "0.0.0.0")
         self.assertIn("127.0.0.1:${HERMES_API_PORT:-8642}:8642", self.hermes["ports"])
@@ -153,6 +163,20 @@ class ComposeContractTests(unittest.TestCase):
         self.assertIn("COPY bootstrap/tests /workspace/docker/hermes-agent/bootstrap/tests", dockerfile)
         self.assertIn("python -m unittest discover", dockerfile)
         self.assertTrue(dockerfile.rstrip().endswith("FROM hermes-bootstrap-runtime\n\nWORKDIR /"))
+
+    def test_runtime_image_installs_the_official_onepassword_cli(self) -> None:
+        dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "https://downloads.1password.com/linux/keys/1password.asc",
+            dockerfile,
+        )
+        self.assertIn(
+            "https://downloads.1password.com/linux/debian/%s stable main",
+            dockerfile,
+        )
+        self.assertIn("apt-get install -y --no-install-recommends 1password-cli", dockerfile)
+        self.assertIn("op --version", dockerfile)
 
     def test_host_resolved_contract_matches_the_structural_contract(self) -> None:
         config_path = os.environ.get(RESOLVED_CONFIG_ENV)

--- a/docker/hermes-agent/bootstrap/tests/test_configfiles.py
+++ b/docker/hermes-agent/bootstrap/tests/test_configfiles.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from hermes_bootstrap.configfiles import reconcile_onepassword_configurations
+from hermes_bootstrap.manifest import load_manifest
+from hermes_bootstrap.transaction import Transaction
+
+
+MANIFEST = Path(__file__).parents[2] / "bootstrap-manifest.yaml"
+
+
+class OnePasswordConfigFileTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name).resolve() / "data"
+        self.root.mkdir(mode=0o700)
+        self.manifest = load_manifest(MANIFEST)
+
+    def test_reconciler_preserves_unmanaged_config_and_adds_managed_refs(self) -> None:
+        path = self.root / "config.yaml"
+        path.write_text(
+            "model:\n  name: test\n"
+            "secrets:\n"
+            "  onepassword:\n"
+            "    cache_ttl_seconds: 42\n"
+            "    env:\n"
+            "      OPENAI_API_KEY: op://Private/OpenAI/credential\n",
+            encoding="utf-8",
+        )
+
+        tx = Transaction.begin(self.root)
+        reconcile_onepassword_configurations(
+            self.manifest, (("default", self.root),), tx
+        )
+        tx.commit()
+
+        config = yaml.safe_load(path.read_text(encoding="utf-8"))
+        onepassword = config["secrets"]["onepassword"]
+        self.assertEqual(config["model"]["name"], "test")
+        self.assertEqual(onepassword["cache_ttl_seconds"], 300)
+        self.assertEqual(
+            onepassword["env"]["OPENAI_API_KEY"],
+            "op://Private/OpenAI/credential",
+        )
+        self.assertEqual(
+            onepassword["env"]["SLACK_BOT_TOKEN"],
+            "op://openclaw/SlackBot-OpenClaw/bot_token",
+        )
+
+    def test_reconciler_is_idempotent(self) -> None:
+        path = self.root / "config.yaml"
+        path.write_text("model:\n  name: test\n", encoding="utf-8")
+
+        first = Transaction.begin(self.root)
+        reconcile_onepassword_configurations(
+            self.manifest, (("default", self.root),), first
+        )
+        first.commit()
+        expected = path.read_bytes()
+
+        second = Transaction.begin(self.root)
+        reconcile_onepassword_configurations(
+            self.manifest, (("default", self.root),), second
+        )
+        second.commit()
+
+        self.assertEqual(path.read_bytes(), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker/hermes-agent/bootstrap/tests/test_onepassword.py
+++ b/docker/hermes-agent/bootstrap/tests/test_onepassword.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from hermes_bootstrap.manifest import load_manifest
+from hermes_bootstrap.onepassword import build_onepassword_config
+
+
+MANIFEST = Path(__file__).parents[2] / "bootstrap-manifest.yaml"
+
+
+class OnePasswordConfigTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.manifest = load_manifest(MANIFEST)
+
+    def test_default_config_maps_shared_and_default_slack_references(self) -> None:
+        config = build_onepassword_config(self.manifest, "default")
+
+        self.assertEqual(config["enabled"], True)
+        self.assertEqual(config["account"], "my.1password.com")
+        self.assertEqual(config["service_account_token_env"], "OP_SERVICE_ACCOUNT_TOKEN")
+        self.assertEqual(config["binary_path"], "/usr/bin/op")
+        self.assertEqual(config["override_existing"], True)
+        self.assertEqual(
+            config["env"],
+            {
+                "HERMES_DASHBOARD_BASIC_AUTH_USERNAME": (
+                    "op://openclaw/Hermes Agent Dashboard/username"
+                ),
+                "GITHUB_PERSONAL_ACCESS_TOKEN": (
+                    "op://openclaw/GitHubUsedOpenClawPAT/credential"
+                ),
+                "GH_TOKEN": "op://openclaw/GitHubUsedOpenClawPAT/credential",
+                "GITHUB_TOKEN": "op://openclaw/GitHubUsedOpenClawPAT/credential",
+                "SLACK_BOT_TOKEN": "op://openclaw/SlackBot-OpenClaw/bot_token",
+                "SLACK_APP_TOKEN": "op://openclaw/SlackBot-OpenClaw/app_level_token",
+                "SLACK_ALLOWED_USERS": "op://openclaw/SlackBot-OpenClaw/SLACK_ALLOWED_USERS",
+            },
+        )
+
+    def test_named_profile_uses_its_slack_item(self) -> None:
+        config = build_onepassword_config(self.manifest, "rick")
+
+        self.assertEqual(
+            config["env"]["SLACK_BOT_TOKEN"],
+            "op://openclaw/SlackBot-Rick/bot_token",
+        )
+        self.assertNotIn("API_SERVER_KEY", config["env"])
+        self.assertNotIn("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH", config["env"])
+        self.assertNotIn("HERMES_DASHBOARD_BASIC_AUTH_SECRET", config["env"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker/hermes-agent/bootstrap/tests/test_payload.py
+++ b/docker/hermes-agent/bootstrap/tests/test_payload.py
@@ -196,8 +196,8 @@ class PayloadTests(unittest.TestCase):
                             "item": item,
                             "fields": [
                                 {"canonical_name": "bot_token", "labels": ["SLACK_BOT_TOKEN", "bot_token", "bot token"]},
-                                {"canonical_name": "app_token", "labels": ["SLACK_APP_TOKEN", "app_level_token", "app token", "app-level token"]},
-                                {"canonical_name": "allowed_users", "labels": ["SLACK_ALLOWED_USERS", "allowed_users", "allowed users", "allowFrom", "allow_from"]},
+                                {"canonical_name": "app_token", "labels": ["SLACK_APP_TOKEN", "app_level_token", "app token", "app-level token"], "reference": "app_level_token"},
+                                {"canonical_name": "allowed_users", "labels": ["SLACK_ALLOWED_USERS", "allowed_users", "allowed users", "allowFrom", "allow_from"], "reference": "SLACK_ALLOWED_USERS"},
                             ],
                         }
                         for key, item in (

--- a/docker/hermes-agent/bootstrap/tests/test_profile_snapshot.py
+++ b/docker/hermes-agent/bootstrap/tests/test_profile_snapshot.py
@@ -103,6 +103,24 @@ class ProfileSnapshotTests(unittest.TestCase):
         with self.assertRaises(ProfileSnapshotError):
             prepare_profile_snapshots(self.manifest(self.profile("rick")), clean_scratch, allow_missing=False)
 
+    def test_public_profile_config_only_strips_root_onepassword_block(self) -> None:
+        content = (
+            "settings:\n"
+            "  secrets:\n"
+            "    onepassword:\n"
+            "      nested: true\n"
+            "secrets:\n"
+            "  onepassword:\n"
+            "    root: true\n"
+            "  retained: true\n"
+        ).encode("utf-8")
+
+        public = yaml.safe_load(profile_snapshot._public_profile_config(content))
+
+        self.assertEqual(public["settings"]["secrets"]["onepassword"]["nested"], True)
+        self.assertNotIn("onepassword", public["secrets"])
+        self.assertEqual(public["secrets"]["retained"], True)
+
     def test_gitignore_is_an_exact_root_allowlist_with_nested_parents(self) -> None:
         snapshot = self.prepare("rick", owned=["SOUL.md", "assets/icons"])
         self.assertEqual(

--- a/docker/hermes-agent/compose.yml
+++ b/docker/hermes-agent/compose.yml
@@ -8,6 +8,9 @@ services:
     image: local/hermes-agent-gh:latest
     container_name: hermes
     restart: unless-stopped
+    env_file:
+      - path: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.op.env
+        required: false
     shm_size: 1g
     command: gateway run
     depends_on:
@@ -43,6 +46,9 @@ services:
       - bootstrap
     entrypoint: /usr/local/bin/hermes-bootstrap
     command: apply
+    env_file:
+      - path: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.op.env
+        required: false
     volumes:
       - type: bind
         source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}

--- a/docs/hermes-agent/bootstrap.md
+++ b/docs/hermes-agent/bootstrap.md
@@ -1,13 +1,17 @@
 # Hermes Bootstrap Operations
 
 Hermes uses one container-owned bootstrap on every supported host. The host
-adapter supplies prerequisites and secrets; it does not directly write Hermes
-config, profiles, repositories, or `.env` files.
+adapter supplies prerequisites and secrets, and writes only the private
+Compose-side `.op.env` service-account file; Hermes config, profiles,
+repositories, and managed `.env` files remain container-owned.
+
+Hermes の組み込み 1Password 連携と `op` CLI の利用手順は、[Hermes Agent で
+1Password を使う](./onepassword.md)を参照してください。
 
 ## Run Bootstrap
 
 Prerequisites are a running Docker daemon, Docker Compose, an authenticated
-1Password CLI (`op`), access to the seven configured items, and access to the
+1Password CLI (`op`), access to the eight configured items, and access to the
 declared private GitHub repositories. Unix requires native `bash`, `jq`,
 `curl`, `docker`, and `op`. The Unix adapter uses `curl` for bounded gateway
 readiness checks. Windows requires `pwsh`, Docker Desktop native `docker` and
@@ -47,13 +51,15 @@ runs the full-machine installer nor hides a nonzero result.
 
 ```text
 host adapter
+  -> resolve the existing 1Password Service Account into private .op.env
   -> request the non-secret secret plan
-  -> fetch seven full 1Password item JSON objects
-  -> stream header + seven item records + end as NDJSON
+  -> fetch eight full 1Password item JSON objects
+  -> stream header + eight item records + end as NDJSON
   -> docker compose run --rm --no-deps -T hermes-bootstrap apply
   -> load manifest and recover any crash journal
   -> validate payload, credentials, and source access
   -> publish existing profiles, stage sources, and sync shared remotes
+  -> reconcile Hermes onepassword references in root and profile config.yaml files
   -> transactional install under /opt/data
   -> docker compose up -d --force-recreate only after success
 ```

--- a/docs/hermes-agent/onepassword.md
+++ b/docs/hermes-agent/onepassword.md
@@ -1,0 +1,41 @@
+# Hermes Agent で 1Password を使う
+
+Hermes コンテナには公式の 1Password CLI (`op`) を含めています。Hermes の
+組み込み連携は `op://Vault/Item/field` 参照を起動時に解決します。実シークレットや
+サービスアカウントトークンはリポジトリへ保存しません。
+
+## 自動設定
+
+`task hermes:bootstrap` が、既存のSA参照
+個人アカウント `my.1password.com` の
+`op://openclaw/3bgd5qtytxuvuauauyqr2p4iki/credential` からSAを取得し、
+HERMESデータディレクトリの0600 `.op.env` に保存します。その後、defaultと全named
+profileの `config.yaml` にDashboard、GitHub、Slackの `op://` 参照を冪等に登録します。
+
+1Passwordアイテムの作成やSAの発行は行いません。既存の8アイテムを検証し、Google
+Calendarの認証情報はMCPが要求する0600 JSONファイルとして引き続き同期します。
+
+```bash
+task hermes:bootstrap
+```
+
+SAの読み取りに失敗した場合は、ホストの1Password CLIで対象アカウントへサインインし、
+もう一度同じコマンドを実行してください。SA値をSlack、Git、シェル引数、ログへ貼り付けないでください。
+
+`sync` は参照を解決できるか確認する dry-run です。
+
+```bash
+docker exec hermes /opt/hermes/.venv/bin/hermes \
+  secrets onepassword sync
+```
+
+named profile で個別の参照を使う場合は、対象 profile の `HERMES_HOME` を指定して
+同じコマンドを実行します。
+
+```bash
+docker exec hermes env HERMES_HOME=/opt/data/profiles/rick \
+  /opt/hermes/.venv/bin/hermes secrets onepassword status
+```
+
+サービスアカウントの発行・保存・ローテーションは1Password側で行います。このリポジトリには
+`op://` 参照と非秘密設定だけを置き、SA値はruntimeデータディレクトリの `.op.env` にのみ保存します。

--- a/scripts/powershell/handlers/Handler.HermesAgent.ps1
+++ b/scripts/powershell/handlers/Handler.HermesAgent.ps1
@@ -57,6 +57,13 @@ class HermesAgentHandler : SetupHandlerBase {
             $this.EnsureDirectory((Join-Path $dataDir '.xurl'))
             $this.EnsureDirectory($this.GetBrowserDataDir())
 
+            try {
+                $null = Initialize-HermesBootstrapServiceAccountEnvironment -DataDir $dataDir
+            }
+            catch {
+                return $this.CreateFailureResult('Hermes 1Password Service Account is unavailable.')
+            }
+
             $validation = $this.InvokeCompose($composeFile, @('config', '--quiet'))
             if (-not $validation.Success) {
                 return $this.CreateFailureResult("Hermes Compose validation failed: $($validation.Message)")

--- a/scripts/powershell/hermes-bootstrap.ps1
+++ b/scripts/powershell/hermes-bootstrap.ps1
@@ -247,6 +247,15 @@ function Invoke-HermesBootstrapEntrypoint {
                 $null = New-Item -ItemType Directory -Path $directory -Force
             }
 
+            try {
+                $null = Initialize-HermesBootstrapServiceAccountEnvironment -DataDir $paths.DataDir
+            }
+            catch {
+                return New-HermesBootstrapEntrypointResult `
+                    -ExitCode 1 `
+                    -Message 'Hermes 1Password Service Account is unavailable.'
+            }
+
             $config = Invoke-HermesBootstrapDockerPhase `
                 -Arguments @('compose', '-f', $paths.ComposeFile, 'config', '--quiet') `
                 -FailureMessage 'Hermes Compose validation failed.'

--- a/scripts/powershell/lib/HermesBootstrap.ps1
+++ b/scripts/powershell/lib/HermesBootstrap.ps1
@@ -134,6 +134,102 @@ $script:HermesBootstrapAllowedOnePasswordItems = @(
     [PSCustomObject]@{ key = "slack_risarisa"; account = "my.1password.com"; vault = "openclaw"; item = "SlackBot-Risarisa" },
     [PSCustomObject]@{ key = "slack_nancy"; account = "my.1password.com"; vault = "openclaw"; item = "SlackBot-Nancy" }
 )
+$script:DefaultHermesBootstrapServiceAccountInvoker = {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Account,
+        [Parameter(Mandatory)]
+        [string]$Reference
+    )
+
+    $output = @(& op read --account $Account $Reference 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        throw [System.InvalidOperationException]::new('Hermes service account lookup failed.')
+    }
+    return (($output -join "`n").Trim())
+}
+
+function Get-HermesBootstrapServiceAccountReference {
+    [CmdletBinding()]
+    param()
+
+    $reference = [Environment]::GetEnvironmentVariable(
+        'DOTFILES_HERMES_OP_SERVICE_ACCOUNT_TOKEN_REF',
+        'Process'
+    )
+    if ([string]::IsNullOrWhiteSpace($reference)) {
+        return 'op://openclaw/3bgd5qtytxuvuauauyqr2p4iki/credential'
+    }
+    return $reference
+}
+
+function Get-HermesBootstrapServiceAccountAccount {
+    [CmdletBinding()]
+    param()
+
+    $account = [Environment]::GetEnvironmentVariable(
+        'DOTFILES_HERMES_OP_SERVICE_ACCOUNT_ACCOUNT',
+        'Process'
+    )
+    if ([string]::IsNullOrWhiteSpace($account)) {
+        return 'my.1password.com'
+    }
+    return $account
+}
+
+function Initialize-HermesBootstrapServiceAccountEnvironment {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$DataDir,
+        [scriptblock]$InvokeOnePassword = $script:DefaultHermesBootstrapServiceAccountInvoker
+    )
+
+    $null = New-Item -ItemType Directory -Path $DataDir -Force
+    $path = Join-Path $DataDir '.op.env'
+    if (Test-Path -LiteralPath $path) {
+        $existing = Get-Item -LiteralPath $path -Force
+        if (($existing.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0 -or
+            -not ($existing.PSIsContainer -eq $false)) {
+            throw [System.InvalidOperationException]::new('Hermes service-account environment file is invalid.')
+        }
+    }
+    elseif (Test-Path -LiteralPath $path) {
+        throw [System.InvalidOperationException]::new('Hermes service-account environment file is invalid.')
+    }
+
+    $account = Get-HermesBootstrapServiceAccountAccount
+    $reference = Get-HermesBootstrapServiceAccountReference
+    $token = $null
+    $temporary = Join-Path $DataDir ('.op.env.' + [Guid]::NewGuid().ToString('N') + '.tmp')
+    try {
+        $token = [string](& $InvokeOnePassword $account $reference)
+        if ([string]::IsNullOrWhiteSpace($token) -or $token.Contains("`n") -or $token.Contains("`r")) {
+            throw [System.InvalidOperationException]::new('Hermes service account lookup failed.')
+        }
+        $encoding = [System.Text.UTF8Encoding]::new($false)
+        [System.IO.File]::WriteAllText(
+            $temporary,
+            "OP_SERVICE_ACCOUNT_TOKEN=$token`n",
+            $encoding
+        )
+        if (Test-Path -LiteralPath $path) {
+            [System.IO.File]::Replace($temporary, $path, $null, $true)
+        }
+        else {
+            [System.IO.File]::Move($temporary, $path)
+        }
+        return $true
+    }
+    finally {
+        if ($null -ne $token) {
+            $token = $null
+        }
+        if (Test-Path -LiteralPath $temporary) {
+            Remove-Item -LiteralPath $temporary -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
 
 function ConvertFrom-HermesBootstrapJson {
     [CmdletBinding()]
@@ -254,10 +350,19 @@ function Test-HermesBootstrapSecretPlan {
         if ($fields.Count -eq 0) { return $false }
         $fieldNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
         foreach ($field in $fields) {
-            if (-not (Test-HermesBootstrapPropertySet -Value $field -Names @("canonical_name", "labels"))) { return $false }
+            $fieldProperties = @($field.PSObject.Properties.Name | Sort-Object)
+            $validFieldProperties = @(
+                (Test-HermesBootstrapPropertySet -Value $field -Names @("canonical_name", "labels")),
+                (Test-HermesBootstrapPropertySet -Value $field -Names @("canonical_name", "labels", "reference"))
+            )
+            if (-not ($validFieldProperties -contains $true)) { return $false }
             if ($field.canonical_name -isnot [string] -or
                 [string]::IsNullOrWhiteSpace($field.canonical_name) -or
                 $field.canonical_name.Trim() -cne $field.canonical_name) { return $false }
+            if ($fieldProperties -contains "reference" -and
+                ($field.reference -isnot [string] -or
+                [string]::IsNullOrWhiteSpace($field.reference) -or
+                $field.reference.Trim() -cne $field.reference)) { return $false }
             if (-not $fieldNames.Add($field.canonical_name)) { return $false }
             if ($field.labels -is [string] -or $field.labels -isnot [System.Collections.IEnumerable]) { return $false }
             $labels = @($field.labels)

--- a/scripts/powershell/lib/HermesBootstrap.ps1
+++ b/scripts/powershell/lib/HermesBootstrap.ps1
@@ -177,6 +177,37 @@ function Get-HermesBootstrapServiceAccountAccount {
     return $account
 }
 
+function Protect-HermesBootstrapServiceAccountFile {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $isWindowsPlatform = ($PSVersionTable.PSEdition -eq 'Desktop') -or ($IsWindows -eq $true)
+    if (-not $isWindowsPlatform) {
+        return
+    }
+
+    $currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+    if ($null -eq $currentSid) {
+        throw [System.InvalidOperationException]::new('Could not resolve the current Windows user.')
+    }
+
+    $fileSecurity = [System.Security.AccessControl.FileSecurity]::new()
+    $fileSecurity.SetOwner($currentSid)
+    $fileSecurity.SetAccessRuleProtection($true, $false)
+    $readRule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+        $currentSid,
+        [System.Security.AccessControl.FileSystemRights]::Read,
+        [System.Security.AccessControl.InheritanceFlags]::None,
+        [System.Security.AccessControl.PropagationFlags]::None,
+        [System.Security.AccessControl.AccessControlType]::Allow
+    )
+    [void]$fileSecurity.AddAccessRule($readRule)
+    Set-Acl -LiteralPath $Path -AclObject $fileSecurity
+}
+
 function Initialize-HermesBootstrapServiceAccountEnvironment {
     [CmdletBinding()]
     param(
@@ -213,12 +244,14 @@ function Initialize-HermesBootstrapServiceAccountEnvironment {
             "OP_SERVICE_ACCOUNT_TOKEN=$token`n",
             $encoding
         )
+        Protect-HermesBootstrapServiceAccountFile -Path $temporary
         if (Test-Path -LiteralPath $path) {
             [System.IO.File]::Replace($temporary, $path, $null, $true)
         }
         else {
             [System.IO.File]::Move($temporary, $path)
         }
+        Protect-HermesBootstrapServiceAccountFile -Path $path
         return $true
     }
     finally {

--- a/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
+++ b/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
@@ -95,6 +95,8 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             }
         }
 
+        Mock Initialize-HermesBootstrapServiceAccountEnvironment { $true }
+
         Mock Invoke-HermesXApiCredentialScope {
             $script:eventLog.Add('xapi-credentials')
             & $Action

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -58,6 +58,7 @@ Describe 'HermesAgentHandler' {
             $script:eventLog.Add('bootstrap')
             [PSCustomObject]@{ Success = $true; Changed = $true; Message = 'Hermes bootstrap completed.' }
         }
+        Mock Initialize-HermesBootstrapServiceAccountEnvironment { $true }
         Mock Invoke-HermesXApiCredentialScope {
             $script:eventLog.Add('xapi-credentials')
             & $Action

--- a/scripts/powershell/tests/lib/HermesBootstrap.Tests.ps1
+++ b/scripts/powershell/tests/lib/HermesBootstrap.Tests.ps1
@@ -176,7 +176,7 @@ Describe "Initialize-HermesBootstrapServiceAccountEnvironment" {
     }
 
     BeforeEach {
-        $script:serviceAccountDirectory = Join-Path $TestDrive 'hermes-data'
+        $script:serviceAccountDirectory = Join-Path $TestDrive ('hermes-data-' + [Guid]::NewGuid().ToString('N'))
         $null = New-Item -ItemType Directory -Path $script:serviceAccountDirectory
     }
 

--- a/scripts/powershell/tests/lib/HermesBootstrap.Tests.ps1
+++ b/scripts/powershell/tests/lib/HermesBootstrap.Tests.ps1
@@ -205,9 +205,12 @@ Describe "Initialize-HermesBootstrapServiceAccountEnvironment" {
         $envPath = Join-Path $script:serviceAccountDirectory '.op.env'
         $acl = Get-Acl -LiteralPath $envPath
         $currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+        $accessSid = $acl.Access[0].IdentityReference.Translate(
+            [System.Security.Principal.SecurityIdentifier]
+        ).Value
 
         @($acl.Access).Count | Should -Be 1
-        $acl.Access[0].IdentityReference.Value | Should -Be $currentSid
+        $accessSid | Should -Be $currentSid
         $acl.Access[0].IsInherited | Should -BeFalse
     }
 }

--- a/scripts/powershell/tests/lib/HermesBootstrap.Tests.ps1
+++ b/scripts/powershell/tests/lib/HermesBootstrap.Tests.ps1
@@ -196,6 +196,20 @@ Describe "Initialize-HermesBootstrapServiceAccountEnvironment" {
         $content | Should -Be "OP_SERVICE_ACCOUNT_TOKEN=test-service-account-token`n"
         $content.Length | Should -BeGreaterThan 0
     }
+
+    It "writes the service account env file with a user-only ACL on Windows" -Skip:(-not $IsWindows) {
+        Initialize-HermesBootstrapServiceAccountEnvironment `
+            -DataDir $script:serviceAccountDirectory `
+            -InvokeOnePassword { return 'test-service-account-token' }
+
+        $envPath = Join-Path $script:serviceAccountDirectory '.op.env'
+        $acl = Get-Acl -LiteralPath $envPath
+        $currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+
+        @($acl.Access).Count | Should -Be 1
+        $acl.Access[0].IdentityReference.Value | Should -Be $currentSid
+        $acl.Access[0].IsInherited | Should -BeFalse
+    }
 }
 
 function global:New-HermesBootstrapFakeDocker {

--- a/scripts/powershell/tests/lib/HermesBootstrap.Tests.ps1
+++ b/scripts/powershell/tests/lib/HermesBootstrap.Tests.ps1
@@ -170,6 +170,34 @@ Describe "Get-HermesBootstrapSecretPlan" {
     }
 }
 
+Describe "Initialize-HermesBootstrapServiceAccountEnvironment" {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot "../../lib/HermesBootstrap.ps1")
+    }
+
+    BeforeEach {
+        $script:serviceAccountDirectory = Join-Path $TestDrive 'hermes-data'
+        $null = New-Item -ItemType Directory -Path $script:serviceAccountDirectory
+    }
+
+    It "writes the existing service account reference into a private Compose env file" {
+        $result = Initialize-HermesBootstrapServiceAccountEnvironment `
+            -DataDir $script:serviceAccountDirectory `
+            -InvokeOnePassword {
+                param($Account, $Reference)
+                $Account | Should -Be 'my.1password.com'
+                $Reference | Should -Be 'op://openclaw/3bgd5qtytxuvuauauyqr2p4iki/credential'
+                return 'test-service-account-token'
+            }
+
+        $result | Should -BeTrue
+        $envPath = Join-Path $script:serviceAccountDirectory '.op.env'
+        $content = Get-Content -LiteralPath $envPath -Raw
+        $content | Should -Be "OP_SERVICE_ACCOUNT_TOKEN=test-service-account-token`n"
+        $content.Length | Should -BeGreaterThan 0
+    }
+}
+
 function global:New-HermesBootstrapFakeDocker {
     param([Parameter(Mandatory)][string]$Directory)
 

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -19,11 +19,73 @@ dotfiles_hermes_browser_data_dir() {
 }
 
 dotfiles_hermes_prepare_runtime_home() {
-  local data_dir browser_data_dir
+  local data_dir browser_data_dir op_env_path
   data_dir="$(dotfiles_hermes_data_dir)"
   browser_data_dir="$(dotfiles_hermes_browser_data_dir)"
+  op_env_path="$data_dir/.op.env"
 
   mkdir -p "$data_dir" "$data_dir/.xurl" "$browser_data_dir"
+  if [[ -L $op_env_path ]]; then
+    dotfiles_die "Hermes service-account environment file must not be a symlink."
+  fi
+  if [[ -e $op_env_path && ! -f $op_env_path ]]; then
+    dotfiles_die "Hermes service-account environment file must be regular."
+  fi
+  if [[ ! -e $op_env_path ]]; then
+    (umask 077 && : >"$op_env_path") ||
+      dotfiles_die "Could not create Hermes service-account environment file."
+  fi
+  chmod 600 "$op_env_path" ||
+    dotfiles_die "Could not protect Hermes service-account environment file."
+}
+
+dotfiles_hermes_service_account_ref() {
+  printf '%s\n' "${DOTFILES_HERMES_OP_SERVICE_ACCOUNT_TOKEN_REF:-op://openclaw/3bgd5qtytxuvuauauyqr2p4iki/credential}"
+}
+
+dotfiles_hermes_service_account_account() {
+  printf '%s\n' "${DOTFILES_HERMES_OP_SERVICE_ACCOUNT_ACCOUNT:-my.1password.com}"
+}
+
+dotfiles_hermes_prepare_service_account_environment() {
+  local data_dir op_env_path temporary op_command account reference token status=0 xtrace_enabled=0
+
+  data_dir="$(dotfiles_hermes_data_dir)"
+  op_env_path="$data_dir/.op.env"
+  op_command="$(dotfiles_hermes_op_command)" || return 1
+  account="$(dotfiles_hermes_service_account_account)"
+  reference="$(dotfiles_hermes_service_account_ref)"
+
+  if [[ $- == *x* ]]; then
+    xtrace_enabled=1
+    set +x
+  fi
+  if token="$("$op_command" --account "$account" read "$reference" 2>/dev/null)" &&
+    [[ -n $token && $token != *$'\n'* && $token != *$'\r'* ]]; then
+    temporary="$(mktemp "$data_dir/.op.env.XXXXXX")" || status=1
+    if ((status == 0)); then
+      if (umask 077 && printf 'OP_SERVICE_ACCOUNT_TOKEN=%s\n' "$token" >"$temporary") &&
+        chmod 600 "$temporary" &&
+        mv -f "$temporary" "$op_env_path"; then
+        :
+      else
+        status=1
+      fi
+    fi
+  else
+    status=1
+  fi
+  if [[ -n ${temporary:-} && -e $temporary ]]; then
+    rm -f -- "$temporary"
+  fi
+  unset token temporary op_command account reference
+  if ((xtrace_enabled)); then
+    set -x
+  fi
+  if ((status != 0)); then
+    printf 'Hermes 1Password Service Account could not be loaded.\n' >&2
+  fi
+  return "$status"
 }
 
 dotfiles_hermes_op_command() {
@@ -120,9 +182,11 @@ dotfiles_hermes_validate_secret_plan() {
       type == "string" and test("[^[:space:]]") and test("^[^[:cntrl:]]+$");
     def field:
       type == "object"
-      and (keys | sort == ["canonical_name", "labels"])
+      and ((keys | sort == ["canonical_name", "labels"]) or
+        (keys | sort == ["canonical_name", "labels", "reference"]))
       and (.canonical_name | nonblank_string)
-      and (.labels | type == "array" and length > 0 and all(.[]; nonblank_string));
+      and (.labels | type == "array" and length > 0 and all(.[]; nonblank_string))
+      and ((has("reference") | not) or (.reference | nonblank_string));
     def plan_item:
       type == "object"
       and (keys | sort == ["account", "fields", "item", "key", "vault"])
@@ -273,6 +337,8 @@ dotfiles_hermes_start_stack() {
 
   dotfiles_hermes_require_secret_tools
   dotfiles_hermes_prepare_runtime_home
+  dotfiles_hermes_prepare_service_account_environment ||
+    dotfiles_die "Hermes 1Password Service Account is unavailable."
 
   if "$docker_runner" compose -f "$compose_file" config --quiet; then
     :

--- a/tests/bash/bootstrap_acceptance.bats
+++ b/tests/bash/bootstrap_acceptance.bats
@@ -94,6 +94,11 @@ EOF
 	[ "$status" -eq 0 ]
 	[[ "$output" == 'acceptance-session' ]]
 
+	run "$op" --account my.1password.com read \
+		'op://openclaw/3bgd5qtytxuvuauauyqr2p4iki/credential'
+	[ "$status" -eq 0 ]
+	[ "$output" = 'acceptance-hermes-service-account-token' ]
+
 	run "$op" item get "Hermes X API MCP" \
 		--account my.1password.com --vault openclaw --format json
 	[ "$status" -eq 0 ]

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -527,7 +527,7 @@ dotfiles_hermes_start_stack docker "$COMPOSE_FILE"
 
 	[ "$status" -eq 0 ]
 	assert_log_order '<config> <--quiet>' '<build> <hermes> <hermes-bootstrap> <xapi-mcp>' '<stop> <hermes>' '<secret-plan>' '<apply>' '<Hermes Agent Dashboard>' '<GitHubUsedOpenClawPAT>' '<Google Calendar MCP>' '<SlackBot-OpenClaw>' '<SlackBot-Rick>' '<SlackBot-Hoffman>' '<SlackBot-Risarisa>' '<SlackBot-Nancy>' '<Hermes X API MCP>' '<up> <-d> <--force-recreate>'
-	[ "$(grep -c '^op ' "$COMMAND_LOG")" -eq 10 ]
+	[ "$(grep -c '^op ' "$COMMAND_LOG")" -eq 11 ]
 	mapfile -t records < <("$REAL_JQ" -r '.type + ":" + (.key // "")' "$PAYLOAD_CAPTURE")
 	[ "${records[*]}" = 'header: item:dashboard item:github item:google_calendar item:slack_default item:slack_rick item:slack_hoffman item:slack_risarisa item:slack_nancy end:' ]
 	"$REAL_JQ" -e -c 'select(.type == "item") | .item.id == "item-id"' "$PAYLOAD_CAPTURE" >/dev/null


### PR DESCRIPTION
## Summary

- Automatically resolve the personal 1Password service-account token during `task hermes:bootstrap`
- Store the token in a private `.op.env` file and inject it into Hermes Compose services
- Generate 1Password-backed references for the root Hermes config and all four profiles
- Preserve managed references across profile syncs and use the real Slack field names
- Validate Unix and PowerShell bootstrap paths and document the setup

## Verification

- `task hermes:bootstrap`
- 15/15 Slack 1Password references resolved in the running Hermes container
- `task hermes:bootstrap:test` — 554 tests passed, 3 skipped
- `bats tests/bash/hermes_agent.bats` — 20/20 passed
- Hermes PowerShell tests — 21/21 passed
- `task hermes:bootstrap:config` — passed