### PR TITLE
fix: reliably update macOS Homebrew casks

### DIFF
--- a/docs/nix/homebrew-cask-troubleshooting.md
+++ b/docs/nix/homebrew-cask-troubleshooting.md
@@ -1,5 +1,9 @@
 # Homebrew cask のトラブルシューティング
 
+## download の再試行
+
+`Fetching ...` で失敗した場合は `~/Library/Caches/Homebrew/downloads/*.incomplete` を手動削除せず、そのまま `nrs` を再実行します。専用 updater が Homebrew の cache を使って最大3回再試行し、最後に宣言済み cask の収束を検証します。
+
 ## WezTerm nightly の `source_glob` エラー
 
 ### 対象

--- a/docs/nix/package-management.md
+++ b/docs/nix/package-management.md
@@ -48,6 +48,8 @@ Ubuntu / Debian:  ./install.sh
 - Ubuntu/Debian は System Manager が Home Manager と system package/service を適用します。
 - NixOS は NixOS generation に Home Manager と system module を統合します。
 
+`nrs` は nix-darwin で不足 cask を導入した後、宣言済み cask を `--greedy` で更新します。各 download/upgrade は最大3回再試行され、更新前に起動していたアプリは更新後に再起動されます。未更新の cask が残る場合、`nrs` は非ゼロで終了します。
+
 その他 Linux の `DOTFILES_ALLOW_USER_ONLY=1 ./install.sh` は Home Manager のみで、Docker や OS service は管理しません。
 
 macOS で Homebrew cask の適用に失敗する場合は、

