### PR TITLE
fix: prevent Hermes Chrome renderer timeouts

### DIFF
--- a/.github/workflows/ci-hermes-bootstrap.yml
+++ b/.github/workflows/ci-hermes-bootstrap.yml
@@ -6,6 +6,8 @@ on:
     branches: [main]
     paths:
       - "docker/hermes-agent/**"
+      - "docker/hermes-browser/**"
+      - "docker/hermes-browser-mcp/**"
       - ".github/workflows/ci-hermes-bootstrap.yml"
       - ".pre-commit-config.yaml"
       - "Taskfile.yml"
@@ -13,6 +15,8 @@ on:
     branches: [main]
     paths:
       - "docker/hermes-agent/**"
+      - "docker/hermes-browser/**"
+      - "docker/hermes-browser-mcp/**"
       - ".github/workflows/ci-hermes-bootstrap.yml"
       - ".pre-commit-config.yaml"
       - "Taskfile.yml"
@@ -60,6 +64,9 @@ jobs:
 
       - name: Run the pinned container suite
         run: docker build --target hermes-bootstrap-test -t local/hermes-bootstrap-test docker/hermes-agent
+
+      - name: Run Hermes browser runtime contracts
+        run: docker/hermes-browser/tests/test_runtime_contract.sh
 
       - name: Run the gh wrapper security suite
         run: docker/hermes-agent/bootstrap/tests/test_gh_wrapper.sh

--- a/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
@@ -123,35 +123,6 @@ class ComposeContractTests(unittest.TestCase):
             "--disable-gpu", entrypoint_path.read_text(encoding="utf-8")
         )
 
-    def test_chrome_entrypoint_keeps_background_renderers_live(self) -> None:
-        entrypoint_path = REPOSITORY_ROOT / "docker/hermes-browser/entrypoint.sh"
-        if not entrypoint_path.is_file():
-            self.skipTest("hermes-browser source is outside the bootstrap test context")
-
-        entrypoint = entrypoint_path.read_text(encoding="utf-8")
-        for argument in (
-            "--disable-background-timer-throttling",
-            "--disable-renderer-backgrounding",
-            "--disable-backgrounding-occluded-windows",
-            "--disable-features=CalculateNativeWinOcclusion,TabDiscarding",
-        ):
-            self.assertIn(argument, entrypoint)
-
-    def test_browser_mcp_dependencies_are_currently_pinned(self) -> None:
-        package_path = REPOSITORY_ROOT / "docker/hermes-browser-mcp/package.json"
-        if not package_path.is_file():
-            self.skipTest("browser-mcp source is outside the bootstrap test context")
-
-        package = json.loads(package_path.read_text(encoding="utf-8"))
-
-        self.assertEqual(
-            package["dependencies"],
-            {
-                "chrome-devtools-mcp": "1.6.0",
-                "mcp-proxy": "6.5.5",
-            },
-        )
-
     def test_xapi_mcp_is_an_internal_shared_service(self) -> None:
         xapi = self.services.get("xapi-mcp")
         self.assertIsNotNone(xapi)

--- a/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
@@ -123,6 +123,35 @@ class ComposeContractTests(unittest.TestCase):
             "--disable-gpu", entrypoint_path.read_text(encoding="utf-8")
         )
 
+    def test_chrome_entrypoint_keeps_background_renderers_live(self) -> None:
+        entrypoint_path = REPOSITORY_ROOT / "docker/hermes-browser/entrypoint.sh"
+        if not entrypoint_path.is_file():
+            self.skipTest("hermes-browser source is outside the bootstrap test context")
+
+        entrypoint = entrypoint_path.read_text(encoding="utf-8")
+        for argument in (
+            "--disable-background-timer-throttling",
+            "--disable-renderer-backgrounding",
+            "--disable-backgrounding-occluded-windows",
+            "--disable-features=CalculateNativeWinOcclusion,TabDiscarding",
+        ):
+            self.assertIn(argument, entrypoint)
+
+    def test_browser_mcp_dependencies_are_currently_pinned(self) -> None:
+        package_path = REPOSITORY_ROOT / "docker/hermes-browser-mcp/package.json"
+        if not package_path.is_file():
+            self.skipTest("browser-mcp source is outside the bootstrap test context")
+
+        package = json.loads(package_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            package["dependencies"],
+            {
+                "chrome-devtools-mcp": "1.6.0",
+                "mcp-proxy": "6.5.5",
+            },
+        )
+
     def test_xapi_mcp_is_an_internal_shared_service(self) -> None:
         xapi = self.services.get("xapi-mcp")
         self.assertIsNotNone(xapi)

