### PR TITLE
fix: preload WezTerm terminfo before zsh startup

### DIFF
--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -98,6 +98,18 @@ config.set_environment_variables = {
     SNACKS_WEZTERM = "true",
 }
 
+-- zsh resolves TERM=wezterm while it starts, before .zshenv can restore
+-- Home Manager's terminfo path. Provide the Darwin path to child shells
+-- directly from WezTerm so startup never begins without a definition.
+if is_macos then
+    local terminfo_user = os.getenv("USER")
+    if terminfo_user and terminfo_user ~= "" then
+        config.set_environment_variables.TERMINFO_DIRS = "/etc/profiles/per-user/"
+            .. terminfo_user
+            .. "/share/terminfo:/usr/share/terminfo"
+    end
+end
+
 -- Alt key sends escape sequence for fzf Alt+C support
 config.send_composed_key_when_left_alt_is_pressed = false
 config.send_composed_key_when_right_alt_is_pressed = false

--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -104,9 +104,12 @@ config.set_environment_variables = {
 if is_macos then
     local terminfo_user = os.getenv("USER")
     if terminfo_user and terminfo_user ~= "" then
-        config.set_environment_variables.TERMINFO_DIRS = "/etc/profiles/per-user/"
-            .. terminfo_user
-            .. "/share/terminfo:/usr/share/terminfo"
+        local inherited_terminfo_dirs = os.getenv("TERMINFO_DIRS")
+        local terminfo_dirs = "/etc/profiles/per-user/" .. terminfo_user .. "/share/terminfo:/usr/share/terminfo"
+        if inherited_terminfo_dirs and inherited_terminfo_dirs ~= "" then
+            terminfo_dirs = terminfo_dirs .. ":" .. inherited_terminfo_dirs
+        end
+        config.set_environment_variables.TERMINFO_DIRS = terminfo_dirs
     end
 end
 

--- a/docs/superpowers/specs/2026-08-01-macos-dia-browser-design.md
+++ b/docs/superpowers/specs/2026-08-01-macos-dia-browser-design.md
@@ -1,0 +1,21 @@
+# macOS Browser Provider Design
+
+## Goal
+
+macOS では Arc をインストールせず、Dia をインストールする。Windows の Arc は現状のまま維持する。
+
+## Design
+
+パッケージカタログ `nix/packages/sets.nix` を唯一の変更対象とする。
+
+- `arc-browser.support.darwin` を削除する。
+- `arc-browser.winget` と `support.windows` は維持する。
+- 既存の `dia-browser.support.darwin.cask = "thebrowsercompany-dia"` は変更しない。
+
+`darwinCasks` はカタログの `support.darwin.cask` から生成されるため、これにより macOS の Homebrew cask から `arc` が除外され、Dia は引き続き含まれる。Windows の winget マッピングには影響しない。
+
+## Verification
+
+- カタログの Bats テストを実行する。
+- `nix fmt -- --check` 相当の Nix フォーマット検証を行う。
+- `git diff` で Arc の macOS 定義だけが削除され、Windows Arc と Dia の定義が保持されていることを確認する。

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -81,6 +81,15 @@ setup() {
 	[[ "$output" == *'/etc/profiles/per-user/'* ]]
 }
 
+@test "WezTerm provides Darwin terminfo before spawning shells" {
+	local config="$REPO_ROOT/chezmoi/terminals/wezterm/wezterm.lua"
+
+	run grep -F 'config.set_environment_variables.TERMINFO_DIRS' "$config"
+	[ "$status" -eq 0 ]
+	run grep -F '/etc/profiles/per-user/' "$config"
+	[ "$status" -eq 0 ]
+}
+
 @test "Chromium Compose service is pinned to linux amd64" {
 	run awk '
 		/^  chromium:/ { in_chromium=1; next }

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -86,6 +86,8 @@ setup() {
 
 	run grep -F 'config.set_environment_variables.TERMINFO_DIRS' "$config"
 	[ "$status" -eq 0 ]
+	run grep -F 'os.getenv("TERMINFO_DIRS")' "$config"
+	[ "$status" -eq 0 ]
 	run grep -F '/etc/profiles/per-user/' "$config"
 	[ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary
- Preload macOS WezTerm's Nix terminfo path for child shells.
- Prevent zsh startup warnings when Home Manager session variables are inherited with a stale sentinel.
- Add a regression test covering the WezTerm environment injection.

## Root cause
Setting `TERMINFO_DIRS` in `.zshenv` was too late: zsh attempted to resolve `TERM=wezterm` during startup before that assignment took effect.

## Validation
- `bats tests/bash` — 138 tests passed
- `pre-commit run --all-files` — passed
- WezTerm live check with inherited `__HM_SESS_VARS_SOURCED=1` — `infocmp_rc=0`, no startup warning
