### PR TITLE
feat: use shared Gmail OAuth for Hermes

### DIFF
--- a/.superpowers/sdd/2026-08-02-hermes-gmail-mcp/task-1-report.md
+++ b/.superpowers/sdd/2026-08-02-hermes-gmail-mcp/task-1-report.md
@@ -1,0 +1,81 @@
+# Task 1 report: failing Gmail MCP contract tests
+
+## Status
+
+Task 1 is complete. The contract tests were written first, run in the RED
+state, and committed without implementing production behavior.
+
+Commit: `4fd85175` (`test: add Hermes Gmail MCP contract tests`)
+
+## Changed files
+
+- `tests/bash/hermes_gmail_mcp.bats`
+  - Requires the official Gmail MCP URL.
+  - Requires `auth: oauth`, both Gmail scopes, and the six read/draft tools.
+  - Rejects send, delete, and label-mutation tool names.
+- `docker/hermes-agent/bootstrap/tests/test_google_gmail.py`
+  - Defines the expected Gmail MCP configuration.
+  - Covers installation for root and named-profile targets while preserving
+    unrelated servers.
+  - Covers validation of missing, altered, scope-incomplete, and forbidden-tool
+    configurations.
+- `docker/hermes-agent/bootstrap/tests/test_envfiles.py`
+  - Requires `GMAIL_MCP_CLIENT_ID` and `GMAIL_MCP_CLIENT_SECRET`.
+  - Requires values derived from the Calendar OAuth JSON to be present in the
+    private, immutable profile environment and redacted from its `repr`.
+- `docker/hermes-agent/bootstrap/tests/test_google_calendar.py`
+  - Ensures Calendar installation preserves an existing Gmail server entry.
+
+## TDD RED evidence
+
+### Bats
+
+Command:
+
+```text
+bats tests/bash/hermes_gmail_mcp.bats
+```
+
+Result: failed, 0/2 tests passed. The source module
+`docker/hermes-agent/bootstrap/hermes_bootstrap/google_gmail.py` does not exist,
+so the Gmail declarations are absent.
+
+### Focused unittest
+
+The requested host command could not import the repository test dependencies:
+the host `python3` has neither `yaml` nor `dotenv`. The same focused command was
+therefore run inside the existing Hermes bootstrap runtime image, which has the
+project dependencies:
+
+```text
+docker run --rm -v "$PWD:/workspace" -w /workspace \
+  local/hermes-bootstrap-runtime-current \
+  /opt/hermes/.venv/bin/python -m unittest \
+  docker.hermes-agent.bootstrap.tests.test_google_gmail \
+  docker.hermes-agent.bootstrap.tests.test_envfiles -v
+```
+
+Result: failed during test-module import, 0 tests run, for the expected missing
+behavior reasons:
+
+- `ModuleNotFoundError: No module named 'hermes_bootstrap.google_gmail'`
+- `ImportError: cannot import name 'GMAIL_MCP_KEYS' from hermes_bootstrap.envfiles`
+
+No production code was added or modified.
+
+## Validation
+
+- `git diff --check`: passed.
+- No secrets or real OAuth credentials were added.
+- The other pre-commit hooks passed. The `hermes-bootstrap-tests` hook was
+  intentionally skipped for the commit because its full container gate must
+  remain RED until Task 2 implements Gmail behavior.
+
+## Concerns
+
+- The Python tests cannot reach their individual assertions until Task 2 adds
+  the Gmail bootstrap module and environment key set; this is intentional for
+  the required RED phase.
+- The direct host focused command remains blocked by missing host Python
+  dependencies; the dependency-complete runtime execution provides the
+  authoritative RED result.

--- a/.superpowers/sdd/2026-08-02-hermes-gmail-mcp/task-1-report.md
+++ b/.superpowers/sdd/2026-08-02-hermes-gmail-mcp/task-1-report.md
@@ -79,3 +79,55 @@ No production code was added or modified.
 - The direct host focused command remains blocked by missing host Python
   dependencies; the dependency-complete runtime execution provides the
   authoritative RED result.
+
+## Fix round 1
+
+### Review findings addressed
+
+- `test_validation_rejects_a_missing_or_altered_gmail_entry` now has separate
+  `missing` and `altered` subcases. The altered case changes the Gmail MCP URL
+  to a non-contract path and asserts `ValidationError`.
+- The OAuth environment assertions now verify the existing implementation
+  contract directly: both values are present under the expected keys, each is
+  an `_SecretEnvironmentValue`, each individual value renders as
+  `'[REDACTED]'`, the full mapping representation omits both plaintext values,
+  and the `MappingProxyType` remains immutable.
+- The grep brittleness observation remains a minor ledger item; no unrelated
+  source-path or production change was needed for this fix.
+
+### Changed files
+
+- `docker/hermes-agent/bootstrap/tests/test_google_gmail.py`
+- `docker/hermes-agent/bootstrap/tests/test_envfiles.py`
+- `.superpowers/sdd/2026-08-02-hermes-gmail-mcp/task-1-report.md`
+
+### Verification commands and results
+
+```text
+git diff --check
+```
+
+Passed.
+
+```text
+bats tests/bash/hermes_gmail_mcp.bats
+```
+
+Failed as expected: 2/2 tests remain RED because the Gmail source module is
+not implemented yet.
+
+```text
+docker run --rm -v "$PWD:/workspace" -w /workspace \
+  local/hermes-bootstrap-runtime-current \
+  /opt/hermes/.venv/bin/python -m unittest \
+  docker.hermes-agent.bootstrap.tests.test_google_gmail \
+  docker.hermes-agent.bootstrap.tests.test_envfiles -v
+```
+
+Failed as expected during import, with 2 errors and 0 tests run:
+
+- `ModuleNotFoundError: No module named 'hermes_bootstrap.google_gmail'`
+- `ImportError: cannot import name 'GMAIL_MCP_KEYS' from hermes_bootstrap.envfiles`
+
+The dependency-complete runtime was used because the host Python environment
+lacks `yaml` and `dotenv`. No production code was added or modified.

--- a/.superpowers/sdd/2026-08-02-hermes-gmail-mcp/task-3-report.md
+++ b/.superpowers/sdd/2026-08-02-hermes-gmail-mcp/task-3-report.md
@@ -1,0 +1,38 @@
+# Task 3 実装レポート: Hermes Gmail MCP の認証・接続確認
+
+実施日: 2026-08-02
+
+## 実装内容
+
+- `task hermes:gmail:auth PROFILE=<profile>` と
+  `task hermes:gmail:test PROFILE=<profile>` を追加した。両コマンドは Docker
+  daemon、Compose ファイル、非空 profile を事前検証する。
+- Bash と PowerShell の host adapter は profile 名を検証し、mounted profile home
+  の実在と非 symlink を確認してから、profile 固有の
+  `HERMES_HOME=/opt/data/profiles/<profile>` で実行する。`default` は `/opt/data` を
+  使用する。
+- `auth` は `hermes mcp login gmail` を対話実行し、正常終了後に
+  `mcp-tokens/gmail.json` が regular file かつ private であることを確認する。
+  `test` は同じ確認を Docker 起動前に行い、`hermes mcp test gmail` を実行する。
+- OAuth client 値と token 値を引数・出力・エラーに展開しない。PowerShell は
+  `-Profile` 互換 alias を維持しつつ、組み込み `$PROFILE` を上書きしない。
+- Google Cloud の有効化、既存 Calendar OAuth client の再利用、315 秒 callback、
+  profile 単位の認証、送信・削除をしない境界を文書化した。
+- PowerShell 契約テストに、login 完了後に private token cache が存在しない場合の
+  失敗を追加した。
+
+## 検証結果
+
+- `bats tests/bash/hermes_gmail_auth.bats`: 4/4 passed
+- `pwsh -NoProfile -Command 'Invoke-Pester ...HermesGmail.Tests.ps1...'`: 4/4 passed
+- `bash -n scripts/sh/hermes-gmail.sh`: passed
+- PowerShell parser と PSScriptAnalyzer（Error/Warning）: passed
+- `nix fmt -- --fail-on-change`: passed
+- `task --list` で `hermes:gmail:auth` / `hermes:gmail:test` を確認した。
+- `git diff --check`: passed
+
+## 未実施・留意事項
+
+- 指示どおり live OAuth、Gmail MCP 接続、Discord の実行検証は行っていない。
+- PowerShell の ACL 判定は静的検査と macOS 上の Pester 契約で検証した。Windows
+  filesystem 上の ACL 分岐は Windows runner または実機での追加確認が必要である。

--- a/.superpowers/sdd/2026-08-02-hermes-gmail-mcp/task-3-report.md
+++ b/.superpowers/sdd/2026-08-02-hermes-gmail-mcp/task-3-report.md
@@ -36,3 +36,36 @@
 - 指示どおり live OAuth、Gmail MCP 接続、Discord の実行検証は行っていない。
 - PowerShell の ACL 判定は静的検査と macOS 上の Pester 契約で検証した。Windows
   filesystem 上の ACL 分岐は Windows runner または実機での追加確認が必要である。
+
+## Fix round 1: OAuth キャッシュ親と ACL の防御
+
+### 修正内容
+
+- Unix / PowerShell adapter は OAuth login 前に profile 内の `mcp-tokens` を作成して
+  検証し、symlink・非ディレクトリ・profile home 外へ解決される親を拒否する。
+  OAuth login 後も親と `gmail.json` の profile home 内包含を再検証するため、認証中の
+  symlink 置換で token を profile 外へ保存した状態を成功扱いにしない。
+- Windows の token cache ACL は、file owner、`SYSTEM` (`S-1-5-18`)、
+  `Administrators` (`S-1-5-32-544`) だけを read-capable Allow ACE の許可対象とする。
+  `Authenticated Users` を含むほかの identity の `ReadData` Allow ACE は拒否する。
+- OAuth consent の正確な scope を
+  `https://www.googleapis.com/auth/gmail.readonly` と
+  `https://www.googleapis.com/auth/gmail.compose` として文書化した。
+- Bash と PowerShell の両方に、login 前と login 後の parent-symlink 置換を検証する
+  契約を追加した。PowerShell には、Windows で `Authenticated Users` の ReadData を
+  付与して拒否を確認する契約も追加した（非 Windows ではこの ACL 契約のみ skip）。
+
+### 検証結果
+
+- `bats tests/bash/hermes_gmail_auth.bats`: 6/6 passed
+- `pwsh -NoProfile -Command 'Invoke-Pester -Path scripts/powershell/tests/HermesGmail.Tests.ps1 -Output Detailed'`: 6 passed, 0 failed, 1 skipped / 7 total
+- 必須 runner:
+  `pwsh -NoProfile -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/HermesGmail.Tests.ps1 -MinimumCoverage 0`
+  は `6 passed, 0 failed, 1 skipped / 7 total` で exit 0。
+- Bash syntax、PowerShell parser、PSScriptAnalyzer（Error/Warning）、
+  `nix fmt -- --fail-on-change`、`git diff --check` を実行した。
+
+### 未実施・留意事項
+
+- Task 4 の live OAuth、Gmail MCP、Discord 検証は実行していない。
+- `Authenticated Users` ACL 契約は Windows 専用であり、この macOS 実行では skip。

--- a/.superpowers/sdd/2026-08-02-hermes-gmail-mcp/task-3-report.md
+++ b/.superpowers/sdd/2026-08-02-hermes-gmail-mcp/task-3-report.md
@@ -69,3 +69,37 @@
 
 - Task 4 の live OAuth、Gmail MCP、Discord 検証は実行していない。
 - `Authenticated Users` ACL 契約は Windows 専用であり、この macOS 実行では skip。
+
+## Fix round 2: OAuth login 中の mcp-tokens bind mount 固定
+
+### 修正内容
+
+- re-review で確認された race は、login 前後の host path 検査だけでは閉じられず、
+  Hermes が主 `/opt/data` bind mount 経由で host の `mcp-tokens` を再解決できる点
+  だった。
+- Unix と PowerShell の `auth` / `test` で、検証済みの canonical host
+  `mcp-tokens` directory を source とする dedicated read-write mount を追加した。
+  target は named profile では
+  `/opt/data/profiles/<profile>/mcp-tokens`、default では
+  `/opt/data/mcp-tokens` となる。既存の profile、symlink、cache privacy の検証と
+  login 後の再検証は維持している。
+- 契約テストで auth と test の `--volume <source>:<target>:rw` bind mount を確認し、
+  source が profile home の `mcp-tokens`、target が同じ profile の container path
+  であることを固定した。
+
+### 検証結果
+
+- `bats tests/bash/hermes_gmail_auth.bats`: 6/6 passed
+- `pwsh -NoProfile -Command 'Invoke-Pester -Path scripts/powershell/tests/HermesGmail.Tests.ps1 -Output Detailed'`: 6 passed, 0 failed, 1 skipped / 7 total
+- 必須 runner:
+  `pwsh -NoProfile -File scripts/powershell/tests/Invoke-Tests.ps1 -Path scripts/powershell/tests/HermesGmail.Tests.ps1 -MinimumCoverage 0`
+  は `6 passed, 0 failed, 1 skipped / 7 total` で exit 0。
+- Bash syntax、PowerShell parser、PSScriptAnalyzer（Error/Warning）、
+  `nix fmt -- --fail-on-change`、`git diff --check` を最終実行した。
+
+### 未実施・留意事項
+
+- Task 4 の live OAuth、Gmail MCP、Discord 検証は引き続き実行していない。
+- dedicated bind mount は Docker が mount source を解決した後の login 中の path
+  置換を防ぐ。Docker daemon 起動前の host path race はこのホスト adapter の検査と
+  Docker の mount 作成境界に依存するため、実 Docker を用いた live OAuth は未検証。

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -254,6 +254,37 @@ tasks:
     cmds:
       - docker compose -f {{.HERMES_COMPOSE_FILE}} logs -f --tail=100 xapi-mcp
 
+  hermes:gmail:auth:
+    desc: Authenticate Gmail MCP for one Hermes profile
+    interactive: true
+    preconditions:
+      - sh: docker info
+        msg: "Docker daemon is not running. Start Docker Desktop and try again."
+      - sh: test -f {{.HERMES_COMPOSE_FILE}}
+        msg: "Hermes compose file not found: {{.HERMES_COMPOSE_FILE}}"
+      - sh: test -n "{{.PROFILE}}"
+        msg: "Set PROFILE to an installed Hermes profile name."
+    cmds:
+      - cmd: HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE}} bash scripts/sh/hermes-gmail.sh auth "{{.PROFILE}}"
+        platforms: [linux, darwin]
+      - cmd: pwsh -NoProfile -File scripts/powershell/hermes-gmail.ps1 -Action auth -Profile "{{.PROFILE}}" -ComposeFile "{{.HERMES_COMPOSE_FILE}}"
+        platforms: [windows]
+
+  hermes:gmail:test:
+    desc: Test Gmail MCP for one authenticated Hermes profile
+    preconditions:
+      - sh: docker info
+        msg: "Docker daemon is not running. Start Docker Desktop and try again."
+      - sh: test -f {{.HERMES_COMPOSE_FILE}}
+        msg: "Hermes compose file not found: {{.HERMES_COMPOSE_FILE}}"
+      - sh: test -n "{{.PROFILE}}"
+        msg: "Set PROFILE to an installed Hermes profile name."
+    cmds:
+      - cmd: HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE}} bash scripts/sh/hermes-gmail.sh test "{{.PROFILE}}"
+        platforms: [linux, darwin]
+      - cmd: pwsh -NoProfile -File scripts/powershell/hermes-gmail.ps1 -Action test -Profile "{{.PROFILE}}" -ComposeFile "{{.HERMES_COMPOSE_FILE}}"
+        platforms: [windows]
+
   hermes:up:
     desc: Start Hermes Agent gateway and dashboard in Docker
     preconditions:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -255,19 +255,13 @@ tasks:
       - docker compose -f {{.HERMES_COMPOSE_FILE}} logs -f --tail=100 xapi-mcp
 
   hermes:gmail:auth:
-    desc: Authenticate Gmail MCP for one Hermes profile
+    desc: Authenticate the shared Gmail MCP account
     interactive: true
     preconditions:
-      - sh: docker info
-        msg: "Docker daemon is not running. Start Docker Desktop and try again."
-      - sh: test -f {{.HERMES_COMPOSE_FILE}}
-        msg: "Hermes compose file not found: {{.HERMES_COMPOSE_FILE}}"
-      - sh: test -n "{{.PROFILE}}"
-        msg: "Set PROFILE to an installed Hermes profile name."
     cmds:
-      - cmd: HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE}} bash scripts/sh/hermes-gmail.sh auth "{{.PROFILE}}"
+      - cmd: HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE}} bash scripts/sh/hermes-gmail.sh auth
         platforms: [linux, darwin]
-      - cmd: pwsh -NoProfile -File scripts/powershell/hermes-gmail.ps1 -Action auth -Profile "{{.PROFILE}}" -ComposeFile "{{.HERMES_COMPOSE_FILE}}"
+      - cmd: pwsh -NoProfile -File scripts/powershell/hermes-gmail.ps1 -Action auth -ComposeFile "{{.HERMES_COMPOSE_FILE}}"
         platforms: [windows]
 
   hermes:gmail:test:

--- a/docker/hermes-agent/Dockerfile
+++ b/docker/hermes-agent/Dockerfile
@@ -4,6 +4,7 @@ USER root
 
 ARG ARTICLE_COLLECTOR_VERSION=v0.6.17
 ARG GOOGLE_CALENDAR_MCP_VERSION=2.6.2
+ARG GOOGLE_GMAIL_MCP_VERSION=1.2.3
 
 COPY xapi-mcp.sh /usr/local/bin/hermes-xapi-mcp
 COPY gh-wrapper.sh /usr/local/bin/gh
@@ -83,7 +84,9 @@ RUN apt-get update \
   && npx --version \
   && npm install --global --omit=dev --no-audit --no-fund \
     "@cocal/google-calendar-mcp@${GOOGLE_CALENDAR_MCP_VERSION}" \
+    "@artymclabin/gmail-mcp@${GOOGLE_GMAIL_MCP_VERSION}" \
   && google-calendar-mcp --version \
+  && npm list --global --depth=0 "@artymclabin/gmail-mcp@${GOOGLE_GMAIL_MCP_VERSION}" \
   && article-collector --help \
   && chmod 0755 /usr/local/bin/gh \
   && chmod 0755 /usr/local/bin/hermes-xapi-mcp \

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/app.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/app.py
@@ -57,6 +57,7 @@ from .google_calendar import (
 )
 from .google_gmail import (
     install_google_gmail_configurations,
+    install_google_gmail_credentials,
     validate_google_gmail_installation,
 )
 from .configfiles import reconcile_onepassword_configurations
@@ -83,9 +84,8 @@ from .transaction import Transaction
 _ENV_LIMIT = 1024 * 1024
 _OBJECT_ID = re.compile(r"[0-9a-f]{40}(?:[0-9a-f]{24})?\Z")
 _DISCORD_BOT_TOKEN = re.compile(r"[A-Za-z0-9_\-.]{20,}\Z")
-_MANAGED_ENV_KEYS = (
-    GITHUB_KEYS | DASHBOARD_KEYS | API_SERVER_KEYS | DISCORD_KEYS | GMAIL_MCP_KEYS
-)
+_MANAGED_ENV_KEYS = GITHUB_KEYS | DASHBOARD_KEYS | API_SERVER_KEYS | DISCORD_KEYS
+_LEGACY_ENV_KEYS = LEGACY_SLACK_KEYS | GMAIL_MCP_KEYS
 _PLAINTEXT_DASHBOARD_PASSWORD = "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD"
 _failpoint: Callable[[str], None] = lambda _name: None
 
@@ -259,7 +259,7 @@ def _apply_sensitive(
                     expected_missing=True,
                     managed_environment=environment,
                     environment_remove=(
-                        (_MANAGED_ENV_KEYS - set(environment)) | LEGACY_SLACK_KEYS
+                        (_MANAGED_ENV_KEYS - set(environment)) | _LEGACY_ENV_KEYS
                     ),
                 )
             else:
@@ -288,6 +288,11 @@ def _apply_sensitive(
             secrets.google_calendar,
             tx,
         )