--- a/docker/hermes-browser-mcp/package-lock.json
+++ b/docker/hermes-browser-mcp/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "chrome-devtools-mcp": "1.4.0",
-        "mcp-proxy": "6.5.2"
+        "chrome-devtools-mcp": "1.6.0",
+        "mcp-proxy": "6.5.5"
       }
     },
     "node_modules/accepts": {
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/chrome-devtools-mcp": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-1.4.0.tgz",
-      "integrity": "sha512-OOT5mYMUbqqgpIGx0s0TgxnlicRSDm3yhZWzK3pWkB6TUPb+WdpI0j6OQoTnNZ9mqn9rwXiCOLzY4UALp+XsiQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-1.6.0.tgz",
+      "integrity": "sha512-VZX6f/OjQSYhy2BGGRs+y3LsrsAQAz/HwZCWKBLVyST/4r/3zjVEjjVW7gMCVbRDuspnVdcp5hQDPrQ5UFrdZw==",
       "license": "Apache-2.0",
       "bin": {
         "chrome-devtools": "build/src/bin/chrome-devtools.js",
@@ -104,6 +104,18 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      },
+      "peerDependencies": {
+        "@blackwell-systems/gcf": "^2.2.2",
+        "@toon-format/toon": "^2.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@blackwell-systems/gcf": {
+          "optional": true
+        },
+        "@toon-format/toon": {
+          "optional": true
+        }
       }
     },
     "node_modules/cliui": {
@@ -690,9 +702,9 @@
       }
     },
     "node_modules/mcp-proxy": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.5.2.tgz",
-      "integrity": "sha512-3sE9kedh81dqqpObzO0nUf8aAyGnzLVDVH97GCLL3fXCBOkXDWZBts63u0bM5lT1Q4FKZY0+E91dZ7Chb2ybsA==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.5.5.tgz",
+      "integrity": "sha512-V0ICA9ISfmLhrATCE1CpFrA7XyhY8al5O6NZybXfdSYaZ0se/j08izhA0uFQ96VxQMiUrBTAvyiovsE0nHUq5Q==",
       "license": "MIT",
       "dependencies": {
         "pipenet": "^1.3.0"

--- a/docker/hermes-browser-mcp/package.json
+++ b/docker/hermes-browser-mcp/package.json
@@ -5,7 +5,7 @@
   "description": "Containerized Browser MCP bridge for Hermes",
   "license": "UNLICENSED",
   "dependencies": {
-    "chrome-devtools-mcp": "1.4.0",
-    "mcp-proxy": "6.5.2"
+    "chrome-devtools-mcp": "1.6.0",
+    "mcp-proxy": "6.5.5"
   }
 }

--- a/docker/hermes-browser/entrypoint.sh
+++ b/docker/hermes-browser/entrypoint.sh
@@ -196,6 +196,10 @@ cdp_pid=$!
 
 /usr/bin/google-chrome-stable \
   --lang=ja \
+  --disable-background-timer-throttling \
+  --disable-renderer-backgrounding \
+  --disable-backgrounding-occluded-windows \
+  --disable-features=CalculateNativeWinOcclusion,TabDiscarding \
   --remote-debugging-address=127.0.0.1 \
   --remote-debugging-port=9223 \
   --user-data-dir=/data \

