### PR TITLE
fix: restore WezTerm terminfo in inherited zsh sessions

### DIFF
--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -64,6 +64,16 @@ in
     zsh = {
       enable = true;
 
+      # A long-lived GUI process can inherit Home Manager's session sentinel
+      # without retaining the variables that were set alongside it. Restore
+      # WezTerm's Darwin terminfo path in .zshenv so interactive shells can
+      # initialize zsh/terminfo even in that state.
+      envExtra = lib.optionalString pkgs.stdenv.isDarwin ''
+        if [[ "''${TERM-}" == wezterm && -d "/etc/profiles/per-user/''${USER}/share/terminfo" ]]; then
+          export TERMINFO_DIRS="/etc/profiles/per-user/''${USER}/share/terminfo''${TERMINFO_DIRS:+:$TERMINFO_DIRS}:/usr/share/terminfo"
+        fi
+      '';
+
       shellAliases = {
         find = "fd";
         grep = "rg";

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+bats_require_minimum_version 1.5.0
+
 setup() {
 	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
 }
@@ -64,6 +66,19 @@ setup() {
 		END { if (!in_darwin) exit 1 }
 	' "$REPO_ROOT/nix/home/common.nix"
 	[ "$status" -eq 0 ]
+}
+
+@test "Darwin zsh restores WezTerm terminfo after inherited Home Manager sentinels" {
+	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
+
+	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex nix eval --impure --raw --expr "
+		let
+			flake = builtins.getFlake (toString $REPO_ROOT);
+		in flake.darwinConfigurations.macos.config.home-manager.users.codex.programs.zsh.envExtra
+	"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'TERMINFO_DIRS'* ]]
+	[[ "$output" == *'/etc/profiles/per-user/'* ]]
 }
 
 @test "Chromium Compose service is pinned to linux amd64" {


### PR DESCRIPTION
## Summary

- restore the Darwin WezTerm terminfo path in zsh `.zshenv`
- keep startup working when Home Manager session sentinels are inherited by a long-lived GUI process
- add a regression test for the generated Home Manager zsh configuration

## Root cause

A long-lived WezTerm process could inherit `__HM_SESS_VARS_SOURCED=1` while `TERMINFO_DIRS` had been removed from the environment. Home Manager then skipped the session-variable file, leaving zsh unable to resolve `TERM=wezterm`.

## Validation

- `bats tests/bash/macos_config.bats tests/bash/package_catalog.bats`
- `nix fmt -- --ci`
- sentinel reproduction with `infocmp wezterm`