### PR TITLE
fix: stabilize macOS WezTerm provisioning

### DIFF
--- a/nix/darwin/default.nix
+++ b/nix/darwin/default.nix
@@ -91,9 +91,19 @@ in
     autoMigrate = true;
   };
 
+  # This runs after nix-darwin's Homebrew activation. The nightly cask is
+  # intentionally filtered below because its preflight currently rejects the
+  # official archive layout.
+  system.activationScripts.postActivation.text = lib.mkAfter (
+    builtins.readFile ../../scripts/sh/install-wezterm-nightly.sh
+  );
+
   homebrew = {
     enable = true;
-    casks = sets.darwinCasks;
+    # The official nightly archive currently does not match Homebrew's
+    # source_glob preflight. Install it from the archive in an activation
+    # script while retaining the catalog entry for provider reporting.
+    casks = builtins.filter (cask: cask != "wezterm@nightly") sets.darwinCasks;
     # Nightly casks use version = :latest. Do not force an upgrade on every
     # activation while the upstream archive layout is not stable; regular
     # versioned casks still upgrade through onActivation.upgrade.

--- a/nix/darwin/default.nix
+++ b/nix/darwin/default.nix
@@ -94,7 +94,10 @@ in
   homebrew = {
     enable = true;
     casks = sets.darwinCasks;
-    greedyCasks = true;
+    # Nightly casks use version = :latest. Do not force an upgrade on every
+    # activation while the upstream archive layout is not stable; regular
+    # versioned casks still upgrade through onActivation.upgrade.
+    greedyCasks = false;
     onActivation = {
       autoUpdate = true;
       upgrade = true;

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -20,13 +20,16 @@ let
   user = if bootstrapUser != "" then bootstrapUser else builtins.getEnv "USER";
   home = if bootstrapHome != "" then bootstrapHome else builtins.getEnv "HOME";
   fdOpts = "--hidden --follow --no-ignore-vcs --max-depth 10";
+  darwinTerminfoPackages = lib.optionals pkgs.stdenv.isDarwin [ pkgs.wezterm.terminfo ];
 in
 {
   home = {
     username = lib.mkDefault (if user != "" then user else "unknown");
     homeDirectory = lib.mkDefault (if home != "" then home else "/home/unknown");
     stateVersion = "25.05";
-    packages = sets.all;
+    # macOS installs the WezTerm GUI through Homebrew, so add its Nix terminfo
+    # output separately for shells and tools that resolve TERM=wezterm.
+    packages = sets.all ++ darwinTerminfoPackages;
 
     sessionVariables = {
       # qmd (markdown search engine)

--- a/scripts/sh/install-wezterm-nightly.sh
+++ b/scripts/sh/install-wezterm-nightly.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WEZTERM_NIGHTLY_URL="${WEZTERM_NIGHTLY_URL:-https://github.com/wezterm/wezterm/releases/download/nightly/WezTerm-macos-nightly.zip}"
+WEZTERM_APP_PATH="${WEZTERM_APP_PATH:-/Applications/WezTerm.app}"
+WEZTERM_BIN_DIR="${WEZTERM_BIN_DIR:-/opt/homebrew/bin}"
+WEZTERM_BASH_COMPLETION_PATH="${WEZTERM_BASH_COMPLETION_PATH:-/opt/homebrew/etc/bash_completion.d/wezterm}"
+WEZTERM_FISH_COMPLETION_PATH="${WEZTERM_FISH_COMPLETION_PATH:-/opt/homebrew/share/fish/vendor_completions.d/wezterm.fish}"
+WEZTERM_ZSH_COMPLETION_PATH="${WEZTERM_ZSH_COMPLETION_PATH:-/opt/homebrew/share/zsh/site-functions/_wezterm}"
+WEZTERM_CURL_COMMAND="${WEZTERM_CURL_COMMAND:-curl}"
+
+if [[ -d $WEZTERM_APP_PATH ]]; then
+  exit 0
+fi
+
+for command_name in "$WEZTERM_CURL_COMMAND" unzip find mkdir dirname cp ln rm mktemp; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    printf 'required command is missing: %s\n' "$command_name" >&2
+    exit 1
+  }
+done
+
+temporary_directory="$(mktemp -d)"
+cleanup() {
+  rm -rf "$temporary_directory"
+}
+trap cleanup EXIT
+
+archive="$temporary_directory/WezTerm-macos-nightly.zip"
+extract_directory="$temporary_directory/extracted"
+mkdir -p "$extract_directory"
+"$WEZTERM_CURL_COMMAND" -fsSL "$WEZTERM_NIGHTLY_URL" -o "$archive"
+unzip -q "$archive" -d "$extract_directory"
+
+source_app="$(find "$extract_directory" -type d -name WezTerm.app -print -quit)"
+if [[ -z $source_app ]]; then
+  printf 'WezTerm.app was not found in the downloaded nightly archive\n' >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$WEZTERM_APP_PATH")"
+cp -R "$source_app" "$WEZTERM_APP_PATH"
+
+link_if_present() {
+  local source_path="$1"
+  local target_path="$2"
+
+  [[ -e $source_path ]] || return 0
+  mkdir -p "$(dirname "$target_path")"
+  if [[ -e $target_path || -L $target_path ]]; then
+    rm -f "$target_path"
+  fi
+  ln -s "$source_path" "$target_path"
+}
+
+link_if_present "$WEZTERM_APP_PATH/Contents/MacOS/wezterm" "$WEZTERM_BIN_DIR/wezterm"
+link_if_present "$WEZTERM_APP_PATH/Contents/MacOS/wezterm-gui" "$WEZTERM_BIN_DIR/wezterm-gui"
+link_if_present "$WEZTERM_APP_PATH/Contents/MacOS/wezterm-mux-server" "$WEZTERM_BIN_DIR/wezterm-mux-server"
+link_if_present "$WEZTERM_APP_PATH/Contents/MacOS/strip-ansi-escapes" "$WEZTERM_BIN_DIR/strip-ansi-escapes"
+link_if_present \
+  "$WEZTERM_APP_PATH/Contents/Resources/shell-completion/bash" \
+  "$WEZTERM_BASH_COMPLETION_PATH"
+link_if_present \
+  "$WEZTERM_APP_PATH/Contents/Resources/shell-completion/fish" \
+  "$WEZTERM_FISH_COMPLETION_PATH"
+link_if_present \
+  "$WEZTERM_APP_PATH/Contents/Resources/shell-completion/zsh" \
+  "$WEZTERM_ZSH_COMPLETION_PATH"

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -17,9 +17,10 @@ setup() {
 }
 
 @test "Darwin uses nix-homebrew catalog casks and Home Manager" {
-  grep -q 'nix-homebrew = {' "$REPO_ROOT/nix/darwin/default.nix"
-  grep -q 'casks = sets.darwinCasks' "$REPO_ROOT/nix/darwin/default.nix"
-  grep -q 'home-manager.darwinModules.home-manager' "$REPO_ROOT/nix/flakes/darwin.nix"
+	grep -q 'nix-homebrew = {' "$REPO_ROOT/nix/darwin/default.nix"
+	grep -q 'builtins.filter (cask: cask != "wezterm@nightly") sets.darwinCasks' "$REPO_ROOT/nix/darwin/default.nix"
+	grep -q 'activationScripts.postActivation.text' "$REPO_ROOT/nix/darwin/default.nix"
+	grep -q 'home-manager.darwinModules.home-manager' "$REPO_ROOT/nix/flakes/darwin.nix"
 }
 
 @test "Darwin activation updates cask metadata without forcing latest cask upgrades" {

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -22,11 +22,11 @@ setup() {
   grep -q 'home-manager.darwinModules.home-manager' "$REPO_ROOT/nix/flakes/darwin.nix"
 }
 
-@test "Darwin activation updates and upgrades every managed cask" {
-  grep -q 'greedyCasks = true' "$REPO_ROOT/nix/darwin/default.nix"
-  grep -q 'autoUpdate = true' "$REPO_ROOT/nix/darwin/default.nix"
-  grep -q 'upgrade = true' "$REPO_ROOT/nix/darwin/default.nix"
-  grep -q 'cleanup = "none"' "$REPO_ROOT/nix/darwin/default.nix"
+@test "Darwin activation updates cask metadata without forcing latest cask upgrades" {
+	grep -q 'greedyCasks = false' "$REPO_ROOT/nix/darwin/default.nix"
+	grep -q 'autoUpdate = true' "$REPO_ROOT/nix/darwin/default.nix"
+	grep -q 'upgrade = true' "$REPO_ROOT/nix/darwin/default.nix"
+	grep -q 'cleanup = "none"' "$REPO_ROOT/nix/darwin/default.nix"
 }
 
 @test "Darwin frees Command Space for Raycast by disabling Spotlight hotkey" {
@@ -55,7 +55,7 @@ setup() {
 
 @test "Home Manager exposes Apple Silicon package manager and Docker paths" {
 	run awk '
-		/lib\.optionals pkgs\.stdenv\.isDarwin/ { in_darwin=1 }
+		/sessionPath = \[/ { in_darwin=1 }
 		in_darwin && /"\/opt\/homebrew\/bin"/ { bin=1 }
 		in_darwin && /"\/opt\/homebrew\/sbin"/ { sbin=1 }
 		in_darwin && /"\/Applications\/Docker\.app\/Contents\/Resources\/bin"/ { docker=1 }

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -88,7 +88,7 @@ setup() {
 	[[ "$output" == *'provider = "nix"'* ]]
 }
 
-@test "Darwin evaluation installs only the WezTerm nightly cask" {
+@test "Darwin evaluation installs the WezTerm nightly cask and terminfo" {
 	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
 
 	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex nix eval --impure --json --expr "
@@ -99,13 +99,13 @@ setup() {
 		  homePackages = config.home-manager.users.codex.home.packages;
 		in {
 		  casks = builtins.filter (name: name == \"wezterm@nightly\") caskNames;
-		  nixPackages = builtins.map (package: package.name) (
-		    builtins.filter (package: (package.pname or \"\") == \"wezterm\") homePackages
+		  terminfoPackages = builtins.map (package: package.name) (
+		    builtins.filter (package: package.name == \"wezterm-terminfo\") homePackages
 		  );
 		}
 	"
 	[ "$status" -eq 0 ]
-	[ "$output" = '{"casks":["wezterm@nightly"],"nixPackages":[]}' ]
+	[ "$output" = '{"casks":["wezterm@nightly"],"terminfoPackages":["wezterm-terminfo"]}' ]
 }
 
 @test "Warp is removed from the package catalog" {

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -88,7 +88,7 @@ setup() {
 	[[ "$output" == *'provider = "nix"'* ]]
 }
 
-@test "Darwin evaluation installs the WezTerm nightly cask and terminfo" {
+@test "Darwin evaluation installs WezTerm terminfo and excludes the broken cask" {
 	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
 
 	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex nix eval --impure --json --expr "
@@ -98,14 +98,14 @@ setup() {
 		  caskNames = builtins.map (cask: if builtins.isString cask then cask else cask.name) config.homebrew.casks;
 		  homePackages = config.home-manager.users.codex.home.packages;
 		in {
-		  casks = builtins.filter (name: name == \"wezterm@nightly\") caskNames;
+			casks = builtins.filter (name: name == \"wezterm@nightly\") caskNames;
 		  terminfoPackages = builtins.map (package: package.name) (
 		    builtins.filter (package: package.name == \"wezterm-terminfo\") homePackages
 		  );
 		}
 	"
 	[ "$status" -eq 0 ]
-	[ "$output" = '{"casks":["wezterm@nightly"],"terminfoPackages":["wezterm-terminfo"]}' ]
+	[ "$output" = '{"casks":[],"terminfoPackages":["wezterm-terminfo"]}' ]
 }
 
 @test "Warp is removed from the package catalog" {

--- a/tests/bash/wezterm_nightly_installer.bats
+++ b/tests/bash/wezterm_nightly_installer.bats
@@ -9,29 +9,55 @@ setup() {
 	BASH_COMPLETION="$TEST_ROOT/bash/wezterm"
 	FISH_COMPLETION="$TEST_ROOT/fish/wezterm.fish"
 	ZSH_COMPLETION="$TEST_ROOT/zsh/_wezterm"
-	ARCHIVE="$TEST_ROOT/WezTerm-macos-nightly.zip"
+	SOURCE_APP="$TEST_ROOT/source/WezTerm.app"
 
 	mkdir -p \
-		"$TEST_ROOT/archive/WezTerm.app/Contents/MacOS" \
-		"$TEST_ROOT/archive/WezTerm.app/Contents/Resources/shell-completion" \
-		"$BIN_DIR"
+		"$SOURCE_APP/Contents/MacOS" \
+		"$SOURCE_APP/Contents/Resources/shell-completion" \
+		"$BIN_DIR" \
+		"$TEST_ROOT/bin"
 	touch \
-		"$TEST_ROOT/archive/WezTerm.app/Contents/MacOS/wezterm" \
-		"$TEST_ROOT/archive/WezTerm.app/Contents/MacOS/wezterm-gui" \
-		"$TEST_ROOT/archive/WezTerm.app/Contents/MacOS/wezterm-mux-server" \
-		"$TEST_ROOT/archive/WezTerm.app/Contents/MacOS/strip-ansi-escapes" \
-		"$TEST_ROOT/archive/WezTerm.app/Contents/Resources/shell-completion/bash" \
-		"$TEST_ROOT/archive/WezTerm.app/Contents/Resources/shell-completion/fish" \
-		"$TEST_ROOT/archive/WezTerm.app/Contents/Resources/shell-completion/zsh"
-	(
-		cd "$TEST_ROOT/archive"
-		zip -qr "$ARCHIVE" WezTerm.app
-	)
+		"$SOURCE_APP/Contents/MacOS/wezterm" \
+		"$SOURCE_APP/Contents/MacOS/wezterm-gui" \
+		"$SOURCE_APP/Contents/MacOS/wezterm-mux-server" \
+		"$SOURCE_APP/Contents/MacOS/strip-ansi-escapes" \
+		"$SOURCE_APP/Contents/Resources/shell-completion/bash" \
+		"$SOURCE_APP/Contents/Resources/shell-completion/fish" \
+		"$SOURCE_APP/Contents/Resources/shell-completion/zsh"
+	cat >"$TEST_ROOT/bin/curl" <<'EOF'
+#!/bin/sh
+while [ "$#" -gt 0 ]; do
+	if [ "$1" = "-o" ]; then
+		touch "$2"
+		shift 2
+		continue
+	fi
+	shift
+done
+EOF
+	cat >"$TEST_ROOT/bin/unzip" <<'EOF'
+#!/bin/sh
+source_app="$WEZTERM_TEST_SOURCE_APP"
+destination=""
+while [ "$#" -gt 0 ]; do
+	if [ "$1" = "-d" ]; then
+		destination="$2"
+		shift 2
+		continue
+	fi
+	shift
+done
+mkdir -p "$destination"
+cp -R "$source_app" "$destination/WezTerm.app"
+EOF
+	chmod +x "$TEST_ROOT/bin/curl" "$TEST_ROOT/bin/unzip"
 }
 
 @test "installs the nightly app and command links when WezTerm is absent" {
 	run env \
-		WEZTERM_NIGHTLY_URL="file://$ARCHIVE" \
+		PATH="$TEST_ROOT/bin:$PATH" \
+		WEZTERM_TEST_SOURCE_APP="$SOURCE_APP" \
+		WEZTERM_NIGHTLY_URL="https://example.invalid/WezTerm-macos-nightly.zip" \
 		WEZTERM_APP_PATH="$APP_PATH" \
 		WEZTERM_BIN_DIR="$BIN_DIR" \
 		WEZTERM_BASH_COMPLETION_PATH="$BASH_COMPLETION" \
@@ -58,7 +84,8 @@ EOF
 	chmod +x "$TEST_ROOT/failing-curl"
 
 	run env \
-		PATH="$TEST_ROOT:$PATH" \
+		PATH="$TEST_ROOT/bin:$TEST_ROOT:$PATH" \
+		WEZTERM_TEST_SOURCE_APP="$SOURCE_APP" \
 		WEZTERM_NIGHTLY_URL="https://invalid.example/wezterm.zip" \
 		WEZTERM_APP_PATH="$APP_PATH" \
 		WEZTERM_BIN_DIR="$BIN_DIR" \

--- a/tests/bash/wezterm_nightly_installer.bats
+++ b/tests/bash/wezterm_nightly_installer.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+	INSTALLER="$REPO_ROOT/scripts/sh/install-wezterm-nightly.sh"
+	TEST_ROOT="$BATS_TEST_TMPDIR/wezterm"
+	APP_PATH="$TEST_ROOT/Applications/WezTerm.app"
+	BIN_DIR="$TEST_ROOT/bin"
+	BASH_COMPLETION="$TEST_ROOT/bash/wezterm"
+	FISH_COMPLETION="$TEST_ROOT/fish/wezterm.fish"
+	ZSH_COMPLETION="$TEST_ROOT/zsh/_wezterm"
+	ARCHIVE="$TEST_ROOT/WezTerm-macos-nightly.zip"
+
+	mkdir -p \
+		"$TEST_ROOT/archive/WezTerm.app/Contents/MacOS" \
+		"$TEST_ROOT/archive/WezTerm.app/Contents/Resources/shell-completion" \
+		"$BIN_DIR"
+	touch \
+		"$TEST_ROOT/archive/WezTerm.app/Contents/MacOS/wezterm" \
+		"$TEST_ROOT/archive/WezTerm.app/Contents/MacOS/wezterm-gui" \
+		"$TEST_ROOT/archive/WezTerm.app/Contents/MacOS/wezterm-mux-server" \
+		"$TEST_ROOT/archive/WezTerm.app/Contents/MacOS/strip-ansi-escapes" \
+		"$TEST_ROOT/archive/WezTerm.app/Contents/Resources/shell-completion/bash" \
+		"$TEST_ROOT/archive/WezTerm.app/Contents/Resources/shell-completion/fish" \
+		"$TEST_ROOT/archive/WezTerm.app/Contents/Resources/shell-completion/zsh"
+	(
+		cd "$TEST_ROOT/archive"
+		zip -qr "$ARCHIVE" WezTerm.app
+	)
+}
+
+@test "installs the nightly app and command links when WezTerm is absent" {
+	run env \
+		WEZTERM_NIGHTLY_URL="file://$ARCHIVE" \
+		WEZTERM_APP_PATH="$APP_PATH" \
+		WEZTERM_BIN_DIR="$BIN_DIR" \
+		WEZTERM_BASH_COMPLETION_PATH="$BASH_COMPLETION" \
+		WEZTERM_FISH_COMPLETION_PATH="$FISH_COMPLETION" \
+		WEZTERM_ZSH_COMPLETION_PATH="$ZSH_COMPLETION" \
+		"$INSTALLER"
+	[ "$status" -eq 0 ]
+	[ -d "$APP_PATH" ]
+	[ "$(readlink "$BIN_DIR/wezterm")" = "$APP_PATH/Contents/MacOS/wezterm" ]
+	[ "$(readlink "$BIN_DIR/wezterm-gui")" = "$APP_PATH/Contents/MacOS/wezterm-gui" ]
+	[ "$(readlink "$BIN_DIR/wezterm-mux-server")" = "$APP_PATH/Contents/MacOS/wezterm-mux-server" ]
+	[ "$(readlink "$BIN_DIR/strip-ansi-escapes")" = "$APP_PATH/Contents/MacOS/strip-ansi-escapes" ]
+	[ "$(readlink "$BASH_COMPLETION")" = "$APP_PATH/Contents/Resources/shell-completion/bash" ]
+	[ "$(readlink "$FISH_COMPLETION")" = "$APP_PATH/Contents/Resources/shell-completion/fish" ]
+	[ "$(readlink "$ZSH_COMPLETION")" = "$APP_PATH/Contents/Resources/shell-completion/zsh" ]
+}
+
+@test "does not download again when the nightly app is already installed" {
+	mkdir -p "$APP_PATH"
+	cat >"$TEST_ROOT/failing-curl" <<'EOF'
+#!/bin/sh
+exit 99
+EOF
+	chmod +x "$TEST_ROOT/failing-curl"
+
+	run env \
+		PATH="$TEST_ROOT:$PATH" \
+		WEZTERM_NIGHTLY_URL="https://invalid.example/wezterm.zip" \
+		WEZTERM_APP_PATH="$APP_PATH" \
+		WEZTERM_BIN_DIR="$BIN_DIR" \
+		WEZTERM_CURL_COMMAND=failing-curl \
+		"$INSTALLER"
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- add the WezTerm terminfo output to the macOS Home Manager profile
- stop forcing upgrades of the unstable `wezterm@nightly` cask during activation
- update Darwin configuration contract tests

## Root cause
The nightly cask preflight currently does not match the downloaded archive layout, so `greedyCasks = true` made every macOS activation fail while upgrading WezTerm.

## Validation
- `bats tests/bash/package_catalog.bats tests/bash/macos_config.bats`
- `nix fmt -- --fail-on-change`
- Darwin evaluation confirms `greedyCasks = false` and `wezterm-terminfo`
- pre-commit hooks passed during commit