--- a/docs/superpowers/plans/2026-08-06-macos-homebrew-cask-updates.md
+++ b/docs/superpowers/plans/2026-08-06-macos-homebrew-cask-updates.md
@@ -1,0 +1,714 @@
+# macOS Homebrew Cask Updates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `nrs` reliably update every dotfiles-declared macOS Homebrew cask, including greedy casks, with bounded retries, final convergence checks, and restart of applications that were running before the update.
+
+**Architecture:** Keep nix-darwin responsible for Homebrew metadata and missing-cask installation, but disable its implicit upgrade pass. Add a testable Bash updater that reads the evaluated nix-darwin cask list, updates each outdated cask explicitly, and is invoked by `install-macos.sh` between nix-darwin activation and Docker runtime setup.
+
+**Tech Stack:** Bash 3.2-compatible shell, Bats, Nix/nix-darwin, Homebrew Bundle/Cask, jq, Taskfile, pre-commit
+
+## Global Constraints
+
+- Support Apple Silicon macOS 26 or later; do not change Linux, NixOS, WSL, or Windows behavior.
+- Update only casks declared by `darwinConfigurations.macos.config.homebrew.casks`.
+- Treat versioned, `auto_updates`, and `version = :latest` casks as convergence targets by using greedy checks.
+- Attempt each fetch or upgrade at most 3 times, waiting 2 seconds and then 4 seconds between attempts.
+- Preserve the existing dedicated `wezterm@nightly` archive installer; never pass it to the general cask updater.
+- Let Homebrew perform application termination; reopen only applications that were running before the update.
+- A cask-list evaluation error, exhausted retry, or remaining outdated cask must make `nrs` return non-zero.
+- Keep command dependencies injectable so automated tests never modify real Homebrew state or launch/quit real GUI applications.
+- Use `task commit DOTFILES_PATH="$PWD" -- "<message>"` for every implementation commit.
+
+---
+
+### Task 1: Explicit cask discovery, update, retry, and convergence
+
+**Files:**
+
+- Create: `scripts/sh/update-homebrew-casks.sh`
+- Create: `tests/bash/macos_homebrew_cask_update.bats`
+
+**Interfaces:**
+
+- Consumes: `DOTFILES_ROOT`, `DOTFILES_HOMEBREW_CASKS`, `BREW_COMMAND`, `NIX_COMMAND`, `SLEEP_COMMAND`, `DOTFILES_CASK_UPDATE_ATTEMPTS`, and `DOTFILES_CASK_UPDATE_BACKOFF_SECONDS`.
+- Produces: an executable updater whose exit code is zero only when every declared, installed cask is no longer outdated under `--greedy` semantics.
+
+- [ ] **Step 1: Create a fake Homebrew fixture and failing happy-path test**
+
+Create `tests/bash/macos_homebrew_cask_update.bats` with a real invocation of the not-yet-created script. The fake only replaces external Homebrew/Nix/sleep boundaries; assertions target the updater's exit code and command sequence.
+
+```bash
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  UPDATER="$REPO_ROOT/scripts/sh/update-homebrew-casks.sh"
+  TEST_BIN="$BATS_TEST_TMPDIR/bin"
+  BREW_STATE="$BATS_TEST_TMPDIR/brew-state"
+  COMMAND_LOG="$BATS_TEST_TMPDIR/commands.log"
+  mkdir -p "$TEST_BIN" "$BREW_STATE"
+  : >"$COMMAND_LOG"
+
+  export BREW_STATE COMMAND_LOG
+  export BREW_COMMAND="$TEST_BIN/brew"
+  export NIX_COMMAND="$TEST_BIN/nix"
+  export SLEEP_COMMAND="$TEST_BIN/sleep"
+  export JQ_COMMAND="$(command -v jq)"
+  export PGREP_COMMAND="$TEST_BIN/pgrep"
+  export OPEN_COMMAND="$TEST_BIN/open"
+  export DOTFILES_CASK_UPDATE_BACKOFF_SECONDS=2
+
+  cat >"$BREW_COMMAND" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'brew %s\n' "$*" >>"$COMMAND_LOG"
+command_name="${1:-}"
+shift || true
+cask=""
+for argument in "$@"; do cask="$argument"; done
+safe_cask="${cask//\//_}"
+counter_file="$BREW_STATE/${command_name}-${safe_cask}.count"
+count=0
+[[ ! -f $counter_file ]] || count="$(cat "$counter_file")"
+count=$((count + 1))
+printf '%s\n' "$count" >"$counter_file"
+
+case "$command_name" in
+  list)
+    [[ -f "$BREW_STATE/installed-$safe_cask" ]]
+    ;;
+  outdated)
+    [[ ! -f "$BREW_STATE/outdated-$safe_cask" ]] || printf '%s\n' "$cask"
+    ;;
+  fetch)
+    succeed_on="${BREW_FETCH_SUCCEED_ON:-1}"
+    ((count >= succeed_on))
+    ;;
+  upgrade)
+    succeed_on="${BREW_UPGRADE_SUCCEED_ON:-1}"
+    ((count >= succeed_on)) || exit 1
+    [[ ${BREW_KEEP_OUTDATED:-0} == 1 ]] || rm -f "$BREW_STATE/outdated-$safe_cask"
+    ;;
+  info)
+    printf '%s\n' '{"casks":[{"artifacts":[]}]}'
+    ;;
+  *) exit 64 ;;
+esac
+EOF
+
+  cat >"$NIX_COMMAND" <<'EOF'
+#!/usr/bin/env bash
+printf 'nix %s\n' "$*" >>"$COMMAND_LOG"
+printf '%s' "${FAKE_NIX_CASKS:-}"
+EOF
+  cat >"$SLEEP_COMMAND" <<'EOF'
+#!/usr/bin/env bash
+printf 'sleep %s\n' "$*" >>"$COMMAND_LOG"
+EOF
+  printf '#!/usr/bin/env bash\nexit 1\n' >"$PGREP_COMMAND"
+  printf '#!/usr/bin/env bash\nprintf "open %%s\\n" "$*" >>"$COMMAND_LOG"\n' >"$OPEN_COMMAND"
+  chmod +x "$BREW_COMMAND" "$NIX_COMMAND" "$SLEEP_COMMAND" "$PGREP_COMMAND" "$OPEN_COMMAND"
+}
+
+install_cask() {
+  local cask="${1//\//_}"
+  touch "$BREW_STATE/installed-$cask"
+}
+
+mark_outdated() {
+  local cask="${1//\//_}"
+  touch "$BREW_STATE/outdated-$cask"
+}
+
+@test "updates only declared casks that are outdated under greedy semantics" {
+  install_cask claude
+  install_cask google-chrome
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=$'claude\ngoogle-chrome' "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  grep -q '^brew fetch --cask claude$' "$COMMAND_LOG"
+  grep -q '^brew upgrade --cask --greedy claude$' "$COMMAND_LOG"
+  ! grep -q '^brew fetch --cask google-chrome$' "$COMMAND_LOG"
+  ! grep -q '^brew upgrade --cask --greedy google-chrome$' "$COMMAND_LOG"
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+bats tests/bash/macos_homebrew_cask_update.bats
+```
+
+Expected: FAIL because `scripts/sh/update-homebrew-casks.sh` does not exist.
+
+- [ ] **Step 3: Implement the smallest updater that passes the happy path**
+
+Create `scripts/sh/update-homebrew-casks.sh` with Bash 3.2-compatible loops and no arrays that require Bash 4.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${DOTFILES_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)}"
+BREW_COMMAND="${BREW_COMMAND:-/opt/homebrew/bin/brew}"
+NIX_COMMAND="${NIX_COMMAND:-nix}"
+SLEEP_COMMAND="${SLEEP_COMMAND:-sleep}"
+ATTEMPTS="${DOTFILES_CASK_UPDATE_ATTEMPTS:-3}"
+BACKOFF_SECONDS="${DOTFILES_CASK_UPDATE_BACKOFF_SECONDS:-2}"
+export HOMEBREW_NO_AUTO_UPDATE=1
+
+temporary_directory="$(mktemp -d)"
+cask_file="$temporary_directory/casks"
+failure_file="$temporary_directory/failures"
+: >"$failure_file"
+
+cleanup() {
+  rm -rf "$temporary_directory"
+}
+trap cleanup EXIT
+
+load_casks() {
+  if [[ ${DOTFILES_HOMEBREW_CASKS+x} == x ]]; then
+    printf '%s' "$DOTFILES_HOMEBREW_CASKS"
+    return
+  fi
+
+  "$NIX_COMMAND" eval --impure --raw \
+    "$ROOT#darwinConfigurations.macos.config.homebrew.casks" \
+    --apply 'casks: builtins.concatStringsSep "\n" (builtins.map (cask: if builtins.isString cask then cask else cask.name) casks)'
+}
+
+is_installed() {
+  "$BREW_COMMAND" list --cask --versions "$1" >/dev/null 2>&1
+}
+
+is_outdated() {
+  [[ -n $("$BREW_COMMAND" outdated --cask --greedy "$1") ]]
+}
+
+retry_command() {
+  local label="$1"
+  shift
+  local attempt delay
+  for ((attempt = 1; attempt <= ATTEMPTS; attempt++)); do
+    if "$@"; then
+      return 0
+    fi
+    if ((attempt < ATTEMPTS)); then
+      delay=$((BACKOFF_SECONDS * attempt))
+      printf '[macos-cask-update] %s failed (attempt %d/%d); retrying in %ds\n' \
+        "$label" "$attempt" "$ATTEMPTS" "$delay" >&2
+      "$SLEEP_COMMAND" "$delay"
+    fi
+  done
+  printf '[macos-cask-update] %s failed after %d attempts\n' "$label" "$ATTEMPTS" >&2
+  return 1
+}
+
+load_casks >"$cask_file"
+[[ -s $cask_file ]] || {
+  printf '[macos-cask-update] evaluated cask list is empty\n' >&2
+  exit 1
+}
+
+while IFS= read -r cask || [[ -n $cask ]]; do
+  [[ -n $cask ]] || continue
+  if ! is_installed "$cask"; then
+    printf '[macos-cask-update] declared cask is not installed: %s\n' "$cask" >&2
+    printf '%s\n' "$cask" >>"$failure_file"
+    continue
+  fi
+  is_outdated "$cask" || continue
+  if ! retry_command "fetch $cask" "$BREW_COMMAND" fetch --cask "$cask"; then
+    printf '%s\n' "$cask" >>"$failure_file"
+    continue
+  fi
+  if ! retry_command "upgrade $cask" "$BREW_COMMAND" upgrade --cask --greedy "$cask"; then
+    printf '%s\n' "$cask" >>"$failure_file"
+  fi
+done <"$cask_file"
+
+while IFS= read -r cask || [[ -n $cask ]]; do
+  [[ -n $cask ]] || continue
+  if ! is_installed "$cask" || is_outdated "$cask"; then
+    printf '[macos-cask-update] cask did not converge: %s\n' "$cask" >&2
+    grep -Fxq "$cask" "$failure_file" || printf '%s\n' "$cask" >>"$failure_file"
+  fi
+done <"$cask_file"
+
+[[ ! -s $failure_file ]]
+```
+
+Make the new entrypoint executable:
+
+```bash
+chmod +x scripts/sh/update-homebrew-casks.sh
+```
+
+- [ ] **Step 4: Add failing retry and convergence tests**
+
+Append tests with literal expectations that catch missing retry limits, wrong backoff, and missing post-upgrade verification.
+
+```bash
+@test "retries a failed fetch twice before the third attempt succeeds" {
+  install_cask docker-desktop
+  mark_outdated docker-desktop
+
+  run env DOTFILES_HOMEBREW_CASKS=docker-desktop BREW_FETCH_SUCCEED_ON=3 "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "$BREW_STATE/fetch-docker-desktop.count")" -eq 3 ]
+  grep -q '^sleep 2$' "$COMMAND_LOG"
+  grep -q '^sleep 4$' "$COMMAND_LOG"
+}
+
+@test "fails after three upgrade attempts" {
+  install_cask claude
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude BREW_UPGRADE_SUCCEED_ON=4 "$UPDATER"
+
+  [ "$status" -ne 0 ]
+  [ "$(cat "$BREW_STATE/upgrade-claude.count")" -eq 3 ]
+  [[ "$output" == *"upgrade claude failed after 3 attempts"* ]]
+}
+
+@test "fails when a successful upgrade leaves a cask outdated" {
+  install_cask visual-studio-code
+  mark_outdated visual-studio-code
+
+  run env DOTFILES_HOMEBREW_CASKS=visual-studio-code BREW_KEEP_OUTDATED=1 "$UPDATER"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cask did not converge: visual-studio-code"* ]]
+}
+
+@test "fails when nix cannot evaluate the declared cask list" {
+  cat >"$NIX_COMMAND" <<'EOF'
+#!/usr/bin/env bash
+exit 61
+EOF
+  chmod +x "$NIX_COMMAND"
+
+  run env -u DOTFILES_HOMEBREW_CASKS "$UPDATER"
+
+  [ "$status" -ne 0 ]
+  ! grep -q '^brew ' "$COMMAND_LOG"
+}
+```
+
+- [ ] **Step 5: Run focused tests and make them GREEN**
+
+Run:
+
+```bash
+bats tests/bash/macos_homebrew_cask_update.bats
+bash -n scripts/sh/update-homebrew-casks.sh
+shellcheck scripts/sh/update-homebrew-casks.sh
+```
+
+Expected: all updater Bats tests pass; syntax and ShellCheck return zero.
+
+- [ ] **Step 6: Commit the core updater**
+
+```bash
+task commit DOTFILES_PATH="$PWD" -- "feat: update declared macOS casks reliably"
+```
+
+Expected: formatter, pre-commit hooks, and commit succeed.
+
+---
+
+### Task 2: Restart applications that were running before upgrade
+
+**Files:**
+
+- Modify: `scripts/sh/update-homebrew-casks.sh`
+- Modify: `tests/bash/macos_homebrew_cask_update.bats`
+
+**Interfaces:**
+
+- Consumes: Task 1 updater plus `JQ_COMMAND`, `PGREP_COMMAND`, and `OPEN_COMMAND`.
+- Produces: `record_running_apps <cask>` and `reopen_apps`, with cleanup preserving the updater's original exit status.
+
+- [ ] **Step 1: Extend the fake boundaries and write failing restart tests**
+
+Change the fake `brew info` branch so `claude` exposes the complete app artifact shape returned by real Homebrew.
+
+```bash
+  info)
+    if [[ $cask == claude ]]; then
+      printf '%s\n' '{"casks":[{"artifacts":[{"uninstall":[{"quit":["com.anthropic.claudefordesktop"]}]},{"app":["Claude.app"],"target":"/Applications/Claude.app"}]}]}'
+    else
+      printf '%s\n' '{"casks":[{"artifacts":[]}]}'
+    fi
+    ;;
+```
+
+Make fake `pgrep` return zero only for the configured running application, then add success and failure cases.
+
+```bash
+cat >"$PGREP_COMMAND" <<'EOF'
+#!/usr/bin/env bash
+printf 'pgrep %s\n' "$*" >>"$COMMAND_LOG"
+[[ "$*" == *"${FAKE_RUNNING_APP:-never}"* ]]
+EOF
+
+@test "reopens an application that was running before a successful upgrade" {
+  install_cask claude
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude FAKE_RUNNING_APP=/Applications/Claude.app "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  grep -q '^open -gj /Applications/Claude.app$' "$COMMAND_LOG"
+}
+
+@test "reopens a running application after upgrade retries are exhausted" {
+  install_cask claude
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude FAKE_RUNNING_APP=/Applications/Claude.app \
+    BREW_UPGRADE_SUCCEED_ON=4 "$UPDATER"
+
+  [ "$status" -ne 0 ]
+  grep -q '^open -gj /Applications/Claude.app$' "$COMMAND_LOG"
+}
+
+@test "does not open an application that was not running" {
+  install_cask claude
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  ! grep -q '^open ' "$COMMAND_LOG"
+}
+```
+
+- [ ] **Step 2: Run the new tests and verify RED**
+
+Run:
+
+```bash
+bats tests/bash/macos_homebrew_cask_update.bats
+```
+
+Expected: the two running-app tests FAIL because no app paths are recorded or reopened.
+
+- [ ] **Step 3: Add app artifact discovery and exit-trap restart behavior**
+
+Add command defaults and a restart file near the updater's existing setup.
+
+```bash
+JQ_COMMAND="${JQ_COMMAND:-jq}"
+PGREP_COMMAND="${PGREP_COMMAND:-pgrep}"
+OPEN_COMMAND="${OPEN_COMMAND:-open}"
+restart_file="$temporary_directory/restart-apps"
+: >"$restart_file"
+```
+
+Add these functions before the main update loop.
+
+```bash
+record_running_apps() {
+  local cask="$1" app_path
+  while IFS= read -r app_path || [[ -n $app_path ]]; do
+    [[ -n $app_path ]] || continue
+    if "$PGREP_COMMAND" -f "$app_path/Contents/" >/dev/null 2>&1; then
+      grep -Fxq "$app_path" "$restart_file" || printf '%s\n' "$app_path" >>"$restart_file"
+    fi
+  done < <(
+    "$BREW_COMMAND" info --cask "$cask" --json=v2 |
+      "$JQ_COMMAND" -r '
+        .casks[0].artifacts[]?
+        | select(has("app"))
+        | if has("target") then .target else .app[] | "/Applications/" + . end
+      '
+  )
+}
+
+reopen_apps() {
+  local app_path
+  while IFS= read -r app_path || [[ -n $app_path ]]; do
+    [[ -n $app_path ]] || continue
+    "$OPEN_COMMAND" -gj "$app_path" ||
+      printf '[macos-cask-update] failed to reopen application: %s\n' "$app_path" >&2
+  done <"$restart_file"
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  reopen_apps || true
+  rm -rf "$temporary_directory"
+  exit "$status"
+}
+```
+
+Call `record_running_apps "$cask"` immediately after `is_outdated "$cask" || continue` and before prefetching. Keep Homebrew responsible for quitting applications; do not add `kill`, `pkill`, or `osascript` termination logic.
+
+- [ ] **Step 4: Run focused and syntax tests and make them GREEN**
+
+Run:
+
+```bash
+bats tests/bash/macos_homebrew_cask_update.bats
+bash -n scripts/sh/update-homebrew-casks.sh
+shellcheck scripts/sh/update-homebrew-casks.sh tests/bash/macos_homebrew_cask_update.bats
+```
+
+Expected: all restart, retry, error, and convergence cases pass with no lint findings.
+
+- [ ] **Step 5: Perform the mutation check**
+
+Temporarily change `"$OPEN_COMMAND" -gj "$app_path"` to `:` and rerun the Bats file. Expected: the two running-app tests fail. Revert the temporary mutation before continuing.
+
+- [ ] **Step 6: Commit application lifecycle handling**
+
+```bash
+task commit DOTFILES_PATH="$PWD" -- "feat: restore apps after macOS cask updates"
+```
+
+---
+
+### Task 3: Integrate the updater into `nrs` and split nix-darwin responsibilities
+
+**Files:**
+
+- Modify: `scripts/sh/install-macos.sh`
+- Modify: `nix/darwin/default.nix`
+- Modify: `tests/bash/install_macos.bats`
+- Modify: `tests/bash/macos_config.bats`
+
+**Interfaces:**
+
+- Consumes: Task 2 executable updater.
+- Produces: `DOTFILES_HOMEBREW_CASK_UPDATER` override and this runtime order: nix-darwin switch → cask updater → Docker runtime → chezmoi/Hermes verification.
+
+- [ ] **Step 1: Write failing installer-order and failure-propagation tests**
+
+In `tests/bash/install_macos.bats` setup, configure a fake updater.
+
+```bash
+export DOTFILES_HOMEBREW_CASK_UPDATER="$STUB_BIN/update-homebrew-casks"
+export HOMEBREW_CASK_UPDATE_STATUS=0
+write_stub update-homebrew-casks '
+printf "update-homebrew-casks %s\n" "$*" >>"$COMMAND_LOG"
+exit "$HOMEBREW_CASK_UPDATE_STATUS"
+'
+```
+
+Extend the existing installed-prerequisites order assertion so the cask updater must run after nix-darwin and before Docker/chezmoi.
+
+```bash
+assert_log_order \
+  "nix run .#darwin-rebuild -- switch --flake .#macos --impure" \
+  "update-homebrew-casks " \
+  "docker info" \
+  "chezmoi init --source $REPO_ROOT/chezmoi"
+```
+
+Add the failure case.
+
+```bash
+@test "cask update failure stops macOS before Docker runtime and chezmoi" {
+  write_installed_stubs
+  export HOMEBREW_CASK_UPDATE_STATUS=47
+
+  run "$INSTALLER"
+
+  [ "$status" -eq 47 ]
+  grep -q '^update-homebrew-casks ' "$COMMAND_LOG"
+  ! grep -q '^chezmoi ' "$COMMAND_LOG"
+  ! grep -q '^verify-environment ' "$COMMAND_LOG"
+}
+```
+
+- [ ] **Step 2: Write failing evaluated nix-darwin contract test**
+
+Replace the source-grep test named `Darwin activation updates cask metadata without forcing latest cask upgrades` in `tests/bash/macos_config.bats` with an evaluated contract.
+
+```bash
+@test "Darwin separates missing-cask installation from explicit greedy upgrades" {
+  command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
+
+  run env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex \
+    nix eval --impure --json --expr "
+      let config = (builtins.getFlake (toString $REPO_ROOT)).darwinConfigurations.macos.config;
+      in {
+        inherit (config.homebrew) greedyCasks;
+        inherit (config.homebrew.onActivation) autoUpdate upgrade;
+      }
+    "
+
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"autoUpdate":true,"greedyCasks":true,"upgrade":false}' ]
+}
+```
+
+- [ ] **Step 3: Run the integration tests and verify RED**
+
+Run:
+
+```bash
+bats tests/bash/install_macos.bats tests/bash/macos_config.bats
+```
+
+Expected: FAIL because `install-macos.sh` does not invoke the updater and nix-darwin still evaluates to `greedyCasks = false`, `upgrade = true`.
+
+- [ ] **Step 4: Integrate the updater after nix-darwin activation**
+
+Add the command override next to the other `install-macos.sh` path settings.
+
+```bash
+HOMEBREW_CASK_UPDATER="${DOTFILES_HOMEBREW_CASK_UPDATER:-$ROOT/scripts/sh/update-homebrew-casks.sh}"
+```
+
+Add it to `preflight` required paths and call it in `main` at the approved boundary.
+
+```bash
+  apply_darwin_system
+  "$HOMEBREW_CASK_UPDATER"
+  setup_docker_runtime
+```
+
+Do not run the updater through `sudo`; Homebrew and application processes belong to `DOTFILES_USER`.
+
+- [ ] **Step 5: Change nix-darwin's Homebrew contract**
+
+Modify `nix/darwin/default.nix`:
+
+```nix
+    greedyCasks = true;
+    onActivation = {
+      autoUpdate = true;
+      upgrade = false;
+      cleanup = "none";
+    };
+```
+
+Update the nearby comment to state that nix-darwin installs missing casks and `update-homebrew-casks.sh` performs explicit greedy upgrades with retries and verification.
+
+- [ ] **Step 6: Run integration and focused updater tests and make them GREEN**
+
+Run:
+
+```bash
+bats tests/bash/macos_homebrew_cask_update.bats tests/bash/install_macos.bats tests/bash/macos_config.bats
+bash -n scripts/sh/install-macos.sh scripts/sh/update-homebrew-casks.sh
+shellcheck scripts/sh/install-macos.sh scripts/sh/update-homebrew-casks.sh tests/bash/macos_homebrew_cask_update.bats
+```
+
+Expected: all tests and shell checks pass.
+
+- [ ] **Step 7: Evaluate the generated activation command**
+
+Run:
+
+```bash
+system_path="$(DOTFILES_USER=ktome1995 DOTFILES_HOME=/Users/ktome1995 nix build --impure --no-link --print-out-paths .#darwinConfigurations.macos.system)"
+rg -n -C 2 'brew bundle' "$system_path/activate"
+```
+
+Expected: the generated Homebrew activation invokes `brew bundle --no-upgrade`; it must not perform the implicit upgrade pass.
+
+- [ ] **Step 8: Commit `nrs` integration**
+
+```bash
+task commit DOTFILES_PATH="$PWD" -- "fix: converge macOS casks during nrs"
+```
+
+---
+
+### Task 4: Document, run the complete regression suite, and perform the macOS smoke test
+
+**Files:**
+
+- Modify: `docs/nix/package-management.md`
+- Modify: `docs/nix/homebrew-cask-troubleshooting.md`
+
+**Interfaces:**
+
+- Consumes: the integrated updater from Tasks 1–3.
+- Produces: user-facing `nrs` behavior documentation and final verification evidence.
+
+- [ ] **Step 1: Document the new update and failure semantics**
+
+Add this behavior to the macOS section of `docs/nix/package-management.md`:
+
+```markdown
+`nrs` は nix-darwin で不足 cask を導入した後、宣言済み cask を `--greedy` で更新します。各 download/upgrade は最大3回再試行され、更新前に起動していたアプリは更新後に再起動されます。未更新の cask が残る場合、`nrs` は非ゼロで終了します。
+```
+
+Add recovery guidance to `docs/nix/homebrew-cask-troubleshooting.md`:
+
+```markdown
+`Fetching ...` で失敗した場合は `~/Library/Caches/Homebrew/downloads/*.incomplete` を手動削除せず、そのまま `nrs` を再実行します。専用 updater が Homebrew の cache を使って最大3回再試行し、最後に宣言済み cask の収束を検証します。
+```
+
+- [ ] **Step 2: Run the full automated validation**
+
+Run:
+
+```bash
+task test:bash DOTFILES_PATH="$PWD"
+pre-commit run --all-files
+git diff --check
+```
+
+Expected: all 150 existing Bats tests plus the new tests pass, all pre-commit hooks pass, and `git diff --check` emits no output.
+
+- [ ] **Step 3: Review the complete diff against the design**
+
+Run:
+
+```bash
+git diff main...HEAD --stat
+git diff main...HEAD -- \
+  nix/darwin/default.nix \
+  scripts/sh/install-macos.sh \
+  scripts/sh/update-homebrew-casks.sh \
+  tests/bash/install_macos.bats \
+  tests/bash/macos_config.bats \
+  tests/bash/macos_homebrew_cask_update.bats \
+  docs/nix/package-management.md \
+  docs/nix/homebrew-cask-troubleshooting.md
+```
+
+Expected: no unrelated changes; every design success criterion maps to code or a behavioral test.
+
+- [ ] **Step 4: Commit documentation**
+
+```bash
+task commit DOTFILES_PATH="$PWD" -- "docs: explain macOS cask convergence"
+```
+
+- [ ] **Step 5: Run the real macOS smoke test only after warning about app termination**
+
+Because this step updates and quits GUI applications, first notify the user that Claude, Docker Desktop, Orca, Chrome, VS Code, or other declared casks may close and reopen. Then run from a terminal that is not hosted by an application being upgraded:
+
+```bash
+./install.sh
+HOMEBREW_NO_AUTO_UPDATE=1 /opt/homebrew/bin/brew outdated --cask --greedy \
+  1password claude thebrowsercompany-dia docker-desktop google-chrome \
+  stablyai/orca/orca raycast tableplus visual-studio-code
+```
+
+Expected: `./install.sh` completes through `[macos-install] macOS setup complete.` and the final `brew outdated` command prints nothing. `wezterm@nightly` is intentionally absent from this command because its dedicated archive installer owns it.
+
+- [ ] **Step 6: Record final workspace state**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline main..HEAD
+```
+
+Expected: clean worktree with the design, updater, lifecycle, integration, and documentation commits present.

