### PR TITLE
fix: harden Hermes browser MCP requests

### DIFF
--- a/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
@@ -89,6 +89,8 @@ class ComposeContractTests(unittest.TestCase):
                 "node_modules/.bin/mcp-proxy",
                 "--server",
                 "stream",
+                "--requestTimeout",
+                "120000",
                 "--host",
                 "0.0.0.0",
                 "--port",
@@ -96,8 +98,20 @@ class ComposeContractTests(unittest.TestCase):
                 "--",
                 "node_modules/.bin/chrome-devtools-mcp",
                 "--browser-url=http://chromium:9222",
+                "--experimentalPageIdRouting",
                 "--no-usage-statistics",
             ],
+        )
+
+    def test_browser_mcp_routes_page_operations_and_bounds_stuck_requests(self) -> None:
+        command = self.services["browser-mcp"]["command"]
+
+        self.assertIn("--experimentalPageIdRouting", command)
+        self.assertEqual(
+            command[
+                command.index("--requestTimeout") + 1
+            ],
+            "120000",
         )
 
     def test_chrome_entrypoint_does_not_disable_gpu_rendering(self) -> None:

--- a/docker/hermes-agent/compose.yml
+++ b/docker/hermes-agent/compose.yml
@@ -93,6 +93,8 @@ services:
       - node_modules/.bin/mcp-proxy
       - --server
       - stream
+      - --requestTimeout
+      - "120000"
       - --host
       - 0.0.0.0
       - --port
@@ -100,6 +102,7 @@ services:
       - --
       - node_modules/.bin/chrome-devtools-mcp
       - --browser-url=http://chromium:9222
+      - --experimentalPageIdRouting
       - --no-usage-statistics
     depends_on:
       chromium:

--- a/docs/hermes-agent/browser-mcp.md
+++ b/docs/hermes-agent/browser-mcp.md
@@ -7,7 +7,7 @@ host 側の Chrome/Chromium/Brave 実行ファイル、host CDP endpoint、host 
 ## 構成
 
 - `chromium`: 互換性のため service 名は維持しつつ、Xvfb 上の visible Google Chrome を container 内で起動する。CDP は Compose network 内だけに公開し、noVNC viewer だけを `127.0.0.1` に公開する。
-- `browser-mcp`: `chrome-devtools-mcp` を `mcp-proxy` 経由で Streamable HTTP MCP として公開する。
+- `browser-mcp`: `chrome-devtools-mcp` を `mcp-proxy` 経由で Streamable HTTP MCP として公開する。MCP要求は120秒で打ち切り、ページ単位の操作はDevToolsのpage IDでルーティングする。
 - `hermes`: `browser-mcp` service 名で Browser MCP に接続する。
 
 Google Chrome container は `ja_JP.UTF-8` locale と `--lang=ja` で起動し、Chrome UI と日本語入力内容を表示できるようにする。
@@ -95,3 +95,11 @@ docker exec -e HERMES_HOME=/opt/data/profiles/nancy hermes hermes mcp test chrom
 が表示されることを確認する。`hermes tools list --platform slack` では built-in
 `browser` が disabled、`web` が enabled と表示されることも確認する。host noVNC は
 `http://127.0.0.1:6080/` で開く。
+
+長時間のブラウザ処理は、Chrome操作を逐次化し、一覧1ページまたは詳細2〜5件を
+1バッチとして扱う。各バッチの完了時にページ番号・候補ID・URLをcheckpointへ
+記録し、詳細ページを閉じる。`take_snapshot`、`click`、`navigate_page` のいずれかが
+タイムアウトした場合は、そのバッチを未完了として停止し、1回だけ限定的な再読込を
+試す。再発時は同じページへ操作を重ねず、browser servicesを再起動してcheckpoint
+から再開する。レビューや候補判定の並列化は、Chromeからの証拠取得が終わった後に
+行う。


### PR DESCRIPTION
## Summary

- Enable Chrome DevTools MCP page-ID routing for page-scoped operations.
- Bound Browser MCP proxy requests to 120 seconds so a stuck accessibility-tree operation does not occupy the MCP path for five minutes.
- Document serialized browser batches, checkpoints, bounded recovery, and tab cleanup.
- Add a Compose contract test for the new runtime safeguards.

## Root cause

The recurring failure was occurring during page-level `Accessibility.getFullAXTree` and `Runtime.evaluate` operations, while the CDP transport itself remained healthy. The live browser session also accumulated multiple pages and stale contexts. GPU rendering was already enabled, so the mitigation targets MCP request isolation and bounded failure handling.

## Validation

- Browser MCP image rebuilt and `hermes-browser-mcp` recreated locally.
- Nancy profile: Chrome MCP connected in 79 ms and discovered 29 tools.
- Hermes bootstrap container tests: 560 passed, 4 skipped.
- Compose configuration validation passed.
- Scoped pre-commit checks passed.

The repository-wide provenance hook could not run because the sibling `../hermes-home-profile-sync` Git worktree is not present in this checkout; the failure is unrelated to this diff.