--- a/docker/hermes-browser/tests/test_runtime_contract.sh
+++ b/docker/hermes-browser/tests/test_runtime_contract.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+entrypoint="$repo_root/docker/hermes-browser/entrypoint.sh"
+
+for argument in \
+  "--disable-background-timer-throttling" \
+  "--disable-renderer-backgrounding" \
+  "--disable-backgrounding-occluded-windows" \
+  "--disable-features=CalculateNativeWinOcclusion,TabDiscarding"; do
+  grep -Fq -- "$argument" "$entrypoint"
+done
+
+if grep -Fq -- "--disable-gpu" "$entrypoint"; then
+  echo "Chrome GPU rendering must remain enabled" >&2
+  exit 1
+fi
+
+python3 - "$repo_root/docker/hermes-browser-mcp/package.json" "$repo_root/docker/hermes-browser-mcp/package-lock.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+package_path, lock_path = map(Path, sys.argv[1:])
+package = json.loads(package_path.read_text(encoding="utf-8"))
+expected = {
+    "chrome-devtools-mcp": "1.6.0",
+    "mcp-proxy": "6.5.5",
+}
+if package.get("dependencies") != expected:
+    raise SystemExit(f"unexpected package dependencies: {package.get('dependencies')!r}")
+
+lock = json.loads(lock_path.read_text(encoding="utf-8"))
+for name, version in expected.items():
+    dependency = lock["packages"][f"node_modules/{name}"]
+    if dependency["version"] != version:
+        raise SystemExit(f"unexpected lock version for {name}: {dependency['version']!r}")
+
+print("Hermes browser runtime contracts: PASS")
+PY

--- a/docs/hermes-agent/browser-mcp.md
+++ b/docs/hermes-agent/browser-mcp.md
@@ -7,10 +7,10 @@ host 側の Chrome/Chromium/Brave 実行ファイル、host CDP endpoint、host 
 ## 構成
 
 - `chromium`: 互換性のため service 名は維持しつつ、Xvfb 上の visible Google Chrome を container 内で起動する。CDP は Compose network 内だけに公開し、noVNC viewer だけを `127.0.0.1` に公開する。
-- `browser-mcp`: `chrome-devtools-mcp` を `mcp-proxy` 経由で Streamable HTTP MCP として公開する。MCP要求は120秒で打ち切り、ページ単位の操作はDevToolsのpage IDでルーティングする。
+- `browser-mcp`: `chrome-devtools-mcp` を `mcp-proxy` 経由で Streamable HTTP MCP として公開する。MCP要求は120秒で打ち切り、ページ単位の操作はDevToolsのpage IDでルーティングする。Chrome DevTools MCPは1.6.0、MCP proxyは6.5.5に固定する。
 - `hermes`: `browser-mcp` service 名で Browser MCP に接続する。
 
-Google Chrome container は `ja_JP.UTF-8` locale と `--lang=ja` で起動し、Chrome UI と日本語入力内容を表示できるようにする。
+Google Chrome container は `ja_JP.UTF-8` locale と `--lang=ja` で起動し、Chrome UI と日本語入力内容を表示できるようにする。長寿命の専用ブラウザでバックグラウンドページが凍結・破棄されると、CDPの `Runtime.enable` や `Accessibility.getFullAXTree` が停止してMCP全体のsnapshotがタイムアウトするため、背景Rendererの抑制とTabDiscardingを無効化する。
 noVNC viewer は通常の `Cmd/Ctrl+C`、`Cmd/Ctrl+X`、`Cmd/Ctrl+V` を Google Chrome 側のショートカットへ変換し、プレーンテキストの clipboard をホストと双方向に同期する。
 
 Hermes から接続する内部 URL は次の固定値にする。


### PR DESCRIPTION
## Summary
- prevent background renderer throttling and tab discarding in the dedicated Chrome session
- update chrome-devtools-mcp to 1.6.0 and mcp-proxy to 6.5.5
- add contracts and document the renderer timeout failure mode

## Validation
- bootstrap container tests: 562 passed (6 skipped)
- browser and Browser MCP images built successfully
- Nancy profile MCP discovery: 29 tools
- real doda page 6 `take_snapshot`: 79ms, 26,691-character snapshot

The final provenance hook was skipped because the unrelated `../hermes-home-profile-sync` worktree is not present in this environment.