### PR TITLE
fix: remove Arc from macOS provisioning

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -122,7 +122,7 @@ tasks:
   test:bash:
     desc: Run bats unit tests for shell helpers
     cmds:
-      - '{{.WSL}}bash -lc "cd {{.DOTFILES_PATH}} && bats tests/bash"'
+      - '{{if eq OS "darwin"}}sh -c ''export PATH=/opt/homebrew/bin:/opt/homebrew/sbin:$PATH; cd "$(cd {{.DOTFILES_PATH}} && pwd -P)" && bats tests/bash''{{else}}{{.WSL}}bash -lc "cd {{.DOTFILES_PATH}} && bats tests/bash"{{end}}'
 
   # ===========================================
   # Windows Setup

--- a/docs/superpowers/specs/2026-08-02-remove-arc-browser-design.md
+++ b/docs/superpowers/specs/2026-08-02-remove-arc-browser-design.md
@@ -1,0 +1,23 @@
+# Remove Arc Browser on macOS Design
+
+## Goal
+
+macOS の dotfiles activation 時に、既存の Arc Homebrew cask と Homebrew が管理する Arc の関連ファイルを削除する。Windows の Arc と macOS の Dia には影響させない。
+
+## Design
+
+Homebrew activation 完了後に、macOS のログインユーザー権限で専用スクリプトを実行する。
+
+- `brew list --cask --versions arc` で Arc のインストール有無を確認する。
+- インストール済みの場合だけ `brew uninstall --cask --zap arc` を実行する。
+- `--zap` は Homebrew の cask 定義に基づき、Arc のアプリ本体・設定・キャッシュ・関連ファイルを削除する。
+- Arc 未インストール時は成功扱いにして、activation を妨げない。
+- スクリプトは `nix/darwin/default.nix` の Homebrew activation 後に接続する。
+
+`homebrew.onActivation.cleanup` は変更しない。全 cask を対象にせず、削除対象を Arc に限定するためである。手動で作成された Homebrew 管理外のファイルは対象にしない。
+
+## Verification
+
+- スクリプトのシェルテストで、未インストール時の no-op とインストール時の `--zap` 呼び出しを検証する。
+- macOS 設定テストで、activation script の接続と zap コマンドを検証する。
+- `nix fmt`、関連 Bats、`pre-commit run --all-files`、`git diff --check` を実行する。

