### PR TITLE
feat: add continuous WezTerm pane resize keys

### DIFF
--- a/chezmoi/terminals/wezterm/wezterm.lua
+++ b/chezmoi/terminals/wezterm/wezterm.lua
@@ -188,10 +188,11 @@ if is_macos then
         { key = "DownArrow", mods = "LEADER", action = act.ActivatePaneDirection("Down") },
         { key = "h", mods = "LEADER", action = focus_adjacent_window("left") },
         { key = "l", mods = "LEADER", action = focus_adjacent_window("right") },
-        { key = "LeftArrow", mods = "LEADER|SHIFT", action = act.AdjustPaneSize({ "Left", 5 }) },
-        { key = "UpArrow", mods = "LEADER|SHIFT", action = act.AdjustPaneSize({ "Up", 5 }) },
-        { key = "RightArrow", mods = "LEADER|SHIFT", action = act.AdjustPaneSize({ "Right", 5 }) },
-        { key = "DownArrow", mods = "LEADER|SHIFT", action = act.AdjustPaneSize({ "Down", 5 }) },
+        -- iTerm2-style pane resize: hold Ctrl+Command and repeat Arrow
+        { key = "LeftArrow", mods = "SUPER|CTRL", action = act.AdjustPaneSize({ "Left", 1 }) },
+        { key = "UpArrow", mods = "SUPER|CTRL", action = act.AdjustPaneSize({ "Up", 1 }) },
+        { key = "RightArrow", mods = "SUPER|CTRL", action = act.AdjustPaneSize({ "Right", 1 }) },
+        { key = "DownArrow", mods = "SUPER|CTRL", action = act.AdjustPaneSize({ "Down", 1 }) },
     }
 else
     pane_control_bindings = {

--- a/docs/chezmoi/keybindings.md
+++ b/docs/chezmoi/keybindings.md
@@ -10,17 +10,18 @@
 
 ## 統一ルール
 
-| グループ                  | 役割                  | 例                                  |
-| ------------------------- | --------------------- | ----------------------------------- |
-| `Command` (WezTerm macOS) | GUI pane split        | `Command+D` / `Command+Shift+D`     |
-| `Leader` (WezTerm macOS)  | GUI pane/window 操作  | `Ctrl+Space` + key                  |
-| `Alt` (Windows GUI)       | GUI pane/window focus | `Alt+矢印`                          |
-| `Alt+Shift` (Windows GUI) | GUI pane split/resize | `Alt+Shift+=/-`、`Alt+Shift+矢印`   |
-| `Ctrl+Shift`              | GUI pane close        | `Ctrl+Shift+W`                      |
-| `Ctrl`                    | Unix/Vim/tmux focus   | `Ctrl+H/J/K/L`                      |
-| `Shift+Enter`             | 複数行入力            | AI CLI / terminal prompt 改行       |
-| `Space` (`Leader`)        | ツール機能呼び出し    | 検索、エクスプローラ、タブ操作      |
-| `Alt` (Shell)             | CLI 補助操作          | fzf/zoxide ウィジェット (`Q/D/T/R`) |
+| グループ                       | 役割                  | 例                                  |
+| ------------------------------ | --------------------- | ----------------------------------- |
+| `Command` (WezTerm macOS)      | GUI pane split        | `Command+D` / `Command+Shift+D`     |
+| `Ctrl+Command` (WezTerm macOS) | GUI pane resize       | `Ctrl+Command+矢印`                 |
+| `Leader` (WezTerm macOS)       | GUI pane/window 操作  | `Ctrl+Space` + key                  |
+| `Alt` (Windows GUI)            | GUI pane/window focus | `Alt+矢印`                          |
+| `Alt+Shift` (Windows GUI)      | GUI pane split/resize | `Alt+Shift+=/-`、`Alt+Shift+矢印`   |
+| `Ctrl+Shift`                   | GUI pane close        | `Ctrl+Shift+W`                      |
+| `Ctrl`                         | Unix/Vim/tmux focus   | `Ctrl+H/J/K/L`                      |
+| `Shift+Enter`                  | 複数行入力            | AI CLI / terminal prompt 改行       |
+| `Space` (`Leader`)             | ツール機能呼び出し    | 検索、エクスプローラ、タブ操作      |
+| `Alt` (Shell)                  | CLI 補助操作          | fzf/zoxide ウィジェット (`Q/D/T/R`) |
 
 ## 現在の適用状況
 
@@ -31,7 +32,7 @@
   - `Command+D`: 右分割
   - `Command+Shift+D`: 下分割
   - `Leader` (`Ctrl+Space`) + 矢印: ペイン移動
-  - `Leader` (`Ctrl+Space`) + `Shift+矢印`: ペイン resize
+  - `Ctrl+Command+矢印`: ペイン resize（1セル、連打・長押し対応）
   - `Ctrl+Shift+W`: ペイン close
   - `Leader` (`Ctrl+Space`) + `h/l`: WezTerm window focus
   - `Ctrl+Alt+W`: ペイン zoom
@@ -105,6 +106,6 @@
 
 - 新しいショートカットを追加する前に、この表のどのグループに属するかを先に決める
 - GUI アプリの pane split は、WezTerm macOSでは`Command+D` / `Command+Shift+D`、Windows Terminalでは`Alt+Shift`を優先する
-- WezTerm macOS の pane 移動・window focus は`Leader`、Windows Terminalでは`Alt` / `Alt+Shift`を優先する
+- WezTerm macOS の pane 移動・window focus は`Leader`、pane resize は`Ctrl+Command+矢印`、Windows Terminalでは`Alt` / `Alt+Shift`を優先する
 - tmux/Neovim など Unix/Vim 系は `Ctrl+H/J/K/L` を優先して維持する
 - `Vim` 拡張前提の操作説明は追加しない

--- a/scripts/powershell/tests/chezmoi/Keybindings.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/Keybindings.Tests.ps1
@@ -82,6 +82,7 @@ Describe '標準キーバインド方針' {
         $docs | Should -Match 'Command\+Shift\+D' -Because "macOS WezTerm should provide the second standard split shortcut"
         $docs | Should -Match 'Leader.*WezTerm' -Because "macOS WezTerm navigation should keep the leader"
         $docs | Should -Match 'Ctrl\+Space' -Because "macOS WezTerm leader should be Ctrl+Space"
+        $docs | Should -Match 'Ctrl\+Command\+矢印' -Because "macOS WezTerm resize should use a repeatable modifier chord"
         $docs | Should -Match 'Leader.*pane' -Because "macOS WezTerm leader should control panes"
         $docs | Should -Match 'Alt\+H/J/K/L' -Because "other GUI editors should keep Alt focus"
         $docs | Should -Match 'Ctrl\+H/J/K/L' -Because "Unix/Vim/tmux focus should keep the standard Ctrl+H/J/K/L layer"
@@ -123,10 +124,11 @@ Describe '標準キーバインド方針' {
         $content | Should -Match '\{ key = "RightArrow", mods = "ALT", action = act\.ActivatePaneDirection\("Right"\) \}'
         $content | Should -Match '\{ key = "DownArrow", mods = "ALT", action = act\.ActivatePaneDirection\("Down"\) \}'
 
-        $content | Should -Match '\{ key = "LeftArrow", mods = "LEADER\|SHIFT", action = act\.AdjustPaneSize\(\{ "Left", 5 \}\) \}'
-        $content | Should -Match '\{ key = "UpArrow", mods = "LEADER\|SHIFT", action = act\.AdjustPaneSize\(\{ "Up", 5 \}\) \}'
-        $content | Should -Match '\{ key = "RightArrow", mods = "LEADER\|SHIFT", action = act\.AdjustPaneSize\(\{ "Right", 5 \}\) \}'
-        $content | Should -Match '\{ key = "DownArrow", mods = "LEADER\|SHIFT", action = act\.AdjustPaneSize\(\{ "Down", 5 \}\) \}'
+        $content | Should -Match '\{ key = "LeftArrow", mods = "SUPER\|CTRL", action = act\.AdjustPaneSize\(\{ "Left", 1 \}\) \}'
+        $content | Should -Match '\{ key = "UpArrow", mods = "SUPER\|CTRL", action = act\.AdjustPaneSize\(\{ "Up", 1 \}\) \}'
+        $content | Should -Match '\{ key = "RightArrow", mods = "SUPER\|CTRL", action = act\.AdjustPaneSize\(\{ "Right", 1 \}\) \}'
+        $content | Should -Match '\{ key = "DownArrow", mods = "SUPER\|CTRL", action = act\.AdjustPaneSize\(\{ "Down", 1 \}\) \}'
+        $content | Should -Not -Match 'mods = "LEADER\|SHIFT", action = act\.AdjustPaneSize'
 
         $content | Should -Match '\{ key = "LeftArrow", mods = "ALT\|SHIFT", action = act\.AdjustPaneSize\(\{ "Left", 5 \}\) \}'
         $content | Should -Match '\{ key = "UpArrow", mods = "ALT\|SHIFT", action = act\.AdjustPaneSize\(\{ "Up", 5 \}\) \}'


### PR DESCRIPTION
## Summary

- change macOS WezTerm pane resizing from `Leader` + `Shift` + arrow to `Ctrl` + `Command` + arrow
- resize one cell per key event for smooth repeated or held input
- add Pester contracts for all four directions and removal of the old binding
- update the shared keybinding documentation

## Why

The previous leader sequence had to be re-entered for each resize operation, which made continuous pane adjustment cumbersome. The new chord follows the common macOS/iTerm2 convention and can be repeated while holding the modifiers.

## Impact

This changes only macOS WezTerm pane resizing. Pane movement, splitting, zoom, close, window focus, Windows/Linux WezTerm, and Windows Terminal bindings remain unchanged.

## Validation

- Pester keybinding tests: 7/7 passed
- `wezterm show-keys`: all four `CTRL | SUPER` directions resolve to one-cell `AdjustPaneSize`
- live repeated-input check: three inputs changed pane width by exactly three cells and the layout was restored
- full pre-commit suite passed, including formatting, PowerShell tests, chezmoi template lint, and Hermes bootstrap container tests
- task-scoped and final branch reviews found no issues