--- a/docs/superpowers/specs/2026-08-06-macos-homebrew-cask-updates-design.md
+++ b/docs/superpowers/specs/2026-08-06-macos-homebrew-cask-updates-design.md
@@ -1,0 +1,142 @@
+# macOS Homebrew Cask Updates Design
+
+## Goal
+
+`nrs` が nix-darwin の適用だけで完了したように見える状態をなくし、dotfiles で宣言した macOS デスクトップアプリを確実に更新する。
+
+成功条件は次のとおり。
+
+- 通常の versioned cask と、`auto_updates` または `version = :latest` を持つ greedy cask の両方を更新する。
+- 大きな cask のダウンロードが一時的に失敗しても最大 3 回再試行する。
+- 更新前に起動していたアプリは Homebrew に終了を委譲し、更新後または失敗時に再起動する。
+- 更新後に宣言済み cask が古いままなら `nrs` を成功扱いにしない。
+- `wezterm@nightly` は既存の専用インストーラーで管理し、一般 cask 更新には混ぜない。
+- 初回 bootstrap と再実行の両方で同じ `install.sh` entrypoint を維持する。
+
+## Root Cause
+
+nix-darwin の現在の Homebrew activation は `brew bundle` を 1 回実行する。`homebrew.onActivation.upgrade = true` は暗黙の upgrade 動作に依存しているため、ログには `Fetching ...` しか出ず、どの cask のダウンロードまたは更新で停止したかが分かりにくい。
+
+今回の実行では Docker Desktop の DMG が約 183 MB の `.incomplete` ファイルとして残り、`brew bundle` が upgrade に到達しなかった。`/run/current-system` も古い Brewfile の generation のままであり、`nrs` 全体が完了していない。一方、`brew outdated --cask` は Claude、Docker Desktop、Orca、Visual Studio Code を通常の更新対象として検出している。
+
+さらに `greedyCasks = false` のため、通常の `brew outdated --cask` では Google Chrome のような自動更新型 cask が除外される。したがって、ダウンロードが成功しても全デスクトップアプリの収束条件にはならない。
+
+## Scope
+
+### In scope
+
+- nix-darwin の Homebrew activation を「不足 cask の導入」と「明示的な cask 更新」に分離する。
+- 宣言済み cask 名を nix-darwin configuration から取得する。
+- cask ごとの prefetch、upgrade、再試行、最終検証を行う shell script を追加する。
+- 起動中だったアプリを更新後または失敗時に再起動する。
+- `install-macos.sh` の macOS 収束フローに更新処理を追加する。
+- Bats で成功、再試行、恒久的失敗、未更新検出、アプリ再起動を検証する。
+- macOS 設定契約テストを新しい責務分離へ更新する。
+
+### Out of scope
+
+- Homebrew で管理していない `/Applications` 配下のアプリ更新。
+- Mac App Store アプリの更新。
+- `wezterm@nightly` の既存 archive layout workaround の廃止。
+- Homebrew tap、formula、cask catalog の全面再設計。
+- GUI updater や LaunchAgent によるバックグラウンド更新。
+- `nrs` 実行中のアプリ作業内容の保存。
+
+## Architecture
+
+### nix-darwin Homebrew activation
+
+`nix/darwin/default.nix` は `homebrew.onActivation.autoUpdate = true` を維持し、tap と cask metadata を更新する。`homebrew.onActivation.upgrade` は `false` に変更し、nix-darwin が生成する `brew bundle --no-upgrade` には不足 cask の導入だけを担当させる。
+
+`greedyCasks = true` に変更し、生成される Brewfile と設定契約に auto-update cask も収束対象であることを明示する。ただし実際の更新は後段の専用スクリプトが `--greedy` を付けて行う。
+
+### `scripts/sh/update-homebrew-casks.sh`
+
+このスクリプトは通常ユーザー権限で実行し、次の責務だけを持つ。
+
+1. `nix eval` で `darwinConfigurations.macos.config.homebrew.casks` の cask 名を改行区切りで取得する。
+2. 各宣言済み cask を `brew outdated --cask --greedy` で判定する。
+3. 更新対象ごとに `brew fetch --cask` を最大 3 回実行し、未完了ダウンロードを再開する。
+4. cask の app artifact が実行中なら、その app path を再起動リストへ記録する。
+5. `brew upgrade --cask --greedy` を cask ごとに最大 3 回実行する。アプリ終了は Homebrew の cask artifact 処理に委譲する。
+6. 宣言済み cask に outdated が残っていないことを再検査する。
+7. trap で、更新前に実行中だったアプリを成功・失敗のどちらでも再起動する。
+
+再試行は初回を含めて 3 回とし、試行間は 2 秒、4 秒の待機とする。cask ごとに処理することで、失敗した cask 名と段階をログへ明示する。
+
+テストでは実マシンの Homebrew や GUI を変更しないように、`BREW_COMMAND`、`NIX_COMMAND`、`OPEN_COMMAND`、`PGREP_COMMAND`、`SLEEP_COMMAND` と cask list override を環境変数で差し替えられるようにする。本番の既定値は macOS の実コマンドと nix-darwin configuration を使う。
+
+### `scripts/sh/install-macos.sh`
+
+macOS の順序を次のようにする。
+
+1. Docker Desktop を停止する。
+2. nix-darwin を適用し、不足 cask と Home Manager を収束させる。
+3. 専用 cask updater を通常ユーザーとして実行する。
+4. Docker Desktop runtime をセットアップまたは再起動する。
+5. chezmoi、Hermes、runtime verification を続行する。
+
+cask updater が失敗した場合は `set -e` により Docker、chezmoi、Hermes の後続処理へ進まず、`nrs` を非ゼロで終了する。
+
+## Data Flow
+
+1. `nrs` alias が `~/.dotfiles/install.sh` を起動する。
+2. `install.sh` が Apple Silicon macOS を判定し、`install-macos.sh` へ委譲する。
+3. nix-darwin が最新 metadata で不足 cask を導入するが、既存 cask の upgrade は行わない。
+4. updater が同じ flake configuration から宣言済み cask 名を読み出す。
+5. updater が outdated 判定、prefetch、upgrade、検証を cask ごとに実行する。
+6. updater が起動中だったアプリを再度開く。
+7. 未更新がゼロの場合だけ残りの macOS setup を続行する。
+
+宣言元を `sets.darwinCasks` と shell の二重管理にはしない。updater は評価済み nix-darwin configuration を読むため、cask の追加・削除がそのまま更新対象へ反映される。
+
+## Error Handling
+
+- cask list の評価に失敗した場合は更新対象なしとして扱わず、即座に失敗する。
+- `brew fetch` または `brew upgrade` が失敗した場合は、cask 名、処理段階、試行回数を stderr へ出して再試行する。
+- 3 回失敗した cask が 1 つでもあれば、他の再起動処理を済ませた後に非ゼロで終了する。
+- upgrade command が成功しても cask が outdated のままなら検証失敗にする。
+- updater の途中終了でも trap を通じて記録済みアプリの再起動を試みる。再起動失敗は元の更新エラーを隠さない。
+- Docker Desktop は既存の `setup_docker_runtime` が起動と engine readiness を保証する。
+- `wezterm@nightly` は nix-darwin の cask list から除外済みのため updater 対象にならず、既存の `install-wezterm-nightly.sh` が扱う。
+
+## Testing
+
+### Behavioral Bats tests
+
+`tests/bash/macos_homebrew_cask_update.bats` で fake command を使い、次を検証する。
+
+- 宣言済みで outdated な cask だけを `fetch` と `upgrade --greedy` に渡す。
+- fetch が 2 回失敗して 3 回目に成功した場合、upgrade と最終検証まで進む。
+- upgrade が 3 回失敗した場合、スクリプトは非ゼロで終了し、cask 名と試行回数を報告する。
+- upgrade command 成功後も outdated が残る場合、スクリプトは非ゼロで終了する。
+- 更新前に実行中だった app artifact は成功時に再起動する。
+- 更新失敗時にも記録済み app artifact の再起動を試みる。
+- cask list 評価失敗は「更新なし」と誤認せず失敗する。
+
+### Configuration contract tests
+
+`tests/bash/macos_config.bats` で次を検証する。
+
+- `greedyCasks = true` である。
+- `autoUpdate = true` と `upgrade = false` の責務分離になっている。
+- `install-macos.sh` が nix-darwin 適用後、Docker runtime 起動前に updater を呼ぶ。
+- updater が `wezterm@nightly` を直接管理しない。
+
+### Validation
+
+- updater の Bats test
+- `tests/bash/macos_config.bats`
+- Bash syntax check と ShellCheck
+- `task test:bash DOTFILES_PATH="$PWD"`
+- `nix fmt -- --check` 相当の repository formatting check
+- `nix eval --impure` による macOS configuration 評価
+- 実行前後の `brew outdated --cask --greedy` と `brew bundle check` による macOS smoke test
+
+実 macOS smoke test はアプリを終了するため、実装検証の最後に実行し、Orca を含む作業セッションへの影響を事前に通知する。
+
+## Migration and Rollback
+
+次回の `nrs` から新しい updater が自動実行される。既存の Homebrew installation と Caskroom を再作成せず、outdated cask だけを更新する。残っている `.incomplete` download は Homebrew の fetch に再利用または置換させる。
+
+rollback は `install-macos.sh` から updater 呼び出しを外し、`greedyCasks = false`、`onActivation.upgrade = true` に戻すことで可能。cask 更新自体は通常の Homebrew upgrade なので、rollback 時にアプリ version を downgrade しない。

