### PR TITLE
Restore Chrome GPU rendering

### DIFF
--- a/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
@@ -100,6 +100,15 @@ class ComposeContractTests(unittest.TestCase):
             ],
         )
 
+    def test_chrome_entrypoint_does_not_disable_gpu_rendering(self) -> None:
+        entrypoint_path = REPOSITORY_ROOT / "docker/hermes-browser/entrypoint.sh"
+        if not entrypoint_path.is_file():
+            self.skipTest("hermes-browser source is outside the bootstrap test context")
+
+        self.assertNotIn(
+            "--disable-gpu", entrypoint_path.read_text(encoding="utf-8")
+        )
+
     def test_xapi_mcp_is_an_internal_shared_service(self) -> None:
         xapi = self.services.get("xapi-mcp")
         self.assertIsNotNone(xapi)

--- a/docker/hermes-browser/entrypoint.sh
+++ b/docker/hermes-browser/entrypoint.sh
@@ -195,7 +195,6 @@ socat TCP-LISTEN:9222,fork,reuseaddr,bind=0.0.0.0 EXEC:"python3 /tmp/hermes-cdp-
 cdp_pid=$!
 
 /usr/bin/google-chrome-stable \
-  --disable-gpu \
   --lang=ja \
   --remote-debugging-address=127.0.0.1 \
   --remote-debugging-port=9223 \


### PR DESCRIPTION
## Summary

- Remove the forced `--disable-gpu` flag from the Hermes Chrome container.
- Add a contract test to prevent GPU rendering from being disabled again.

## Why

The Hermes Chrome entrypoint was explicitly disabling GPU rendering. Removing that flag restores Chrome's default GPU rendering path while preserving the existing Xvfb, CDP, and Browser MCP setup.

## Validation

- `task hermes:bootstrap:test` — 559 tests passed, 4 skipped.
- `sh -n docker/hermes-browser/entrypoint.sh`
- `docker compose -f docker/hermes-agent/compose.yml config`
- All active Hermes profiles connected to Chrome MCP successfully.
