### PR TITLE
fix: preserve WezTerm backspace and track nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,13 @@ NixOS では `system-manager.target` の代わりに `readlink /run/current-syst
 .\scripts\powershell\Test-Environment.ps1 -Runtime
 ```
 
+### macOS で WezTerm nightly cask の適用に失敗する
+
+Homebrew 更新後も `wezterm@nightly` のインストールが `source_glob` または
+`rb_file_s_rename` エラーで失敗する場合は、
+[Homebrew cask のトラブルシューティング](./docs/nix/homebrew-cask-troubleshooting.md)
+を参照してください。
+
 ### Windows Terminal 設定が反映されない
 
 1. Windows で `chezmoi apply` を実行

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -104,6 +104,8 @@ config.send_composed_key_when_right_alt_is_pressed = false
 config.keys = {
     -- Shift+Enter → insert newline (Claude Code, Codex, multi-line prompts)
     { key = "Return", mods = "SHIFT", action = act.SendString("\n") },
+    -- Preserve Backspace when it is pressed immediately after the leader key.
+    { key = "Backspace", mods = "LEADER", action = act.SendKey({ key = "Backspace" }) },
     -- Pass Ctrl+Shift+h/l through to Neovim; WezTerm defaults Ctrl+Shift+l to the debug overlay.
     { key = "h", mods = "CTRL|SHIFT", action = act.SendKey({ key = "h", mods = "CTRL|SHIFT" }) },
     { key = "l", mods = "CTRL|SHIFT", action = act.SendKey({ key = "l", mods = "CTRL|SHIFT" }) },

--- a/docs/nix/homebrew-cask-troubleshooting.md
+++ b/docs/nix/homebrew-cask-troubleshooting.md
@@ -1,0 +1,120 @@
+# Homebrew cask のトラブルシューティング
+
+## WezTerm nightly の `source_glob` エラー
+
+### 対象
+
+2026-07-29 時点の Homebrew 6.0.11 では、公式 `wezterm@nightly` cask の
+`preflight_steps` が `source_glob` を使う一方、実行中の Homebrew がその引数を
+正しく処理できず、インストールに失敗する場合があります。
+
+代表的なエラー:
+
+```text
+Error: No such file or directory @ rb_file_s_rename -
+(/opt/homebrew/Caskroom/wezterm@nightly/latest/{WezTerm-*,wezterm-*}/WezTerm.app, ...)
+```
+
+これは WezTerm の設定や配布 archive の破損ではなく、Homebrew 本体と
+[公式 cask 定義](https://github.com/Homebrew/homebrew-cask/blob/main/Casks/w/wezterm%40nightly.rb)
+の一時的な互換性差です。
+
+### 最初に試すこと
+
+Homebrew を更新し、公式 cask をそのまま再試行します。
+
+```zsh
+brew update
+brew install --cask wezterm@nightly
+```
+
+すでにインストール済みの場合:
+
+```zsh
+brew upgrade --cask --greedy wezterm@nightly
+```
+
+これで成功する場合、以下の暫定回避は不要です。
+
+### 暫定回避
+
+この手順は上記の `rb_file_s_rename` エラーが再現し、Homebrew の更新でも解消
+しない場合だけ使用します。公式 tap の cask ファイルを一時編集するため、
+インストール後に必ず復元してください。
+
+1. 公式 cask tap をローカルに取得し、作業前に差分がないことを確認します。
+
+   ```zsh
+   brew tap --force homebrew/cask
+   cask_tap="$(brew --repository homebrew/cask)"
+   git -C "$cask_tap" diff --exit-code
+   ```
+
+   差分が表示された場合は、既存の変更を上書きせず作業を中止します。
+
+2. cask 定義を開きます。
+
+   ```zsh
+   cask_file="$cask_tap/Casks/w/wezterm@nightly.rb"
+   "${EDITOR:-vi}" "$cask_file"
+   ```
+
+3. `preflight_steps do` から対応する `end` までを、次の `preflight` block に
+   一時的に置き換えます。
+
+   ```ruby
+   preflight do
+     source_app = staged_path.glob("{WezTerm-*,wezterm-*}/WezTerm.app").first
+     raise "WezTerm.app was not found in the staged archive" if source_app.nil?
+
+     FileUtils.mv source_app, staged_path/"WezTerm.app"
+   end
+   ```
+
+4. API版ではなく、編集したローカル cask 定義を使ってインストールします。
+
+   ```zsh
+   HOMEBREW_NO_AUTO_UPDATE=1 \
+     HOMEBREW_NO_INSTALL_FROM_API=1 \
+     brew install --cask wezterm@nightly
+   ```
+
+5. インストール結果を確認します。
+
+   ```zsh
+   brew list --cask --versions wezterm@nightly
+   /opt/homebrew/bin/wezterm --version
+   test -d /Applications/WezTerm.app
+   ```
+
+### 復元と後片付け
+
+次の `git restore` は、上記手順で編集した cask 定義だけを公式状態へ戻します。
+手順1で既存差分がないことを確認してから実行してください。
+
+```zsh
+git -C "$cask_tap" restore -- Casks/w/wezterm@nightly.rb
+git -C "$cask_tap" diff --exit-code
+brew untap homebrew/cask
+```
+
+一部の Homebrew バージョンでは、tap の削除完了後に `brew untap` が Git の
+終了コードで失敗扱いになることがあります。その場合は、次のコマンドが何も
+出力しなければ tap は削除済みです。
+
+```zsh
+brew tap | rg '^homebrew/cask$'
+```
+
+最後に、cask とバイナリが残っていることを再確認します。
+
+```zsh
+brew list --cask --versions wezterm@nightly
+/opt/homebrew/bin/wezterm --version
+```
+
+### 終了条件
+
+Homebrew 更新後に公式 cask を無編集でインストールまたは更新できるように
+なった時点で、この暫定回避は使用しません。ローカル tap や変更済み cask
+定義を恒久的に残さないでください。

--- a/docs/nix/package-management.md
+++ b/docs/nix/package-management.md
@@ -50,6 +50,11 @@ Ubuntu / Debian:  ./install.sh
 
 その他 Linux の `DOTFILES_ALLOW_USER_ONLY=1 ./install.sh` は Home Manager のみで、Docker や OS service は管理しません。
 
+macOS で Homebrew cask の適用に失敗する場合は、
+[Homebrew cask のトラブルシューティング](./homebrew-cask-troubleshooting.md)
+を参照してください。WezTerm nightly の既知の一時回避と、公式状態へ戻す手順を
+記載しています。
+
 ## 生成ファイル
 
 Windows manifest は直接編集しません。更新時は以下を生成し、repository の JSON と一致させます。

--- a/docs/superpowers/plans/2026-07-28-wezterm-backspace-latest.md
+++ b/docs/superpowers/plans/2026-07-28-wezterm-backspace-latest.md
@@ -1,0 +1,166 @@
+# WezTerm Backspace and macOS Nightly Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve Backspace after the WezTerm leader key and install the continuously updated WezTerm nightly cask on macOS.
+
+**Architecture:** Keep terminal behavior in the WezTerm Lua configuration and package-provider selection in the existing catalog. Darwin uses the official `wezterm@nightly` Homebrew cask and excludes the Nix WezTerm package, while Linux and Windows retain their current providers.
+
+**Tech Stack:** Lua, Nix, nix-darwin, Homebrew casks, Pester, Bats
+
+## Global Constraints
+
+- Keep `Ctrl+Space` as the WezTerm leader with its existing timeout.
+- Preserve the Linux Nix provider and Windows nightly winget provider.
+- Use the existing nix-darwin activation-time Homebrew update and upgrade path.
+- Do not add a second updater.
+
+---
+
+### Task 1: Leader Backspace Passthrough
+
+**Files:**
+- Modify: `scripts/powershell/tests/chezmoi/Keybindings.Tests.ps1`
+- Modify: `chezmoi/terminals/wezterm/wezterm.lua`
+
+**Interfaces:**
+- Consumes: WezTerm `LEADER` modifier and `act.SendKey`
+- Produces: A `LEADER+Backspace` assignment that sends an unmodified Backspace event
+
+- [ ] **Step 1: Write the failing keybinding contract**
+
+Add this assertion to the existing WezTerm keybinding test:
+
+```powershell
+$content | Should -Match 'key = "Backspace", mods = "LEADER", action = act\.SendKey\(\{ key = "Backspace" \}\)'
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path scripts/powershell/tests/chezmoi/Keybindings.Tests.ps1 -Output Detailed"
+```
+
+Expected: the WezTerm keybinding test fails because the leader Backspace assignment is absent.
+
+- [ ] **Step 3: Add the minimal WezTerm assignment**
+
+Add this entry immediately after the Shift+Enter assignment:
+
+```lua
+{ key = "Backspace", mods = "LEADER", action = act.SendKey({ key = "Backspace" }) },
+```
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the command from Step 2.
+
+Expected: all tests in `Keybindings.Tests.ps1` pass.
+
+### Task 2: macOS WezTerm Nightly Provider
+
+**Files:**
+- Modify: `tests/bash/package_catalog.bats`
+- Modify: `nix/packages/sets.nix`
+
+**Interfaces:**
+- Consumes: package catalog `pkg` and `support` metadata
+- Produces: Darwin cask `wezterm@nightly`, Linux Nix provider, existing Windows winget provider
+
+- [ ] **Step 1: Write the failing catalog and evaluation contract**
+
+Add a Bats test that extracts the WezTerm catalog entry and requires:
+
+```nix
+pkg = if pkgs.stdenv.isDarwin then null else pkgs.wezterm;
+support.darwin.provider = "homebrew-cask";
+support.darwin.cask = "wezterm@nightly";
+support.linux.provider = "nix";
+```
+
+The test must also evaluate `darwinConfigurations.macos` and assert that the
+normalized Homebrew cask list contains `wezterm@nightly` while the Home Manager
+package list contains no package whose `pname` is `wezterm`.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+bats tests/bash/package_catalog.bats
+```
+
+Expected: the new WezTerm provider test fails because Darwin still resolves the Nix package and has no WezTerm cask.
+
+- [ ] **Step 3: Implement the provider metadata**
+
+Change the WezTerm entry to:
+
+```nix
+wezterm = {
+  pkg = if pkgs.stdenv.isDarwin then null else pkgs.wezterm;
+  winget = "wez.wezterm.nightly";
+  category = "terminal";
+  support = {
+    darwin = {
+      provider = "homebrew-cask";
+      cask = "wezterm@nightly";
+    };
+    linux = {
+      provider = "nix";
+    };
+  };
+};
+```
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the command from Step 2.
+
+Expected: all package catalog tests pass.
+
+### Task 3: Final Verification
+
+**Files:**
+- Verify all modified implementation and test files
+
+**Interfaces:**
+- Consumes: completed Tasks 1 and 2
+- Produces: formatted, evaluated, regression-tested branch
+
+- [ ] **Step 1: Format**
+
+Run:
+
+```bash
+nix fmt
+```
+
+- [ ] **Step 2: Run relevant tests**
+
+Run:
+
+```bash
+bats tests/bash/package_catalog.bats tests/bash/macos_config.bats
+pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path scripts/powershell/tests/chezmoi/Keybindings.Tests.ps1 -Output Detailed"
+```
+
+- [ ] **Step 3: Evaluate the macOS configuration**
+
+Run:
+
+```bash
+DOTFILES_USER=codex DOTFILES_HOME=/Users/codex nix eval --impure --json .#darwinConfigurations.macos.config.homebrew.casks
+DOTFILES_USER=codex DOTFILES_HOME=/Users/codex nix build --no-link .#darwinConfigurations.macos.system
+```
+
+- [ ] **Step 4: Review the final diff**
+
+Run:
+
+```bash
+git diff --check
+git diff origin/main...HEAD
+```

--- a/docs/superpowers/plans/2026-07-28-wezterm-backspace-latest.md
+++ b/docs/superpowers/plans/2026-07-28-wezterm-backspace-latest.md
@@ -20,10 +20,12 @@
 ### Task 1: Leader Backspace Passthrough
 
 **Files:**
+
 - Modify: `scripts/powershell/tests/chezmoi/Keybindings.Tests.ps1`
 - Modify: `chezmoi/terminals/wezterm/wezterm.lua`
 
 **Interfaces:**
+
 - Consumes: WezTerm `LEADER` modifier and `act.SendKey`
 - Produces: A `LEADER+Backspace` assignment that sends an unmodified Backspace event
 
@@ -62,10 +64,12 @@ Expected: all tests in `Keybindings.Tests.ps1` pass.
 ### Task 2: macOS WezTerm Nightly Provider
 
 **Files:**
+
 - Modify: `tests/bash/package_catalog.bats`
 - Modify: `nix/packages/sets.nix`
 
 **Interfaces:**
+
 - Consumes: package catalog `pkg` and `support` metadata
 - Produces: Darwin cask `wezterm@nightly`, Linux Nix provider, existing Windows winget provider
 
@@ -124,9 +128,11 @@ Expected: all package catalog tests pass.
 ### Task 3: Final Verification
 
 **Files:**
+
 - Verify all modified implementation and test files
 
 **Interfaces:**
+
 - Consumes: completed Tasks 1 and 2
 - Produces: formatted, evaluated, regression-tested branch
 

--- a/docs/superpowers/specs/2026-07-28-wezterm-backspace-latest-design.md
+++ b/docs/superpowers/specs/2026-07-28-wezterm-backspace-latest-design.md
@@ -1,0 +1,56 @@
+# WezTerm Backspace and macOS Nightly Design
+
+## Context
+
+WezTerm uses `Ctrl+Space` as a two-second leader key. While the leader is
+active, an unassigned Backspace event is consumed instead of being sent to the
+foreground terminal application.
+
+On macOS, WezTerm is currently installed from the pinned nixpkgs package.
+LaunchServices can retain an older Nix Store application path after the command
+in the active Home Manager profile has moved to a newer store path. The package
+catalog already defines Homebrew casks as the provider for macOS GUI
+applications and upgrades them during every nix-darwin activation.
+
+## Goals
+
+- Send Backspace to the foreground application even when the WezTerm leader is
+  active.
+- Install WezTerm nightly from a stable `/Applications/WezTerm.app` path on
+  macOS.
+- Upgrade the macOS GUI and bundled CLI commands together during every
+  nix-darwin activation.
+- Preserve the existing Nix provider on Linux and nightly winget provider on
+  Windows.
+
+## Design
+
+Add a `LEADER+Backspace` key assignment that performs
+`SendKey({ key = "Backspace" })`. This consumes the leader state while
+forwarding the Backspace event to the active pane.
+
+Change the WezTerm catalog entry so its Nix package is omitted only while
+evaluating on Darwin. Declare `wezterm@nightly` as the Darwin Homebrew cask and
+declare the Nix provider explicitly for Linux. The existing nix-darwin
+configuration already enables `autoUpdate`, `upgrade`, and `greedyCasks`, so no
+second update mechanism is needed.
+
+The Homebrew nightly cask is intentionally selected instead of the stable cask:
+its version is `latest`, it downloads WezTerm's upstream nightly release, and it
+installs both `WezTerm.app` and the bundled CLI commands.
+
+## Verification
+
+- A Pester keybinding contract requires the leader Backspace passthrough.
+- A Bats package-catalog contract requires the Darwin nightly cask, explicit
+  Linux Nix provider, and Darwin exclusion of the Nix package.
+- Each new contract is run before implementation to observe the expected
+  failure and again after implementation to observe success.
+- Run formatting, focused tests, package-provider evaluation, and the relevant
+  repository test suites.
+
+## Non-Goals
+
+- Changing the leader key or timeout.
+- Changing the Linux or Windows WezTerm release channel.
+- Adding an updater outside the existing nix-darwin/Homebrew activation path.

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -212,9 +212,18 @@ let
 
     # ── terminal ──────────────────────────────────────────
     wezterm = {
-      pkg = pkgs.wezterm;
+      pkg = if pkgs.stdenv.isDarwin then null else pkgs.wezterm;
       winget = "wez.wezterm.nightly";
       category = "terminal";
+      support = {
+        darwin = {
+          provider = "homebrew-cask";
+          cask = "wezterm@nightly";
+        };
+        linux = {
+          provider = "nix";
+        };
+      };
     };
     tmux = {
       pkg = pkgs.tmux;

--- a/scripts/powershell/tests/chezmoi/Keybindings.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/Keybindings.Tests.ps1
@@ -115,6 +115,7 @@ Describe '標準キーバインド方針' {
         $content | Should -Match '\{ key = "j", mods = "CTRL\|ALT", action = act\.AdjustPaneSize\(\{ "Down", 5 \}\) \}'
         $content | Should -Match '\{ key = "k", mods = "CTRL\|ALT", action = act\.AdjustPaneSize\(\{ "Up", 5 \}\) \}'
         $content | Should -Match '\{ key = "l", mods = "CTRL\|ALT", action = act\.AdjustPaneSize\(\{ "Right", 5 \}\) \}'
+        $content | Should -Match '\{ key = "Backspace", mods = "LEADER", action = act\.SendKey\(\{ key = "Backspace" \}\) \}'
     }
 
     It 'Warp keybindings are no longer managed' {

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+bats_require_minimum_version 1.5.0
+
 setup() {
 	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
 	SETS="$REPO_ROOT/nix/packages/sets.nix"
@@ -89,7 +91,7 @@ setup() {
 @test "Darwin evaluation installs only the WezTerm nightly cask" {
 	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
 
-	run env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex nix eval --impure --json --expr "
+	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex nix eval --impure --json --expr "
 		let
 		  flake = builtins.getFlake (toString $REPO_ROOT);
 		  config = flake.darwinConfigurations.macos.config;

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -71,6 +71,41 @@ setup() {
 	grep -q 'cask = "stablyai/orca/orca"' "$SETS"
 }
 
+@test "WezTerm uses the nightly Homebrew cask on Darwin and Nix on Linux" {
+	run awk '
+		/wezterm = \{/ { in_entry=1 }
+		in_entry { print }
+		in_entry && /^    };/ { exit }
+	' "$SETS"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'pkg = if pkgs.stdenv.isDarwin then null else pkgs.wezterm;'* ]]
+	[[ "$output" == *'cask = "wezterm@nightly"'* ]]
+	[[ "$output" == *'darwin = {'* ]]
+	[[ "$output" == *'linux = {'* ]]
+	[[ "$output" == *'provider = "homebrew-cask"'* ]]
+	[[ "$output" == *'provider = "nix"'* ]]
+}
+
+@test "Darwin evaluation installs only the WezTerm nightly cask" {
+	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
+
+	run env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex nix eval --impure --json --expr "
+		let
+		  flake = builtins.getFlake (toString $REPO_ROOT);
+		  config = flake.darwinConfigurations.macos.config;
+		  caskNames = builtins.map (cask: if builtins.isString cask then cask else cask.name) config.homebrew.casks;
+		  homePackages = config.home-manager.users.codex.home.packages;
+		in {
+		  casks = builtins.filter (name: name == \"wezterm@nightly\") caskNames;
+		  nixPackages = builtins.map (package: package.name) (
+		    builtins.filter (package: (package.pname or \"\") == \"wezterm\") homePackages
+		  );
+		}
+	"
+	[ "$status" -eq 0 ]
+	[ "$output" = '{"casks":["wezterm@nightly"],"nixPackages":[]}' ]
+}
+
 @test "Warp is removed from the package catalog" {
 	! grep -q 'warp-terminal' "$SETS"
 	! grep -q 'Warp.Warp' "$SETS"


### PR DESCRIPTION
## Summary

- pass Backspace through while the WezTerm leader key table is active
- manage `wezterm@nightly` with Homebrew cask on macOS while retaining Nix on Linux
- add regression coverage for the key binding and platform package providers
- document the temporary Homebrew 6.0.11 `source_glob` cask workaround, verification, and cleanup steps

## Root cause

WezTerm's `Ctrl+Space` leader remains active for two seconds. Backspace had no leader-table mapping, so pressing it during that window was swallowed instead of reaching the terminal application.

On macOS, the Nix package also did not guarantee the latest WezTerm nightly. The Darwin provider now uses the official `wezterm@nightly` Homebrew cask, which participates in the existing automatic, greedy cask upgrade policy.

## User impact

Backspace continues to work immediately after the leader key is pressed, and macOS installations track the official WezTerm nightly cask. The troubleshooting runbook records the temporary upstream compatibility workaround without leaving a modified tap behind.

## Validation

- `HERMES_HOME_PROVENANCE_REPOSITORY=/Users/ktome1995/Program/hermes-home-profile-sync pre-commit run --all-files`
- `bats tests/bash` (134 passed)
- `nix build .#checks.aarch64-darwin.treefmt .#checks.aarch64-darwin.package-provider-coverage --no-link`
- `nix build .#darwinConfigurations.macos.system --impure --no-link`
- `/opt/homebrew/bin/wezterm --config-file chezmoi/terminals/wezterm/wezterm.lua show-keys --lua`
- `git diff --check origin/main...HEAD`