--- a/nix/darwin/default.nix
+++ b/nix/darwin/default.nix
@@ -109,13 +109,12 @@ in
     # source_glob preflight. Install it from the archive in an activation
     # script while retaining the catalog entry for provider reporting.
     casks = builtins.filter (cask: cask != "wezterm@nightly") sets.darwinCasks;
-    # Nightly casks use version = :latest. Do not force an upgrade on every
-    # activation while the upstream archive layout is not stable; regular
-    # versioned casks still upgrade through onActivation.upgrade.
-    greedyCasks = false;
+    # nix-darwin installs missing casks. Explicit greedy upgrades, retries,
+    # and verification are handled by update-homebrew-casks.sh.
+    greedyCasks = true;
     onActivation = {
       autoUpdate = true;
-      upgrade = true;
+      upgrade = false;
       cleanup = "none";
     };
   };

--- a/scripts/sh/install-macos.sh
+++ b/scripts/sh/install-macos.sh
@@ -14,6 +14,7 @@ DOCKER_APP="${DOTFILES_DOCKER_APP_PATH:-/Applications/Docker.app}"
 DOCKER_SETUP_MARKER="${DOTFILES_DOCKER_SETUP_MARKER:-$HOME/.config/dotfiles/docker-desktop-installed}"
 DOCKER_WAIT_ATTEMPTS="${DOTFILES_DOCKER_WAIT_ATTEMPTS:-120}"
 VERIFY_ENVIRONMENT="${DOTFILES_VERIFY_ENVIRONMENT:-$ROOT/scripts/sh/verify-environment.sh}"