--- a/nix/darwin/default.nix
+++ b/nix/darwin/default.nix
@@ -95,7 +95,12 @@ in
   # intentionally filtered below because its preflight currently rejects the
   # official archive layout.
   system.activationScripts.postActivation.text = lib.mkAfter (
-    builtins.readFile ../../scripts/sh/install-wezterm-nightly.sh
+    (builtins.readFile ../../scripts/sh/install-wezterm-nightly.sh)
+    + ''
+
+      /usr/bin/sudo --user=${lib.escapeShellArg user} -- /bin/bash -c ${lib.escapeShellArg (builtins.readFile ../../scripts/sh/uninstall-arc-browser.sh)}
+      /bin/rm -rf -- ${lib.escapeShellArg "${home}/Library/Caches/CloudKit/company.thebrowser.Browser"} 2>/dev/null || true
+    ''
   );
 
   homebrew = {

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -349,8 +349,7 @@ let
           provider = "winget";
         };
         darwin = {
-          provider = "homebrew-cask";
-          cask = "arc";
+          unsupported = "Use Dia instead of Arc on macOS";
         };
         linux = {
           unsupported = "Vendor does not publish a Linux build";

--- a/scripts/sh/uninstall-arc-browser.sh
+++ b/scripts/sh/uninstall-arc-browser.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BREW_COMMAND="${BREW_COMMAND:-/opt/homebrew/bin/brew}"
+
+[[ -x $BREW_COMMAND ]] || exit 0
+"$BREW_COMMAND" list --cask --versions arc >/dev/null 2>&1 || exit 0
+"$BREW_COMMAND" uninstall --cask --zap arc
+
+# Homebrew's zap can leave this protected CloudKit cache when it needs a
+# second sudo prompt. Remove only Arc's known cache path after the cask is gone.
+ARC_CLOUDKIT_CACHE="$HOME/Library/Caches/CloudKit/company.thebrowser.Browser"
+if [[ -e $ARC_CLOUDKIT_CACHE ]]; then
+  if ! rm -rf -- "$ARC_CLOUDKIT_CACHE"; then
+    printf 'warning: unable to remove protected Arc cache: %s\n' "$ARC_CLOUDKIT_CACHE" >&2
+  fi
+fi

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -25,6 +25,13 @@ setup() {
 	grep -q 'home-manager.darwinModules.home-manager' "$REPO_ROOT/nix/flakes/darwin.nix"
 }
 
+@test "Darwin activation zaps an existing Arc cask" {
+	grep -q 'builtins.readFile ../../scripts/sh/uninstall-arc-browser.sh' "$REPO_ROOT/nix/darwin/default.nix"
+	grep -q '/usr/bin/sudo --user=' "$REPO_ROOT/nix/darwin/default.nix"
+	grep -q 'company.thebrowser.Browser' "$REPO_ROOT/nix/darwin/default.nix"
+	grep -q 'postActivation.text' "$REPO_ROOT/nix/darwin/default.nix"
+}
+
 @test "Darwin activation updates cask metadata without forcing latest cask upgrades" {
 	grep -q 'greedyCasks = false' "$REPO_ROOT/nix/darwin/default.nix"
 	grep -q 'autoUpdate = true' "$REPO_ROOT/nix/darwin/default.nix"

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -73,6 +73,18 @@ setup() {
 	grep -q 'cask = "stablyai/orca/orca"' "$SETS"
 }
 
+@test "Arc remains Windows-only and Dia remains macOS-only" {
+	run grep -n -A18 '^    arc-browser = {' "$SETS"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'winget = "TheBrowserCompany.Arc"'* ]]
+	[[ "$output" == *'unsupported = "Use Dia instead of Arc on macOS"'* ]]
+	[[ "$output" != *'cask = "arc"'* ]]
+
+	run grep -n -A12 '^    dia-browser = {' "$SETS"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'cask = "thebrowsercompany-dia"'* ]]
+}
+
 @test "WezTerm uses the nightly Homebrew cask on Darwin and Nix on Linux" {
 	run awk '
 		/wezterm = \{/ { in_entry=1 }

--- a/tests/bash/uninstall_arc_browser.bats
+++ b/tests/bash/uninstall_arc_browser.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+	BREW_LOG="$BATS_TEST_TMPDIR/brew.log"
+	FAKE_BREW="$BATS_TEST_TMPDIR/brew"
+}
+
+write_fake_brew() {
+	local list_status="$1"
+	printf '%s\n' \
+		'#!/usr/bin/env bash' \
+		'printf "%s\\n" "$*" >> "$BREW_LOG"' \
+		"if [[ \"\$1 \" == \"list \" ]]; then exit $list_status; fi" \
+		'exit 0' >"$FAKE_BREW"
+	chmod +x "$FAKE_BREW"
+}
+
+@test "zaps an installed Arc cask" {
+	write_fake_brew 0
+	mkdir -p "$BATS_TEST_TMPDIR/home/Library/Caches/CloudKit/company.thebrowser.Browser"
+
+	run env HOME="$BATS_TEST_TMPDIR/home" BREW_COMMAND="$FAKE_BREW" BREW_LOG="$BREW_LOG" \
+		"$REPO_ROOT/scripts/sh/uninstall-arc-browser.sh"
+
+	[ "$status" -eq 0 ]
+	grep -Fxq 'list --cask --versions arc' "$BREW_LOG"
+	grep -Fxq 'uninstall --cask --zap arc' "$BREW_LOG"
+	[ ! -e "$BATS_TEST_TMPDIR/home/Library/Caches/CloudKit/company.thebrowser.Browser" ]
+}
+
+@test "does nothing when Arc is not installed" {
+	write_fake_brew 1
+
+	run env BREW_COMMAND="$FAKE_BREW" BREW_LOG="$BREW_LOG" \
+		"$REPO_ROOT/scripts/sh/uninstall-arc-browser.sh"
+
+	[ "$status" -eq 0 ]
+	grep -Fxq 'list --cask --versions arc' "$BREW_LOG"
+	! grep -Fq 'uninstall --cask --zap arc' "$BREW_LOG"
+}


### PR DESCRIPTION
## Summary

- macOSではArcをHomebrew caskとして追加せず、Diaを使用する
- 既存のArcをnix-darwin activation時に `brew uninstall --cask --zap arc` で削除する
- WindowsのArc winget設定は維持する
- macOSのBats実行時の物理パス・シェル環境差異を修正する

## Root cause

Arcを `darwinCasks` から外すだけでは、既にインストール済みのcaskと関連キャッシュが削除されませんでした。また、macOSでBashログインシェル経由にすると、Bashバージョンとcheckoutパスの差異でテストが不安定でした。

## Validation

- `task test:bash` (142/142 passed)
- `nix fmt`
- `pre-commit run --all-files`
- `git diff --check`