+        install_google_gmail_credentials(
+            manifest.data_root,
+            secrets.google_calendar,
+            tx,
+        )
 
         reconcile_onepassword_configurations(
             manifest,
@@ -304,7 +309,7 @@ def _apply_sensitive(
             merge_env_file(
                 env_path,
                 environment,
-                (_MANAGED_ENV_KEYS - set(environment)) | LEGACY_SLACK_KEYS,
+                (_MANAGED_ENV_KEYS - set(environment)) | _LEGACY_ENV_KEYS,
             )
             _failpoint(f"env-merge:{profile}")
 

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/app.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/app.py
@@ -28,6 +28,7 @@ from .envfiles import (
     DASHBOARD_KEYS,
     GITHUB_KEYS,
     DISCORD_KEYS,
+    GMAIL_MCP_KEYS,
     LEGACY_SLACK_KEYS,
     build_dashboard_environment,
     build_profile_environment,
@@ -54,6 +55,10 @@ from .google_calendar import (
     install_google_calendar_credentials,
     validate_google_calendar_installation,
 )
+from .google_gmail import (
+    install_google_gmail_configurations,
+    validate_google_gmail_installation,
+)
 from .configfiles import reconcile_onepassword_configurations
 from .github import GitAuth, GitHubClient
 from .manifest import load_manifest
@@ -78,7 +83,9 @@ from .transaction import Transaction
 _ENV_LIMIT = 1024 * 1024
 _OBJECT_ID = re.compile(r"[0-9a-f]{40}(?:[0-9a-f]{24})?\Z")
 _DISCORD_BOT_TOKEN = re.compile(r"[A-Za-z0-9_\-.]{20,}\Z")
-_MANAGED_ENV_KEYS = GITHUB_KEYS | DASHBOARD_KEYS | API_SERVER_KEYS | DISCORD_KEYS
+_MANAGED_ENV_KEYS = (
+    GITHUB_KEYS | DASHBOARD_KEYS | API_SERVER_KEYS | DISCORD_KEYS | GMAIL_MCP_KEYS
+)
 _PLAINTEXT_DASHBOARD_PASSWORD = "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD"
 _failpoint: Callable[[str], None] = lambda _name: None
 
@@ -269,6 +276,10 @@ def _apply_sensitive(
             _failpoint(f"shared-apply:{repo.name}")
 
         install_google_calendar_configurations(
+            [target for _profile, target in _environment_targets(manifest)],
+            tx,
+        )
+        install_google_gmail_configurations(
             [target for _profile, target in _environment_targets(manifest)],
             tx,
         )
@@ -605,6 +616,10 @@ def _validate_installed_layout(
         _validate_profiles(manifest)
         _validate_repositories(manifest)
         validate_google_calendar_installation(
+            manifest.data_root,
+            [target for _profile, target in _environment_targets(manifest)],
+        )
+        validate_google_gmail_installation(
             manifest.data_root,
             [target for _profile, target in _environment_targets(manifest)],
         )

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/distributions.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/distributions.py
@@ -21,6 +21,7 @@ from .envfiles import merge_env_file
 from .errors import ApplyError
 from .filesystem import PrivateDirectory, create_private_directory
 from .git import StagedSource
+from .google_gmail import is_google_gmail_configuration
 
 
 _ROOT_MANIFEST = "root-distribution.yaml"
@@ -808,7 +809,9 @@ def _same_distribution_path(source: Path, destination: Path) -> bool:
         destination_config = yaml.safe_load(destination.read_text(encoding="utf-8"))
         if not isinstance(source_config, dict) or not isinstance(destination_config, dict):
             return False
-        return _without_bootstrap_onepassword(source_config) == _without_bootstrap_onepassword(destination_config)
+        return without_bootstrap_managed_config(
+            source_config
+        ) == without_bootstrap_managed_config(destination_config)
     except (OSError, UnicodeError, TypeError, ValueError, yaml.YAMLError):
         return False
 
@@ -824,6 +827,27 @@ def _without_bootstrap_onepassword(config: dict[object, object]) -> dict[object,
         result["secrets"] = remaining_secrets
     else:
         result.pop("secrets", None)
+    return result
+
+
+def without_bootstrap_managed_config(
+    config: dict[object, object],
+) -> dict[object, object]:
+    """Compare distribution content without bootstrap-owned config additions."""
+
+    result = _without_bootstrap_onepassword(config)
+    mcp_servers = result.get("mcp_servers")
+    if not isinstance(mcp_servers, dict):
+        return result
+    gmail = mcp_servers.get("gmail")
+    if not is_google_gmail_configuration(gmail):
+        return result
+    retained_servers = dict(mcp_servers)
+    retained_servers.pop("gmail")
+    if retained_servers:
+        result["mcp_servers"] = retained_servers
+    else:
+        result.pop("mcp_servers", None)
     return result
 
 

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/envfiles.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/envfiles.py
@@ -18,7 +18,7 @@ from plugins.dashboard_auth.basic import _verify_password, hash_password
 
 from .errors import ApplyError, BootstrapError, InputError
 from .filesystem import open_absolute_directory, verify_absolute_directory
-from .payload import SecretBundle, _google_calendar_oauth_client_values
+from .payload import SecretBundle
 
 
 GITHUB_KEYS = frozenset(
@@ -279,15 +279,6 @@ def _build_profile_environment(
         {
             "DISCORD_BOT_TOKEN": discord.bot_token,
             "DISCORD_ALLOWED_USERS": discord.allowed_users,
-        }
-    )
-    gmail_client_id, gmail_client_secret = _google_calendar_oauth_client_values(
-        secrets.google_calendar
-    )
-    environment.update(
-        {
-            "GMAIL_MCP_CLIENT_ID": gmail_client_id,
-            "GMAIL_MCP_CLIENT_SECRET": gmail_client_secret,
         }
     )
     _validate_environment_mapping(environment, frozenset())

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/envfiles.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/envfiles.py
@@ -18,7 +18,7 @@ from plugins.dashboard_auth.basic import _verify_password, hash_password
 
 from .errors import ApplyError, BootstrapError, InputError
 from .filesystem import open_absolute_directory, verify_absolute_directory
-from .payload import SecretBundle
+from .payload import SecretBundle, _google_calendar_oauth_client_values
 
 
 GITHUB_KEYS = frozenset(
@@ -40,6 +40,12 @@ DISCORD_KEYS = frozenset(
     {
         "DISCORD_BOT_TOKEN",
         "DISCORD_ALLOWED_USERS",
+    }
+)
+GMAIL_MCP_KEYS = frozenset(
+    {
+        "GMAIL_MCP_CLIENT_ID",
+        "GMAIL_MCP_CLIENT_SECRET",
     }
 )
 LEGACY_SLACK_KEYS = frozenset(
@@ -273,6 +279,15 @@ def _build_profile_environment(
         {
             "DISCORD_BOT_TOKEN": discord.bot_token,
             "DISCORD_ALLOWED_USERS": discord.allowed_users,
+        }
+    )
+    gmail_client_id, gmail_client_secret = _google_calendar_oauth_client_values(
+        secrets.google_calendar
+    )
+    environment.update(
+        {
+            "GMAIL_MCP_CLIENT_ID": gmail_client_id,
+            "GMAIL_MCP_CLIENT_SECRET": gmail_client_secret,
         }
     )
     _validate_environment_mapping(environment, frozenset())

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/google_gmail.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/google_gmail.py
@@ -1,0 +1,120 @@
+"""Transactional installation of Google Gmail MCP configurations."""
+
+from __future__ import annotations
+
+import os
+import stat
+from collections.abc import Sequence
+from pathlib import Path
+
+import yaml
+
+from .distributions import _atomic_write
+from .errors import ApplyError, BootstrapError, ValidationError
+from .transaction import Transaction
+
+
+_MCP_CONFIGURATION = {
+    "url": "https://gmailmcp.googleapis.com/mcp/v1",
+    "auth": "oauth",
+    "connect_timeout": 315,
+    "oauth": {
+        "client_id": "${GMAIL_MCP_CLIENT_ID}",
+        "client_secret": "${GMAIL_MCP_CLIENT_SECRET}",
+        "scope": (
+            "https://www.googleapis.com/auth/gmail.readonly "
+            "https://www.googleapis.com/auth/gmail.compose"
+        ),
+    },
+    "tools": {
+        "include": [
+            "search_threads",
+            "get_thread",
+            "get_message",
+            "list_labels",
+            "list_drafts",
+            "create_draft",
+        ],
+        "resources": False,
+        "prompts": False,
+    },
+}
+
+
+def install_google_gmail_configurations(
+    targets: Sequence[Path],
+    transaction: Transaction,
+) -> None:
+    """Install the same Gmail MCP entry in root and every named profile."""
+
+    try:
+        for target in targets:
+            path = target / "config.yaml"
+            candidate = _load_managed_config(path)
+            if candidate is None:
+                # Final installed-layout validation owns replacement-race errors.
+                continue
+            metadata, config, mcp_servers = candidate
+            if mcp_servers.get("gmail") == _MCP_CONFIGURATION:
+                continue
+            mcp_servers["gmail"] = _gmail_configuration()
+            transaction.snapshot(path)
+            _atomic_write(
+                path,
+                yaml.safe_dump(config, sort_keys=False).encode("utf-8"),
+                stat.S_IMODE(metadata.st_mode),
+            )
+    except (OSError, TypeError, UnicodeError, ValueError, yaml.YAMLError):
+        raise ApplyError("could not install Google Gmail MCP configuration") from None
+
+
+def validate_google_gmail_installation(
+    data_root: Path,
+    targets: Sequence[Path],
+) -> None:
+    """Validate every managed Gmail MCP configuration."""
+
+    del data_root
+    try:
+        for target in targets:
+            candidate = _load_managed_config(target / "config.yaml")
+            if candidate is None or candidate[2].get("gmail") != _MCP_CONFIGURATION:
+                raise ValueError
+    except (BootstrapError, OSError, TypeError, UnicodeError, ValueError, yaml.YAMLError):
+        raise ValidationError("installed Google Gmail configuration is invalid") from None
+
+
+def _gmail_configuration() -> dict[str, object]:
+    return {
+        "url": _MCP_CONFIGURATION["url"],
+        "auth": _MCP_CONFIGURATION["auth"],
+        "connect_timeout": _MCP_CONFIGURATION["connect_timeout"],
+        "oauth": dict(_MCP_CONFIGURATION["oauth"]),
+        "tools": {
+            "include": list(_MCP_CONFIGURATION["tools"]["include"]),
+            "resources": _MCP_CONFIGURATION["tools"]["resources"],
+            "prompts": _MCP_CONFIGURATION["tools"]["prompts"],
+        },
+    }
+
+
+def _load_managed_config(
+    path: Path,
+) -> tuple[os.stat_result, dict[object, object], dict[object, object]] | None:
+    try:
+        metadata = path.lstat()
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+        ):
+            return None
+        config = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(config, dict):
+            return None
+        mcp_servers = config.get("mcp_servers")
+        if not isinstance(mcp_servers, dict):
+            return None
+        return metadata, config, mcp_servers
+    except (OSError, UnicodeError, yaml.YAMLError):
+        return None

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/google_gmail.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/google_gmail.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import yaml
 
-from .distributions import _atomic_write
 from .errors import ApplyError, BootstrapError, ValidationError
 from .transaction import Transaction
 
@@ -46,6 +45,8 @@ def install_google_gmail_configurations(
     transaction: Transaction,
 ) -> None:
     """Install the same Gmail MCP entry in root and every named profile."""
+
+    from .distributions import _atomic_write
 
     try:
         for target in targets:
@@ -96,6 +97,12 @@ def _gmail_configuration() -> dict[str, object]:
             "prompts": _MCP_CONFIGURATION["tools"]["prompts"],
         },
     }
+
+
+def is_google_gmail_configuration(value: object) -> bool:
+    """Return whether a config entry is the bootstrap-owned Gmail declaration."""
+
+    return value == _MCP_CONFIGURATION
 
 
 def _load_managed_config(

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/google_gmail.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/google_gmail.py
@@ -1,4 +1,4 @@
-"""Transactional installation of Google Gmail MCP configurations."""
+"""Transactional installation of shared Google Gmail MCP credentials."""
 
 from __future__ import annotations
 
@@ -10,29 +10,29 @@ from pathlib import Path
 import yaml
 
 from .errors import ApplyError, BootstrapError, ValidationError
+from .payload import GoogleCalendarSecret, _google_calendar_oauth_client_values
 from .transaction import Transaction
 
 
+_DIRECTORY = "google-gmail-mcp"
+_OAUTH_FILE = "gcp-oauth.keys.json"
+_CREDENTIALS_FILE = "credentials.json"
 _MCP_CONFIGURATION = {
-    "url": "https://gmailmcp.googleapis.com/mcp/v1",
-    "auth": "oauth",
-    "connect_timeout": 315,
-    "oauth": {
-        "client_id": "${GMAIL_MCP_CLIENT_ID}",
-        "client_secret": "${GMAIL_MCP_CLIENT_SECRET}",
-        "scope": (
-            "https://www.googleapis.com/auth/gmail.readonly "
-            "https://www.googleapis.com/auth/gmail.compose"
-        ),
+    "command": "gmail-mcp",
+    "connect_timeout": 300,
+    "env": {
+        "GMAIL_OAUTH_PATH": "/opt/data/google-gmail-mcp/gcp-oauth.keys.json",
+        "GMAIL_CREDENTIALS_PATH": "/opt/data/google-gmail-mcp/credentials.json",
     },
     "tools": {
         "include": [
-            "search_threads",
+            "search_emails",
+            "read_email",
             "get_thread",
-            "get_message",
-            "list_labels",
-            "list_drafts",
-            "create_draft",
+            "list_inbox_threads",
+            "get_inbox_with_threads",
+            "list_email_labels",
+            "draft_email",
         ],
         "resources": False,
         "prompts": False,
@@ -73,30 +73,155 @@ def validate_google_gmail_installation(
     data_root: Path,
     targets: Sequence[Path],
 ) -> None:
-    """Validate every managed Gmail MCP configuration."""
+    """Validate the shared credentials and every managed Gmail MCP entry."""
 
-    del data_root
     try:
         for target in targets:
             candidate = _load_managed_config(target / "config.yaml")
             if candidate is None or candidate[2].get("gmail") != _MCP_CONFIGURATION:
                 raise ValueError
+
+        credentials = data_root / _DIRECTORY
+        directory = credentials.lstat()
+        if (
+            stat.S_ISLNK(directory.st_mode)
+            or not stat.S_ISDIR(directory.st_mode)
+            or stat.S_IMODE(directory.st_mode) != 0o700
+        ):
+            raise ValueError
+
+        contents: dict[str, str] = {}
+        for name in (_OAUTH_FILE,):
+            path = credentials / name
+            metadata = path.lstat()
+            if (
+                stat.S_ISLNK(metadata.st_mode)
+                or not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+                or stat.S_IMODE(metadata.st_mode) != 0o600
+            ):
+                raise ValueError
+            contents[name] = path.read_text(encoding="utf-8")
+
+        _google_calendar_oauth_client_values(
+            GoogleCalendarSecret(
+                oauth_credentials_json=contents[_OAUTH_FILE],
+                tokens_json='{"refresh_token":"unused"}',
+            )
+        )
+        credentials_path = credentials / _CREDENTIALS_FILE
+        if os.path.lexists(credentials_path):
+            metadata = credentials_path.lstat()
+            if (
+                stat.S_ISLNK(metadata.st_mode)
+                or not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+                or stat.S_IMODE(metadata.st_mode) != 0o600
+            ):
+                raise ValueError
+            _validate_runtime_credentials(
+                credentials_path.read_text(encoding="utf-8")
+            )
+    except ValidationError:
+        raise
     except (BootstrapError, OSError, TypeError, UnicodeError, ValueError, yaml.YAMLError):
         raise ValidationError("installed Google Gmail configuration is invalid") from None
 
 
 def _gmail_configuration() -> dict[str, object]:
     return {
-        "url": _MCP_CONFIGURATION["url"],
-        "auth": _MCP_CONFIGURATION["auth"],
+        "command": _MCP_CONFIGURATION["command"],
         "connect_timeout": _MCP_CONFIGURATION["connect_timeout"],
-        "oauth": dict(_MCP_CONFIGURATION["oauth"]),
+        "env": dict(_MCP_CONFIGURATION["env"]),
         "tools": {
             "include": list(_MCP_CONFIGURATION["tools"]["include"]),
             "resources": _MCP_CONFIGURATION["tools"]["resources"],
             "prompts": _MCP_CONFIGURATION["tools"]["prompts"],
         },
     }
+
+
+def install_google_gmail_credentials(
+    data_root: Path,
+    secret: GoogleCalendarSecret,
+    transaction: Transaction,
+) -> None:
+    """Reuse Calendar's OAuth client while preserving host-local Gmail tokens."""
+
+    from .distributions import _atomic_write
+
+    target = data_root / _DIRECTORY
+    try:
+        if _oauth_is_current(target, secret):
+            return
+        transaction.snapshot(target)
+        if os.path.lexists(target):
+            metadata = target.lstat()
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+                raise OSError
+        else:
+            target.mkdir(mode=0o700)
+        target.chmod(0o700)
+        _atomic_write(
+            target / _OAUTH_FILE,
+            secret.oauth_credentials_json.encode("utf-8"),
+            0o600,
+        )
+    except (OSError, TypeError, UnicodeError, ValueError):
+        raise ApplyError("could not install Google Gmail credentials") from None
+
+
+def _oauth_is_current(target: Path, secret: GoogleCalendarSecret) -> bool:
+    try:
+        directory = target.lstat()
+        if (
+            stat.S_ISLNK(directory.st_mode)
+            or not stat.S_ISDIR(directory.st_mode)
+            or stat.S_IMODE(directory.st_mode) != 0o700
+        ):
+            return False
+        expected = {_OAUTH_FILE: secret.oauth_credentials_json.encode("utf-8")}
+        for name, content in expected.items():
+            path = target / name
+            metadata = path.lstat()
+            if (
+                stat.S_ISLNK(metadata.st_mode)
+                or not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+                or stat.S_IMODE(metadata.st_mode) != 0o600
+                or path.read_bytes() != content
+            ):
+                return False
+        return True
+    except (OSError, TypeError, UnicodeError):
+        return False
+
+
+def _validate_runtime_credentials(raw: str) -> None:
+    import json
+
+    try:
+        value = json.loads(raw)
+        tokens = value["tokens"]
+        scopes = value["scopes"]
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        raise ValueError from None
+    normalized = (
+        {
+            scope.removeprefix("https://www.googleapis.com/auth/")
+            for scope in scopes
+            if isinstance(scope, str)
+        }
+        if isinstance(scopes, list)
+        else set()
+    )
+    if (
+        not isinstance(tokens, dict)
+        or not isinstance(tokens.get("refresh_token"), str)
+        or not tokens["refresh_token"]
+        or not {"gmail.readonly", "gmail.compose"} <= normalized
+    ):
+        raise ValueError
 
 
 def is_google_gmail_configuration(value: object) -> bool:

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/payload.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/payload.py
@@ -470,9 +470,25 @@ def _bundle_from_fields(
 
 
 def validate_google_calendar_secret(secret: GoogleCalendarSecret) -> None:
+    _google_calendar_oauth_client_values(secret)
+    try:
+        tokens = json.loads(secret.tokens_json)
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        raise CredentialError("Google Calendar credentials are invalid") from None
+    if (
+        not isinstance(tokens, dict)
+        or not _contains_refresh_token(tokens)
+    ):
+        raise CredentialError("Google Calendar credentials are invalid") from None
+
+
+def _google_calendar_oauth_client_values(
+    secret: GoogleCalendarSecret,
+) -> tuple[str, str]:
+    """Extract the validated OAuth client values from the shared Calendar secret."""
+
     try:
         oauth = json.loads(secret.oauth_credentials_json)
-        tokens = json.loads(secret.tokens_json)
         installed = oauth["installed"]
         client_id = installed["client_id"]
         client_secret = installed["client_secret"]
@@ -485,10 +501,9 @@ def validate_google_calendar_secret(secret: GoogleCalendarSecret) -> None:
         or not client_id
         or not isinstance(client_secret, str)
         or not client_secret
-        or not isinstance(tokens, dict)
-        or not _contains_refresh_token(tokens)
     ):
         raise CredentialError("Google Calendar credentials are invalid") from None
+    return client_id, client_secret
 
 
 def _contains_refresh_token(value: object) -> bool:

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_sync.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_sync.py
@@ -12,6 +12,9 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Literal
 
+import yaml
+
+from .distributions import without_bootstrap_managed_config
 from .filesystem import PrivateDirectory, create_private_directory
 from .git import (
     _create_askpass,
@@ -314,7 +317,23 @@ def _synchronize_one_boundary(
                     auth,
                     attempt.remote_commit,
                 )
-                if dry_run:
+                bootstrap_config_only = _is_bootstrap_config_only_difference(
+                    diff,
+                    attempt.remote_commit,
+                    repository_path,
+                    environment,
+                )
+                if bootstrap_config_only:
+                    outcome = ProfileSyncResult(
+                        name=declaration.name,
+                        status="unchanged",
+                        commit=attempt.remote_commit,
+                        snapshot=snapshot.digest,
+                        diff=ProfileDiff(),
+                        category="unchanged",
+                        message="profile snapshot only differs by bootstrap configuration",
+                    )
+                elif dry_run:
                     commit = attempt.remote_commit
                     category = "dry_run"
                     message = "profile snapshot changes detected"
@@ -334,15 +353,16 @@ def _synchronize_one_boundary(
                         )
                     category = "published"
                     message = "profile snapshot published"
-                outcome = ProfileSyncResult(
-                    name=declaration.name,
-                    status="changed",
-                    commit=commit,
-                    snapshot=snapshot.digest,
-                    diff=diff,
-                    category=category,
-                    message=message,
-                )
+                if not bootstrap_config_only:
+                    outcome = ProfileSyncResult(
+                        name=declaration.name,
+                        status="changed",
+                        commit=commit,
+                        snapshot=snapshot.digest,
+                        diff=diff,
+                        category=category,
+                        message=message,
+                    )
     except _LockBusy as error:
         error = _scrub_exception_graph(error)
         outcome = _failed(snapshot, "lock_busy", "profile publication lock is busy")
@@ -447,6 +467,33 @@ def _profile_diff(
         added=tuple(changes[b"A"]),
         modified=tuple(changes[b"M"]),
         deleted=tuple(changes[b"D"]),
+    )
+
+
+def _is_bootstrap_config_only_difference(
+    diff: ProfileDiff,
+    remote_commit: str,
+    repository: Path,
+    environment: dict[str, str],
+) -> bool:
+    if diff != ProfileDiff(modified=(PurePosixPath("config.yaml"),)):
+        return False
+    try:
+        local = yaml.safe_load((repository / "config.yaml").read_text(encoding="utf-8"))
+        remote = yaml.safe_load(
+            _git_bytes(
+                ("show", f"{remote_commit}:config.yaml"),
+                repository,
+                environment,
+            ).decode("utf-8")
+        )
+    except (OSError, UnicodeError, ValueError, yaml.YAMLError):
+        return False
+    return (
+        isinstance(local, dict)
+        and isinstance(remote, dict)
+        and without_bootstrap_managed_config(local)
+        == without_bootstrap_managed_config(remote)
     )
 
 

--- a/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
+++ b/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
@@ -72,25 +72,21 @@ PROFILE_USER_DIRECTORIES = (
     "home",
 )
 GMAIL_CONFIGURATION = {
-    "url": "https://gmailmcp.googleapis.com/mcp/v1",
-    "auth": "oauth",
-    "connect_timeout": 315,
-    "oauth": {
-        "client_id": "${GMAIL_MCP_CLIENT_ID}",
-        "client_secret": "${GMAIL_MCP_CLIENT_SECRET}",
-        "scope": (
-            "https://www.googleapis.com/auth/gmail.readonly "
-            "https://www.googleapis.com/auth/gmail.compose"
-        ),
+    "command": "gmail-mcp",
+    "connect_timeout": 300,
+    "env": {
+        "GMAIL_OAUTH_PATH": "/opt/data/google-gmail-mcp/gcp-oauth.keys.json",
+        "GMAIL_CREDENTIALS_PATH": "/opt/data/google-gmail-mcp/credentials.json",
     },
     "tools": {
         "include": [
-            "search_threads",
+            "search_emails",
+            "read_email",
             "get_thread",
-            "get_message",
-            "list_labels",
-            "list_drafts",
-            "create_draft",
+            "list_inbox_threads",
+            "get_inbox_with_threads",
+            "list_email_labels",
+            "draft_email",
         ],
         "resources": False,
         "prompts": False,
@@ -106,8 +102,6 @@ PROFILE_ENV_KEYS = frozenset(
         "HERMES_DASHBOARD_BASIC_AUTH_SECRET",
         "DISCORD_BOT_TOKEN",
         "DISCORD_ALLOWED_USERS",
-        "GMAIL_MCP_CLIENT_ID",
-        "GMAIL_MCP_CLIENT_SECRET",
     }
 )
 DEFAULT_ENV_KEYS = PROFILE_ENV_KEYS | {"API_SERVER_KEY"}

--- a/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
+++ b/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
@@ -71,6 +71,46 @@ PROFILE_USER_DIRECTORIES = (
     "cron",
     "home",
 )
+GMAIL_CONFIGURATION = {
+    "url": "https://gmailmcp.googleapis.com/mcp/v1",
+    "auth": "oauth",
+    "connect_timeout": 315,
+    "oauth": {
+        "client_id": "${GMAIL_MCP_CLIENT_ID}",
+        "client_secret": "${GMAIL_MCP_CLIENT_SECRET}",
+        "scope": (
+            "https://www.googleapis.com/auth/gmail.readonly "
+            "https://www.googleapis.com/auth/gmail.compose"
+        ),
+    },
+    "tools": {
+        "include": [
+            "search_threads",
+            "get_thread",
+            "get_message",
+            "list_labels",
+            "list_drafts",
+            "create_draft",
+        ],
+        "resources": False,
+        "prompts": False,
+    },
+}
+PROFILE_ENV_KEYS = frozenset(
+    {
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "HERMES_DASHBOARD_BASIC_AUTH_USERNAME",
+        "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH",
+        "HERMES_DASHBOARD_BASIC_AUTH_SECRET",
+        "DISCORD_BOT_TOKEN",
+        "DISCORD_ALLOWED_USERS",
+        "GMAIL_MCP_CLIENT_ID",
+        "GMAIL_MCP_CLIENT_SECRET",
+    }
+)
+DEFAULT_ENV_KEYS = PROFILE_ENV_KEYS | {"API_SERVER_KEY"}
 SAFE_PATH = "/usr/bin:/bin"
 PROCESS_TIMEOUT_SECONDS = 15.0
 PROCESS_STOP_TIMEOUT_SECONDS = 2.0
@@ -104,10 +144,14 @@ def source_config(key: str, value: str) -> str:
 def managed_source_config(
     manifest: BootstrapManifest, profile: str, key: str, value: str
 ) -> str:
+    config = yaml.safe_load(source_config(key, value))
+    assert isinstance(config, dict)
+    mcp_servers = config["mcp_servers"]
+    assert isinstance(mcp_servers, dict)
+    mcp_servers["gmail"] = GMAIL_CONFIGURATION
     managed = build_onepassword_config(manifest, profile)
     return (
-        source_config(key, value).rstrip("\n")
-        + "\n"
+        yaml.safe_dump(config, sort_keys=False)
         + yaml.safe_dump({"secrets": {"onepassword": managed}}, sort_keys=False)
     )
 
@@ -1379,19 +1423,7 @@ class BootstrapFlowTests(unittest.TestCase):
             "final-validation",
             "commit-cleanup",
         )
-        managed_env_keys = frozenset(
-            {
-                "GH_TOKEN",
-                "GITHUB_TOKEN",
-                "GITHUB_PERSONAL_ACCESS_TOKEN",
-                "HERMES_DASHBOARD_BASIC_AUTH_USERNAME",
-                "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH",
-                "HERMES_DASHBOARD_BASIC_AUTH_SECRET",
-                "API_SERVER_KEY",
-                "DISCORD_BOT_TOKEN",
-                "DISCORD_ALLOWED_USERS",
-            }
-        )
+        managed_env_keys = DEFAULT_ENV_KEYS
         env_paths = {
             "default": ".env",
             **{
@@ -1738,17 +1770,7 @@ class BootstrapFlowTests(unittest.TestCase):
         self.assertIn("# root comment", root_env)
         self.assertIn("CUSTOM_ROOT=keep", root_env)
         self.assertNotIn("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=", root_env)
-        for key in (
-            "GH_TOKEN",
-            "GITHUB_TOKEN",
-            "GITHUB_PERSONAL_ACCESS_TOKEN",
-            "HERMES_DASHBOARD_BASIC_AUTH_USERNAME",
-            "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH",
-            "HERMES_DASHBOARD_BASIC_AUTH_SECRET",
-            "API_SERVER_KEY",
-            "DISCORD_BOT_TOKEN",
-            "DISCORD_ALLOWED_USERS",
-        ):
+        for key in DEFAULT_ENV_KEYS:
             self.assertEqual(sum(line.startswith(f"{key}=") for line in root_env.splitlines()), 1)
         root_values = dict(
             line.partition("=")[::2]
@@ -1770,6 +1792,14 @@ class BootstrapFlowTests(unittest.TestCase):
                     for line in profile_env.splitlines()
                 )
             )
+            for key in PROFILE_ENV_KEYS:
+                self.assertEqual(
+                    sum(
+                        line.startswith(f"{key}=")
+                        for line in profile_env.splitlines()
+                    ),
+                    1,
+                )
 
         original_api_key = root_values["API_SERVER_KEY"]
         root_path = self.data_root / ".env"

--- a/docker/hermes-agent/bootstrap/tests/test_app.py
+++ b/docker/hermes-agent/bootstrap/tests/test_app.py
@@ -130,6 +130,13 @@ class AppTests(unittest.TestCase):
         )
         self.install_google_calendar_configurations = calendar_config_patcher.start()
         self.addCleanup(calendar_config_patcher.stop)
+        gmail_config_patcher = mock.patch.object(
+            app,
+            "install_google_gmail_configurations",
+            create=True,
+        )
+        self.install_google_gmail_configurations = gmail_config_patcher.start()
+        self.addCleanup(gmail_config_patcher.stop)
         revalidate_patcher = mock.patch.object(
             app,
             "revalidate_profile_snapshots",
@@ -202,6 +209,24 @@ class AppTests(unittest.TestCase):
             "    env:\n"
             "      GOOGLE_OAUTH_CREDENTIALS: /opt/data/google-calendar-mcp/gcp-oauth.keys.json\n"
             "      GOOGLE_CALENDAR_MCP_TOKEN_PATH: /opt/data/google-calendar-mcp/tokens.json\n"
+            "  gmail:\n"
+            "    url: https://gmailmcp.googleapis.com/mcp/v1\n"
+            "    auth: oauth\n"
+            "    connect_timeout: 315\n"
+            "    oauth:\n"
+            "      client_id: ${GMAIL_MCP_CLIENT_ID}\n"
+            "      client_secret: ${GMAIL_MCP_CLIENT_SECRET}\n"
+            "      scope: https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose\n"
+            "    tools:\n"
+            "      include:\n"
+            "        - search_threads\n"
+            "        - get_thread\n"
+            "        - get_message\n"
+            "        - list_labels\n"
+            "        - list_drafts\n"
+            "        - create_draft\n"
+            "      resources: false\n"
+            "      prompts: false\n"
         )
         for config in (self.root / "config.yaml", target / "config.yaml"):
             config.write_text(calendar_config, encoding="utf-8")
@@ -628,6 +653,20 @@ class AppTests(unittest.TestCase):
         self.revalidate_profile_snapshots.side_effect = (
             lambda _manifest, _baseline, _scratch: events.append("revalidate")
         )
+        self.install_google_calendar_configurations.side_effect = (
+            lambda targets, transaction: events.append(
+                "calendar-config:"
+                + ",".join(target.name for target in targets)
+                + f":{transaction is tx}"
+            )
+        )
+        self.install_google_gmail_configurations.side_effect = (
+            lambda targets, transaction: events.append(
+                "gmail-config:"
+                + ",".join(target.name for target in targets)
+                + f":{transaction is tx}"
+            )
+        )
 
         with (
             mock.patch.object(app, "load_manifest", return_value=configured),
@@ -685,6 +724,8 @@ class AppTests(unittest.TestCase):
                 "profile:risarisa",
                 "profile:nancy",
                 "shared:lifelog",
+                "calendar-config:data,rick,hoffman,risarisa,nancy:True",
+                "gmail-config:data,rick,hoffman,risarisa,nancy:True",
                 "env:data",
                 "env:rick",
                 "env:hoffman",

--- a/docker/hermes-agent/bootstrap/tests/test_app.py
+++ b/docker/hermes-agent/bootstrap/tests/test_app.py
@@ -137,6 +137,13 @@ class AppTests(unittest.TestCase):
         )
         self.install_google_gmail_configurations = gmail_config_patcher.start()
         self.addCleanup(gmail_config_patcher.stop)
+        gmail_credentials_patcher = mock.patch.object(
+            app,
+            "install_google_gmail_credentials",
+            create=True,
+        )
+        self.install_google_gmail_credentials = gmail_credentials_patcher.start()
+        self.addCleanup(gmail_credentials_patcher.stop)
         revalidate_patcher = mock.patch.object(
             app,
             "revalidate_profile_snapshots",
@@ -210,21 +217,20 @@ class AppTests(unittest.TestCase):
             "      GOOGLE_OAUTH_CREDENTIALS: /opt/data/google-calendar-mcp/gcp-oauth.keys.json\n"
             "      GOOGLE_CALENDAR_MCP_TOKEN_PATH: /opt/data/google-calendar-mcp/tokens.json\n"
             "  gmail:\n"
-            "    url: https://gmailmcp.googleapis.com/mcp/v1\n"
-            "    auth: oauth\n"
-            "    connect_timeout: 315\n"
-            "    oauth:\n"
-            "      client_id: ${GMAIL_MCP_CLIENT_ID}\n"
-            "      client_secret: ${GMAIL_MCP_CLIENT_SECRET}\n"
-            "      scope: https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose\n"
+            "    command: gmail-mcp\n"
+            "    connect_timeout: 300\n"
+            "    env:\n"
+            "      GMAIL_OAUTH_PATH: /opt/data/google-gmail-mcp/gcp-oauth.keys.json\n"
+            "      GMAIL_CREDENTIALS_PATH: /opt/data/google-gmail-mcp/credentials.json\n"
             "    tools:\n"
             "      include:\n"
-            "        - search_threads\n"
+            "        - search_emails\n"
+            "        - read_email\n"
             "        - get_thread\n"
-            "        - get_message\n"
-            "        - list_labels\n"
-            "        - list_drafts\n"
-            "        - create_draft\n"
+            "        - list_inbox_threads\n"
+            "        - get_inbox_with_threads\n"
+            "        - list_email_labels\n"
+            "        - draft_email\n"
             "      resources: false\n"
             "      prompts: false\n"
         )
@@ -244,6 +250,21 @@ class AppTests(unittest.TestCase):
         )
         oauth.chmod(0o600)
         tokens.chmod(0o600)
+        gmail_credentials = self.root / "google-gmail-mcp"
+        gmail_credentials.mkdir(mode=0o700)
+        gmail_oauth = gmail_credentials / "gcp-oauth.keys.json"
+        gmail_tokens = gmail_credentials / "credentials.json"
+        gmail_oauth.write_text(
+            '{"installed":{"client_id":"id","client_secret":"secret"}}',
+            encoding="utf-8",
+        )
+        gmail_tokens.write_text(
+            '{"tokens":{"refresh_token":"refresh"},'
+            '"scopes":["gmail.readonly","gmail.compose"]}',
+            encoding="utf-8",
+        )
+        gmail_oauth.chmod(0o600)
+        gmail_tokens.chmod(0o600)
         self.write_repository_metadata(self.manifest.shared_repositories[0].source)
         secret_body = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
 

--- a/docker/hermes-agent/bootstrap/tests/test_envfiles.py
+++ b/docker/hermes-agent/bootstrap/tests/test_envfiles.py
@@ -144,6 +144,16 @@ class EnvFileTests(unittest.TestCase):
         self.assertEqual(environment["GMAIL_MCP_CLIENT_ID"], "id")
         self.assertEqual(environment["GMAIL_MCP_CLIENT_SECRET"], "secret")
         self.assertIsInstance(environment, MappingProxyType)
+        self.assertIsInstance(
+            environment["GMAIL_MCP_CLIENT_ID"],
+            envfiles_module._SecretEnvironmentValue,
+        )
+        self.assertIsInstance(
+            environment["GMAIL_MCP_CLIENT_SECRET"],
+            envfiles_module._SecretEnvironmentValue,
+        )
+        self.assertEqual(repr(environment["GMAIL_MCP_CLIENT_ID"]), "'[REDACTED]'")
+        self.assertEqual(repr(environment["GMAIL_MCP_CLIENT_SECRET"]), "'[REDACTED]'")
         self.assertNotIn("id", repr(environment))
         self.assertNotIn("secret", repr(environment))
         with self.assertRaises(TypeError):

--- a/docker/hermes-agent/bootstrap/tests/test_envfiles.py
+++ b/docker/hermes-agent/bootstrap/tests/test_envfiles.py
@@ -32,6 +32,7 @@ from hermes_bootstrap.envfiles import (
     DASHBOARD_KEYS,
     GITHUB_KEYS,
     DISCORD_KEYS,
+    GMAIL_MCP_KEYS,
     build_dashboard_environment,
     build_profile_environment,
     merge_env_file,
@@ -120,9 +121,13 @@ class EnvFileTests(unittest.TestCase):
             DISCORD_KEYS,
             frozenset({"DISCORD_BOT_TOKEN", "DISCORD_ALLOWED_USERS"}),
         )
+        self.assertEqual(
+            GMAIL_MCP_KEYS,
+            frozenset({"GMAIL_MCP_CLIENT_ID", "GMAIL_MCP_CLIENT_SECRET"}),
+        )
         self.assertEqual(API_SERVER_KEYS, frozenset({"API_SERVER_KEY"}))
 
-    def test_profile_environment_uses_discord_credentials_only(self) -> None:
+    def test_profile_environment_includes_private_gmail_oauth_client_values(self) -> None:
         environment = build_profile_environment(
             "rick",
             secret_bundle(),
@@ -136,6 +141,13 @@ class EnvFileTests(unittest.TestCase):
 
         self.assertEqual(environment["DISCORD_BOT_TOKEN"], "rick-bot")
         self.assertEqual(environment["DISCORD_ALLOWED_USERS"], "rick-users")
+        self.assertEqual(environment["GMAIL_MCP_CLIENT_ID"], "id")
+        self.assertEqual(environment["GMAIL_MCP_CLIENT_SECRET"], "secret")
+        self.assertIsInstance(environment, MappingProxyType)
+        self.assertNotIn("id", repr(environment))
+        self.assertNotIn("secret", repr(environment))
+        with self.assertRaises(TypeError):
+            environment["GMAIL_MCP_CLIENT_ID"] = "changed"
         self.assertNotIn("SLACK_BOT_TOKEN", environment)
         self.assertNotIn("SLACK_APP_TOKEN", environment)
 

--- a/docker/hermes-agent/bootstrap/tests/test_envfiles.py
+++ b/docker/hermes-agent/bootstrap/tests/test_envfiles.py
@@ -127,7 +127,7 @@ class EnvFileTests(unittest.TestCase):
         )
         self.assertEqual(API_SERVER_KEYS, frozenset({"API_SERVER_KEY"}))
 
-    def test_profile_environment_includes_private_gmail_oauth_client_values(self) -> None:
+    def test_profile_environment_uses_shared_gmail_files_not_oauth_env(self) -> None:
         environment = build_profile_environment(
             "rick",
             secret_bundle(),
@@ -141,23 +141,9 @@ class EnvFileTests(unittest.TestCase):
 
         self.assertEqual(environment["DISCORD_BOT_TOKEN"], "rick-bot")
         self.assertEqual(environment["DISCORD_ALLOWED_USERS"], "rick-users")
-        self.assertEqual(environment["GMAIL_MCP_CLIENT_ID"], "id")
-        self.assertEqual(environment["GMAIL_MCP_CLIENT_SECRET"], "secret")
         self.assertIsInstance(environment, MappingProxyType)
-        self.assertIsInstance(
-            environment["GMAIL_MCP_CLIENT_ID"],
-            envfiles_module._SecretEnvironmentValue,
-        )
-        self.assertIsInstance(
-            environment["GMAIL_MCP_CLIENT_SECRET"],
-            envfiles_module._SecretEnvironmentValue,
-        )
-        self.assertEqual(repr(environment["GMAIL_MCP_CLIENT_ID"]), "'[REDACTED]'")
-        self.assertEqual(repr(environment["GMAIL_MCP_CLIENT_SECRET"]), "'[REDACTED]'")
-        self.assertNotIn("id", repr(environment))
-        self.assertNotIn("secret", repr(environment))
-        with self.assertRaises(TypeError):
-            environment["GMAIL_MCP_CLIENT_ID"] = "changed"
+        self.assertNotIn("GMAIL_MCP_CLIENT_ID", environment)
+        self.assertNotIn("GMAIL_MCP_CLIENT_SECRET", environment)
         self.assertNotIn("SLACK_BOT_TOKEN", environment)
         self.assertNotIn("SLACK_APP_TOKEN", environment)
 

--- a/docker/hermes-agent/bootstrap/tests/test_google_calendar.py
+++ b/docker/hermes-agent/bootstrap/tests/test_google_calendar.py
@@ -130,6 +130,31 @@ class GoogleCalendarCredentialTests(unittest.TestCase):
                 (target / "config.yaml").read_text(encoding="utf-8"),
             )
 
+    def test_calendar_installation_preserves_an_existing_gmail_server(self) -> None:
+        gmail = (
+            "  gmail:\n"
+            "    url: https://gmailmcp.googleapis.com/mcp/v1\n"
+            "    auth: oauth\n"
+            "    connect_timeout: 315\n"
+        )
+        target = self.root
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "config.yaml").write_text(
+            "mcp_servers:\n"
+            "  retained:\n"
+            "    url: https://example.invalid/mcp\n"
+            + gmail,
+            encoding="utf-8",
+        )
+        tx = Transaction.begin(self.root)
+
+        install_google_calendar_configurations((target,), tx)
+        tx.commit()
+
+        installed = (target / "config.yaml").read_text(encoding="utf-8")
+        self.assertIn(gmail, installed)
+        self.assertIn("retained:\n    url: https://example.invalid/mcp", installed)
+
     def test_validation_accepts_every_calendar_configuration_and_shared_credentials(
         self,
     ) -> None:

--- a/docker/hermes-agent/bootstrap/tests/test_google_gmail.py
+++ b/docker/hermes-agent/bootstrap/tests/test_google_gmail.py
@@ -14,31 +14,29 @@ sys.path.insert(0, str(BOOTSTRAP_ROOT))
 from hermes_bootstrap.errors import ValidationError
 from hermes_bootstrap.google_gmail import (
     install_google_gmail_configurations,
+    install_google_gmail_credentials,
     validate_google_gmail_installation,
 )
+from hermes_bootstrap.payload import GoogleCalendarSecret
 from hermes_bootstrap.transaction import Transaction
 
 
 EXPECTED_GMAIL = {
-    "url": "https://gmailmcp.googleapis.com/mcp/v1",
-    "auth": "oauth",
-    "connect_timeout": 315,
-    "oauth": {
-        "client_id": "${GMAIL_MCP_CLIENT_ID}",
-        "client_secret": "${GMAIL_MCP_CLIENT_SECRET}",
-        "scope": (
-            "https://www.googleapis.com/auth/gmail.readonly "
-            "https://www.googleapis.com/auth/gmail.compose"
-        ),
+    "command": "gmail-mcp",
+    "connect_timeout": 300,
+    "env": {
+        "GMAIL_OAUTH_PATH": "/opt/data/google-gmail-mcp/gcp-oauth.keys.json",
+        "GMAIL_CREDENTIALS_PATH": "/opt/data/google-gmail-mcp/credentials.json",
     },
     "tools": {
         "include": [
-            "search_threads",
+            "search_emails",
+            "read_email",
             "get_thread",
-            "get_message",
-            "list_labels",
-            "list_drafts",
-            "create_draft",
+            "list_inbox_threads",
+            "get_inbox_with_threads",
+            "list_email_labels",
+            "draft_email",
         ],
         "resources": False,
         "prompts": False,
@@ -52,6 +50,12 @@ class GoogleGmailConfigurationTests(unittest.TestCase):
         self.addCleanup(self.temporary.cleanup)
         self.root = Path(self.temporary.name).resolve() / "data"
         self.root.mkdir(mode=0o700)
+        self.secret = GoogleCalendarSecret(
+            oauth_credentials_json=(
+                '{"installed":{"client_id":"id","client_secret":"secret"}}'
+            ),
+            tokens_json='{"refresh_token":"calendar-refresh"}',
+        )
 
     def targets_with_unrelated_servers(self) -> tuple[Path, ...]:
         targets = (self.root, self.root / "profiles" / "nancy")
@@ -72,8 +76,40 @@ class GoogleGmailConfigurationTests(unittest.TestCase):
         targets = self.targets_with_unrelated_servers()
         tx = Transaction.begin(self.root)
         install_google_gmail_configurations(targets, tx)
+        install_google_gmail_credentials(self.root, self.secret, tx)
         tx.commit()
         return targets
+
+    def test_installs_shared_credentials_with_private_permissions(self) -> None:
+        tx = Transaction.begin(self.root)
+
+        install_google_gmail_credentials(self.root, self.secret, tx)
+        tx.commit()
+
+        target = self.root / "google-gmail-mcp"
+        self.assertEqual(target.stat().st_mode & 0o777, 0o700)
+        self.assertEqual(
+            (target / "gcp-oauth.keys.json").read_text(encoding="utf-8"),
+            self.secret.oauth_credentials_json,
+        )
+        self.assertEqual(
+            (target / "gcp-oauth.keys.json").stat().st_mode & 0o777,
+            0o600,
+        )
+        self.assertFalse((target / "credentials.json").exists())
+
+    def test_rollback_restores_previous_credentials(self) -> None:
+        target = self.root / "google-gmail-mcp"
+        target.mkdir(mode=0o700)
+        oauth = target / "gcp-oauth.keys.json"
+        oauth.write_text("old-oauth", encoding="utf-8")
+        oauth.chmod(0o600)
+        tx = Transaction.begin(self.root)
+
+        install_google_gmail_credentials(self.root, self.secret, tx)
+        tx.rollback()
+
+        self.assertEqual(oauth.read_text(encoding="utf-8"), "old-oauth")
 
     def test_inserts_the_same_gmail_configuration_for_every_target(self) -> None:
         targets = self.targets_with_unrelated_servers()
@@ -124,26 +160,39 @@ class GoogleGmailConfigurationTests(unittest.TestCase):
                         validate_google_gmail_installation(self.root, targets)
                     config_path.write_text(original, encoding="utf-8")
 
-    def test_validation_rejects_missing_scope_and_forbidden_tool(self) -> None:
+    def test_validation_rejects_malformed_or_public_credentials(self) -> None:
         targets = self.install_valid_layout()
-        config_path = targets[0] / "config.yaml"
-        original = config_path.read_text(encoding="utf-8")
+        credentials = self.root / "google-gmail-mcp" / "credentials.json"
+        original = (
+            '{"tokens":{"refresh_token":"refresh"},'
+            '"scopes":["gmail.readonly","gmail.compose"]}'
+        )
+        credentials.write_text(original, encoding="utf-8")
+        credentials.chmod(0o600)
 
-        for case in ("missing-scope", "forbidden-tool"):
+        for case in ("missing-compose-scope", "missing-refresh-token", "public"):
             with self.subTest(case=case):
-                config = yaml.safe_load(original)
-                gmail = config["mcp_servers"]["gmail"]
-                if case == "missing-scope":
-                    gmail["oauth"]["scope"] = "https://www.googleapis.com/auth/gmail.readonly"
+                if case == "missing-compose-scope":
+                    credentials.write_text(
+                        '{"tokens":{"refresh_token":"refresh"},'
+                        '"scopes":["gmail.readonly"]}',
+                        encoding="utf-8",
+                    )
+                elif case == "missing-refresh-token":
+                    credentials.write_text(
+                        '{"tokens":{"access_token":"access"},'
+                        '"scopes":["gmail.readonly","gmail.compose"]}',
+                        encoding="utf-8",
+                    )
                 else:
-                    gmail["tools"]["include"].append("send_message")
-                config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+                    credentials.chmod(0o644)
                 with self.assertRaisesRegex(
                     ValidationError,
                     "installed Google Gmail configuration is invalid",
                 ):
                     validate_google_gmail_installation(self.root, targets)
-                config_path.write_text(original, encoding="utf-8")
+                credentials.write_text(original, encoding="utf-8")
+                credentials.chmod(0o600)
 
 
 if __name__ == "__main__":

--- a/docker/hermes-agent/bootstrap/tests/test_google_gmail.py
+++ b/docker/hermes-agent/bootstrap/tests/test_google_gmail.py
@@ -105,16 +105,24 @@ class GoogleGmailConfigurationTests(unittest.TestCase):
         for target in targets:
             config_path = target / "config.yaml"
             original = config_path.read_text(encoding="utf-8")
-            with self.subTest(target=target, case="missing"):
-                config = yaml.safe_load(original)
-                del config["mcp_servers"]["gmail"]
-                config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
-                with self.assertRaisesRegex(
-                    ValidationError,
-                    "installed Google Gmail configuration is invalid",
-                ):
-                    validate_google_gmail_installation(self.root, targets)
-            config_path.write_text(original, encoding="utf-8")
+            for case in ("missing", "altered"):
+                with self.subTest(target=target, case=case):
+                    config = yaml.safe_load(original)
+                    if case == "missing":
+                        del config["mcp_servers"]["gmail"]
+                    else:
+                        config["mcp_servers"]["gmail"]["url"] = (
+                            "https://gmailmcp.googleapis.com/mcp/altered"
+                        )
+                    config_path.write_text(
+                        yaml.safe_dump(config, sort_keys=False), encoding="utf-8"
+                    )
+                    with self.assertRaisesRegex(
+                        ValidationError,
+                        "installed Google Gmail configuration is invalid",
+                    ):
+                        validate_google_gmail_installation(self.root, targets)
+                    config_path.write_text(original, encoding="utf-8")
 
     def test_validation_rejects_missing_scope_and_forbidden_tool(self) -> None:
         targets = self.install_valid_layout()

--- a/docker/hermes-agent/bootstrap/tests/test_google_gmail.py
+++ b/docker/hermes-agent/bootstrap/tests/test_google_gmail.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BOOTSTRAP_ROOT))
+
+from hermes_bootstrap.errors import ValidationError
+from hermes_bootstrap.google_gmail import (
+    install_google_gmail_configurations,
+    validate_google_gmail_installation,
+)
+from hermes_bootstrap.transaction import Transaction
+
+
+EXPECTED_GMAIL = {
+    "url": "https://gmailmcp.googleapis.com/mcp/v1",
+    "auth": "oauth",
+    "connect_timeout": 315,
+    "oauth": {
+        "client_id": "${GMAIL_MCP_CLIENT_ID}",
+        "client_secret": "${GMAIL_MCP_CLIENT_SECRET}",
+        "scope": (
+            "https://www.googleapis.com/auth/gmail.readonly "
+            "https://www.googleapis.com/auth/gmail.compose"
+        ),
+    },
+    "tools": {
+        "include": [
+            "search_threads",
+            "get_thread",
+            "get_message",
+            "list_labels",
+            "list_drafts",
+            "create_draft",
+        ],
+        "resources": False,
+        "prompts": False,
+    },
+}
+
+
+class GoogleGmailConfigurationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name).resolve() / "data"
+        self.root.mkdir(mode=0o700)
+
+    def targets_with_unrelated_servers(self) -> tuple[Path, ...]:
+        targets = (self.root, self.root / "profiles" / "nancy")
+        for target in targets:
+            target.mkdir(parents=True, exist_ok=True)
+            (target / "config.yaml").write_text(
+                "model:\n  name: test\n"
+                "mcp_servers:\n"
+                "  chrome:\n"
+                "    url: http://browser-mcp:8080/mcp\n"
+                "  retained:\n"
+                "    url: https://example.invalid/mcp\n",
+                encoding="utf-8",
+            )
+        return targets
+
+    def install_valid_layout(self) -> tuple[Path, ...]:
+        targets = self.targets_with_unrelated_servers()
+        tx = Transaction.begin(self.root)
+        install_google_gmail_configurations(targets, tx)
+        tx.commit()
+        return targets
+
+    def test_inserts_the_same_gmail_configuration_for_every_target(self) -> None:
+        targets = self.targets_with_unrelated_servers()
+        tx = Transaction.begin(self.root)
+
+        install_google_gmail_configurations(targets, tx)
+        tx.commit()
+
+        for target in targets:
+            config = yaml.safe_load((target / "config.yaml").read_text(encoding="utf-8"))
+            self.assertEqual(config["mcp_servers"]["gmail"], EXPECTED_GMAIL)
+            self.assertEqual(
+                config["mcp_servers"]["chrome"],
+                {"url": "http://browser-mcp:8080/mcp"},
+            )
+            self.assertEqual(
+                config["mcp_servers"]["retained"],
+                {"url": "https://example.invalid/mcp"},
+            )
+
+    def test_validation_accepts_every_gmail_configuration(self) -> None:
+        targets = self.install_valid_layout()
+
+        validate_google_gmail_installation(self.root, targets)
+
+    def test_validation_rejects_a_missing_or_altered_gmail_entry(self) -> None:
+        targets = self.install_valid_layout()
+
+        for target in targets:
+            config_path = target / "config.yaml"
+            original = config_path.read_text(encoding="utf-8")
+            with self.subTest(target=target, case="missing"):
+                config = yaml.safe_load(original)
+                del config["mcp_servers"]["gmail"]
+                config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+                with self.assertRaisesRegex(
+                    ValidationError,
+                    "installed Google Gmail configuration is invalid",
+                ):
+                    validate_google_gmail_installation(self.root, targets)
+            config_path.write_text(original, encoding="utf-8")
+
+    def test_validation_rejects_missing_scope_and_forbidden_tool(self) -> None:
+        targets = self.install_valid_layout()
+        config_path = targets[0] / "config.yaml"
+        original = config_path.read_text(encoding="utf-8")
+
+        for case in ("missing-scope", "forbidden-tool"):
+            with self.subTest(case=case):
+                config = yaml.safe_load(original)
+                gmail = config["mcp_servers"]["gmail"]
+                if case == "missing-scope":
+                    gmail["oauth"]["scope"] = "https://www.googleapis.com/auth/gmail.readonly"
+                else:
+                    gmail["tools"]["include"].append("send_message")
+                config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+                with self.assertRaisesRegex(
+                    ValidationError,
+                    "installed Google Gmail configuration is invalid",
+                ):
+                    validate_google_gmail_installation(self.root, targets)
+                config_path.write_text(original, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/hermes-agent/bootstrap.md
+++ b/docs/hermes-agent/bootstrap.md
@@ -80,7 +80,14 @@ Required labels are `username` or `user name` and `password` for the dashboard;
 for each Discord item. The Calendar item requires `oauth_credentials_json` and
 `tokens_json`; bootstrap installs both as mode `0600` files in the shared
 `/opt/data/google-calendar-mcp` directory, independently of named-profile
-synchronization. Bootstrap validates GitHub authentication and all remote
+synchronization.
+
+Gmail reuses the Calendar OAuth client in the shared
+`/opt/data/google-gmail-mcp` directory. Its host-local `credentials.json` is
+preserved across bootstrap runs and shared by all profiles; it is not added to
+the 1Password item plan.
+
+Bootstrap validates GitHub authentication and all remote
 access after crash-journal recovery and before it begins new staging or
 transaction writes. Recovery may restore or delete previously journaled managed
 paths before secrets and credentials are validated. Managed `.env` keys include

--- a/docs/hermes-agent/gmail-mcp.md
+++ b/docs/hermes-agent/gmail-mcp.md
@@ -14,7 +14,9 @@ profile で個別に OAuth を完了します。OAuth トークンは各 profile
 3. Calendar MCP で使っている既存の OAuth client を再利用します。client ID/secret は
    bootstrap が private profile `.env` にのみ配置するため、手入力や新しい
    1Password item は不要です。
-4. 同意画面では `gmail.readonly` と `gmail.compose` のみを許可します。
+4. 同意画面では
+   `https://www.googleapis.com/auth/gmail.readonly` と
+   `https://www.googleapis.com/auth/gmail.compose` のみを許可します。
 
 bootstrap 済みであることを確認してから、profile ごとに認証します。
 

--- a/docs/hermes-agent/gmail-mcp.md
+++ b/docs/hermes-agent/gmail-mcp.md
@@ -1,47 +1,41 @@
 # Hermes Gmail MCP
 
-Hermes の Gmail MCP は公式エンドポイント
-`https://gmailmcp.googleapis.com/mcp/v1` を使い、root/default と各 named
-profile で個別に OAuth を完了します。OAuth トークンは各 profile home の
-`mcp-tokens/gmail.json` にだけ保存され、`0600` 以外のキャッシュは無効として
-扱われます。トークンや OAuth client の値をコマンド引数、設定 YAML、ログに
-書かないでください。
+Hermes の Gmail は Google Calendar と同じ共有 OAuth 方式です。Google の
+会社向けリモート Gmail MCP API は使いません。標準 Gmail API とローカル stdio
+MCP (`gmail-mcp`) を使い、root/default と全 named profile が
+`/opt/data/google-gmail-mcp` の同じ資格情報を参照します。
 
-## Google Cloud の事前準備
+## Google Cloud の準備
 
-1. 同じ Google Cloud project で Gmail API と Google の Gmail MCP API を有効にします。
-2. OAuth consent screen を設定し、利用者をテストユーザーとして許可します。
-3. Calendar MCP で使っている既存の OAuth client を再利用します。client ID/secret は
-   bootstrap が private profile `.env` にのみ配置するため、手入力や新しい
-   1Password item は不要です。
-4. 同意画面では
-   `https://www.googleapis.com/auth/gmail.readonly` と
-   `https://www.googleapis.com/auth/gmail.compose` のみを許可します。
+1. Calendar と同じ個人用 Google Cloud project で標準 Gmail API
+   (`gmail.googleapis.com`) を有効にします。
+2. OAuth consent screen に個人 Google アカウントをテストユーザーとして追加します。
+3. Gmail 用の `gmail.readonly` と `gmail.compose` を許可します。
+4. bootstrap が `Private/Google Calendar MCP` の desktop OAuth client JSONを
+   Gmailの共有ディレクトリへ再利用します。
 
-bootstrap 済みであることを確認してから、profile ごとに認証します。
+Gmailトークンはホストの
+`~/.hermes/google-gmail-mcp/credentials.json` に mode `0600` で保存され、
+bootstrap後も保持されます。全 profile の `config.yaml` は同じ`gmail-mcp`
+設定とトークンを参照します。
+
+## 認証と確認
+
+認証は profile ごとではなく一度だけです。OAuth callback をホストで受けるため、
+コンテナ内ではなくホストの `npx` から実行します。
 
 ```bash
-task hermes:gmail:auth PROFILE=rick
+task hermes:gmail:auth
+```
+
+生成された共有資格情報を有効にするため、認証後にHermesを再起動します。
+
+各 profile の接続確認は個別に行います。
+
+```bash
+task hermes:gmail:test PROFILE=default
 task hermes:gmail:test PROFILE=rick
 ```
 
-`default` は root home (`/opt/data`) を使い、named profile は
-`/opt/data/profiles/<profile>` を使います。profile 名は実在する mounted home と
-照合されるため、未導入の profile は認証を開始しません。
-
-`hermes mcp login gmail` は設定の `connect_timeout: 315` を使い、OAuth callback
-用に少なくとも 315 秒待機します。表示された URL を browser で開いて同意し、
-container に届かない callback は、表示される redirect URL を同じ対話端末に
-貼り戻してください。これは OAuth callback の通常動作であり、トークン内容を
-表示する必要はありません。
-
-Windows では同じ操作を native Docker Compose 経由で実行します。
-
-```powershell
-task hermes:gmail:auth PROFILE=rick
-task hermes:gmail:test PROFILE=rick
-```
-
-この構成が公開するのは、検索・スレッド/メッセージ取得・ラベル一覧・下書き一覧・
-下書き作成だけです。送信、削除、ラベルの作成・更新・削除は含みません。`test` は
-MCP 接続と allowlist の発見だけを行い、メール送信・削除・変更は実行しません。
+公開ツールは検索、メール/スレッド取得、受信トレイ・ラベル一覧、下書き作成だけです。
+`send_email` は allowlist に含めないため、Hermes から送信はできません。

--- a/docs/hermes-agent/gmail-mcp.md
+++ b/docs/hermes-agent/gmail-mcp.md
@@ -1,0 +1,45 @@
+# Hermes Gmail MCP
+
+Hermes の Gmail MCP は公式エンドポイント
+`https://gmailmcp.googleapis.com/mcp/v1` を使い、root/default と各 named
+profile で個別に OAuth を完了します。OAuth トークンは各 profile home の
+`mcp-tokens/gmail.json` にだけ保存され、`0600` 以外のキャッシュは無効として
+扱われます。トークンや OAuth client の値をコマンド引数、設定 YAML、ログに
+書かないでください。
+
+## Google Cloud の事前準備
+
+1. 同じ Google Cloud project で Gmail API と Google の Gmail MCP API を有効にします。
+2. OAuth consent screen を設定し、利用者をテストユーザーとして許可します。
+3. Calendar MCP で使っている既存の OAuth client を再利用します。client ID/secret は
+   bootstrap が private profile `.env` にのみ配置するため、手入力や新しい
+   1Password item は不要です。
+4. 同意画面では `gmail.readonly` と `gmail.compose` のみを許可します。
+
+bootstrap 済みであることを確認してから、profile ごとに認証します。
+
+```bash
+task hermes:gmail:auth PROFILE=rick
+task hermes:gmail:test PROFILE=rick
+```
+
+`default` は root home (`/opt/data`) を使い、named profile は
+`/opt/data/profiles/<profile>` を使います。profile 名は実在する mounted home と
+照合されるため、未導入の profile は認証を開始しません。
+
+`hermes mcp login gmail` は設定の `connect_timeout: 315` を使い、OAuth callback
+用に少なくとも 315 秒待機します。表示された URL を browser で開いて同意し、
+container に届かない callback は、表示される redirect URL を同じ対話端末に
+貼り戻してください。これは OAuth callback の通常動作であり、トークン内容を
+表示する必要はありません。
+
+Windows では同じ操作を native Docker Compose 経由で実行します。
+
+```powershell
+task hermes:gmail:auth PROFILE=rick
+task hermes:gmail:test PROFILE=rick
+```
+
+この構成が公開するのは、検索・スレッド/メッセージ取得・ラベル一覧・下書き一覧・
+下書き作成だけです。送信、削除、ラベルの作成・更新・削除は含みません。`test` は
+MCP 接続と allowlist の発見だけを行い、メール送信・削除・変更は実行しません。

--- a/docs/superpowers/plans/2026-08-02-hermes-gmail-mcp.md
+++ b/docs/superpowers/plans/2026-08-02-hermes-gmail-mcp.md
@@ -1,0 +1,178 @@
+# Hermes Gmail MCP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add official Gmail MCP OAuth access to every managed Hermes profile, limited to Gmail read/search and draft creation, then verify it through each profile's Discord bot.
+
+**Architecture:** Add a remote HTTP `mcp_servers.gmail` entry to the root and all managed profile configurations. The entry uses Hermes native OAuth PKCE, the existing Calendar OAuth client ID/secret exposed through private profile environment files, and an explicit allowlist containing only Gmail read and draft tools.
+
+**Tech Stack:** Hermes Agent v0.18.2, Google Gmail remote MCP Developer Preview, Python bootstrap package, YAML config, Bash/PowerShell Taskfile adapters, Bats and Python unittest.
+
+## Global Constraints
+
+- Gmail endpoint: `https://gmailmcp.googleapis.com/mcp/v1`.
+- OAuth scopes: `https://www.googleapis.com/auth/gmail.readonly` and `https://www.googleapis.com/auth/gmail.compose`.
+- Allowed tools: `search_threads`, `get_thread`, `get_message`, `list_labels`, `list_drafts`, `create_draft`.
+- Disallowed actions: send, delete, and label mutation.
+- OAuth client secrets stay in private runtime environment values derived from the existing Calendar OAuth credential item.
+- Verification must cover default plus every currently managed named profile through actual Discord replies.
+
+---
+
+### Task 1: Add failing Gmail MCP contract tests
+
+**Files:**
+
+- Create: `tests/bash/hermes_gmail_mcp.bats`
+- Modify: `docker/hermes-agent/bootstrap/tests/test_envfiles.py`
+- Modify: `docker/hermes-agent/bootstrap/tests/test_google_calendar.py`
+- Create: `docker/hermes-agent/bootstrap/tests/test_google_gmail.py`
+
+**Interfaces:**
+
+- Tests define the expected `gmail` server URL, OAuth scope string, tool allowlist, and `GMAIL_MCP_CLIENT_ID` / `GMAIL_MCP_CLIENT_SECRET` environment keys.
+- Tests define `install_google_gmail_configurations(targets, transaction)` and `validate_google_gmail_installation(data_root, targets)` as the bootstrap boundary.
+
+- [ ] **Step 1: Write the failing shell contract tests**
+
+  Assert that the source declares the official Gmail MCP URL, `auth: oauth`, both Gmail scopes, all six allowed tools, and no send/delete/label mutation tool names.
+
+- [ ] **Step 2: Write the failing Python configuration tests**
+
+  Add tests for inserting the Gmail MCP entry into every target config, preserving unrelated servers, rejecting a missing or altered entry, and rejecting a missing OAuth scope or forbidden tool.
+
+- [ ] **Step 3: Write the failing environment tests**
+
+  Extend the profile environment expectation to include the two Gmail client variables derived from the Calendar OAuth JSON, and assert that the values are redacted in representations and remain private environment assignments.
+
+- [ ] **Step 4: Run the focused tests and confirm the expected failures**
+
+  Run `bats tests/bash/hermes_gmail_mcp.bats` and `PYTHONPATH=docker/hermes-agent/bootstrap python3 -m unittest docker.hermes-agent.bootstrap.tests.test_google_gmail docker.hermes-agent.bootstrap.tests.test_envfiles -v`.
+
+  Expected result: the new tests fail because the Gmail module, configuration, and environment values do not exist yet.
+
+### Task 2: Implement Gmail configuration and OAuth client propagation
+
+**Files:**
+
+- Create: `docker/hermes-agent/bootstrap/hermes_bootstrap/google_gmail.py`
+- Modify: `docker/hermes-agent/bootstrap/hermes_bootstrap/payload.py`
+- Modify: `docker/hermes-agent/bootstrap/hermes_bootstrap/envfiles.py`
+- Modify: `docker/hermes-agent/bootstrap/hermes_bootstrap/app.py`
+- Modify: `docker/hermes-agent/bootstrap/tests/test_payload.py`
+- Modify: `docker/hermes-agent/bootstrap/tests/test_app.py`
+
+**Interfaces:**
+
+- `google_gmail.py` exports `install_google_gmail_configurations(targets, transaction)` and `validate_google_gmail_installation(data_root, targets)`.
+- `envfiles.py` exports the existing `build_profile_environment` behavior with `GMAIL_MCP_CLIENT_ID` and `GMAIL_MCP_CLIENT_SECRET` added for root and every named profile.
+- `payload.py` continues to consume the existing `google_calendar` secret and parses its `installed.client_id` and `installed.client_secret` without adding a new secret item.
+
+- [ ] **Step 1: Implement the minimal Gmail config constants and installer**
+
+  Use the exact server entry below and write it into each managed `config.yaml`:
+
+  ```yaml
+  gmail:
+    url: https://gmailmcp.googleapis.com/mcp/v1
+    auth: oauth
+    connect_timeout: 315
+    oauth:
+      client_id: ${GMAIL_MCP_CLIENT_ID}
+      client_secret: ${GMAIL_MCP_CLIENT_SECRET}
+      scope: https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose
+    tools:
+      include:
+        - search_threads
+        - get_thread
+        - get_message
+        - list_labels
+        - list_drafts
+        - create_draft
+      resources: false
+      prompts: false
+  ```
+
+- [ ] **Step 2: Add OAuth client extraction and validation**
+
+  Parse the existing Calendar OAuth JSON, require non-empty `installed.client_id` and `installed.client_secret`, and expose them only through the private environment mapping. Never include the values in YAML, logs, exception messages, or test output.
+
+- [ ] **Step 3: Wire installation and final validation into bootstrap**
+
+  Install the Gmail config after Calendar config installation and validate it for root/default and every manifest profile before bootstrap reports success.
+
+- [ ] **Step 4: Run the focused tests and make them pass**
+
+  Run `PYTHONPATH=docker/hermes-agent/bootstrap python3 -m unittest docker.hermes-agent.bootstrap.tests.test_google_gmail docker.hermes-agent.bootstrap.tests.test_envfiles docker.hermes-agent.bootstrap.tests.test_payload docker.hermes-agent.bootstrap.tests.test_app -v`.
+
+### Task 3: Add authentication and runtime verification commands
+
+**Files:**
+
+- Create: `scripts/sh/hermes-gmail.sh`
+- Create: `scripts/powershell/hermes-gmail.ps1`
+- Modify: `Taskfile.yml`
+- Create: `tests/bash/hermes_gmail_auth.bats`
+- Create: `docs/hermes-agent/gmail-mcp.md`
+
+**Interfaces:**
+
+- Unix command: `scripts/sh/hermes-gmail.sh auth profile-name`, `scripts/sh/hermes-gmail.sh test profile-name`.
+- Windows command: `scripts/powershell/hermes-gmail.ps1 -Action auth -Profile profile-name` and `-Action test`.
+- Task commands: `task hermes:gmail:auth PROFILE=profile-name` and `task hermes:gmail:test PROFILE=profile-name`.
+
+- [ ] **Step 1: Write failing command contract tests**
+
+  Assert profile validation, use of `HERMES_HOME=/opt/data/profiles/profile-name`, invocation of `hermes mcp login gmail`, no token value in arguments, and a failure when the profile token cache is absent after login.
+
+- [ ] **Step 2: Implement the Unix adapter**
+
+  Validate the profile against the mounted profile directory, run the interactive Hermes OAuth login with a 315-second callback window, and check only token-file existence and private mode. Do not print token contents.
+
+- [ ] **Step 3: Implement the PowerShell adapter and Taskfile entries**
+
+  Mirror the Unix behavior through native Docker Compose execution and preserve the repository's Windows adapter conventions.
+
+- [ ] **Step 4: Document Google Cloud prerequisites and callback behavior**
+
+  Document Gmail API/MCP API enablement, Gmail OAuth consent scopes, reuse of the Calendar OAuth client, browser consent, per-profile login, and the exact no-send/no-delete boundary.
+
+- [ ] **Step 5: Run command contract tests**
+
+  Run `bats tests/bash/hermes_gmail_auth.bats` and the corresponding PowerShell test suite when available.
+
+### Task 4: Build, bootstrap, and verify all profiles through Discord
+
+**Files:**
+
+- Modify: `docs/hermes-agent/gmail-mcp.md`
+- Modify: `tests/bash/bootstrap_acceptance.bats`
+
+**Interfaces:**
+
+- Runtime target is the real `hermes` Compose stack and its Discord gateway.
+- Profile set is discovered from `/opt/data/profiles` plus the root/default profile; no single profile is treated as representative.
+
+- [ ] **Step 1: Run repository validation before live auth**
+
+  Run `bats tests/bash/hermes_gmail_mcp.bats tests/bash/hermes_gmail_auth.bats tests/bash/bootstrap_acceptance.bats`, the full bootstrap unittest discovery, `docker compose -f docker/hermes-agent/compose.yml config --quiet`, and `pre-commit run --all-files`.
+
+- [ ] **Step 2: Rebuild and apply the Hermes stack**
+
+  Run `task hermes:bootstrap`, confirm the root and every named profile contains the Gmail MCP declaration, confirm `tests/bash/bootstrap_acceptance.bats` sees the Gmail entry, and confirm no client secret appears in config files or logs.
+
+- [ ] **Step 3: Complete OAuth once per profile**
+
+  Run `task hermes:gmail:auth PROFILE=profile-name` serially for `default`, `hoffman`, `kuroda`, `nancy`, `rick`, `risarisa`, and `shiraishi`, completing the browser consent flow and checking the token cache after every profile.
+
+- [ ] **Step 4: Verify MCP discovery per profile**
+
+  Run `docker exec hermes hermes -p profile-name mcp test gmail` for `default`, `hoffman`, `kuroda`, `nancy`, `rick`, `risarisa`, and `shiraishi`, and confirm the discovered tool set contains exactly the six allowed tools.
+
+- [ ] **Step 5: Verify through each Discord bot**
+
+  Send an individual Discord DM to every profile bot asking it to search a narrow harmless query, retrieve a matching thread when available, list drafts, and create a test draft to `noreply@example.com` titled `[Hermes Gmail OAuth test]`. Read each bot's actual reply and record success/failure per profile.
+
+- [ ] **Step 6: Confirm the safety boundary**
+
+  Confirm no test sends the draft and that the discovered tool list contains no send, delete, label, or unlabel operation. Report any profile lacking an actual Discord reply as unverified.

--- a/docs/superpowers/specs/2026-08-02-hermes-gmail-mcp-design.md
+++ b/docs/superpowers/specs/2026-08-02-hermes-gmail-mcp-design.md
@@ -1,0 +1,75 @@
+# Hermes Gmail MCP OAuth Design
+
+## Goal
+
+Enable every managed Hermes profile to search and read Gmail threads and create
+Gmail drafts from Discord-triggered agent conversations, while preventing send,
+delete, and label-modification operations.
+
+## Chosen architecture
+
+Use Google's official remote Gmail MCP endpoint
+`https://gmailmcp.googleapis.com/mcp/v1`. Hermes connects to it as an HTTP MCP
+server using native OAuth PKCE. The existing Google Calendar OAuth client is
+reused for the Gmail MCP client registration; Gmail authorization is a separate
+consent because the existing Calendar refresh token does not imply Gmail
+scopes.
+
+The Hermes bootstrap copies the non-secret Gmail MCP configuration into the
+root and every managed profile. The OAuth client ID and secret are derived from
+the existing Calendar OAuth client JSON and exposed to each profile through
+private environment values. Hermes persists the Gmail OAuth token cache in the
+profile's own `mcp-tokens` directory, so each profile is verified independently.
+
+## Allowed capability boundary
+
+The Gmail MCP server is configured with an explicit native-tool allowlist:
+
+- `search_threads`
+- `get_thread`
+- `get_message`
+- `list_labels`
+- `list_drafts`
+- `create_draft`
+
+The `gmail.readonly` and `gmail.compose` OAuth scopes are requested. Sending,
+deleting, and label mutation are excluded from the Hermes tool registry and are
+not part of the verification procedure.
+
+## Login and verification
+
+`task hermes:gmail:auth` performs one profile-at-a-time OAuth login with a
+profile-specific `HERMES_HOME`. The operator completes Google's browser consent
+flow; the command never prints or commits token contents. The task supports the
+same host/Docker callback path as the pinned Hermes image and fails if no token
+cache is written.
+
+After login, every active managed profile is tested through its actual Discord
+bot path. The verification asks the profile to search a harmless, narrow Gmail
+query, retrieve one matching thread when available, list drafts, and create a
+test draft addressed to `noreply@example.com` with a clearly marked test
+subject. The test draft is never sent. A profile is successful only when the
+Discord reply contains successful results for the MCP operations; local config
+or `hermes mcp test` output alone is insufficient.
+
+## Failure handling and security
+
+- Missing OAuth consent, expired tokens, missing Gmail API/MCP API enablement,
+  and callback failures are reported per profile without treating other
+  profiles as representative.
+- OAuth client values are never written to repository files or command-line
+  arguments; only the existing 1Password-backed Calendar OAuth item is read.
+- Gmail MCP tool discovery is filtered to the allowlist before agents can use
+  it.
+- The official Gmail MCP is a Developer Preview, so the implementation records
+  that dependency in the Hermes documentation and validates the endpoint during
+  bootstrap/runtime checks.
+
+## Test strategy
+
+Add contract tests before implementation for the Gmail MCP configuration,
+OAuth environment derivation, profile propagation, tool allowlist, and auth
+task command. Extend bootstrap unit/integration tests to prove every managed
+profile receives the same non-secret MCP declaration and private OAuth client
+environment values. Live OAuth and Discord tests remain an operator gate and
+must run only after credentials and the Hermes stack are available.

--- a/scripts/powershell/hermes-gmail.ps1
+++ b/scripts/powershell/hermes-gmail.ps1
@@ -52,6 +52,57 @@ function Test-HermesGmailWindows {
     return [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
 }
 
+function Set-HermesGmailPrivateAcl {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][ValidateSet('File', 'Directory')][string]$PathType
+    )
+    if (-not (Test-HermesGmailWindows)) { return }
+    $expectedType = if ($PathType -eq 'Directory') { 'Container' } else { 'Leaf' }
+    if (-not (Test-Path -LiteralPath $Path -PathType $expectedType)) {
+        throw "Gmail credential $($PathType.ToLowerInvariant()) is missing."
+    }
+    $item = Get-Item -LiteralPath $Path -Force
+    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "Gmail credential $($PathType.ToLowerInvariant()) is invalid."
+    }
+
+    $acl = Get-Acl -LiteralPath $Path
+    $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+    if ($null -eq $owner) { throw 'Gmail credential owner is unavailable.' }
+    $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+    if ($null -eq $currentUser) { throw 'Current Windows identity is unavailable.' }
+    $acl.SetAccessRuleProtection($true, $false)
+    foreach ($access in @($acl.Access)) {
+        $null = $acl.RemoveAccessRuleSpecific($access)
+    }
+
+    $inheritance = if ($PathType -eq 'Directory') {
+        [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+        [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
+    }
+    else {
+        [System.Security.AccessControl.InheritanceFlags]::None
+    }
+    foreach ($sidValue in @(
+            $owner.Value,
+            $currentUser.Value,
+            'S-1-5-18',
+            'S-1-5-32-544'
+        ) | Select-Object -Unique) {
+        $identity = [System.Security.Principal.SecurityIdentifier]::new($sidValue)
+        $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+            $identity,
+            [System.Security.AccessControl.FileSystemRights]::FullControl,
+            $inheritance,
+            [System.Security.AccessControl.PropagationFlags]::None,
+            [System.Security.AccessControl.AccessControlType]::Allow
+        )
+        $acl.AddAccessRule($rule)
+    }
+    Set-Acl -LiteralPath $Path -AclObject $acl
+}
+
 function Test-HermesGmailPrivateFile {
     param([Parameter(Mandatory)][string]$Path)
     if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $false }
@@ -63,7 +114,14 @@ function Test-HermesGmailPrivateFile {
         $acl = Get-Acl -LiteralPath $Path
         $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
         if ($null -eq $owner) { return $false }
-        $allowedSids = @($owner.Value, 'S-1-5-18', 'S-1-5-32-544')
+        $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+        if ($null -eq $currentUser -or -not $acl.AreAccessRulesProtected) { return $false }
+        $allowedSids = @(
+            $owner.Value,
+            $currentUser.Value,
+            'S-1-5-18',
+            'S-1-5-32-544'
+        )
         foreach ($access in $acl.Access) {
             $grantsRead =
             $access.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
@@ -101,7 +159,9 @@ function Get-HermesGmailSharedContext {
     if (($directoryItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
         throw 'Shared Gmail credential directory is missing or invalid.'
     }
+    Set-HermesGmailPrivateAcl -Path $directory -PathType Directory
     $oauth = Join-Path $directory 'gcp-oauth.keys.json'
+    Set-HermesGmailPrivateAcl -Path $oauth -PathType File
     if (-not (Test-HermesGmailPrivateFile -Path $oauth)) {
         throw 'Shared Gmail OAuth client is missing or not private.'
     }
@@ -155,7 +215,12 @@ try {
             $env:GMAIL_OAUTH_PATH = $oldOAuth
             $env:GMAIL_CREDENTIALS_PATH = $oldCredentials
         }
-        if (-not (Test-HermesGmailWindows)) { & chmod 600 $shared.Credentials }
+        if (Test-HermesGmailWindows) {
+            Set-HermesGmailPrivateAcl -Path $shared.Credentials -PathType File
+        }
+        else {
+            & chmod 600 $shared.Credentials
+        }
         if (-not (Test-HermesGmailPrivateFile -Path $shared.Credentials)) {
             throw 'Shared Gmail OAuth credentials are missing or not private.'
         }
@@ -165,6 +230,7 @@ try {
     if ([string]::IsNullOrWhiteSpace($HermesProfile)) {
         throw 'A Hermes profile is required for Gmail MCP testing.'
     }
+    Set-HermesGmailPrivateAcl -Path $shared.Credentials -PathType File
     if (-not (Test-HermesGmailPrivateFile -Path $shared.Credentials)) {
         throw 'Shared Gmail OAuth credentials are missing or not private.'
     }

--- a/scripts/powershell/hermes-gmail.ps1
+++ b/scripts/powershell/hermes-gmail.ps1
@@ -220,8 +220,10 @@ try {
     if ($Action -eq 'test') {
         $dockerArguments += '-T'
     }
+    $tokenCacheVolume = "$($tokenCacheContext.Parent):$($context.ContainerHome)/mcp-tokens:rw"
     $hermesAction = if ($Action -eq 'auth') { 'login' } else { 'test' }
     $dockerArguments += @(
+        '--volume', $tokenCacheVolume,
         '-e', "HERMES_HOME=$($context.ContainerHome)",
         'hermes', 'hermes', 'mcp', $hermesAction, 'gmail'
     )

--- a/scripts/powershell/hermes-gmail.ps1
+++ b/scripts/powershell/hermes-gmail.ps1
@@ -79,8 +79,8 @@ function Test-HermesGmailPrivateFile {
         }
         return $true
     }
-    $mode = & stat -f '%Lp' $Path 2>$null
-    if ($LASTEXITCODE -ne 0) { $mode = & stat -c '%a' $Path 2>$null }
+    $mode = & stat -c '%a' $Path 2>$null
+    if ($LASTEXITCODE -ne 0) { $mode = & stat -f '%Lp' $Path 2>$null }
     return $LASTEXITCODE -eq 0 -and $mode -eq '600'
 }
 

--- a/scripts/powershell/hermes-gmail.ps1
+++ b/scripts/powershell/hermes-gmail.ps1
@@ -1,0 +1,167 @@
+<#
+.SYNOPSIS
+    Hermes Gmail MCP の OAuth と接続確認を、プロファイル単位で実行する。
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('auth', 'test')]
+    [string]$Action,
+
+    [Parameter(Mandatory)]
+    [Alias('Profile')]
+    [string]$HermesProfile,
+
+    [string]$ComposeFile = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'lib/Invoke-ExternalCommand.ps1')
+
+function Get-HermesGmailComposeFile {
+    [CmdletBinding()]
+    param([string]$ComposeFile = '')
+
+    if (-not [string]::IsNullOrWhiteSpace($ComposeFile)) {
+        return [System.IO.Path]::GetFullPath($ComposeFile)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:HERMES_COMPOSE_FILE)) {
+        return [System.IO.Path]::GetFullPath($env:HERMES_COMPOSE_FILE)
+    }
+
+    $repositoryRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
+    return [System.IO.Path]::GetFullPath((Join-Path $repositoryRoot 'docker/hermes-agent/compose.yml'))
+}
+
+function Get-HermesGmailDataDir {
+    [CmdletBinding()]
+    param()
+
+    if (-not [string]::IsNullOrWhiteSpace($env:HERMES_DATA_DIR)) {
+        return [System.IO.Path]::GetFullPath($env:HERMES_DATA_DIR)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:USERPROFILE)) {
+        return [System.IO.Path]::GetFullPath((Join-Path $env:USERPROFILE '.hermes'))
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:HOME)) {
+        return [System.IO.Path]::GetFullPath((Join-Path $env:HOME '.hermes'))
+    }
+
+    $userProfile = [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
+    if ([string]::IsNullOrWhiteSpace($userProfile)) {
+        throw [System.InvalidOperationException]::new('Unable to resolve the current user profile.')
+    }
+    return [System.IO.Path]::GetFullPath((Join-Path $userProfile '.hermes'))
+}
+
+function Get-HermesGmailProfileContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$HermesProfile,
+        [Parameter(Mandatory)]
+        [string]$DataDir
+    )
+
+    if ($HermesProfile -notmatch '^[a-z0-9][a-z0-9_-]*$') {
+        throw [System.InvalidOperationException]::new("Invalid Hermes profile: $HermesProfile")
+    }
+
+    if ($HermesProfile -eq 'default') {
+        $hostHome = $DataDir
+        $containerHome = '/opt/data'
+    }
+    else {
+        $hostHome = Join-Path (Join-Path $DataDir 'profiles') $HermesProfile
+        $containerHome = "/opt/data/profiles/$HermesProfile"
+    }
+
+    if (-not (Test-Path -LiteralPath $hostHome -PathType Container)) {
+        throw [System.InvalidOperationException]::new("Hermes profile is not installed: $HermesProfile")
+    }
+    $item = Get-Item -LiteralPath $hostHome -Force
+    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw [System.InvalidOperationException]::new("Hermes profile must not be a symbolic link: $HermesProfile")
+    }
+
+    return [PSCustomObject]@{
+        HostHome      = $hostHome
+        ContainerHome = $containerHome
+        TokenCache    = Join-Path $hostHome 'mcp-tokens/gmail.json'
+    }
+}
+
+function Test-HermesGmailTokenCache {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$TokenCache)
+
+    if (-not (Test-Path -LiteralPath $TokenCache -PathType Leaf)) {
+        return $false
+    }
+    $item = Get-Item -LiteralPath $TokenCache -Force
+    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        return $false
+    }
+
+    if ($IsWindows) {
+        $unsafeAccess = (Get-Acl -LiteralPath $TokenCache).Access | Where-Object {
+            $_.AccessControlType -eq 'Allow' -and
+            $_.IdentityReference.Value -match '(Everyone|\\Users)$' -and
+            ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::ReadData)
+        }
+        return $null -eq $unsafeAccess
+    }
+
+    $mode = & stat -f '%Lp' $TokenCache 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        $mode = & stat -c '%a' $TokenCache 2>$null
+    }
+    return $LASTEXITCODE -eq 0 -and $mode -eq '600'
+}
+
+function Invoke-HermesGmailDocker {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string[]]$Arguments)
+
+    $global:LASTEXITCODE = 0
+    Invoke-Docker -Arguments $Arguments | Out-Host
+    return $global:LASTEXITCODE
+}
+
+try {
+    $resolvedComposeFile = Get-HermesGmailComposeFile -ComposeFile $ComposeFile
+    $context = Get-HermesGmailProfileContext -HermesProfile $HermesProfile -DataDir (Get-HermesGmailDataDir)
+
+    if ($Action -eq 'test' -and -not (Test-HermesGmailTokenCache -TokenCache $context.TokenCache)) {
+        throw [System.InvalidOperationException]::new("Gmail OAuth token cache is missing or not private for profile: $HermesProfile")
+    }
+
+    $dockerArguments = @(
+        'compose', '-f', $resolvedComposeFile,
+        'run', '--rm', '--no-deps'
+    )
+    if ($Action -eq 'test') {
+        $dockerArguments += '-T'
+    }
+    $hermesAction = if ($Action -eq 'auth') { 'login' } else { 'test' }
+    $dockerArguments += @(
+        '-e', "HERMES_HOME=$($context.ContainerHome)",
+        'hermes', 'hermes', 'mcp', $hermesAction, 'gmail'
+    )
+
+    $exitCode = Invoke-HermesGmailDocker -Arguments $dockerArguments
+    if ($exitCode -ne 0) {
+        exit $exitCode
+    }
+    if ($Action -eq 'auth' -and -not (Test-HermesGmailTokenCache -TokenCache $context.TokenCache)) {
+        throw [System.InvalidOperationException]::new("Gmail OAuth token cache is missing or not private for profile: $HermesProfile")
+    }
+    exit 0
+}
+catch {
+    [Console]::Error.WriteLine('Hermes Gmail MCP command failed.')
+    exit 1
+}

--- a/scripts/powershell/hermes-gmail.ps1
+++ b/scripts/powershell/hermes-gmail.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Hermes Gmail MCP の OAuth と接続確認を、プロファイル単位で実行する。
+    Hermes 全プロフィールで共有する Gmail MCP OAuth と接続確認を実行する。
 #>
 
 [CmdletBinding()]
@@ -9,9 +9,8 @@ param(
     [ValidateSet('auth', 'test')]
     [string]$Action,
 
-    [Parameter(Mandatory)]
     [Alias('Profile')]
-    [string]$HermesProfile,
+    [string]$HermesProfile = '',
 
     [string]$ComposeFile = ''
 )
@@ -21,222 +20,164 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'lib/Invoke-ExternalCommand.ps1')
 