+HOMEBREW_CASK_UPDATER="${DOTFILES_HOMEBREW_CASK_UPDATER:-$ROOT/scripts/sh/update-homebrew-casks.sh}"
 BASHRC_PATH="${DOTFILES_BASHRC_PATH:-/etc/bashrc}"
 ZSHRC_PATH="${DOTFILES_ZSHRC_PATH:-/etc/zshrc}"
 USER_PROFILE_ROOT="${DOTFILES_USER_PROFILE_ROOT:-/etc/profiles/per-user}"
@@ -34,6 +35,7 @@ preflight() {
     "$ROOT/flake.nix" \
     "$ROOT/chezmoi" \
     "$COMPOSE_FILE" \
+    "$HOMEBREW_CASK_UPDATER" \
     "$VERIFY_ENVIRONMENT"; do
     [[ -e $required ]] || dotfiles_die "Required repository path is missing: $required"
   done
@@ -148,6 +150,7 @@ main() {
   preserve_shell_rc_for_nix_darwin
   stop_existing_docker_desktop
   apply_darwin_system
+  "$HOMEBREW_CASK_UPDATER"
   setup_docker_runtime
   apply_chezmoi
   dotfiles_hermes_start_stack docker "$DOTFILES_ROOT/docker/hermes-agent/compose.yml"

--- a/scripts/sh/update-homebrew-casks.sh
+++ b/scripts/sh/update-homebrew-casks.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${DOTFILES_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)}"
+BREW_COMMAND="${BREW_COMMAND:-/opt/homebrew/bin/brew}"
+NIX_COMMAND="${NIX_COMMAND:-nix}"
+SLEEP_COMMAND="${SLEEP_COMMAND:-sleep}"
+ATTEMPTS="${DOTFILES_CASK_UPDATE_ATTEMPTS:-3}"
+BACKOFF_SECONDS="${DOTFILES_CASK_UPDATE_BACKOFF_SECONDS:-2}"
+export HOMEBREW_NO_AUTO_UPDATE=1
+
+temporary_directory="$(mktemp -d)"
+cask_file="$temporary_directory/casks"
+failure_file="$temporary_directory/failures"
+: >"$failure_file"
+
+cleanup() {
+  rm -rf "$temporary_directory"
+}
+trap cleanup EXIT
+
+load_casks() {
+  if [[ ${DOTFILES_HOMEBREW_CASKS+x} == x ]]; then
+    printf '%s' "$DOTFILES_HOMEBREW_CASKS"
+    return
+  fi
+
+  "$NIX_COMMAND" eval --impure --raw \
+    "$ROOT#darwinConfigurations.macos.config.homebrew.casks" \
+    --apply 'casks: builtins.concatStringsSep "\n" (builtins.map (cask: if builtins.isString cask then cask else cask.name) casks)'
+}
+
+is_installed() {
+  "$BREW_COMMAND" list --cask --versions "$1" >/dev/null 2>&1
+}
+
+is_outdated() {
+  [[ -n $("$BREW_COMMAND" outdated --cask --greedy "$1") ]]
+}
+
+retry_command() {
+  local label="$1"
+  shift
+  local attempt delay
+  for ((attempt = 1; attempt <= ATTEMPTS; attempt++)); do
+    if "$@"; then
+      return 0
+    fi
+    if ((attempt < ATTEMPTS)); then
+      delay=$((BACKOFF_SECONDS * attempt))
+      printf '[macos-cask-update] %s failed (attempt %d/%d); retrying in %ds\n' \
+        "$label" "$attempt" "$ATTEMPTS" "$delay" >&2
+      "$SLEEP_COMMAND" "$delay"
+    fi
+  done
+  printf '[macos-cask-update] %s failed after %d attempts\n' "$label" "$ATTEMPTS" >&2
+  return 1
+}
+
+load_casks >"$cask_file"
+[[ -s $cask_file ]] || {
+  printf '[macos-cask-update] evaluated cask list is empty\n' >&2
+  exit 1
+}
+
+while IFS= read -r cask || [[ -n $cask ]]; do
+  [[ -n $cask ]] || continue
+  if ! is_installed "$cask"; then
+    printf '[macos-cask-update] declared cask is not installed: %s\n' "$cask" >&2
+    printf '%s\n' "$cask" >>"$failure_file"
+    continue
+  fi
+  is_outdated "$cask" || continue
+  if ! retry_command "fetch $cask" "$BREW_COMMAND" fetch --cask "$cask"; then
+    printf '%s\n' "$cask" >>"$failure_file"
+    continue
+  fi
+  if ! retry_command "upgrade $cask" "$BREW_COMMAND" upgrade --cask --greedy "$cask"; then
+    printf '%s\n' "$cask" >>"$failure_file"
+  fi
+done <"$cask_file"
+
+while IFS= read -r cask || [[ -n $cask ]]; do
+  [[ -n $cask ]] || continue
+  if ! is_installed "$cask" || is_outdated "$cask"; then
+    printf '[macos-cask-update] cask did not converge: %s\n' "$cask" >&2
+    grep -Fxq "$cask" "$failure_file" || printf '%s\n' "$cask" >>"$failure_file"
+  fi
+done <"$cask_file"
+
+[[ ! -s $failure_file ]]

--- a/scripts/sh/update-homebrew-casks.sh
+++ b/scripts/sh/update-homebrew-casks.sh
@@ -9,6 +9,21 @@ ATTEMPTS="${DOTFILES_CASK_UPDATE_ATTEMPTS:-3}"
 BACKOFF_SECONDS="${DOTFILES_CASK_UPDATE_BACKOFF_SECONDS:-2}"
 export HOMEBREW_NO_AUTO_UPDATE=1
 
+case "$ATTEMPTS" in
+1 | 2 | 3) ;;
+*)
+  printf '[macos-cask-update] DOTFILES_CASK_UPDATE_ATTEMPTS must be an integer between 1 and 3: %s\n' \
+    "$ATTEMPTS" >&2
+  exit 2
+  ;;
+esac
+
+if [[ $BACKOFF_SECONDS != 2 ]]; then
+  printf '[macos-cask-update] DOTFILES_CASK_UPDATE_BACKOFF_SECONDS must be 2: %s\n' \
+    "$BACKOFF_SECONDS" >&2
+  exit 2
+fi
+
 temporary_directory="$(mktemp -d)"
 cask_file="$temporary_directory/casks"
 failure_file="$temporary_directory/failures"
@@ -34,8 +49,18 @@ is_installed() {
   "$BREW_COMMAND" list --cask --versions "$1" >/dev/null 2>&1
 }
 