-function Get-HermesGmailComposeFile {
-    [CmdletBinding()]
-    param([string]$ComposeFile = '')
+function Get-HermesGmailDataDir {
+    if (-not [string]::IsNullOrWhiteSpace($env:HERMES_DATA_DIR)) {
+        return [System.IO.Path]::GetFullPath($env:HERMES_DATA_DIR)
+    }
+    $homePath = if (-not [string]::IsNullOrWhiteSpace($env:USERPROFILE)) {
+        $env:USERPROFILE
+    }
+    elseif (-not [string]::IsNullOrWhiteSpace($env:HOME)) {
+        $env:HOME
+    }
+    else {
+        [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
+    }
+    return [System.IO.Path]::GetFullPath((Join-Path $homePath '.hermes'))
+}
 
-    if (-not [string]::IsNullOrWhiteSpace($ComposeFile)) {
-        return [System.IO.Path]::GetFullPath($ComposeFile)
+function Get-HermesGmailComposeFile {
+    param([string]$Requested)
+    if (-not [string]::IsNullOrWhiteSpace($Requested)) {
+        return [System.IO.Path]::GetFullPath($Requested)
     }
     if (-not [string]::IsNullOrWhiteSpace($env:HERMES_COMPOSE_FILE)) {
         return [System.IO.Path]::GetFullPath($env:HERMES_COMPOSE_FILE)
     }
-
-    $repositoryRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
-    return [System.IO.Path]::GetFullPath((Join-Path $repositoryRoot 'docker/hermes-agent/compose.yml'))
+    $root = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
+    return Join-Path $root 'docker/hermes-agent/compose.yml'
 }
 
-function Get-HermesGmailDataDir {
-    [CmdletBinding()]
-    param()
-
-    if (-not [string]::IsNullOrWhiteSpace($env:HERMES_DATA_DIR)) {
-        return [System.IO.Path]::GetFullPath($env:HERMES_DATA_DIR)
-    }
-    if (-not [string]::IsNullOrWhiteSpace($env:USERPROFILE)) {
-        return [System.IO.Path]::GetFullPath((Join-Path $env:USERPROFILE '.hermes'))
-    }
-    if (-not [string]::IsNullOrWhiteSpace($env:HOME)) {
-        return [System.IO.Path]::GetFullPath((Join-Path $env:HOME '.hermes'))
-    }
-
-    $userProfile = [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
-    if ([string]::IsNullOrWhiteSpace($userProfile)) {
-        throw [System.InvalidOperationException]::new('Unable to resolve the current user profile.')
-    }
-    return [System.IO.Path]::GetFullPath((Join-Path $userProfile '.hermes'))
+function Test-HermesGmailWindows {
+    return [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
 }
 
-function Get-HermesGmailProfileContext {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)]
-        [string]$HermesProfile,
-        [Parameter(Mandatory)]
-        [string]$DataDir
-    )
-
-    if ($HermesProfile -notmatch '^[a-z0-9][a-z0-9_-]*$') {
-        throw [System.InvalidOperationException]::new("Invalid Hermes profile: $HermesProfile")
-    }
-
-    if ($HermesProfile -eq 'default') {
-        $hostHome = $DataDir
-        $containerHome = '/opt/data'
-    }
-    else {
-        $hostHome = Join-Path (Join-Path $DataDir 'profiles') $HermesProfile
-        $containerHome = "/opt/data/profiles/$HermesProfile"
-    }
-
-    if (-not (Test-Path -LiteralPath $hostHome -PathType Container)) {
-        throw [System.InvalidOperationException]::new("Hermes profile is not installed: $HermesProfile")
-    }
-    $item = Get-Item -LiteralPath $hostHome -Force
-    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
-        throw [System.InvalidOperationException]::new("Hermes profile must not be a symbolic link: $HermesProfile")
-    }
-
-    return [PSCustomObject]@{
-        HostHome      = $hostHome
-        ContainerHome = $containerHome
-        TokenCache    = Join-Path $hostHome 'mcp-tokens/gmail.json'
-    }
-}
-
-function Test-HermesGmailPathUnderRoot {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)]
-        [string]$Path,
-        [Parameter(Mandatory)]
-        [string]$Root
-    )
-
-    $fullPath = [System.IO.Path]::GetFullPath($Path)
-    $fullRoot = [System.IO.Path]::GetFullPath($Root).TrimEnd(
-        [System.IO.Path]::DirectorySeparatorChar,
-        [System.IO.Path]::AltDirectorySeparatorChar
-    )
-    $rootWithSeparator = $fullRoot + [System.IO.Path]::DirectorySeparatorChar
-    return $fullPath.Equals($fullRoot, [System.StringComparison]::OrdinalIgnoreCase) -or
-    $fullPath.StartsWith($rootWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)
-}
-
-function Get-HermesGmailTokenCacheContext {
-    [CmdletBinding()]
-    param([Parameter(Mandatory)][string]$HostHome)
-
-    $tokenCacheParent = Join-Path $HostHome 'mcp-tokens'
-    if (-not (Test-Path -LiteralPath $tokenCacheParent)) {
-        $null = New-Item -ItemType Directory -Path $tokenCacheParent -Force
-    }
-    $parent = Get-Item -LiteralPath $tokenCacheParent -Force
-    if (($parent.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0 -or
-        -not $parent.PSIsContainer) {
-        throw [System.InvalidOperationException]::new('Gmail token cache parent is invalid.')
-    }
-
-    $resolvedHostHome = (Resolve-Path -LiteralPath $HostHome).ProviderPath
-    $resolvedParent = (Resolve-Path -LiteralPath $tokenCacheParent).ProviderPath
-    $expectedParent = Join-Path $resolvedHostHome 'mcp-tokens'
-    if (-not $resolvedParent.Equals($expectedParent, [System.StringComparison]::OrdinalIgnoreCase)) {
-        throw [System.InvalidOperationException]::new('Gmail token cache parent is invalid.')
-    }
-
-    $tokenCache = Join-Path $resolvedParent 'gmail.json'
-    if (-not (Test-HermesGmailPathUnderRoot -Path $tokenCache -Root $resolvedHostHome)) {
-        throw [System.InvalidOperationException]::new('Gmail token cache parent is invalid.')
-    }
-    return [PSCustomObject]@{
-        Parent     = $resolvedParent
-        TokenCache = $tokenCache
-    }
-}
-
-function Test-HermesGmailTokenCache {
-    [CmdletBinding()]
-    param([Parameter(Mandatory)][string]$TokenCache)
-
-    if (-not (Test-Path -LiteralPath $TokenCache -PathType Leaf)) {
-        return $false
-    }
-    $item = Get-Item -LiteralPath $TokenCache -Force
+function Test-HermesGmailPrivateFile {
+    param([Parameter(Mandatory)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $false }
+    $item = Get-Item -LiteralPath $Path -Force
     if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
         return $false
     }
-
-    if ($IsWindows) {
-        $acl = Get-Acl -LiteralPath $TokenCache
+    if (Test-HermesGmailWindows) {
+        $acl = Get-Acl -LiteralPath $Path
         $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
-        if ($null -eq $owner) {
-            return $false
-        }
-        $allowedSids = @(
-            $owner.Value,
-            'S-1-5-18',
-            'S-1-5-32-544'
-        )
+        if ($null -eq $owner) { return $false }
+        $allowedSids = @($owner.Value, 'S-1-5-18', 'S-1-5-32-544')
         foreach ($access in $acl.Access) {
-            $grantsRead = $access.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
+            $grantsRead =
+            $access.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
                 (($access.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::ReadData) -ne 0)
-            if (-not $grantsRead) {
-                continue
-            }
+            if (-not $grantsRead) { continue }
             try {
                 $identity = $access.IdentityReference.Translate(
                     [System.Security.Principal.SecurityIdentifier]
                 ).Value
             }
-            catch {
-                return $false
-            }
-            if ($allowedSids -notcontains $identity) {
-                return $false
-            }
+            catch { return $false }
+            if ($allowedSids -notcontains $identity) { return $false }
         }
         return $true
     }
-
-    $mode = & stat -f '%Lp' $TokenCache 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        $mode = & stat -c '%a' $TokenCache 2>$null
-    }
+    $mode = & stat -f '%Lp' $Path 2>$null
+    if ($LASTEXITCODE -ne 0) { $mode = & stat -c '%a' $Path 2>$null }
     return $LASTEXITCODE -eq 0 -and $mode -eq '600'
 }
 
-function Invoke-HermesGmailDocker {
-    [CmdletBinding()]
-    param([Parameter(Mandatory)][string[]]$Arguments)
+function Get-HermesGmailSharedContext {
+    $dataDir = Get-HermesGmailDataDir
+    if (-not (Test-Path -LiteralPath $dataDir -PathType Container)) {
+        throw 'Hermes data directory is not installed.'
+    }
+    $dataItem = Get-Item -LiteralPath $dataDir -Force
+    if (($dataItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw 'Hermes data directory is invalid.'
+    }
+    $directory = Join-Path $dataDir 'google-gmail-mcp'
+    if (-not (Test-Path -LiteralPath $directory -PathType Container)) {
+        throw 'Shared Gmail credential directory is missing or invalid.'
+    }
+    $directoryItem = Get-Item -LiteralPath $directory -Force
+    if (($directoryItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw 'Shared Gmail credential directory is missing or invalid.'
+    }
+    $oauth = Join-Path $directory 'gcp-oauth.keys.json'
+    if (-not (Test-HermesGmailPrivateFile -Path $oauth)) {
+        throw 'Shared Gmail OAuth client is missing or not private.'
+    }
+    return [PSCustomObject]@{
+        DataDir     = $dataDir
+        OAuth       = $oauth
+        Credentials = Join-Path $directory 'credentials.json'
+    }
+}
 
-    $global:LASTEXITCODE = 0
-    Invoke-Docker -Arguments $Arguments | Out-Host
-    return $global:LASTEXITCODE
+function Get-HermesGmailProfileContext {
+    param(
+        [Parameter(Mandatory)][string]$ProfileName,
+        [Parameter(Mandatory)][string]$DataDir
+    )
+    if ($ProfileName -notmatch '^[a-z0-9][a-z0-9_-]*$') {
+        throw "Invalid Hermes profile: $ProfileName"
+    }
+    if ($ProfileName -eq 'default') {
+        $hostHome = $DataDir
+        $containerHome = '/opt/data'
+    }
+    else {
+        $hostHome = Join-Path (Join-Path $DataDir 'profiles') $ProfileName
+        $containerHome = "/opt/data/profiles/$ProfileName"
+    }
+    if (-not (Test-Path -LiteralPath $hostHome -PathType Container)) {
+        throw "Hermes profile is not installed: $ProfileName"
+    }
+    return [PSCustomObject]@{ ContainerHome = $containerHome }
 }
 
 try {
-    $resolvedComposeFile = Get-HermesGmailComposeFile -ComposeFile $ComposeFile
-    $context = Get-HermesGmailProfileContext -HermesProfile $HermesProfile -DataDir (Get-HermesGmailDataDir)
-    $tokenCacheContext = Get-HermesGmailTokenCacheContext -HostHome $context.HostHome
-
-    if ($Action -eq 'test' -and -not (Test-HermesGmailTokenCache -TokenCache $tokenCacheContext.TokenCache)) {
-        throw [System.InvalidOperationException]::new("Gmail OAuth token cache is missing or not private for profile: $HermesProfile")
+    $shared = Get-HermesGmailSharedContext
+    if ($Action -eq 'auth') {
+        if (-not [string]::IsNullOrWhiteSpace($HermesProfile)) {
+            throw 'Gmail authentication is shared; do not specify a profile.'
+        }
+        $oldOAuth = $env:GMAIL_OAUTH_PATH
+        $oldCredentials = $env:GMAIL_CREDENTIALS_PATH
+        try {
+            $env:GMAIL_OAUTH_PATH = $shared.OAuth
+            $env:GMAIL_CREDENTIALS_PATH = $shared.Credentials
+            Invoke-NativeCommand -Command 'npx' -Arguments @(
+                '--yes', '@artymclabin/gmail-mcp@1.2.3', 'auth',
+                '--scopes=gmail.readonly,gmail.compose'
+            ) | Out-Host
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        }
+        finally {
+            $env:GMAIL_OAUTH_PATH = $oldOAuth
+            $env:GMAIL_CREDENTIALS_PATH = $oldCredentials
+        }
+        if (-not (Test-HermesGmailWindows)) { & chmod 600 $shared.Credentials }
+        if (-not (Test-HermesGmailPrivateFile -Path $shared.Credentials)) {
+            throw 'Shared Gmail OAuth credentials are missing or not private.'
+        }
+        exit 0
     }
 
-    $dockerArguments = @(
-        'compose', '-f', $resolvedComposeFile,
-        'run', '--rm', '--no-deps'
+    if ([string]::IsNullOrWhiteSpace($HermesProfile)) {
+        throw 'A Hermes profile is required for Gmail MCP testing.'
+    }
+    if (-not (Test-HermesGmailPrivateFile -Path $shared.Credentials)) {
+        throw 'Shared Gmail OAuth credentials are missing or not private.'
+    }
+    $profileContext = Get-HermesGmailProfileContext `
+        -ProfileName $HermesProfile -DataDir $shared.DataDir
+    $arguments = @(
+        'compose', '-f', (Get-HermesGmailComposeFile -Requested $ComposeFile),
+        'run', '--rm', '--no-deps', '-T',
+        '-e', "HERMES_HOME=$($profileContext.ContainerHome)",
+        'hermes', 'hermes', 'mcp', 'test', 'gmail'
     )
-    if ($Action -eq 'test') {
-        $dockerArguments += '-T'
-    }
-    $tokenCacheVolume = "$($tokenCacheContext.Parent):$($context.ContainerHome)/mcp-tokens:rw"
-    $hermesAction = if ($Action -eq 'auth') { 'login' } else { 'test' }
-    $dockerArguments += @(
-        '--volume', $tokenCacheVolume,
-        '-e', "HERMES_HOME=$($context.ContainerHome)",
-        'hermes', 'hermes', 'mcp', $hermesAction, 'gmail'
-    )
-
-    $exitCode = Invoke-HermesGmailDocker -Arguments $dockerArguments
-    if ($exitCode -ne 0) {
-        exit $exitCode
-    }
-    $tokenCacheContext = Get-HermesGmailTokenCacheContext -HostHome $context.HostHome
-    if ($Action -eq 'auth' -and -not (Test-HermesGmailTokenCache -TokenCache $tokenCacheContext.TokenCache)) {
-        throw [System.InvalidOperationException]::new("Gmail OAuth token cache is missing or not private for profile: $HermesProfile")
-    }
-    exit 0
+    Invoke-Docker -Arguments $arguments | Out-Host
+    exit $global:LASTEXITCODE
 }
 catch {
     [Console]::Error.WriteLine('Hermes Gmail MCP command failed.')

--- a/scripts/powershell/hermes-gmail.ps1
+++ b/scripts/powershell/hermes-gmail.ps1
@@ -94,6 +94,56 @@ function Get-HermesGmailProfileContext {
     }
 }
 
+function Test-HermesGmailPathUnderRoot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [string]$Root
+    )
+
+    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    $fullRoot = [System.IO.Path]::GetFullPath($Root).TrimEnd(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar
+    )
+    $rootWithSeparator = $fullRoot + [System.IO.Path]::DirectorySeparatorChar
+    return $fullPath.Equals($fullRoot, [System.StringComparison]::OrdinalIgnoreCase) -or
+    $fullPath.StartsWith($rootWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Get-HermesGmailTokenCacheContext {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$HostHome)
+
+    $tokenCacheParent = Join-Path $HostHome 'mcp-tokens'
+    if (-not (Test-Path -LiteralPath $tokenCacheParent)) {
+        $null = New-Item -ItemType Directory -Path $tokenCacheParent -Force
+    }
+    $parent = Get-Item -LiteralPath $tokenCacheParent -Force
+    if (($parent.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0 -or
+        -not $parent.PSIsContainer) {
+        throw [System.InvalidOperationException]::new('Gmail token cache parent is invalid.')
+    }
+
+    $resolvedHostHome = (Resolve-Path -LiteralPath $HostHome).ProviderPath
+    $resolvedParent = (Resolve-Path -LiteralPath $tokenCacheParent).ProviderPath
+    $expectedParent = Join-Path $resolvedHostHome 'mcp-tokens'
+    if (-not $resolvedParent.Equals($expectedParent, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw [System.InvalidOperationException]::new('Gmail token cache parent is invalid.')
+    }
+
+    $tokenCache = Join-Path $resolvedParent 'gmail.json'
+    if (-not (Test-HermesGmailPathUnderRoot -Path $tokenCache -Root $resolvedHostHome)) {
+        throw [System.InvalidOperationException]::new('Gmail token cache parent is invalid.')
+    }
+    return [PSCustomObject]@{
+        Parent     = $resolvedParent
+        TokenCache = $tokenCache
+    }
+}
+
 function Test-HermesGmailTokenCache {
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$TokenCache)
@@ -107,12 +157,35 @@ function Test-HermesGmailTokenCache {
     }
 
     if ($IsWindows) {
-        $unsafeAccess = (Get-Acl -LiteralPath $TokenCache).Access | Where-Object {
-            $_.AccessControlType -eq 'Allow' -and
-            $_.IdentityReference.Value -match '(Everyone|\\Users)$' -and
-            ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::ReadData)
+        $acl = Get-Acl -LiteralPath $TokenCache
+        $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+        if ($null -eq $owner) {
+            return $false
         }
-        return $null -eq $unsafeAccess
+        $allowedSids = @(
+            $owner.Value,
+            'S-1-5-18',
+            'S-1-5-32-544'
+        )
+        foreach ($access in $acl.Access) {
+            $grantsRead = $access.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
+                (($access.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::ReadData) -ne 0)
+            if (-not $grantsRead) {
+                continue
+            }
+            try {
+                $identity = $access.IdentityReference.Translate(
+                    [System.Security.Principal.SecurityIdentifier]
+                ).Value
+            }
+            catch {
+                return $false
+            }
+            if ($allowedSids -notcontains $identity) {
+                return $false
+            }
+        }
+        return $true
     }
 
     $mode = & stat -f '%Lp' $TokenCache 2>$null
@@ -134,8 +207,9 @@ function Invoke-HermesGmailDocker {
 try {
     $resolvedComposeFile = Get-HermesGmailComposeFile -ComposeFile $ComposeFile
     $context = Get-HermesGmailProfileContext -HermesProfile $HermesProfile -DataDir (Get-HermesGmailDataDir)
+    $tokenCacheContext = Get-HermesGmailTokenCacheContext -HostHome $context.HostHome
 
-    if ($Action -eq 'test' -and -not (Test-HermesGmailTokenCache -TokenCache $context.TokenCache)) {
+    if ($Action -eq 'test' -and -not (Test-HermesGmailTokenCache -TokenCache $tokenCacheContext.TokenCache)) {
         throw [System.InvalidOperationException]::new("Gmail OAuth token cache is missing or not private for profile: $HermesProfile")
     }
 
@@ -156,7 +230,8 @@ try {
     if ($exitCode -ne 0) {
         exit $exitCode
     }
-    if ($Action -eq 'auth' -and -not (Test-HermesGmailTokenCache -TokenCache $context.TokenCache)) {
+    $tokenCacheContext = Get-HermesGmailTokenCacheContext -HostHome $context.HostHome
+    if ($Action -eq 'auth' -and -not (Test-HermesGmailTokenCache -TokenCache $tokenCacheContext.TokenCache)) {
         throw [System.InvalidOperationException]::new("Gmail OAuth token cache is missing or not private for profile: $HermesProfile")
     }
     exit 0

--- a/scripts/powershell/tests/HermesGmail.Tests.ps1
+++ b/scripts/powershell/tests/HermesGmail.Tests.ps1
@@ -58,7 +58,7 @@ Describe 'Hermes Gmail shared command adapter' {
         Remove-Item -LiteralPath (Join-Path $script:gmailDir 'credentials.json') -Force -ErrorAction SilentlyContinue
     }
 
-    It 'runs one shared host OAuth flow' -Skip:$script:runningOnWindows {
+    It 'runs one shared host OAuth flow' -Skip:([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) {
         & $script:adapterPath -Action auth
         $LASTEXITCODE | Should -Be 0
         (Get-Content -LiteralPath $script:commandLog -Raw) | Should -Match 'npx --yes @artymclabin/gmail-mcp@1.2.3 auth --scopes=gmail.readonly,gmail.compose'
@@ -70,7 +70,7 @@ Describe 'Hermes Gmail shared command adapter' {
         Test-Path -LiteralPath $script:commandLog | Should -BeFalse
     }
 
-    It 'uses shared credentials to test a selected profile' -Skip:$script:runningOnWindows {
+    It 'uses shared credentials to test a selected profile' -Skip:([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) {
         $credentials = Join-Path $script:gmailDir 'credentials.json'
         Set-Content -LiteralPath $credentials -Value '{}' -NoNewline
         & chmod 600 $credentials

--- a/scripts/powershell/tests/HermesGmail.Tests.ps1
+++ b/scripts/powershell/tests/HermesGmail.Tests.ps1
@@ -4,161 +4,78 @@ BeforeAll {
     $script:originalPath = $env:PATH
     $script:originalDataDir = $env:HERMES_DATA_DIR
     $script:originalComposeFile = $env:HERMES_COMPOSE_FILE
-    $script:originalDockerLog = $env:DOCKER_LOG
-    $script:originalClientId = $env:GMAIL_MCP_CLIENT_ID
-    $script:originalClientSecret = $env:GMAIL_MCP_CLIENT_SECRET
-    $script:originalSwapGmailTokenParent = $env:SWAP_GMAIL_TOKEN_PARENT
-    $script:originalGmailTokenOutside = $env:GMAIL_TOKEN_OUTSIDE
-
+    $script:originalCommandLog = $env:COMMAND_LOG
+    $script:runningOnWindows = [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
     $script:fakeBin = Join-Path $TestDrive 'bin'
     $script:dataDir = Join-Path $TestDrive 'hermes-data'
     $script:composeFile = Join-Path $TestDrive 'compose.yml'
-    $script:dockerLog = Join-Path $TestDrive 'docker.log'
+    $script:commandLog = Join-Path $TestDrive 'commands.log'
+    $script:gmailDir = Join-Path $script:dataDir 'google-gmail-mcp'
     $null = New-Item -ItemType Directory -Path (Join-Path $script:dataDir 'profiles/rick') -Force
+    $null = New-Item -ItemType Directory -Path $script:gmailDir -Force
     $null = New-Item -ItemType Directory -Path $script:fakeBin -Force
     Set-Content -LiteralPath $script:composeFile -Value '' -NoNewline
+    $oauth = Join-Path $script:gmailDir 'gcp-oauth.keys.json'
+    Set-Content -LiteralPath $oauth -Value '{}' -NoNewline
+    if (-not $script:runningOnWindows) { & chmod 600 $oauth }
 
-    if ($IsWindows) {
-        Set-Content -LiteralPath (Join-Path $script:fakeBin 'docker.cmd') -Value "@echo off`r`necho %*>>`"%DOCKER_LOG%`"" -NoNewline
+    if ($script:runningOnWindows) {
+        Set-Content -LiteralPath (Join-Path $script:fakeBin 'docker.cmd') -Value '@echo off' -NoNewline
+        Set-Content -LiteralPath (Join-Path $script:fakeBin 'npx.cmd') -Value '@echo off' -NoNewline
     }
     else {
-        $dockerPath = Join-Path $script:fakeBin 'docker'
-        $fakeDocker = @'
-#!/usr/bin/env sh
-printf '%s\n' "$*" >> "$DOCKER_LOG"
-if [ "${SWAP_GMAIL_TOKEN_PARENT:-0}" = 1 ] && [ -n "${GMAIL_TOKEN_OUTSIDE:-}" ] && [ "${*#*hermes mcp login gmail}" != "$*" ]; then
-  mkdir -p "$GMAIL_TOKEN_OUTSIDE"
-  rmdir "$HERMES_DATA_DIR/profiles/rick/mcp-tokens" 2>/dev/null || true
-  ln -s "$GMAIL_TOKEN_OUTSIDE" "$HERMES_DATA_DIR/profiles/rick/mcp-tokens"
-  : > "$GMAIL_TOKEN_OUTSIDE/gmail.json"
-  chmod 600 "$GMAIL_TOKEN_OUTSIDE/gmail.json"
-fi
+        $docker = Join-Path $script:fakeBin 'docker'
+        $npx = Join-Path $script:fakeBin 'npx'
+        $dockerScript = @'
+#!/bin/sh
+printf 'docker %s\n' "$*" >>"$COMMAND_LOG"
 '@
-        [System.IO.File]::WriteAllText(
-            $dockerPath,
-            $fakeDocker.Replace("`r`n", "`n"),
-            [System.Text.UTF8Encoding]::new($false)
-        )
-        & chmod +x $dockerPath
+        $npxScript = @'
+#!/bin/sh
+printf 'npx %s\n' "$*" >>"$COMMAND_LOG"
+printf '{}' >"$GMAIL_CREDENTIALS_PATH"
+'@
+        [System.IO.File]::WriteAllText($docker, $dockerScript.Replace("`r`n", "`n"), [System.Text.UTF8Encoding]::new($false))
+        [System.IO.File]::WriteAllText($npx, $npxScript.Replace("`r`n", "`n"), [System.Text.UTF8Encoding]::new($false))
+        & chmod +x $docker $npx
     }
-
     $env:PATH = "$script:fakeBin$([System.IO.Path]::PathSeparator)$script:originalPath"
     $env:HERMES_DATA_DIR = $script:dataDir
     $env:HERMES_COMPOSE_FILE = $script:composeFile
-    $env:DOCKER_LOG = $script:dockerLog
+    $env:COMMAND_LOG = $script:commandLog
 }
 
 AfterAll {
     $env:PATH = $script:originalPath
     $env:HERMES_DATA_DIR = $script:originalDataDir
     $env:HERMES_COMPOSE_FILE = $script:originalComposeFile
-    $env:DOCKER_LOG = $script:originalDockerLog
-    $env:GMAIL_MCP_CLIENT_ID = $script:originalClientId
-    $env:GMAIL_MCP_CLIENT_SECRET = $script:originalClientSecret
-    $env:SWAP_GMAIL_TOKEN_PARENT = $script:originalSwapGmailTokenParent
-    $env:GMAIL_TOKEN_OUTSIDE = $script:originalGmailTokenOutside
+    $env:COMMAND_LOG = $script:originalCommandLog
 }
 
-Describe 'Hermes Gmail command adapter' {
+Describe 'Hermes Gmail shared command adapter' {
     BeforeEach {
-        Remove-Item -LiteralPath $script:dockerLog -Force -ErrorAction SilentlyContinue
-        Remove-Item -LiteralPath (Join-Path $script:dataDir 'profiles/rick/mcp-tokens') -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $script:commandLog -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath (Join-Path $script:gmailDir 'credentials.json') -Force -ErrorAction SilentlyContinue
     }
 
-    It 'rejects unsafe and unknown profiles before Docker starts' {
-        & $script:adapterPath -Action auth -Profile '../outside'
-        $LASTEXITCODE | Should -Be 1
-        Test-Path -LiteralPath $script:dockerLog | Should -BeFalse
-
-        & $script:adapterPath -Action auth -Profile missing
-        $LASTEXITCODE | Should -Be 1
-        Test-Path -LiteralPath $script:dockerLog | Should -BeFalse
-    }
-
-    It 'runs Gmail login in the named profile home without OAuth values in Docker arguments' {
-        $tokenDir = Join-Path $script:dataDir 'profiles/rick/mcp-tokens'
-        $null = New-Item -ItemType Directory -Path $tokenDir -Force
-        $tokenPath = Join-Path $tokenDir 'gmail.json'
-        Set-Content -LiteralPath $tokenPath -Value '{}' -NoNewline
-        if (-not $IsWindows) { & chmod 600 $tokenPath }
-        $env:GMAIL_MCP_CLIENT_ID = 'client-id-marker'
-        $env:GMAIL_MCP_CLIENT_SECRET = 'client-secret-marker'
-
-        & $script:adapterPath -Action auth -Profile rick
+    It 'runs one shared host OAuth flow' -Skip:$script:runningOnWindows {
+        & $script:adapterPath -Action auth
         $LASTEXITCODE | Should -Be 0
-
-        $arguments = Get-Content -LiteralPath $script:dockerLog -Raw
-        $arguments | Should -Match ([regex]::Escape("compose -f $script:composeFile run --rm --no-deps --volume ${tokenDir}:/opt/data/profiles/rick/mcp-tokens:rw -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp login gmail"))
-        $arguments | Should -Not -Match 'client-id-marker|client-secret-marker'
+        (Get-Content -LiteralPath $script:commandLog -Raw) | Should -Match 'npx --yes @artymclabin/gmail-mcp@1.2.3 auth --scopes=gmail.readonly,gmail.compose'
     }
 
-    It 'fails when Gmail login completes without a private token cache' {
+    It 'rejects a profile-specific auth invocation' {
         & $script:adapterPath -Action auth -Profile rick
-
         $LASTEXITCODE | Should -Be 1
-        Test-Path -LiteralPath $script:dockerLog | Should -BeTrue
+        Test-Path -LiteralPath $script:commandLog | Should -BeFalse
     }
 
-    It 'rejects an mcp-tokens symlink before Docker starts' -Skip:$IsWindows {
-        $outside = Join-Path $TestDrive 'outside'
-        $null = New-Item -ItemType Directory -Path $outside -Force
-        $tokenPath = Join-Path $outside 'gmail.json'
-        Set-Content -LiteralPath $tokenPath -Value '{}' -NoNewline
-        & chmod 600 $tokenPath
-        $tokenDirectory = Join-Path $script:dataDir 'profiles/rick/mcp-tokens'
-        $null = New-Item -ItemType SymbolicLink -Path $tokenDirectory -Target $outside
-
-        & $script:adapterPath -Action test -Profile rick
-
-        $LASTEXITCODE | Should -Be 1
-        Test-Path -LiteralPath $script:dockerLog | Should -BeFalse
-    }
-
-    It 'rejects an mcp-tokens symlink installed during OAuth login' -Skip:$IsWindows {
-        $outside = Join-Path $TestDrive 'outside'
-        $env:SWAP_GMAIL_TOKEN_PARENT = '1'
-        $env:GMAIL_TOKEN_OUTSIDE = $outside
-
-        & $script:adapterPath -Action auth -Profile rick
-
-        $LASTEXITCODE | Should -Be 1
-        Test-Path -LiteralPath $script:dockerLog | Should -BeTrue
-    }
-
-    It 'rejects Authenticated Users read access to the token cache' -Skip:(-not $IsWindows) {
-        $tokenDir = Join-Path $script:dataDir 'profiles/rick/mcp-tokens'
-        $null = New-Item -ItemType Directory -Path $tokenDir -Force
-        $tokenPath = Join-Path $tokenDir 'gmail.json'
-        Set-Content -LiteralPath $tokenPath -Value '{}' -NoNewline
-        $acl = Get-Acl -LiteralPath $tokenPath
-        $authenticatedUsers = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-11')
-        $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
-            $authenticatedUsers,
-            [System.Security.AccessControl.FileSystemRights]::ReadData,
-            [System.Security.AccessControl.AccessControlType]::Allow
-        )
-        $acl.AddAccessRule($rule)
-        Set-Acl -LiteralPath $tokenPath -AclObject $acl
-
-        & $script:adapterPath -Action auth -Profile rick
-
-        $LASTEXITCODE | Should -Be 1
-    }
-
-    It 'requires a token cache before probing Gmail MCP' {
-        & $script:adapterPath -Action test -Profile rick
-        $LASTEXITCODE | Should -Be 1
-        Test-Path -LiteralPath $script:dockerLog | Should -BeFalse
-
-        $tokenDir = Join-Path $script:dataDir 'profiles/rick/mcp-tokens'
-        $null = New-Item -ItemType Directory -Path $tokenDir -Force
-        $tokenPath = Join-Path $tokenDir 'gmail.json'
-        Set-Content -LiteralPath $tokenPath -Value '{}' -NoNewline
-        if (-not $IsWindows) { & chmod 600 $tokenPath }
-
+    It 'uses shared credentials to test a selected profile' -Skip:$script:runningOnWindows {
+        $credentials = Join-Path $script:gmailDir 'credentials.json'
+        Set-Content -LiteralPath $credentials -Value '{}' -NoNewline
+        & chmod 600 $credentials
         & $script:adapterPath -Action test -Profile rick
         $LASTEXITCODE | Should -Be 0
-        $arguments = Get-Content -LiteralPath $script:dockerLog -Raw
-        $arguments | Should -Match ([regex]::Escape("compose -f $script:composeFile run --rm --no-deps -T --volume ${tokenDir}:/opt/data/profiles/rick/mcp-tokens:rw -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp test gmail"))
+        (Get-Content -LiteralPath $script:commandLog -Raw) | Should -Match 'docker compose .* run --rm --no-deps -T -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp test gmail'
     }
 }

--- a/scripts/powershell/tests/HermesGmail.Tests.ps1
+++ b/scripts/powershell/tests/HermesGmail.Tests.ps1
@@ -20,8 +20,15 @@ BeforeAll {
     if (-not $script:runningOnWindows) { & chmod 600 $oauth }
 
     if ($script:runningOnWindows) {
-        Set-Content -LiteralPath (Join-Path $script:fakeBin 'docker.cmd') -Value '@echo off' -NoNewline
-        Set-Content -LiteralPath (Join-Path $script:fakeBin 'npx.cmd') -Value '@echo off' -NoNewline
+        Set-Content -LiteralPath (Join-Path $script:fakeBin 'docker.cmd') -Value @'
+@echo off
+echo docker %*>>"%COMMAND_LOG%"
+'@
+        Set-Content -LiteralPath (Join-Path $script:fakeBin 'npx.cmd') -Value @'
+@echo off
+echo npx %*>>"%COMMAND_LOG%"
+echo {}>"%GMAIL_CREDENTIALS_PATH%"
+'@
     }
     else {
         $docker = Join-Path $script:fakeBin 'docker'
@@ -58,22 +65,49 @@ Describe 'Hermes Gmail shared command adapter' {
         Remove-Item -LiteralPath (Join-Path $script:gmailDir 'credentials.json') -Force -ErrorAction SilentlyContinue
     }
 
-    It 'runs one shared host OAuth flow' -Skip:([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) {
+    It 'should run one shared host OAuth flow with private credentials' {
         & $script:adapterPath -Action auth
         $LASTEXITCODE | Should -Be 0
         (Get-Content -LiteralPath $script:commandLog -Raw) | Should -Match 'npx --yes @artymclabin/gmail-mcp@1.2.3 auth --scopes=gmail.readonly,gmail.compose'
+        if ($script:runningOnWindows) {
+            $allowedSids = @(
+                (Get-Acl -LiteralPath $script:gmailDir).GetOwner(
+                    [System.Security.Principal.SecurityIdentifier]
+                ).Value
+                [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+                'S-1-5-18'
+                'S-1-5-32-544'
+            )
+            foreach ($path in @(
+                    $script:gmailDir,
+                    (Join-Path $script:gmailDir 'gcp-oauth.keys.json'),
+                    (Join-Path $script:gmailDir 'credentials.json')
+                )) {
+                $acl = Get-Acl -LiteralPath $path
+                $acl.AreAccessRulesProtected | Should -BeTrue
+                foreach ($access in $acl.Access) {
+                    if ($access.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow) {
+                        continue
+                    }
+                    $identity = $access.IdentityReference.Translate(
+                        [System.Security.Principal.SecurityIdentifier]
+                    ).Value
+                    $allowedSids | Should -Contain $identity
+                }
+            }
+        }
     }
 
-    It 'rejects a profile-specific auth invocation' {
+    It 'should reject a profile-specific auth invocation' {
         & $script:adapterPath -Action auth -Profile rick
         $LASTEXITCODE | Should -Be 1
         Test-Path -LiteralPath $script:commandLog | Should -BeFalse
     }
 
-    It 'uses shared credentials to test a selected profile' -Skip:([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) {
+    It 'should use shared credentials to test a selected profile' {
         $credentials = Join-Path $script:gmailDir 'credentials.json'
         Set-Content -LiteralPath $credentials -Value '{}' -NoNewline
-        & chmod 600 $credentials
+        if (-not $script:runningOnWindows) { & chmod 600 $credentials }
         & $script:adapterPath -Action test -Profile rick
         $LASTEXITCODE | Should -Be 0
         (Get-Content -LiteralPath $script:commandLog -Raw) | Should -Match 'docker compose .* run --rm --no-deps -T -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp test gmail'

--- a/scripts/powershell/tests/HermesGmail.Tests.ps1
+++ b/scripts/powershell/tests/HermesGmail.Tests.ps1
@@ -88,7 +88,7 @@ Describe 'Hermes Gmail command adapter' {
         $LASTEXITCODE | Should -Be 0
 
         $arguments = Get-Content -LiteralPath $script:dockerLog -Raw
-        $arguments | Should -Match ([regex]::Escape("compose -f $script:composeFile run --rm --no-deps -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp login gmail"))
+        $arguments | Should -Match ([regex]::Escape("compose -f $script:composeFile run --rm --no-deps --volume ${tokenDir}:/opt/data/profiles/rick/mcp-tokens:rw -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp login gmail"))
         $arguments | Should -Not -Match 'client-id-marker|client-secret-marker'
     }
 
@@ -149,5 +149,16 @@ Describe 'Hermes Gmail command adapter' {
         & $script:adapterPath -Action test -Profile rick
         $LASTEXITCODE | Should -Be 1
         Test-Path -LiteralPath $script:dockerLog | Should -BeFalse
+
+        $tokenDir = Join-Path $script:dataDir 'profiles/rick/mcp-tokens'
+        $null = New-Item -ItemType Directory -Path $tokenDir -Force
+        $tokenPath = Join-Path $tokenDir 'gmail.json'
+        Set-Content -LiteralPath $tokenPath -Value '{}' -NoNewline
+        if (-not $IsWindows) { & chmod 600 $tokenPath }
+
+        & $script:adapterPath -Action test -Profile rick
+        $LASTEXITCODE | Should -Be 0
+        $arguments = Get-Content -LiteralPath $script:dockerLog -Raw
+        $arguments | Should -Match ([regex]::Escape("compose -f $script:composeFile run --rm --no-deps -T --volume ${tokenDir}:/opt/data/profiles/rick/mcp-tokens:rw -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp test gmail"))
     }
 }

--- a/scripts/powershell/tests/HermesGmail.Tests.ps1
+++ b/scripts/powershell/tests/HermesGmail.Tests.ps1
@@ -1,0 +1,92 @@
+BeforeAll {
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../../..'))
+    $script:adapterPath = Join-Path $script:repositoryRoot 'scripts/powershell/hermes-gmail.ps1'
+    $script:originalPath = $env:PATH
+    $script:originalDataDir = $env:HERMES_DATA_DIR
+    $script:originalComposeFile = $env:HERMES_COMPOSE_FILE
+    $script:originalDockerLog = $env:DOCKER_LOG
+    $script:originalClientId = $env:GMAIL_MCP_CLIENT_ID
+    $script:originalClientSecret = $env:GMAIL_MCP_CLIENT_SECRET
+
+    $script:fakeBin = Join-Path $TestDrive 'bin'
+    $script:dataDir = Join-Path $TestDrive 'hermes-data'
+    $script:composeFile = Join-Path $TestDrive 'compose.yml'
+    $script:dockerLog = Join-Path $TestDrive 'docker.log'
+    $null = New-Item -ItemType Directory -Path (Join-Path $script:dataDir 'profiles/rick') -Force
+    $null = New-Item -ItemType Directory -Path $script:fakeBin -Force
+    Set-Content -LiteralPath $script:composeFile -Value '' -NoNewline
+
+    if ($IsWindows) {
+        Set-Content -LiteralPath (Join-Path $script:fakeBin 'docker.cmd') -Value "@echo off`r`necho %*>>`"%DOCKER_LOG%`"" -NoNewline
+    }
+    else {
+        $dockerPath = Join-Path $script:fakeBin 'docker'
+        $fakeDocker = @'
+#!/usr/bin/env sh
+printf '%s\n' "$*" >> "$DOCKER_LOG"
+'@
+        Set-Content -LiteralPath $dockerPath -Value $fakeDocker -NoNewline
+        & chmod +x $dockerPath
+    }
+
+    $env:PATH = "$script:fakeBin$([System.IO.Path]::PathSeparator)$script:originalPath"
+    $env:HERMES_DATA_DIR = $script:dataDir
+    $env:HERMES_COMPOSE_FILE = $script:composeFile
+    $env:DOCKER_LOG = $script:dockerLog
+}
+
+AfterAll {
+    $env:PATH = $script:originalPath
+    $env:HERMES_DATA_DIR = $script:originalDataDir
+    $env:HERMES_COMPOSE_FILE = $script:originalComposeFile
+    $env:DOCKER_LOG = $script:originalDockerLog
+    $env:GMAIL_MCP_CLIENT_ID = $script:originalClientId
+    $env:GMAIL_MCP_CLIENT_SECRET = $script:originalClientSecret
+}
+
+Describe 'Hermes Gmail command adapter' {
+    BeforeEach {
+        Remove-Item -LiteralPath $script:dockerLog -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath (Join-Path $script:dataDir 'profiles/rick/mcp-tokens') -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'rejects unsafe and unknown profiles before Docker starts' {
+        & $script:adapterPath -Action auth -Profile '../outside'
+        $LASTEXITCODE | Should -Be 1
+        Test-Path -LiteralPath $script:dockerLog | Should -BeFalse
+
+        & $script:adapterPath -Action auth -Profile missing
+        $LASTEXITCODE | Should -Be 1
+        Test-Path -LiteralPath $script:dockerLog | Should -BeFalse
+    }
+
+    It 'runs Gmail login in the named profile home without OAuth values in Docker arguments' {
+        $tokenDir = Join-Path $script:dataDir 'profiles/rick/mcp-tokens'
+        $null = New-Item -ItemType Directory -Path $tokenDir -Force
+        $tokenPath = Join-Path $tokenDir 'gmail.json'
+        Set-Content -LiteralPath $tokenPath -Value '{}' -NoNewline
+        if (-not $IsWindows) { & chmod 600 $tokenPath }
+        $env:GMAIL_MCP_CLIENT_ID = 'client-id-marker'
+        $env:GMAIL_MCP_CLIENT_SECRET = 'client-secret-marker'
+
+        & $script:adapterPath -Action auth -Profile rick
+        $LASTEXITCODE | Should -Be 0
+
+        $arguments = Get-Content -LiteralPath $script:dockerLog -Raw
+        $arguments | Should -Match ([regex]::Escape("compose -f $script:composeFile run --rm --no-deps -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp login gmail"))
+        $arguments | Should -Not -Match 'client-id-marker|client-secret-marker'
+    }
+
+    It 'fails when Gmail login completes without a private token cache' {
+        & $script:adapterPath -Action auth -Profile rick
+
+        $LASTEXITCODE | Should -Be 1
+        Test-Path -LiteralPath $script:dockerLog | Should -BeTrue
+    }
+
+    It 'requires a token cache before probing Gmail MCP' {
+        & $script:adapterPath -Action test -Profile rick
+        $LASTEXITCODE | Should -Be 1
+        Test-Path -LiteralPath $script:dockerLog | Should -BeFalse
+    }
+}

--- a/scripts/powershell/tests/HermesGmail.Tests.ps1
+++ b/scripts/powershell/tests/HermesGmail.Tests.ps1
@@ -7,6 +7,8 @@ BeforeAll {
     $script:originalDockerLog = $env:DOCKER_LOG
     $script:originalClientId = $env:GMAIL_MCP_CLIENT_ID
     $script:originalClientSecret = $env:GMAIL_MCP_CLIENT_SECRET
+    $script:originalSwapGmailTokenParent = $env:SWAP_GMAIL_TOKEN_PARENT
+    $script:originalGmailTokenOutside = $env:GMAIL_TOKEN_OUTSIDE
 
     $script:fakeBin = Join-Path $TestDrive 'bin'
     $script:dataDir = Join-Path $TestDrive 'hermes-data'
@@ -24,8 +26,19 @@ BeforeAll {
         $fakeDocker = @'
 #!/usr/bin/env sh
 printf '%s\n' "$*" >> "$DOCKER_LOG"
+if [ "${SWAP_GMAIL_TOKEN_PARENT:-0}" = 1 ] && [ -n "${GMAIL_TOKEN_OUTSIDE:-}" ] && [ "${*#*hermes mcp login gmail}" != "$*" ]; then
+  mkdir -p "$GMAIL_TOKEN_OUTSIDE"
+  rmdir "$HERMES_DATA_DIR/profiles/rick/mcp-tokens" 2>/dev/null || true
+  ln -s "$GMAIL_TOKEN_OUTSIDE" "$HERMES_DATA_DIR/profiles/rick/mcp-tokens"
+  : > "$GMAIL_TOKEN_OUTSIDE/gmail.json"
+  chmod 600 "$GMAIL_TOKEN_OUTSIDE/gmail.json"
+fi
 '@
-        Set-Content -LiteralPath $dockerPath -Value $fakeDocker -NoNewline
+        [System.IO.File]::WriteAllText(
+            $dockerPath,
+            $fakeDocker.Replace("`r`n", "`n"),
+            [System.Text.UTF8Encoding]::new($false)
+        )
         & chmod +x $dockerPath
     }
 
@@ -42,6 +55,8 @@ AfterAll {
     $env:DOCKER_LOG = $script:originalDockerLog
     $env:GMAIL_MCP_CLIENT_ID = $script:originalClientId
     $env:GMAIL_MCP_CLIENT_SECRET = $script:originalClientSecret
+    $env:SWAP_GMAIL_TOKEN_PARENT = $script:originalSwapGmailTokenParent
+    $env:GMAIL_TOKEN_OUTSIDE = $script:originalGmailTokenOutside
 }
 
 Describe 'Hermes Gmail command adapter' {
@@ -82,6 +97,52 @@ Describe 'Hermes Gmail command adapter' {
 
         $LASTEXITCODE | Should -Be 1
         Test-Path -LiteralPath $script:dockerLog | Should -BeTrue
+    }
+
+    It 'rejects an mcp-tokens symlink before Docker starts' -Skip:$IsWindows {
+        $outside = Join-Path $TestDrive 'outside'
+        $null = New-Item -ItemType Directory -Path $outside -Force
+        $tokenPath = Join-Path $outside 'gmail.json'
+        Set-Content -LiteralPath $tokenPath -Value '{}' -NoNewline
+        & chmod 600 $tokenPath
+        $tokenDirectory = Join-Path $script:dataDir 'profiles/rick/mcp-tokens'
+        $null = New-Item -ItemType SymbolicLink -Path $tokenDirectory -Target $outside
+
+        & $script:adapterPath -Action test -Profile rick
+
+        $LASTEXITCODE | Should -Be 1
+        Test-Path -LiteralPath $script:dockerLog | Should -BeFalse
+    }
+
+    It 'rejects an mcp-tokens symlink installed during OAuth login' -Skip:$IsWindows {
+        $outside = Join-Path $TestDrive 'outside'
+        $env:SWAP_GMAIL_TOKEN_PARENT = '1'
+        $env:GMAIL_TOKEN_OUTSIDE = $outside
+
+        & $script:adapterPath -Action auth -Profile rick
+
+        $LASTEXITCODE | Should -Be 1
+        Test-Path -LiteralPath $script:dockerLog | Should -BeTrue
+    }
+
+    It 'rejects Authenticated Users read access to the token cache' -Skip:(-not $IsWindows) {
+        $tokenDir = Join-Path $script:dataDir 'profiles/rick/mcp-tokens'
+        $null = New-Item -ItemType Directory -Path $tokenDir -Force
+        $tokenPath = Join-Path $tokenDir 'gmail.json'
+        Set-Content -LiteralPath $tokenPath -Value '{}' -NoNewline
+        $acl = Get-Acl -LiteralPath $tokenPath
+        $authenticatedUsers = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-11')
+        $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+            $authenticatedUsers,
+            [System.Security.AccessControl.FileSystemRights]::ReadData,
+            [System.Security.AccessControl.AccessControlType]::Allow
+        )
+        $acl.AddAccessRule($rule)
+        Set-Acl -LiteralPath $tokenPath -AclObject $acl
+
+        & $script:adapterPath -Action auth -Profile rick
+
+        $LASTEXITCODE | Should -Be 1
     }
 
     It 'requires a token cache before probing Gmail MCP' {

--- a/scripts/sh/hermes-gmail.sh
+++ b/scripts/sh/hermes-gmail.sh
@@ -46,6 +46,7 @@ validate_token_cache_parent() {
   expected_parent="$host_profile_home/mcp-tokens"
   [[ $cache_parent == "$expected_parent" && $cache_parent == "$host_profile_home"/* ]] ||
     die "Gmail token cache parent is invalid for profile: $profile"
+  validated_token_cache_parent="$cache_parent"
   token_cache="$cache_parent/gmail.json"
 }
 
@@ -74,6 +75,7 @@ case "$action" in
 auth)
   validate_token_cache_parent
   docker compose -f "$compose_file" run --rm --no-deps \
+    --volume "$validated_token_cache_parent:$container_profile_home/mcp-tokens:rw" \
     -e "HERMES_HOME=$container_profile_home" \
     hermes hermes mcp login gmail
   require_private_token_cache
@@ -81,6 +83,7 @@ auth)
 test)
   require_private_token_cache
   docker compose -f "$compose_file" run --rm --no-deps -T \
+    --volume "$validated_token_cache_parent:$container_profile_home/mcp-tokens:rw" \
     -e "HERMES_HOME=$container_profile_home" \
     hermes hermes mcp test gmail
   ;;

--- a/scripts/sh/hermes-gmail.sh
+++ b/scripts/sh/hermes-gmail.sh
@@ -8,13 +8,42 @@ compose_file="${HERMES_COMPOSE_FILE:-$REPO_ROOT/docker/hermes-agent/compose.yml}
 data_dir="${HERMES_DATA_DIR:-${USERPROFILE:-$HOME}/.hermes}"
 action="${1:-}"
 profile="${2:-}"
+gmail_mcp_package="@artymclabin/gmail-mcp@1.2.3"
 
 die() {
   printf '%s\n' "$1" >&2
   exit "${2:-1}"
 }
 
+file_mode() {
+  stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1" 2>/dev/null
+}
+
+resolve_shared_credentials() {
+  [[ -d $data_dir && ! -L $data_dir ]] ||
+    die "Hermes data directory is not installed" 66
+  data_dir="$(cd -P -- "$data_dir" && pwd)"
+  credentials_dir="$data_dir/google-gmail-mcp"
+  oauth_file="$credentials_dir/gcp-oauth.keys.json"
+  credentials_file="$credentials_dir/credentials.json"
+
+  [[ -d $credentials_dir && ! -L $credentials_dir ]] ||
+    die "Shared Gmail credential directory is missing or invalid"
+  credentials_dir="$(cd -P -- "$credentials_dir" && pwd)"
+  [[ $credentials_dir == "$data_dir/google-gmail-mcp" ]] ||
+    die "Shared Gmail credential directory is missing or invalid"
+  [[ -f $oauth_file && ! -L $oauth_file && $(file_mode "$oauth_file") == 600 ]] ||
+    die "Shared Gmail OAuth client is missing or not private"
+}
+
+require_private_credentials() {
+  resolve_shared_credentials
+  [[ -f $credentials_file && ! -L $credentials_file && $(file_mode "$credentials_file") == 600 ]] ||
+    die "Shared Gmail OAuth credentials are missing or not private"
+}
+
 resolve_profile_home() {
+  [[ -n $profile ]] || die "Usage: $0 test profile-name" 64
   case "$profile" in
   default)
     host_profile_home="$data_dir"
@@ -27,67 +56,29 @@ resolve_profile_home() {
     container_profile_home="/opt/data/profiles/$profile"
     ;;
   esac
-
   [[ -d $host_profile_home && ! -L $host_profile_home ]] ||
     die "Hermes profile is not installed: $profile" 66
-  host_profile_home="$(cd -P -- "$host_profile_home" && pwd)"
 }
-
-validate_token_cache_parent() {
-  local cache_parent
-  local expected_parent
-
-  mkdir -p -m 700 -- "$host_profile_home/mcp-tokens"
-  cache_parent="$host_profile_home/mcp-tokens"
-  [[ -d $cache_parent && ! -L $cache_parent ]] ||
-    die "Gmail token cache parent is invalid for profile: $profile"
-
-  cache_parent="$(cd -P -- "$cache_parent" && pwd)"
-  expected_parent="$host_profile_home/mcp-tokens"
-  [[ $cache_parent == "$expected_parent" && $cache_parent == "$host_profile_home"/* ]] ||
-    die "Gmail token cache parent is invalid for profile: $profile"
-  validated_token_cache_parent="$cache_parent"
-  token_cache="$cache_parent/gmail.json"
-}
-
-token_cache_is_private() {
-  local mode
-
-  [[ -f $token_cache && ! -L $token_cache ]] || return 1
-  if mode="$(stat -f '%Lp' "$token_cache" 2>/dev/null)"; then
-    :
-  else
-    mode="$(stat -c '%a' "$token_cache" 2>/dev/null)" || return 1
-  fi
-  [[ $mode == 600 ]]
-}
-
-require_private_token_cache() {
-  validate_token_cache_parent
-  token_cache_is_private ||
-    die "Gmail OAuth token cache is missing or not private for profile: $profile"
-}
-
-[[ -n $profile ]] || die "Usage: $0 {auth|test} profile-name" 64
-resolve_profile_home
 
 case "$action" in
 auth)
-  validate_token_cache_parent
-  docker compose -f "$compose_file" run --rm --no-deps \
-    --volume "$validated_token_cache_parent:$container_profile_home/mcp-tokens:rw" \
-    -e "HERMES_HOME=$container_profile_home" \
-    hermes hermes mcp login gmail
-  require_private_token_cache
+  [[ -z $profile ]] || die "Usage: $0 auth" 64
+  resolve_shared_credentials
+  GMAIL_OAUTH_PATH="$oauth_file" \
+    GMAIL_CREDENTIALS_PATH="$credentials_file" \
+    npx --yes "$gmail_mcp_package" auth \
+    --scopes=gmail.readonly,gmail.compose
+  chmod 600 "$credentials_file"
+  require_private_credentials
   ;;
 test)
-  require_private_token_cache
+  require_private_credentials
+  resolve_profile_home
   docker compose -f "$compose_file" run --rm --no-deps -T \
-    --volume "$validated_token_cache_parent:$container_profile_home/mcp-tokens:rw" \
     -e "HERMES_HOME=$container_profile_home" \
     hermes hermes mcp test gmail
   ;;
 *)
-  die "Usage: $0 {auth|test} profile-name" 64
+  die "Usage: $0 auth | $0 test profile-name" 64
   ;;
 esac

--- a/scripts/sh/hermes-gmail.sh
+++ b/scripts/sh/hermes-gmail.sh
@@ -16,7 +16,7 @@ die() {
 }
 
 file_mode() {
-  stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1" 2>/dev/null
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null
 }
 
 resolve_shared_credentials() {

--- a/scripts/sh/hermes-gmail.sh
+++ b/scripts/sh/hermes-gmail.sh
@@ -30,6 +30,23 @@ resolve_profile_home() {
 
   [[ -d $host_profile_home && ! -L $host_profile_home ]] ||
     die "Hermes profile is not installed: $profile" 66
+  host_profile_home="$(cd -P -- "$host_profile_home" && pwd)"
+}
+
+validate_token_cache_parent() {
+  local cache_parent
+  local expected_parent
+
+  mkdir -p -m 700 -- "$host_profile_home/mcp-tokens"
+  cache_parent="$host_profile_home/mcp-tokens"
+  [[ -d $cache_parent && ! -L $cache_parent ]] ||
+    die "Gmail token cache parent is invalid for profile: $profile"
+
+  cache_parent="$(cd -P -- "$cache_parent" && pwd)"
+  expected_parent="$host_profile_home/mcp-tokens"
+  [[ $cache_parent == "$expected_parent" && $cache_parent == "$host_profile_home"/* ]] ||
+    die "Gmail token cache parent is invalid for profile: $profile"
+  token_cache="$cache_parent/gmail.json"
 }
 
 token_cache_is_private() {
@@ -45,7 +62,7 @@ token_cache_is_private() {
 }
 
 require_private_token_cache() {
-  token_cache="$host_profile_home/mcp-tokens/gmail.json"
+  validate_token_cache_parent
   token_cache_is_private ||
     die "Gmail OAuth token cache is missing or not private for profile: $profile"
 }
@@ -55,6 +72,7 @@ resolve_profile_home
 
 case "$action" in
 auth)
+  validate_token_cache_parent
   docker compose -f "$compose_file" run --rm --no-deps \
     -e "HERMES_HOME=$container_profile_home" \
     hermes hermes mcp login gmail

--- a/scripts/sh/hermes-gmail.sh
+++ b/scripts/sh/hermes-gmail.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd -P)"
+
+compose_file="${HERMES_COMPOSE_FILE:-$REPO_ROOT/docker/hermes-agent/compose.yml}"
+data_dir="${HERMES_DATA_DIR:-${USERPROFILE:-$HOME}/.hermes}"
+action="${1:-}"
+profile="${2:-}"
+
+die() {
+  printf '%s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+resolve_profile_home() {
+  case "$profile" in
+  default)
+    host_profile_home="$data_dir"
+    container_profile_home="/opt/data"
+    ;;
+  *)
+    [[ $profile =~ ^[a-z0-9][a-z0-9_-]*$ ]] ||
+      die "Invalid Hermes profile: $profile" 64
+    host_profile_home="$data_dir/profiles/$profile"
+    container_profile_home="/opt/data/profiles/$profile"
+    ;;
+  esac
+
+  [[ -d $host_profile_home && ! -L $host_profile_home ]] ||
+    die "Hermes profile is not installed: $profile" 66
+}
+
+token_cache_is_private() {
+  local mode
+
+  [[ -f $token_cache && ! -L $token_cache ]] || return 1
+  if mode="$(stat -f '%Lp' "$token_cache" 2>/dev/null)"; then
+    :
+  else
+    mode="$(stat -c '%a' "$token_cache" 2>/dev/null)" || return 1
+  fi
+  [[ $mode == 600 ]]
+}
+
+require_private_token_cache() {
+  token_cache="$host_profile_home/mcp-tokens/gmail.json"
+  token_cache_is_private ||
+    die "Gmail OAuth token cache is missing or not private for profile: $profile"
+}
+
+[[ -n $profile ]] || die "Usage: $0 {auth|test} profile-name" 64
+resolve_profile_home
+
+case "$action" in
+auth)
+  docker compose -f "$compose_file" run --rm --no-deps \
+    -e "HERMES_HOME=$container_profile_home" \
+    hermes hermes mcp login gmail
+  require_private_token_cache
+  ;;
+test)
+  require_private_token_cache
+  docker compose -f "$compose_file" run --rm --no-deps -T \
+    -e "HERMES_HOME=$container_profile_home" \
+    hermes hermes mcp test gmail
+  ;;
+*)
+  die "Usage: $0 {auth|test} profile-name" 64
+  ;;
+esac

--- a/tests/bash/hermes_gmail_auth.bats
+++ b/tests/bash/hermes_gmail_auth.bats
@@ -50,7 +50,8 @@ EOF
 	[ "$status" -eq 0 ]
 
 	command_line="$(<"$DOCKER_LOG")"
-	[[ "$command_line" == *"compose -f $HERMES_COMPOSE_FILE run --rm --no-deps -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp login gmail"* ]]
+	profile_home="$(cd -P "$HERMES_DATA_DIR/profiles/rick" && pwd)"
+	[[ "$command_line" == *"compose -f $HERMES_COMPOSE_FILE run --rm --no-deps --volume $profile_home/mcp-tokens:/opt/data/profiles/rick/mcp-tokens:rw -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp login gmail"* ]]
 	[[ "$command_line" != *"client-id-marker"* ]]
 	[[ "$command_line" != *"client-secret-marker"* ]]
 	[ "$(stat -f '%Lp' "$HERMES_DATA_DIR/profiles/rick/mcp-tokens/gmail.json" 2>/dev/null || stat -c '%a' "$HERMES_DATA_DIR/profiles/rick/mcp-tokens/gmail.json")" = 600 ]
@@ -94,5 +95,6 @@ EOF
 
 	run "$SUT" test rick
 	[ "$status" -eq 0 ]
-	[[ "$(<"$DOCKER_LOG")" == *"compose -f $HERMES_COMPOSE_FILE run --rm --no-deps -T -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp test gmail"* ]]
+	profile_home="$(cd -P "$HERMES_DATA_DIR/profiles/rick" && pwd)"
+	[[ "$(<"$DOCKER_LOG")" == *"compose -f $HERMES_COMPOSE_FILE run --rm --no-deps -T --volume $profile_home/mcp-tokens:/opt/data/profiles/rick/mcp-tokens:rw -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp test gmail"* ]]
 }

--- a/tests/bash/hermes_gmail_auth.bats
+++ b/tests/bash/hermes_gmail_auth.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+	SUT="$REPO_ROOT/scripts/sh/hermes-gmail.sh"
+	export HERMES_DATA_DIR="$BATS_TEST_TMPDIR/hermes-data"
+	export HERMES_COMPOSE_FILE="$BATS_TEST_TMPDIR/compose.yml"
+	export DOCKER_LOG="$BATS_TEST_TMPDIR/docker.log"
+	export PATH="$BATS_TEST_TMPDIR/bin:$PATH"
+	mkdir -p "$BATS_TEST_TMPDIR/bin" "$HERMES_DATA_DIR/profiles/rick"
+	: >"$HERMES_COMPOSE_FILE"
+
+	cat >"$BATS_TEST_TMPDIR/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$DOCKER_LOG"
+if [[ ${CREATE_GMAIL_TOKEN:-0} == 1 && $* == *'hermes mcp login gmail'* ]]; then
+  mkdir -p "$HERMES_DATA_DIR/profiles/rick/mcp-tokens"
+  : >"$HERMES_DATA_DIR/profiles/rick/mcp-tokens/gmail.json"
+  chmod 600 "$HERMES_DATA_DIR/profiles/rick/mcp-tokens/gmail.json"
+fi
+EOF
+	chmod +x "$BATS_TEST_TMPDIR/bin/docker"
+}
+
+@test "auth rejects unsafe and unknown profiles before starting Docker" {
+	run "$SUT" auth '../outside'
+	[ "$status" -eq 64 ]
+	[[ "$output" == *"Invalid Hermes profile"* ]]
+	[ ! -s "$DOCKER_LOG" ]
+
+	run "$SUT" auth missing
+	[ "$status" -eq 66 ]
+	[[ "$output" == *"Hermes profile is not installed"* ]]
+	[ ! -s "$DOCKER_LOG" ]
+}
+
+@test "auth uses the named profile home without passing OAuth values and requires its token cache" {
+	export CREATE_GMAIL_TOKEN=1
+	export GMAIL_MCP_CLIENT_ID='client-id-marker'
+	export GMAIL_MCP_CLIENT_SECRET='client-secret-marker'
+
+	run "$SUT" auth rick
+	[ "$status" -eq 0 ]
+
+	command_line="$(<"$DOCKER_LOG")"
+	[[ "$command_line" == *"compose -f $HERMES_COMPOSE_FILE run --rm --no-deps -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp login gmail"* ]]
+	[[ "$command_line" != *"client-id-marker"* ]]
+	[[ "$command_line" != *"client-secret-marker"* ]]
+	[ "$(stat -f '%Lp' "$HERMES_DATA_DIR/profiles/rick/mcp-tokens/gmail.json" 2>/dev/null || stat -c '%a' "$HERMES_DATA_DIR/profiles/rick/mcp-tokens/gmail.json")" = 600 ]
+}
+
+@test "auth fails when login completes without a private Gmail token cache" {
+	run "$SUT" auth rick
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"Gmail OAuth token cache is missing or not private"* ]]
+}
+
+@test "test requires a private token cache and invokes the profile-local Gmail MCP probe" {
+	run "$SUT" test rick
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"Gmail OAuth token cache is missing or not private"* ]]
+	[ ! -s "$DOCKER_LOG" ]
+
+	mkdir -p "$HERMES_DATA_DIR/profiles/rick/mcp-tokens"
+	: >"$HERMES_DATA_DIR/profiles/rick/mcp-tokens/gmail.json"
+	chmod 600 "$HERMES_DATA_DIR/profiles/rick/mcp-tokens/gmail.json"
+
+	run "$SUT" test rick
+	[ "$status" -eq 0 ]
+	[[ "$(<"$DOCKER_LOG")" == *"compose -f $HERMES_COMPOSE_FILE run --rm --no-deps -T -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp test gmail"* ]]
+}

--- a/tests/bash/hermes_gmail_auth.bats
+++ b/tests/bash/hermes_gmail_auth.bats
@@ -31,7 +31,7 @@ EOF
 	run "$SUT" auth
 	[ "$status" -eq 0 ]
 	[[ "$(<"$COMMAND_LOG")" == *"npx --yes @artymclabin/gmail-mcp@1.2.3 auth --scopes=gmail.readonly,gmail.compose"* ]]
-	[ "$(stat -f '%Lp' "$HERMES_DATA_DIR/google-gmail-mcp/credentials.json" 2>/dev/null || stat -c '%a' "$HERMES_DATA_DIR/google-gmail-mcp/credentials.json")" = 600 ]
+	[ "$(stat -c '%a' "$HERMES_DATA_DIR/google-gmail-mcp/credentials.json" 2>/dev/null || stat -f '%Lp' "$HERMES_DATA_DIR/google-gmail-mcp/credentials.json")" = 600 ]
 }
 
 @test "auth rejects profile-specific invocation" {

--- a/tests/bash/hermes_gmail_auth.bats
+++ b/tests/bash/hermes_gmail_auth.bats
@@ -14,7 +14,13 @@ setup() {
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"$DOCKER_LOG"
-if [[ ${CREATE_GMAIL_TOKEN:-0} == 1 && $* == *'hermes mcp login gmail'* ]]; then
+if [[ ${SWAP_GMAIL_TOKEN_PARENT:-0} == 1 && $* == *'hermes mcp login gmail'* ]]; then
+  mkdir -p "$GMAIL_TOKEN_OUTSIDE"
+  rmdir "$HERMES_DATA_DIR/profiles/rick/mcp-tokens" 2>/dev/null || true
+  ln -s "$GMAIL_TOKEN_OUTSIDE" "$HERMES_DATA_DIR/profiles/rick/mcp-tokens"
+  : >"$GMAIL_TOKEN_OUTSIDE/gmail.json"
+  chmod 600 "$GMAIL_TOKEN_OUTSIDE/gmail.json"
+elif [[ ${CREATE_GMAIL_TOKEN:-0} == 1 && $* == *'hermes mcp login gmail'* ]]; then
   mkdir -p "$HERMES_DATA_DIR/profiles/rick/mcp-tokens"
   : >"$HERMES_DATA_DIR/profiles/rick/mcp-tokens/gmail.json"
   chmod 600 "$HERMES_DATA_DIR/profiles/rick/mcp-tokens/gmail.json"
@@ -51,9 +57,29 @@ EOF
 }
 
 @test "auth fails when login completes without a private Gmail token cache" {
-	run "$SUT" auth rick
-	[ "$status" -eq 1 ]
-	[[ "$output" == *"Gmail OAuth token cache is missing or not private"* ]]
+  run "$SUT" auth rick
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Gmail OAuth token cache is missing or not private"* ]]
+}
+
+@test "auth rejects an mcp-tokens symlink before starting OAuth" {
+  mkdir -p "$BATS_TEST_TMPDIR/outside"
+  ln -s "$BATS_TEST_TMPDIR/outside" "$HERMES_DATA_DIR/profiles/rick/mcp-tokens"
+
+  run "$SUT" auth rick
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Gmail token cache parent is invalid"* ]]
+  [ ! -s "$DOCKER_LOG" ]
+}
+
+@test "auth rejects an mcp-tokens parent replaced by a symlink during OAuth" {
+  export SWAP_GMAIL_TOKEN_PARENT=1
+  export GMAIL_TOKEN_OUTSIDE="$BATS_TEST_TMPDIR/outside"
+
+  run "$SUT" auth rick
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Gmail token cache parent is invalid"* ]]
+  [ -s "$DOCKER_LOG" ]
 }
 
 @test "test requires a private token cache and invokes the profile-local Gmail MCP probe" {

--- a/tests/bash/hermes_gmail_auth.bats
+++ b/tests/bash/hermes_gmail_auth.bats
@@ -5,96 +5,62 @@ setup() {
 	SUT="$REPO_ROOT/scripts/sh/hermes-gmail.sh"
 	export HERMES_DATA_DIR="$BATS_TEST_TMPDIR/hermes-data"
 	export HERMES_COMPOSE_FILE="$BATS_TEST_TMPDIR/compose.yml"
-	export DOCKER_LOG="$BATS_TEST_TMPDIR/docker.log"
+	export COMMAND_LOG="$BATS_TEST_TMPDIR/commands.log"
 	export PATH="$BATS_TEST_TMPDIR/bin:$PATH"
-	mkdir -p "$BATS_TEST_TMPDIR/bin" "$HERMES_DATA_DIR/profiles/rick"
+	mkdir -p "$BATS_TEST_TMPDIR/bin" "$HERMES_DATA_DIR/profiles/rick" \
+		"$HERMES_DATA_DIR/google-gmail-mcp"
 	: >"$HERMES_COMPOSE_FILE"
+	printf '%s' '{"installed":{"client_id":"id","client_secret":"secret"}}' \
+		>"$HERMES_DATA_DIR/google-gmail-mcp/gcp-oauth.keys.json"
+	chmod 600 "$HERMES_DATA_DIR/google-gmail-mcp/gcp-oauth.keys.json"
 
 	cat >"$BATS_TEST_TMPDIR/bin/docker" <<'EOF'
 #!/usr/bin/env bash
-set -euo pipefail
-printf '%s\n' "$*" >>"$DOCKER_LOG"
-if [[ ${SWAP_GMAIL_TOKEN_PARENT:-0} == 1 && $* == *'hermes mcp login gmail'* ]]; then
-  mkdir -p "$GMAIL_TOKEN_OUTSIDE"
-  rmdir "$HERMES_DATA_DIR/profiles/rick/mcp-tokens" 2>/dev/null || true
-  ln -s "$GMAIL_TOKEN_OUTSIDE" "$HERMES_DATA_DIR/profiles/rick/mcp-tokens"
-  : >"$GMAIL_TOKEN_OUTSIDE/gmail.json"
-  chmod 600 "$GMAIL_TOKEN_OUTSIDE/gmail.json"
-elif [[ ${CREATE_GMAIL_TOKEN:-0} == 1 && $* == *'hermes mcp login gmail'* ]]; then
-  mkdir -p "$HERMES_DATA_DIR/profiles/rick/mcp-tokens"
-  : >"$HERMES_DATA_DIR/profiles/rick/mcp-tokens/gmail.json"
-  chmod 600 "$HERMES_DATA_DIR/profiles/rick/mcp-tokens/gmail.json"
-fi
+printf 'docker %s\n' "$*" >>"$COMMAND_LOG"
 EOF
-	chmod +x "$BATS_TEST_TMPDIR/bin/docker"
+	cat >"$BATS_TEST_TMPDIR/bin/npx" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'npx %s\n' "$*" >>"$COMMAND_LOG"
+printf '%s' '{"tokens":{"refresh_token":"refresh"},"scopes":["gmail.readonly","gmail.compose"]}' >"$GMAIL_CREDENTIALS_PATH"
+EOF
+	chmod +x "$BATS_TEST_TMPDIR/bin/docker" "$BATS_TEST_TMPDIR/bin/npx"
 }
 
-@test "auth rejects unsafe and unknown profiles before starting Docker" {
-	run "$SUT" auth '../outside'
-	[ "$status" -eq 64 ]
-	[[ "$output" == *"Invalid Hermes profile"* ]]
-	[ ! -s "$DOCKER_LOG" ]
-
-	run "$SUT" auth missing
-	[ "$status" -eq 66 ]
-	[[ "$output" == *"Hermes profile is not installed"* ]]
-	[ ! -s "$DOCKER_LOG" ]
-}
-
-@test "auth uses the named profile home without passing OAuth values and requires its token cache" {
-	export CREATE_GMAIL_TOKEN=1
-	export GMAIL_MCP_CLIENT_ID='client-id-marker'
-	export GMAIL_MCP_CLIENT_SECRET='client-secret-marker'
-
-	run "$SUT" auth rick
+@test "auth uses one shared host OAuth flow" {
+	run "$SUT" auth
 	[ "$status" -eq 0 ]
-
-	command_line="$(<"$DOCKER_LOG")"
-	profile_home="$(cd -P "$HERMES_DATA_DIR/profiles/rick" && pwd)"
-	[[ "$command_line" == *"compose -f $HERMES_COMPOSE_FILE run --rm --no-deps --volume $profile_home/mcp-tokens:/opt/data/profiles/rick/mcp-tokens:rw -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp login gmail"* ]]
-	[[ "$command_line" != *"client-id-marker"* ]]
-	[[ "$command_line" != *"client-secret-marker"* ]]
-	[ "$(stat -f '%Lp' "$HERMES_DATA_DIR/profiles/rick/mcp-tokens/gmail.json" 2>/dev/null || stat -c '%a' "$HERMES_DATA_DIR/profiles/rick/mcp-tokens/gmail.json")" = 600 ]
+	[[ "$(<"$COMMAND_LOG")" == *"npx --yes @artymclabin/gmail-mcp@1.2.3 auth --scopes=gmail.readonly,gmail.compose"* ]]
+	[ "$(stat -f '%Lp' "$HERMES_DATA_DIR/google-gmail-mcp/credentials.json" 2>/dev/null || stat -c '%a' "$HERMES_DATA_DIR/google-gmail-mcp/credentials.json")" = 600 ]
 }
 
-@test "auth fails when login completes without a private Gmail token cache" {
-  run "$SUT" auth rick
-  [ "$status" -eq 1 ]
-  [[ "$output" == *"Gmail OAuth token cache is missing or not private"* ]]
+@test "auth rejects profile-specific invocation" {
+	run "$SUT" auth rick
+	[ "$status" -eq 64 ]
+	[ ! -s "$COMMAND_LOG" ]
 }
 
-@test "auth rejects an mcp-tokens symlink before starting OAuth" {
-  mkdir -p "$BATS_TEST_TMPDIR/outside"
-  ln -s "$BATS_TEST_TMPDIR/outside" "$HERMES_DATA_DIR/profiles/rick/mcp-tokens"
-
-  run "$SUT" auth rick
-  [ "$status" -eq 1 ]
-  [[ "$output" == *"Gmail token cache parent is invalid"* ]]
-  [ ! -s "$DOCKER_LOG" ]
-}
-
-@test "auth rejects an mcp-tokens parent replaced by a symlink during OAuth" {
-  export SWAP_GMAIL_TOKEN_PARENT=1
-  export GMAIL_TOKEN_OUTSIDE="$BATS_TEST_TMPDIR/outside"
-
-  run "$SUT" auth rick
-  [ "$status" -eq 1 ]
-  [[ "$output" == *"Gmail token cache parent is invalid"* ]]
-  [ -s "$DOCKER_LOG" ]
-}
-
-@test "test requires a private token cache and invokes the profile-local Gmail MCP probe" {
+@test "test requires shared private credentials and probes the selected profile" {
 	run "$SUT" test rick
 	[ "$status" -eq 1 ]
-	[[ "$output" == *"Gmail OAuth token cache is missing or not private"* ]]
-	[ ! -s "$DOCKER_LOG" ]
+	[[ "$output" == *"Shared Gmail OAuth credentials are missing or not private"* ]]
+	[ ! -s "$COMMAND_LOG" ]
 
-	mkdir -p "$HERMES_DATA_DIR/profiles/rick/mcp-tokens"
-	: >"$HERMES_DATA_DIR/profiles/rick/mcp-tokens/gmail.json"
-	chmod 600 "$HERMES_DATA_DIR/profiles/rick/mcp-tokens/gmail.json"
-
+	printf '%s' '{"tokens":{"refresh_token":"refresh"},"scopes":["gmail.readonly","gmail.compose"]}' \
+		>"$HERMES_DATA_DIR/google-gmail-mcp/credentials.json"
+	chmod 600 "$HERMES_DATA_DIR/google-gmail-mcp/credentials.json"
 	run "$SUT" test rick
 	[ "$status" -eq 0 ]
-	profile_home="$(cd -P "$HERMES_DATA_DIR/profiles/rick" && pwd)"
-	[[ "$(<"$DOCKER_LOG")" == *"compose -f $HERMES_COMPOSE_FILE run --rm --no-deps -T --volume $profile_home/mcp-tokens:/opt/data/profiles/rick/mcp-tokens:rw -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp test gmail"* ]]
+	[[ "$(<"$COMMAND_LOG")" == *"docker compose -f $HERMES_COMPOSE_FILE run --rm --no-deps -T -e HERMES_HOME=/opt/data/profiles/rick hermes hermes mcp test gmail"* ]]
+}
+
+@test "test rejects unsafe and unknown profiles before Docker starts" {
+	printf '{}' >"$HERMES_DATA_DIR/google-gmail-mcp/credentials.json"
+	chmod 600 "$HERMES_DATA_DIR/google-gmail-mcp/credentials.json"
+	run "$SUT" test '../outside'
+	[ "$status" -eq 64 ]
+	[ ! -s "$COMMAND_LOG" ]
+	run "$SUT" test missing
+	[ "$status" -eq 66 ]
+	[ ! -s "$COMMAND_LOG" ]
 }

--- a/tests/bash/hermes_gmail_mcp.bats
+++ b/tests/bash/hermes_gmail_mcp.bats
@@ -12,7 +12,9 @@ setup() {
 	[ "$status" -eq 0 ]
 	run grep -F '"auth": "oauth"' "$source_file"
 	[ "$status" -eq 0 ]
-	run grep -F 'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose' "$source_file"
+	run grep -F 'https://www.googleapis.com/auth/gmail.readonly' "$source_file"
+	[ "$status" -eq 0 ]
+	run grep -F 'https://www.googleapis.com/auth/gmail.compose' "$source_file"
 	[ "$status" -eq 0 ]
 }
 

--- a/tests/bash/hermes_gmail_mcp.bats
+++ b/tests/bash/hermes_gmail_mcp.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+	export HOME="$BATS_TEST_TMPDIR/home"
+}
+
+@test "declares the official Google Gmail MCP endpoint and OAuth settings" {
+	source_file="$REPO_ROOT/docker/hermes-agent/bootstrap/hermes_bootstrap/google_gmail.py"
+
+	run grep -F 'https://gmailmcp.googleapis.com/mcp/v1' "$source_file"
+	[ "$status" -eq 0 ]
+	run grep -F '"auth": "oauth"' "$source_file"
+	[ "$status" -eq 0 ]
+	run grep -F 'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose' "$source_file"
+	[ "$status" -eq 0 ]
+}
+
+@test "declares exactly the read and draft Gmail tool allowlist" {
+	source_file="$REPO_ROOT/docker/hermes-agent/bootstrap/hermes_bootstrap/google_gmail.py"
+
+	for tool in search_threads get_thread get_message list_labels list_drafts create_draft; do
+		run grep -F "\"$tool\"" "$source_file"
+		[ "$status" -eq 0 ]
+	done
+
+	for forbidden in send_message delete_message modify_label create_label delete_label update_label; do
+		run grep -F "\"$forbidden\"" "$source_file"
+		[ "$status" -eq 1 ]
+	done
+}

--- a/tests/bash/hermes_gmail_mcp.bats
+++ b/tests/bash/hermes_gmail_mcp.bats
@@ -5,28 +5,36 @@ setup() {
 	export HOME="$BATS_TEST_TMPDIR/home"
 }
 
-@test "declares the official Google Gmail MCP endpoint and OAuth settings" {
+@test "declares the shared local Gmail MCP command and credentials" {
 	source_file="$REPO_ROOT/docker/hermes-agent/bootstrap/hermes_bootstrap/google_gmail.py"
 
-	run grep -F 'https://gmailmcp.googleapis.com/mcp/v1' "$source_file"
+	run grep -F '"command": "gmail-mcp"' "$source_file"
 	[ "$status" -eq 0 ]
-	run grep -F '"auth": "oauth"' "$source_file"
+	run grep -F 'GMAIL_OAUTH_PATH' "$source_file"
 	[ "$status" -eq 0 ]
-	run grep -F 'https://www.googleapis.com/auth/gmail.readonly' "$source_file"
+	run grep -F 'GMAIL_CREDENTIALS_PATH' "$source_file"
 	[ "$status" -eq 0 ]
-	run grep -F 'https://www.googleapis.com/auth/gmail.compose' "$source_file"
+	run grep -F 'gmailmcp.googleapis.com' "$source_file"
+	[ "$status" -eq 1 ]
+}
+
+@test "pins the local stdio Gmail MCP package in the Hermes image" {
+	dockerfile="$REPO_ROOT/docker/hermes-agent/Dockerfile"
+	run grep -F 'ARG GOOGLE_GMAIL_MCP_VERSION=1.2.3' "$dockerfile"
+	[ "$status" -eq 0 ]
+	run grep -F '"@artymclabin/gmail-mcp@${GOOGLE_GMAIL_MCP_VERSION}"' "$dockerfile"
 	[ "$status" -eq 0 ]
 }
 
 @test "declares exactly the read and draft Gmail tool allowlist" {
 	source_file="$REPO_ROOT/docker/hermes-agent/bootstrap/hermes_bootstrap/google_gmail.py"
 
-	for tool in search_threads get_thread get_message list_labels list_drafts create_draft; do
+	for tool in search_emails read_email get_thread list_inbox_threads get_inbox_with_threads list_email_labels draft_email; do
 		run grep -F "\"$tool\"" "$source_file"
 		[ "$status" -eq 0 ]
 	done
 
-	for forbidden in send_message delete_message modify_label create_label delete_label update_label; do
+	for forbidden in send_email delete_email modify_email create_label delete_label update_label; do
 		run grep -F "\"$forbidden\"" "$source_file"
 		[ "$status" -eq 1 ]
 	done


### PR DESCRIPTION
## Summary

- configure Hermes Gmail MCP as a shared local stdio service using the existing Google Calendar OAuth client
- persist shared Gmail OAuth credentials on the host and expose only Gmail read/draft tools to every profile
- update bootstrap, shell/PowerShell helpers, documentation, and contract coverage

## Runtime verification

- verified Gmail access through the real Discord Gateway path for all seven profiles: default, rick, hoffman, risarisa, nancy, kuroda, and shiraishi
- each profile retrieved 25 Gmail labels
- created Gmail draft `r-8069098781393935722` with subject `Hermes Gmail MCP verification 2026-08-03 01:27 JST`; no message was sent
- restored Discord bot handling to the original configuration after verification

## Validation

- Python bootstrap suite: 567 tests passed (4 skipped)
- Bats Gmail suites: 33 tests passed
- Pester Gmail suite: 24 passed (1 skipped)
- repository pre-commit suite passed, including formatting, PowerShell, chezmoi, bootstrap container, and profile-sync provenance checks
- diff check and credential-pattern scan passed