-is_outdated() {
-  [[ -n $("$BREW_COMMAND" outdated --cask --greedy "$1") ]]
+OUTDATED_OUTPUT=""
+OUTDATED_STATUS=0
+
+check_outdated() {
+  local cask="$1"
+  if OUTDATED_OUTPUT=$("$BREW_COMMAND" outdated --cask --greedy "$cask"); then
+    OUTDATED_STATUS=0
+  else
+    OUTDATED_STATUS=$?
+    printf '[macos-cask-update] failed to check outdated status for %s (status %d)\n' \
+      "$cask" "$OUTDATED_STATUS" >&2
+  fi
 }
 
 retry_command() {
@@ -70,7 +95,12 @@ while IFS= read -r cask || [[ -n $cask ]]; do
     printf '%s\n' "$cask" >>"$failure_file"
     continue
   fi
-  is_outdated "$cask" || continue
+  check_outdated "$cask"
+  if ((OUTDATED_STATUS != 0)); then
+    printf '%s\n' "$cask" >>"$failure_file"
+    continue
+  fi
+  [[ -n $OUTDATED_OUTPUT ]] || continue
   if ! retry_command "fetch $cask" "$BREW_COMMAND" fetch --cask "$cask"; then
     printf '%s\n' "$cask" >>"$failure_file"
     continue
@@ -82,7 +112,13 @@ done <"$cask_file"
 
 while IFS= read -r cask || [[ -n $cask ]]; do
   [[ -n $cask ]] || continue
-  if ! is_installed "$cask" || is_outdated "$cask"; then
+  if is_installed "$cask"; then
+    check_outdated "$cask"
+  else
+    OUTDATED_STATUS=0
+    OUTDATED_OUTPUT="$cask"
+  fi
+  if ((OUTDATED_STATUS != 0)) || [[ -n $OUTDATED_OUTPUT ]]; then
     printf '[macos-cask-update] cask did not converge: %s\n' "$cask" >&2
     grep -Fxq "$cask" "$failure_file" || printf '%s\n' "$cask" >>"$failure_file"
   fi

--- a/scripts/sh/update-homebrew-casks.sh
+++ b/scripts/sh/update-homebrew-casks.sh
@@ -92,20 +92,28 @@ retry_command() {
 }
 
 record_running_apps() {
-  local cask="$1" app_path
+  local cask="$1" app_path status app_file
+  app_file="$temporary_directory/app-paths"
+  if "$BREW_COMMAND" info --cask "$cask" --json=v2 |
+    "$JQ_COMMAND" -r '
+      .casks[0].artifacts[]?
+      | select(has("app"))
+      | if has("target") then .target else .app[] | "/Applications/" + . end
+    ' >"$app_file"; then
+    :
+  else
+    status=$?
+    printf '[macos-cask-update] failed to inspect application artifacts for %s (status %d)\n' \
+      "$cask" "$status" >&2
+    return "$status"
+  fi
+
   while IFS= read -r app_path || [[ -n $app_path ]]; do
     [[ -n $app_path ]] || continue
     if "$PGREP_COMMAND" -f "$app_path/Contents/" >/dev/null 2>&1; then
       grep -Fxq "$app_path" "$restart_file" || printf '%s\n' "$app_path" >>"$restart_file"
     fi
-  done < <(
-    "$BREW_COMMAND" info --cask "$cask" --json=v2 |
-      "$JQ_COMMAND" -r '
-        .casks[0].artifacts[]?
-        | select(has("app"))
-        | if has("target") then .target else .app[] | "/Applications/" + . end
-      '
-  )
+  done <"$app_file"
 }
 
 reopen_apps() {
@@ -136,7 +144,10 @@ while IFS= read -r cask || [[ -n $cask ]]; do
     continue
   fi
   [[ -n $OUTDATED_OUTPUT ]] || continue
-  record_running_apps "$cask"
+  if ! record_running_apps "$cask"; then
+    printf '%s\n' "$cask" >>"$failure_file"
+    continue
+  fi
   if ! retry_command "fetch $cask" "$BREW_COMMAND" fetch --cask "$cask"; then
     printf '%s\n' "$cask" >>"$failure_file"
     continue

--- a/scripts/sh/update-homebrew-casks.sh
+++ b/scripts/sh/update-homebrew-casks.sh
@@ -5,6 +5,9 @@ ROOT="${DOTFILES_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)}"
 BREW_COMMAND="${BREW_COMMAND:-/opt/homebrew/bin/brew}"
 NIX_COMMAND="${NIX_COMMAND:-nix}"
 SLEEP_COMMAND="${SLEEP_COMMAND:-sleep}"
+JQ_COMMAND="${JQ_COMMAND:-jq}"
+PGREP_COMMAND="${PGREP_COMMAND:-pgrep}"
+OPEN_COMMAND="${OPEN_COMMAND:-open}"
 ATTEMPTS="${DOTFILES_CASK_UPDATE_ATTEMPTS:-3}"
 BACKOFF_SECONDS="${DOTFILES_CASK_UPDATE_BACKOFF_SECONDS:-2}"
 export HOMEBREW_NO_AUTO_UPDATE=1
@@ -27,10 +30,16 @@ fi
 temporary_directory="$(mktemp -d)"
 cask_file="$temporary_directory/casks"
 failure_file="$temporary_directory/failures"
+restart_file="$temporary_directory/restart-apps"
 : >"$failure_file"
+: >"$restart_file"
 
 cleanup() {
+  local status=$?
+  trap - EXIT
+  reopen_apps || true
   rm -rf "$temporary_directory"
+  exit "$status"
 }
 trap cleanup EXIT
 
@@ -82,6 +91,32 @@ retry_command() {
   return 1
 }
 
+record_running_apps() {
+  local cask="$1" app_path
+  while IFS= read -r app_path || [[ -n $app_path ]]; do
+    [[ -n $app_path ]] || continue
+    if "$PGREP_COMMAND" -f "$app_path/Contents/" >/dev/null 2>&1; then
+      grep -Fxq "$app_path" "$restart_file" || printf '%s\n' "$app_path" >>"$restart_file"
+    fi
+  done < <(
+    "$BREW_COMMAND" info --cask "$cask" --json=v2 |
+      "$JQ_COMMAND" -r '
+        .casks[0].artifacts[]?
+        | select(has("app"))
+        | if has("target") then .target else .app[] | "/Applications/" + . end
+      '
+  )
+}
+
+reopen_apps() {
+  local app_path
+  while IFS= read -r app_path || [[ -n $app_path ]]; do
+    [[ -n $app_path ]] || continue
+    "$OPEN_COMMAND" -gj "$app_path" ||
+      printf '[macos-cask-update] failed to reopen application: %s\n' "$app_path" >&2
+  done <"$restart_file"
+}
+
 load_casks >"$cask_file"
 [[ -s $cask_file ]] || {
   printf '[macos-cask-update] evaluated cask list is empty\n' >&2
@@ -101,6 +136,7 @@ while IFS= read -r cask || [[ -n $cask ]]; do
     continue
   fi
   [[ -n $OUTDATED_OUTPUT ]] || continue
+  record_running_apps "$cask"
   if ! retry_command "fetch $cask" "$BREW_COMMAND" fetch --cask "$cask"; then
     printf '%s\n' "$cask" >>"$failure_file"
     continue

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -188,7 +188,13 @@ EOF
 #!/usr/bin/env bash
 printf 'verify-environment %s\n' "$*" >>"$COMMAND_LOG"
 EOF
-	chmod +x "$MOCK_REPO/install.sh" "$MOCK_REPO/scripts/sh/verify-environment.sh"
+	cat >"$MOCK_REPO/scripts/sh/update-homebrew-casks.sh" <<'EOF'
+#!/usr/bin/env bash
+printf 'update-homebrew-casks %s\n' "$*" >>"$COMMAND_LOG"
+EOF
+	chmod +x "$MOCK_REPO/install.sh" \
+		"$MOCK_REPO/scripts/sh/update-homebrew-casks.sh" \
+		"$MOCK_REPO/scripts/sh/verify-environment.sh"
 
 	write_fixture_stub uname '
 case "${1:-}" in

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -37,6 +37,8 @@ setup() {
 	export DOTFILES_DOCKER_WAIT_ATTEMPTS=2
 	export DOTFILES_WAIT_SLEEP_SECONDS=0
 	export DOTFILES_VERIFY_ENVIRONMENT="$STUB_BIN/verify-environment"
+	export DOTFILES_HOMEBREW_CASK_UPDATER="$STUB_BIN/update-homebrew-casks"
+	export HOMEBREW_CASK_UPDATE_STATUS=0
 
 	write_stub uname '
 case "${1:-}" in
@@ -68,6 +70,10 @@ printf "sudo %s\n" "$*" >>"$COMMAND_LOG"
 exec "$@"
 '
 	write_stub verify-environment 'printf "verify-environment %s\n" "$*" >>"$COMMAND_LOG"'
+	write_stub update-homebrew-casks '
+printf "update-homebrew-casks %s\n" "$*" >>"$COMMAND_LOG"
+exit "$HOMEBREW_CASK_UPDATE_STATUS"
+'
 	write_stub jq 'exec "$REAL_JQ" "$@"'
 	write_stub op '
 printf "op %s\n" "$*" >>"$COMMAND_LOG"
@@ -195,6 +201,8 @@ assert_log_order() {
 	grep -q "^sudo /usr/bin/env .*DOTFILES_USER=test-user .* $STUB_BIN/nix run .#darwin-rebuild -- switch --flake .#macos --impure$" "$COMMAND_LOG"
 	assert_log_order \
 		"nix run .#darwin-rebuild -- switch --flake .#macos --impure" \
+		"update-homebrew-casks " \
+		"docker info" \
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet" \
@@ -210,6 +218,18 @@ assert_log_order() {
 	! grep -q 'brew install --cask' "$COMMAND_LOG"
 	! grep -q 'desktop.docker.com/mac' "$COMMAND_LOG"
 	! grep -q 'docker-install' "$COMMAND_LOG"
+}
+
+@test "cask update failure stops macOS before Docker runtime and chezmoi" {
+	write_installed_stubs
+	export HOMEBREW_CASK_UPDATE_STATUS=47
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 47 ]
+	grep -q '^update-homebrew-casks ' "$COMMAND_LOG"
+	! grep -q '^chezmoi ' "$COMMAND_LOG"
+	! grep -q '^verify-environment ' "$COMMAND_LOG"
 }
 
 @test "Hermes bootstrap failure stops macOS before service recreation and acceptance" {

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -35,7 +35,7 @@ setup() {
 @test "Darwin separates missing-cask installation from explicit greedy upgrades" {
 	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
 
-	run env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex \
+	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex \
 		nix eval --impure --json --expr "
 			let config = (builtins.getFlake (toString $REPO_ROOT)).darwinConfigurations.macos.config;
 			in {
@@ -45,7 +45,12 @@ setup() {
 		"
 
 	[ "$status" -eq 0 ]
-	[ "$output" = '{"autoUpdate":true,"greedyCasks":true,"upgrade":false}' ]
+	run jq -e '
+		.autoUpdate == true and
+		.greedyCasks == true and
+		.upgrade == false
+	' <<<"$output"
+	[ "$status" -eq 0 ]
 }
 
 @test "Darwin frees Command Space for Raycast by disabling Spotlight hotkey" {

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -32,11 +32,20 @@ setup() {
 	grep -q 'postActivation.text' "$REPO_ROOT/nix/darwin/default.nix"
 }
 
-@test "Darwin activation updates cask metadata without forcing latest cask upgrades" {
-	grep -q 'greedyCasks = false' "$REPO_ROOT/nix/darwin/default.nix"
-	grep -q 'autoUpdate = true' "$REPO_ROOT/nix/darwin/default.nix"
-	grep -q 'upgrade = true' "$REPO_ROOT/nix/darwin/default.nix"
-	grep -q 'cleanup = "none"' "$REPO_ROOT/nix/darwin/default.nix"
+@test "Darwin separates missing-cask installation from explicit greedy upgrades" {
+	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
+
+	run env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex \
+		nix eval --impure --json --expr "
+			let config = (builtins.getFlake (toString $REPO_ROOT)).darwinConfigurations.macos.config;
+			in {
+				inherit (config.homebrew) greedyCasks;
+				inherit (config.homebrew.onActivation) autoUpdate upgrade;
+			}
+		"
+
+	[ "$status" -eq 0 ]
+	[ "$output" = '{"autoUpdate":true,"greedyCasks":true,"upgrade":false}' ]
 }
 
 @test "Darwin frees Command Space for Raycast by disabling Spotlight hotkey" {

--- a/tests/bash/macos_homebrew_cask_update.bats
+++ b/tests/bash/macos_homebrew_cask_update.bats
@@ -54,6 +54,7 @@ case "$command_name" in
     [[ ${BREW_KEEP_OUTDATED:-0} == 1 ]] || rm -f "$BREW_STATE/outdated-$safe_cask"
     ;;
   info)
+    [[ ${BREW_INFO_FAIL:-0} != 1 ]] || exit 66
     cask="${2:-}"
     if [[ $cask == claude ]]; then
       printf '%s\n' '{"casks":[{"artifacts":[{"uninstall":[{"quit":["com.anthropic.claudefordesktop"]}]},{"app":["Claude.app"],"target":"/Applications/Claude.app"}]}]}'
@@ -145,6 +146,12 @@ mark_outdated() {
 
   [ "$status" -eq 0 ]
   grep -q '^open -gj /Applications/Claude.app$' "$COMMAND_LOG"
+  pgrep_line="$(grep -n -m1 '^pgrep ' "$COMMAND_LOG" | cut -d: -f1)"
+  fetch_line="$(grep -n -m1 '^brew fetch ' "$COMMAND_LOG" | cut -d: -f1)"
+  upgrade_line="$(grep -n -m1 '^brew upgrade ' "$COMMAND_LOG" | cut -d: -f1)"
+  open_line="$(grep -n -m1 '^open ' "$COMMAND_LOG" | cut -d: -f1)"
+  [ "$pgrep_line" -lt "$fetch_line" ]
+  [ "$upgrade_line" -lt "$open_line" ]
 }
 
 @test "reopens a running application after upgrade retries are exhausted" {
@@ -166,6 +173,34 @@ mark_outdated() {
 
   [ "$status" -eq 0 ]
   run ! grep -q '^open ' "$COMMAND_LOG"
+}
+
+@test "fails without upgrading when brew info cannot describe app artifacts" {
+  install_cask claude
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude BREW_INFO_FAIL=1 "$UPDATER"
+
+  [ "$status" -ne 0 ]
+  run ! grep -q '^brew fetch ' "$COMMAND_LOG"
+  run ! grep -q '^brew upgrade ' "$COMMAND_LOG"
+}
+
+@test "fails without upgrading when jq cannot parse app artifacts" {
+  install_cask claude
+  mark_outdated claude
+  jq_failure="$TEST_BIN/jq-failure"
+  cat >"$jq_failure" <<'EOF'
+#!/usr/bin/env bash
+exit 67
+EOF
+  chmod +x "$jq_failure"
+
+  run env DOTFILES_HOMEBREW_CASKS=claude JQ_COMMAND="$jq_failure" "$UPDATER"
+
+  [ "$status" -ne 0 ]
+  run ! grep -q '^brew fetch ' "$COMMAND_LOG"
+  run ! grep -q '^brew upgrade ' "$COMMAND_LOG"
 }
 
 @test "fails when a successful upgrade leaves a cask outdated" {

--- a/tests/bash/macos_homebrew_cask_update.bats
+++ b/tests/bash/macos_homebrew_cask_update.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+bats_require_minimum_version 1.5.0
+
 setup() {
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
   UPDATER="$REPO_ROOT/scripts/sh/update-homebrew-casks.sh"
@@ -13,7 +15,8 @@ setup() {
   export BREW_COMMAND="$TEST_BIN/brew"
   export NIX_COMMAND="$TEST_BIN/nix"
   export SLEEP_COMMAND="$TEST_BIN/sleep"
-  export JQ_COMMAND="$(command -v jq)"
+  JQ_COMMAND="$(command -v jq)"
+  export JQ_COMMAND
   export PGREP_COMMAND="$TEST_BIN/pgrep"
   export OPEN_COMMAND="$TEST_BIN/open"
   export DOTFILES_CASK_UPDATE_BACKOFF_SECONDS=2
@@ -51,7 +54,12 @@ case "$command_name" in
     [[ ${BREW_KEEP_OUTDATED:-0} == 1 ]] || rm -f "$BREW_STATE/outdated-$safe_cask"
     ;;
   info)
-    printf '%s\n' '{"casks":[{"artifacts":[]}]}'
+    cask="${2:-}"
+    if [[ $cask == claude ]]; then
+      printf '%s\n' '{"casks":[{"artifacts":[{"uninstall":[{"quit":["com.anthropic.claudefordesktop"]}]},{"app":["Claude.app"],"target":"/Applications/Claude.app"}]}]}'
+    else
+      printf '%s\n' '{"casks":[{"artifacts":[]}]}'
+    fi
     ;;
   *) exit 64 ;;
 esac
@@ -66,8 +74,15 @@ EOF
 #!/usr/bin/env bash
 printf 'sleep %s\n' "$*" >>"$COMMAND_LOG"
 EOF
-  printf '#!/usr/bin/env bash\nexit 1\n' >"$PGREP_COMMAND"
-  printf '#!/usr/bin/env bash\nprintf "open %%s\\n" "$*" >>"$COMMAND_LOG"\n' >"$OPEN_COMMAND"
+  cat >"$PGREP_COMMAND" <<'EOF'
+#!/usr/bin/env bash
+printf 'pgrep %s\n' "$*" >>"$COMMAND_LOG"
+[[ "$*" == *"${FAKE_RUNNING_APP:-never}"* ]]
+EOF
+  cat >"$OPEN_COMMAND" <<'EOF'
+#!/usr/bin/env bash
+printf 'open %s\n' "$*" >>"$COMMAND_LOG"
+EOF
   chmod +x "$BREW_COMMAND" "$NIX_COMMAND" "$SLEEP_COMMAND" "$PGREP_COMMAND" "$OPEN_COMMAND"
 }
 
@@ -93,10 +108,10 @@ mark_outdated() {
   [ "$status" -eq 0 ]
   grep -q '^brew fetch --cask claude$' "$COMMAND_LOG"
   grep -q '^brew upgrade --cask --greedy claude$' "$COMMAND_LOG"
-  ! grep -q '^brew fetch --cask google-chrome$' "$COMMAND_LOG"
-  ! grep -q '^brew upgrade --cask --greedy google-chrome$' "$COMMAND_LOG"
+  run ! grep -q '^brew fetch --cask google-chrome$' "$COMMAND_LOG"
+  run ! grep -q '^brew upgrade --cask --greedy google-chrome$' "$COMMAND_LOG"
   [ "$(grep '^brew outdated ' "$COMMAND_LOG")" = $'brew outdated --cask --greedy claude\nbrew outdated --cask --greedy google-chrome\nbrew outdated --cask --greedy claude\nbrew outdated --cask --greedy google-chrome' ]
-  ! grep -q '^brew .* undeclared-cask$' "$COMMAND_LOG"
+  run ! grep -q '^brew .* undeclared-cask$' "$COMMAND_LOG"
 }
 
 @test "retries a failed fetch twice before the third attempt succeeds" {
@@ -122,6 +137,37 @@ mark_outdated() {
   [[ "$output" == *"upgrade claude failed after 3 attempts"* ]]
 }
 
+@test "reopens an application that was running before a successful upgrade" {
+  install_cask claude
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude FAKE_RUNNING_APP=/Applications/Claude.app "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  grep -q '^open -gj /Applications/Claude.app$' "$COMMAND_LOG"
+}
+
+@test "reopens a running application after upgrade retries are exhausted" {
+  install_cask claude
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude FAKE_RUNNING_APP=/Applications/Claude.app \
+    BREW_UPGRADE_SUCCEED_ON=4 "$UPDATER"
+
+  [ "$status" -ne 0 ]
+  grep -q '^open -gj /Applications/Claude.app$' "$COMMAND_LOG"
+}
+
+@test "does not open an application that was not running" {
+  install_cask claude
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  run ! grep -q '^open ' "$COMMAND_LOG"
+}
+
 @test "fails when a successful upgrade leaves a cask outdated" {
   install_cask visual-studio-code
   mark_outdated visual-studio-code
@@ -142,7 +188,7 @@ EOF
   run env -u DOTFILES_HOMEBREW_CASKS "$UPDATER"
 
   [ "$status" -ne 0 ]
-  ! grep -q '^brew ' "$COMMAND_LOG"
+  run ! grep -q '^brew ' "$COMMAND_LOG"
 }
 
 @test "fails when brew cannot determine whether a declared cask is outdated" {
@@ -152,8 +198,8 @@ EOF
 
   [ "$status" -ne 0 ]
   [[ "$output" == *"failed to check outdated status for claude (status 65)"* ]]
-  ! grep -q '^brew fetch ' "$COMMAND_LOG"
-  ! grep -q '^brew upgrade ' "$COMMAND_LOG"
+  run ! grep -q '^brew fetch ' "$COMMAND_LOG"
+  run ! grep -q '^brew upgrade ' "$COMMAND_LOG"
 }
 
 @test "rejects more than three update attempts before invoking brew" {
@@ -165,7 +211,7 @@ EOF
 
   [ "$status" -ne 0 ]
   [[ "$output" == *"DOTFILES_CASK_UPDATE_ATTEMPTS must be an integer between 1 and 3: 4"* ]]
-  ! grep -q '^brew ' "$COMMAND_LOG"
+  run ! grep -q '^brew ' "$COMMAND_LOG"
 }
 
 @test "rejects a backoff other than two seconds before invoking brew" {
@@ -176,5 +222,5 @@ EOF
 
   [ "$status" -ne 0 ]
   [[ "$output" == *"DOTFILES_CASK_UPDATE_BACKOFF_SECONDS must be 2: 3"* ]]
-  ! grep -q '^brew ' "$COMMAND_LOG"
+  run ! grep -q '^brew ' "$COMMAND_LOG"
 }

--- a/tests/bash/macos_homebrew_cask_update.bats
+++ b/tests/bash/macos_homebrew_cask_update.bats
@@ -38,6 +38,7 @@ case "$command_name" in
     [[ -f "$BREW_STATE/installed-$safe_cask" ]]
     ;;
   outdated)
+    [[ ${BREW_OUTDATED_FAIL:-0} != 1 ]] || exit 65
     [[ ! -f "$BREW_STATE/outdated-$safe_cask" ]] || printf '%s\n' "$cask"
     ;;
   fetch)
@@ -83,7 +84,9 @@ mark_outdated() {
 @test "updates only declared casks that are outdated under greedy semantics" {
   install_cask claude
   install_cask google-chrome
+  install_cask undeclared-cask
   mark_outdated claude
+  mark_outdated undeclared-cask
 
   run env DOTFILES_HOMEBREW_CASKS=$'claude\ngoogle-chrome' "$UPDATER"
 
@@ -92,6 +95,8 @@ mark_outdated() {
   grep -q '^brew upgrade --cask --greedy claude$' "$COMMAND_LOG"
   ! grep -q '^brew fetch --cask google-chrome$' "$COMMAND_LOG"
   ! grep -q '^brew upgrade --cask --greedy google-chrome$' "$COMMAND_LOG"
+  [ "$(grep '^brew outdated ' "$COMMAND_LOG")" = $'brew outdated --cask --greedy claude\nbrew outdated --cask --greedy google-chrome\nbrew outdated --cask --greedy claude\nbrew outdated --cask --greedy google-chrome' ]
+  ! grep -q '^brew .* undeclared-cask$' "$COMMAND_LOG"
 }
 
 @test "retries a failed fetch twice before the third attempt succeeds" {
@@ -137,5 +142,39 @@ EOF
   run env -u DOTFILES_HOMEBREW_CASKS "$UPDATER"
 
   [ "$status" -ne 0 ]
+  ! grep -q '^brew ' "$COMMAND_LOG"
+}
+
+@test "fails when brew cannot determine whether a declared cask is outdated" {
+  install_cask claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude BREW_OUTDATED_FAIL=1 "$UPDATER"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed to check outdated status for claude (status 65)"* ]]
+  ! grep -q '^brew fetch ' "$COMMAND_LOG"
+  ! grep -q '^brew upgrade ' "$COMMAND_LOG"
+}
+
+@test "rejects more than three update attempts before invoking brew" {
+  install_cask claude
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude \
+    DOTFILES_CASK_UPDATE_ATTEMPTS=4 BREW_UPGRADE_SUCCEED_ON=4 "$UPDATER"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"DOTFILES_CASK_UPDATE_ATTEMPTS must be an integer between 1 and 3: 4"* ]]
+  ! grep -q '^brew ' "$COMMAND_LOG"
+}
+
+@test "rejects a backoff other than two seconds before invoking brew" {
+  install_cask claude
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude DOTFILES_CASK_UPDATE_BACKOFF_SECONDS=3 "$UPDATER"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"DOTFILES_CASK_UPDATE_BACKOFF_SECONDS must be 2: 3"* ]]
   ! grep -q '^brew ' "$COMMAND_LOG"
 }

--- a/tests/bash/macos_homebrew_cask_update.bats
+++ b/tests/bash/macos_homebrew_cask_update.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  UPDATER="$REPO_ROOT/scripts/sh/update-homebrew-casks.sh"
+  TEST_BIN="$BATS_TEST_TMPDIR/bin"
+  BREW_STATE="$BATS_TEST_TMPDIR/brew-state"
+  COMMAND_LOG="$BATS_TEST_TMPDIR/commands.log"
+  mkdir -p "$TEST_BIN" "$BREW_STATE"
+  : >"$COMMAND_LOG"
+
+  export BREW_STATE COMMAND_LOG
+  export BREW_COMMAND="$TEST_BIN/brew"
+  export NIX_COMMAND="$TEST_BIN/nix"
+  export SLEEP_COMMAND="$TEST_BIN/sleep"
+  export JQ_COMMAND="$(command -v jq)"
+  export PGREP_COMMAND="$TEST_BIN/pgrep"
+  export OPEN_COMMAND="$TEST_BIN/open"
+  export DOTFILES_CASK_UPDATE_BACKOFF_SECONDS=2
+
+  cat >"$BREW_COMMAND" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'brew %s\n' "$*" >>"$COMMAND_LOG"
+command_name="${1:-}"
+shift || true
+cask=""
+for argument in "$@"; do cask="$argument"; done
+safe_cask="${cask//\//_}"
+counter_file="$BREW_STATE/${command_name}-${safe_cask}.count"
+count=0
+[[ ! -f $counter_file ]] || count="$(cat "$counter_file")"
+count=$((count + 1))
+printf '%s\n' "$count" >"$counter_file"
+
+case "$command_name" in
+  list)
+    [[ -f "$BREW_STATE/installed-$safe_cask" ]]
+    ;;
+  outdated)
+    [[ ! -f "$BREW_STATE/outdated-$safe_cask" ]] || printf '%s\n' "$cask"
+    ;;
+  fetch)
+    succeed_on="${BREW_FETCH_SUCCEED_ON:-1}"
+    ((count >= succeed_on))
+    ;;
+  upgrade)
+    succeed_on="${BREW_UPGRADE_SUCCEED_ON:-1}"
+    ((count >= succeed_on)) || exit 1
+    [[ ${BREW_KEEP_OUTDATED:-0} == 1 ]] || rm -f "$BREW_STATE/outdated-$safe_cask"
+    ;;
+  info)
+    printf '%s\n' '{"casks":[{"artifacts":[]}]}'
+    ;;
+  *) exit 64 ;;
+esac
+EOF
+
+  cat >"$NIX_COMMAND" <<'EOF'
+#!/usr/bin/env bash
+printf 'nix %s\n' "$*" >>"$COMMAND_LOG"
+printf '%s' "${FAKE_NIX_CASKS:-}"
+EOF
+  cat >"$SLEEP_COMMAND" <<'EOF'
+#!/usr/bin/env bash
+printf 'sleep %s\n' "$*" >>"$COMMAND_LOG"
+EOF
+  printf '#!/usr/bin/env bash\nexit 1\n' >"$PGREP_COMMAND"
+  printf '#!/usr/bin/env bash\nprintf "open %%s\\n" "$*" >>"$COMMAND_LOG"\n' >"$OPEN_COMMAND"
+  chmod +x "$BREW_COMMAND" "$NIX_COMMAND" "$SLEEP_COMMAND" "$PGREP_COMMAND" "$OPEN_COMMAND"
+}
+
+install_cask() {
+  local cask="${1//\//_}"
+  touch "$BREW_STATE/installed-$cask"
+}
+
+mark_outdated() {
+  local cask="${1//\//_}"
+  touch "$BREW_STATE/outdated-$cask"
+}
+
+@test "updates only declared casks that are outdated under greedy semantics" {
+  install_cask claude
+  install_cask google-chrome
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=$'claude\ngoogle-chrome' "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  grep -q '^brew fetch --cask claude$' "$COMMAND_LOG"
+  grep -q '^brew upgrade --cask --greedy claude$' "$COMMAND_LOG"
+  ! grep -q '^brew fetch --cask google-chrome$' "$COMMAND_LOG"
+  ! grep -q '^brew upgrade --cask --greedy google-chrome$' "$COMMAND_LOG"
+}
+
+@test "retries a failed fetch twice before the third attempt succeeds" {
+  install_cask docker-desktop
+  mark_outdated docker-desktop
+
+  run env DOTFILES_HOMEBREW_CASKS=docker-desktop BREW_FETCH_SUCCEED_ON=3 "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "$BREW_STATE/fetch-docker-desktop.count")" -eq 3 ]
+  grep -q '^sleep 2$' "$COMMAND_LOG"
+  grep -q '^sleep 4$' "$COMMAND_LOG"
+}
+
+@test "fails after three upgrade attempts" {
+  install_cask claude
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude BREW_UPGRADE_SUCCEED_ON=4 "$UPDATER"
+
+  [ "$status" -ne 0 ]
+  [ "$(cat "$BREW_STATE/upgrade-claude.count")" -eq 3 ]
+  [[ "$output" == *"upgrade claude failed after 3 attempts"* ]]
+}
+
+@test "fails when a successful upgrade leaves a cask outdated" {
+  install_cask visual-studio-code
+  mark_outdated visual-studio-code
+
+  run env DOTFILES_HOMEBREW_CASKS=visual-studio-code BREW_KEEP_OUTDATED=1 "$UPDATER"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cask did not converge: visual-studio-code"* ]]
+}
+
+@test "fails when nix cannot evaluate the declared cask list" {
+  cat >"$NIX_COMMAND" <<'EOF'
+#!/usr/bin/env bash
+exit 61
+EOF
+  chmod +x "$NIX_COMMAND"
+
+  run env -u DOTFILES_HOMEBREW_CASKS "$UPDATER"
+
+  [ "$status" -ne 0 ]
+  ! grep -q '^brew ' "$COMMAND_LOG"
+}


### PR DESCRIPTION
## Summary

- add an explicit updater for every cask declared by nix-darwin
- use greedy outdated checks, bounded fetch/upgrade retries, and a final convergence check
- reopen only applications that were running before Homebrew upgraded them
- keep nix-darwin responsible for metadata and missing-cask installation while disabling its implicit upgrade pass
- document the update and troubleshooting workflow

## Root cause

The previous `nrs` flow delegated upgrades to nix-darwin's activation-time `brew bundle`. Large cask downloads could interrupt activation before the new generation was switched, and non-greedy behavior excluded auto-updating/latest casks. There was no explicit retry or final convergence check.

## Impact

On Apple Silicon macOS, `nrs` now updates only the casks declared in `darwinConfigurations.macos.config.homebrew.casks`, retries each fetch or upgrade at most three times with 2s/4s backoff, fails when casks do not converge, and restores applications that were running before the update. The dedicated `wezterm@nightly` installer remains separate.

## Validation

- `task test:bash DOTFILES_PATH="$PWD"`: 164/164 passed
- `pre-commit run --all-files`: all hooks passed
- Bash 3.2 syntax and ShellCheck passed
- generated activation uses `brew bundle --no-upgrade`
- independent final review: 0 Critical, 0 Important

## Remaining validation

A real `nrs` smoke was not run from the active Orca-hosted session because Homebrew may terminate Orca during its own update. Run it from a terminal not hosted by a declared cask before treating GUI relaunch and real Homebrew convergence as fully proven.