### PR TITLE
fix: handle Homebrew named outdated semantics

### DIFF
--- a/docs/superpowers/plans/2026-08-07-macos-homebrew-outdated-semantics.md
+++ b/docs/superpowers/plans/2026-08-07-macos-homebrew-outdated-semantics.md
@@ -1,0 +1,350 @@
+# macOS Homebrew Cask Outdated Semantics Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `nrs` correctly update named Homebrew casks when current Homebrew reports outdated items with exit status 1, including tap-qualified casks such as `stablyai/orca/orca`.
+
+**Architecture:** Keep the existing per-cask updater and convergence loop. Centralize Homebrew's named-outdated tri-state interpretation in `check_outdated`, and separate the declared cask name used for update commands from the short Homebrew token used for installed-state and stdout matching.
+
+**Tech Stack:** Bash 3.2-compatible shell, Homebrew CLI, Bats 1.5+, ShellCheck, Task, GitHub Actions.
+
+## Global Constraints
+
+- Exit status 1 plus stdout exactly equal to the short token means outdated.
+- Exit status 0 plus empty stdout means current; status 0 plus the expected token remains a compatible outdated result.
+- Status 1 with empty or unexpected stdout, and every status greater than 1, is a real failure.
+- Use the short token for `brew list`; keep the declared name for `outdated`, `info`, `fetch`, and `upgrade`.
+- Preserve retry, backoff, app restart, convergence, tap/formula/MAS, and `wezterm@nightly` behavior.
+- Run the real `nrs` smoke test from macOS Terminal because upgrading Orca can terminate this session.
+- Commit with `task commit DOTFILES_PATH="$PWD" -- "<message>"`.
+
+## File Structure
+
+- Modify `tests/bash/macos_homebrew_cask_update.bats`: model real named-query semantics and cover invalid output and tap-qualified identities.
+- Modify `scripts/sh/update-homebrew-casks.sh`: normalize installed tokens and interpret status/output together.
+- Reference `docs/superpowers/specs/2026-08-06-macos-homebrew-outdated-semantics-design.md`: approved contract.
+
+---
+
+### Task 1: Interpret Named `brew outdated` Results
+
+**Files:**
+
+- Modify: `tests/bash/macos_homebrew_cask_update.bats:24-67,100-238`
+- Modify: `scripts/sh/update-homebrew-casks.sh:61-73`
+
+**Interfaces:**
+
+- Consumes: `brew outdated --cask --greedy <declared-name>` stdout and status.
+- Produces: `check_outdated <declared-name>` setting `OUTDATED_STATUS=0` for a valid query and nonzero for a malformed or failed query; nonempty `OUTDATED_OUTPUT` remains the outdated flag.
+
+- [ ] **Step 1: Make fake Homebrew reproduce named-query status 1**
+
+Replace the fake `outdated)` branch with:
+
+```bash
+  outdated)
+    [[ ${BREW_OUTDATED_FAIL:-0} != 1 ]] || exit 65
+    [[ ${BREW_OUTDATED_EMPTY_STATUS_ONE:-0} != 1 ]] || exit 1
+    if [[ -f "$BREW_STATE/outdated-$safe_cask" ]]; then
+      printf '%s\n' "${BREW_OUTDATED_OUTPUT_OVERRIDE:-$cask}"
+      exit "${BREW_OUTDATED_EXIT_STATUS:-1}"
+    fi
+    ;;
+```
+
+- [ ] **Step 2: Add exact status/output matrix tests**
+
+Add after the existing Homebrew failure test:
+
+```bash
+@test "accepts exit status zero with a matching outdated token for compatibility" {
+  install_cask claude
+  mark_outdated claude
+  run env DOTFILES_HOMEBREW_CASKS=claude BREW_OUTDATED_EXIT_STATUS=0 "$UPDATER"
+  [ "$status" -eq 0 ]
+  grep -q '^brew upgrade --cask --greedy claude$' "$COMMAND_LOG"
+}
+
+@test "rejects exit status one without an outdated token" {
+  install_cask claude
+  run env DOTFILES_HOMEBREW_CASKS=claude BREW_OUTDATED_EMPTY_STATUS_ONE=1 "$UPDATER"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed to check outdated status for claude (status 1)"* ]]
+  run ! grep -q '^brew fetch ' "$COMMAND_LOG"
+}
+
+@test "rejects exit status one with an unexpected outdated token" {
+  install_cask claude
+  mark_outdated claude
+  run env DOTFILES_HOMEBREW_CASKS=claude BREW_OUTDATED_OUTPUT_OVERRIDE=other-cask "$UPDATER"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed to check outdated status for claude (status 1)"* ]]
+  run ! grep -q '^brew fetch ' "$COMMAND_LOG"
+}
+```
+
+- [ ] **Step 3: Prove the new realistic happy path is red**
+
+Run `bats tests/bash/macos_homebrew_cask_update.bats`.
+
+Expected: existing outdated-cask happy paths fail because status 1 is still treated as a command failure.
+
+- [ ] **Step 4: Implement combined status/output interpretation**
+
+Replace `check_outdated` with:
+
+```bash
+check_outdated() {
+  local cask="$1" command_status
+  OUTDATED_OUTPUT=""
+  OUTDATED_STATUS=0
+
+  if OUTDATED_OUTPUT=$("$BREW_COMMAND" outdated --cask --greedy "$cask"); then
+    command_status=0
+  else
+    command_status=$?
+  fi
+
+  if ((command_status == 0)) && [[ -z $OUTDATED_OUTPUT ]]; then
+    return
+  fi
+  if ((command_status <= 1)) && [[ $OUTDATED_OUTPUT == "$cask" ]]; then
+    return
+  fi
+
+  OUTDATED_STATUS=$command_status
+  ((OUTDATED_STATUS != 0)) || OUTDATED_STATUS=1
+  printf '[macos-cask-update] failed to check outdated status for %s (status %d)\n' \
+    "$cask" "$command_status" >&2
+}
+```
+
+- [ ] **Step 5: Prove the status semantics are green**
+
+Run `bats tests/bash/macos_homebrew_cask_update.bats`.
+
+Expected: 16 tests pass, including status 1 outdated, status 0 compatibility, invalid status 1 output, and status 65 failure.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+task commit DOTFILES_PATH="$PWD" -- "fix: handle Homebrew outdated exit status"
+```
+
+Expected: formatter and pre-commit hooks pass; only Task 1 updater and Bats changes are committed.
+
+---
+
+### Task 2: Normalize Tap-Qualified Cask Identity
+
+**Files:**
+
+- Modify: `tests/bash/macos_homebrew_cask_update.bats:24-67,90-116`
+- Modify: `scripts/sh/update-homebrew-casks.sh:57-73,134-172`
+
+**Interfaces:**
+
+- Consumes: a declared name such as `stablyai/orca/orca`.
+- Produces: `cask_token <declared-name>` printing `orca`; installed checks use it, while update commands retain the declared name.
+
+- [ ] **Step 1: Add a tap-qualified regression test**
+
+```bash
+@test "updates a tap-qualified cask using its short installed token" {
+  install_cask orca
+  mark_outdated orca
+  run env DOTFILES_HOMEBREW_CASKS=stablyai/orca/orca "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  grep -q '^brew list --cask --versions orca$' "$COMMAND_LOG"
+  grep -q '^brew outdated --cask --greedy stablyai/orca/orca$' "$COMMAND_LOG"
+  grep -q '^brew info --cask stablyai/orca/orca --json=v2$' "$COMMAND_LOG"
+  grep -q '^brew fetch --cask stablyai/orca/orca$' "$COMMAND_LOG"
+  grep -q '^brew upgrade --cask --greedy stablyai/orca/orca$' "$COMMAND_LOG"
+}
+
+@test "rejects a declared cask without a short token" {
+  run env DOTFILES_HOMEBREW_CASKS=stablyai/orca/ "$UPDATER"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"declared cask is not installed: stablyai/orca/"* ]]
+  run ! grep -q '^brew list ' "$COMMAND_LOG"
+  run ! grep -q '^brew fetch ' "$COMMAND_LOG"
+}
+```
+
+- [ ] **Step 2: Make fake Homebrew state short-token based**
+
+Replace fake state-key derivation with:
+
+```bash
+cask=""
+for argument in "$@"; do cask="$argument"; done
+cask_token="${cask##*/}"
+safe_cask="${cask_token//\//_}"
+```
+
+Change the outdated output default to:
+
+```bash
+printf '%s\n' "${BREW_OUTDATED_OUTPUT_OVERRIDE:-$cask_token}"
+```
+
+- [ ] **Step 3: Prove the tap-qualified path is red**
+
+Run `bats --filter "tap-qualified" tests/bash/macos_homebrew_cask_update.bats`.
+
+Expected: FAIL because the updater asks `brew list` for the full tap-qualified name.
+
+- [ ] **Step 4: Normalize installed and stdout identities once**
+
+Insert and use:
+
+```bash
+cask_token() {
+  printf '%s\n' "${1##*/}"
+}
+
+is_installed() {
+  local token
+  token="$(cask_token "$1")"
+  [[ -n $token ]] && "$BREW_COMMAND" list --cask --versions "$token" >/dev/null 2>&1
+}
+```
+
+Change `check_outdated` locals and comparison to:
+
+```bash
+local cask="$1" token command_status
+token="$(cask_token "$cask")"
+
+if ((command_status <= 1)) && [[ -n $token && $OUTDATED_OUTPUT == "$token" ]]; then
+  return
+fi
+```
+
+The loops keep passing the declared name. Thus `list` receives `orca`, while `outdated`, `info`, `fetch`, and `upgrade` receive `stablyai/orca/orca`.
+
+- [ ] **Step 5: Prove the full focused suite is green**
+
+Run `bats tests/bash/macos_homebrew_cask_update.bats`.
+
+Expected: 18 tests pass, the tap-qualified command log matches the regression assertions, and an empty short token fails before invoking `brew list`.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+task commit DOTFILES_PATH="$PWD" -- "fix: normalize tap-qualified cask tokens"
+```
+
+Expected: formatter and pre-commit hooks pass; the working tree is clean.
+
+---
+
+### Task 3: Validate, Publish, Merge, and Verify on macOS
+
+**Files:**
+
+- Verify: `scripts/sh/update-homebrew-casks.sh`
+- Verify: `tests/bash/macos_homebrew_cask_update.bats`
+- Verify: `tests/bash/macos_config.bats`
+
+**Interfaces:**
+
+- Consumes: both implementation commits and GitHub Actions.
+- Produces: merged PR, fast-forwarded local `main`, successful `nrs`, current declared casks, and a ready Docker daemon.
+
+- [ ] **Step 1: Run compatibility and static checks**
+
+```bash
+/bin/bash -n scripts/sh/update-homebrew-casks.sh
+shellcheck scripts/sh/update-homebrew-casks.sh tests/bash/macos_homebrew_cask_update.bats
+```
+
+Expected: both commands exit 0 with Bash 3.2-compatible syntax.
+
+- [ ] **Step 2: Run focused tests**
+
+```bash
+bats tests/bash/macos_homebrew_cask_update.bats
+bats tests/bash/macos_config.bats
+```
+
+Expected: 18 updater tests and all macOS configuration contract tests pass.
+
+- [ ] **Step 3: Run complete validation**
+
+```bash
+task test:bash DOTFILES_PATH="$PWD"
+pre-commit run --all-files
+```
+
+Expected: 169 Bash tests and every pre-commit hook pass.
+
+- [ ] **Step 4: Review final branch scope**
+
+```bash
+git diff --check main...HEAD
+git diff --stat main...HEAD
+git diff main...HEAD -- scripts/sh/update-homebrew-casks.sh tests/bash/macos_homebrew_cask_update.bats
+git status --short --branch
+```
+
+Expected: only the approved spec, plan, updater, and Bats changes; no whitespace errors; clean worktree.
+
+- [ ] **Step 5: Push and open a ready PR**
+
+```bash
+git push -u origin rurusasu/macos-homebrew-outdated-semantics
+gh pr create --base main --head rurusasu/macos-homebrew-outdated-semantics \
+  --title "fix: handle Homebrew named outdated semantics" \
+  --body-file /tmp/macos-homebrew-outdated-semantics-pr.md
+```
+
+The body records both root causes, the status/output matrix, tap-qualified behavior, and validation results. It is not a draft because the user requested an open PR.
+
+- [ ] **Step 6: Wait for Actions and merge only on success**
+
+```bash
+gh pr checks --watch --fail-fast
+gh pr merge --merge
+```
+
+Expected: every reported check succeeds before merge. A failure is diagnosed and fixed instead of bypassed.
+
+- [ ] **Step 7: Fast-forward local `main`**
+
+```bash
+git -C /Users/ktome1995/Program/dotfiles pull --ff-only origin main
+git -C /Users/ktome1995/Program/dotfiles status --short --branch
+```
+
+Expected: local `main` is clean at the merged result.
+
+- [ ] **Step 8: Run `nrs` from macOS Terminal**
+
+Run outside Orca:
+
+```bash
+cd /Users/ktome1995/Program/dotfiles && nrs
+```
+
+If `sudo` requests a password, pause for user input. Expected: all five declared desktop casks are checked without false failures, updater convergence succeeds, the macOS installer completes, and Docker Desktop restarts.
+
+- [ ] **Step 9: Verify real-machine convergence**
+
+```bash
+for cask in claude docker-desktop google-chrome stablyai/orca/orca visual-studio-code; do
+  output="$(/opt/homebrew/bin/brew outdated --cask --greedy "$cask" 2>&1)"
+  status=$?
+  [[ $status -eq 0 && -z $output ]] || {
+    printf '%s: status=%d output=%s\n' "$cask" "$status" "$output" >&2
+    exit 1
+  }
+done
+/opt/homebrew/bin/brew list --cask --versions orca
+docker info >/dev/null
+```
+
+Expected: every declared cask query returns status 0 with empty stdout, Orca is installed under its short token, and Docker is ready.

--- a/docs/superpowers/specs/2026-08-06-macos-homebrew-outdated-semantics-design.md
+++ b/docs/superpowers/specs/2026-08-06-macos-homebrew-outdated-semantics-design.md
@@ -1,0 +1,111 @@
+# macOS Homebrew Cask Outdated Semantics Fix Design
+
+## Goal
+
+`nrs` の明示的な Homebrew cask 更新処理を、現在の Homebrew CLI の終了コードと tap 修飾名の扱いに適合させる。
+
+成功条件は次のとおり。
+
+- `brew outdated --cask --greedy <cask>` が、更新対象を stdout に出して終了コード 1 を返す場合を正常な「更新あり」と判定する。
+- `stablyai/orca/orca` のような tap 修飾名でも、インストール済みの短縮 token `orca` を正しく照合する。
+- 宣言された tap 修飾名は `info`、`fetch`、`upgrade` で維持し、更新元を曖昧にしない。
+- 実際の検査失敗を更新対象と誤認せず、`nrs` を非ゼロで終了する。
+- 修正後の `nrs` が宣言済み cask を更新し、停止済み Docker Desktop を含む後続処理まで完走する。
+
+## Root Cause
+
+現在の updater は、名前を指定した `brew outdated` の終了コードが 0 以外なら検査失敗としている。しかし現在の Homebrew は、指定した cask が outdated の場合に cask token を stdout へ出し、終了コード 1 を返す。この正常な outdated 状態が検査失敗として記録されるため、更新処理へ進まない。
+
+また、nix-darwin の宣言には `stablyai/orca/orca` が含まれる一方、Homebrew のインストール済み cask registry は短縮 token `orca` を使う。updater が tap 修飾名のまま `brew list --cask --versions` を実行するため、導入済み Orca を未導入と誤判定する。
+
+## Scope
+
+### In scope
+
+- updater 内で、宣言名と Homebrew の短縮 token を明確に分離する。
+- 名前付き `brew outdated` の終了コード 0/1 と stdout を組み合わせて判定する。
+- fake Homebrew を実際の名前付き outdated semantics に合わせる。
+- 通常名、tap 修飾名、真のコマンド異常を Bats で回帰テストする。
+- 修正を PR として公開し、GitHub Actions 成功後にマージする。
+- ローカル `main` へ反映後、`nrs` を再実行して実 cask の収束を確認する。
+
+### Out of scope
+
+- cask 更新フロー全体の再設計。
+- `brew outdated --json` への全面移行。
+- 宣言済み cask を無条件に毎回 upgrade する方式への変更。
+- tap、formula、Mac App Store アプリ、`wezterm@nightly` の管理変更。
+- Homebrew 自体の終了コード仕様の変更。
+
+## Architecture and Components
+
+変更対象は `scripts/sh/update-homebrew-casks.sh` と、その振る舞いを検証する `tests/bash/macos_homebrew_cask_update.bats` に限定する。
+
+updater は cask ごとに二つの識別子を持つ。
+
+- **宣言名**: nix-darwin から取得した値。例: `stablyai/orca/orca`。`outdated`、`info`、`fetch`、`upgrade` と失敗報告に使う。
+- **短縮 token**: 宣言名の最後の `/` より後。例: `orca`。インストール済み照合と `outdated` stdout の検証に使う。
+
+短縮 token の導出は副作用のない小さな shell 関数に分離する。Homebrew への更新指示には常に宣言名を渡すため、同名 cask が複数 tap に存在しても宣言された更新元を維持できる。
+
+`check_outdated` は Homebrew の終了コードだけで成否を決めず、stdout と短縮 token を併せて解釈する。既存のループ構造と最終収束検査は維持し、判定規則だけを一元化する。
+
+## Data Flow
+
+1. nix-darwin configuration から宣言名を読み込む。
+2. 宣言名から短縮 token を導出する。
+3. `brew list --cask --versions <短縮 token>` でインストール済みか確認する。
+4. `brew outdated --cask --greedy <宣言名>` を実行する。
+5. 終了コードと stdout を判定規則に従って解釈する。
+6. outdated の場合だけ、宣言名で app artifact の確認、fetch、upgrade を行う。
+7. 同じ識別子と判定規則で最終収束を検査する。
+
+## Outdated 判定規則
+
+stdout は末尾の改行を除いた完全一致で短縮 token と比較する。
+
+- 終了コード 0、stdout が空: 最新。
+- 終了コード 0、stdout が短縮 token: 更新あり。Homebrew の過去または代替実装との互換性を維持する。
+- 終了コード 1、stdout が短縮 token: 更新あり。現在の名前付き Homebrew query の正常系。
+- 終了コード 1、stdout が空または別の値: 判定不能として失敗。
+- 終了コード 2 以上: Homebrew command の異常として失敗。
+
+stderr は Homebrew の診断としてそのまま利用可能にし、正常な status 1 を独自の失敗ログへ変換しない。
+
+## Error Handling
+
+- 空の短縮 token は無効な宣言として扱い、対象 cask を失敗へ記録する。
+- インストール確認に失敗した場合は、宣言名を含む既存のエラーを維持する。
+- status 1 でも stdout が期待 token と一致しなければ成功扱いにしない。
+- status 2 以上では status を含む検査失敗ログを出し、fetch と upgrade を実行しない。
+- 最初の走査と最終収束検査の両方で同じ規則を使い、upgrade 成功後に残った outdated を見逃さない。
+- updater 失敗時のアプリ再起動 trap、再試行上限、backoff、後続処理の中断は変更しない。
+
+## Testing
+
+fake Homebrew の `outdated` は、対象が古い場合に短縮 token を stdout へ出して status 1 で終了する。これにより、修正前の updater が失敗する回帰テストを先に作る。
+
+Bats では次を検証する。
+
+- 通常 cask が status 1 と一致する token で outdated と判定され、fetch と upgrade へ進む。
+- 最新 cask の status 0 と空 stdout は更新されない。
+- `stablyai/orca/orca` は `brew list` で `orca` を使う。
+- tap 修飾名は `outdated`、`info`、`fetch`、`upgrade` で維持される。
+- tap 修飾名の stdout `orca` と status 1 が正常に outdated と判定される。
+- status 1 と空または不一致 stdout は検査失敗になる。
+- status 65 の command failure は従来どおり失敗になり、更新処理へ進まない。
+- upgrade 後の収束確認にも同じ判定規則が適用される。
+
+検証は focused Bats、Bash 3.2 syntax check、ShellCheck、macOS 設定契約テスト、全 Bash test、pre-commit の順で行う。PR の全 GitHub Actions 成功後にのみマージする。
+
+## Rollout and Runtime Verification
+
+マージ後にローカル `main` を fast-forward し、外部 Terminal から `nrs` を実行する。次を確認する。
+
+- Claude、Docker Desktop、Google Chrome、Orca、Visual Studio Code が検査失敗ではなく更新処理へ進む。
+- Orca が未導入と誤判定されない。
+- updater の最終収束検査に失敗が残らない。
+- `install-macos.sh` の後続処理が完走し、Docker Desktop が再起動する。
+- `brew outdated --cask --greedy` で、専用管理対象を除く宣言済み cask が残らない。
+
+Orca 自身の更新によって現在の Orca セッションが終了する可能性があるため、実行は Orca 内部 terminal ではなく macOS Terminal から行う。

--- a/scripts/sh/update-homebrew-casks.sh
+++ b/scripts/sh/update-homebrew-casks.sh
@@ -54,15 +54,22 @@ load_casks() {
     --apply 'casks: builtins.concatStringsSep "\n" (builtins.map (cask: if builtins.isString cask then cask else cask.name) casks)'
 }
 
+cask_token() {
+  printf '%s\n' "${1##*/}"
+}
+
 is_installed() {
-  "$BREW_COMMAND" list --cask --versions "$1" >/dev/null 2>&1
+  local token
+  token="$(cask_token "$1")"
+  [[ -n $token ]] && "$BREW_COMMAND" list --cask --versions "$token" >/dev/null 2>&1
 }
 
 OUTDATED_OUTPUT=""
 OUTDATED_STATUS=0
 
 check_outdated() {
-  local cask="$1" command_status
+  local cask="$1" token command_status
+  token="$(cask_token "$cask")"
   OUTDATED_OUTPUT=""
   OUTDATED_STATUS=0
 
@@ -75,7 +82,7 @@ check_outdated() {
   if ((command_status == 0)) && [[ -z $OUTDATED_OUTPUT ]]; then
     return
   fi
-  if ((command_status <= 1)) && [[ $OUTDATED_OUTPUT == "$cask" ]]; then
+  if ((command_status <= 1)) && [[ -n $token && $OUTDATED_OUTPUT == "$token" ]]; then
     return
   fi
 

--- a/scripts/sh/update-homebrew-casks.sh
+++ b/scripts/sh/update-homebrew-casks.sh
@@ -62,14 +62,27 @@ OUTDATED_OUTPUT=""
 OUTDATED_STATUS=0
 
 check_outdated() {
-  local cask="$1"
+  local cask="$1" command_status
+  OUTDATED_OUTPUT=""
+  OUTDATED_STATUS=0
+
   if OUTDATED_OUTPUT=$("$BREW_COMMAND" outdated --cask --greedy "$cask"); then
-    OUTDATED_STATUS=0
+    command_status=0
   else
-    OUTDATED_STATUS=$?
-    printf '[macos-cask-update] failed to check outdated status for %s (status %d)\n' \
-      "$cask" "$OUTDATED_STATUS" >&2
+    command_status=$?
   fi
+
+  if ((command_status == 0)) && [[ -z $OUTDATED_OUTPUT ]]; then
+    return
+  fi
+  if ((command_status <= 1)) && [[ $OUTDATED_OUTPUT == "$cask" ]]; then
+    return
+  fi
+
+  OUTDATED_STATUS=$command_status
+  ((OUTDATED_STATUS != 0)) || OUTDATED_STATUS=1
+  printf '[macos-cask-update] failed to check outdated status for %s (status %d)\n' \
+    "$cask" "$command_status" >&2
 }
 
 retry_command() {

--- a/tests/bash/macos_homebrew_cask_update.bats
+++ b/tests/bash/macos_homebrew_cask_update.bats
@@ -29,7 +29,8 @@ command_name="${1:-}"
 shift || true
 cask=""
 for argument in "$@"; do cask="$argument"; done
-safe_cask="${cask//\//_}"
+cask_token="${cask##*/}"
+safe_cask="${cask_token//\//_}"
 counter_file="$BREW_STATE/${command_name}-${safe_cask}.count"
 count=0
 [[ ! -f $counter_file ]] || count="$(cat "$counter_file")"
@@ -44,7 +45,7 @@ case "$command_name" in
     [[ ${BREW_OUTDATED_FAIL:-0} != 1 ]] || exit 65
     [[ ${BREW_OUTDATED_EMPTY_STATUS_ONE:-0} != 1 ]] || exit 1
     if [[ -f "$BREW_STATE/outdated-$safe_cask" ]]; then
-      printf '%s\n' "${BREW_OUTDATED_OUTPUT_OVERRIDE:-$cask}"
+      printf '%s\n' "${BREW_OUTDATED_OUTPUT_OVERRIDE:-$cask_token}"
       exit "${BREW_OUTDATED_EXIT_STATUS:-1}"
     fi
     ;;
@@ -117,6 +118,28 @@ mark_outdated() {
   run ! grep -q '^brew upgrade --cask --greedy google-chrome$' "$COMMAND_LOG"
   [ "$(grep '^brew outdated ' "$COMMAND_LOG")" = $'brew outdated --cask --greedy claude\nbrew outdated --cask --greedy google-chrome\nbrew outdated --cask --greedy claude\nbrew outdated --cask --greedy google-chrome' ]
   run ! grep -q '^brew .* undeclared-cask$' "$COMMAND_LOG"
+}
+
+@test "updates a tap-qualified cask using its short installed token" {
+  install_cask orca
+  mark_outdated orca
+  run env DOTFILES_HOMEBREW_CASKS=stablyai/orca/orca "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  grep -q '^brew list --cask --versions orca$' "$COMMAND_LOG"
+  grep -q '^brew outdated --cask --greedy stablyai/orca/orca$' "$COMMAND_LOG"
+  grep -q '^brew info --cask stablyai/orca/orca --json=v2$' "$COMMAND_LOG"
+  grep -q '^brew fetch --cask stablyai/orca/orca$' "$COMMAND_LOG"
+  grep -q '^brew upgrade --cask --greedy stablyai/orca/orca$' "$COMMAND_LOG"
+}
+
+@test "rejects a declared cask without a short token" {
+  run env DOTFILES_HOMEBREW_CASKS=stablyai/orca/ "$UPDATER"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"declared cask is not installed: stablyai/orca/"* ]]
+  run ! grep -q '^brew list ' "$COMMAND_LOG"
+  run ! grep -q '^brew fetch ' "$COMMAND_LOG"
 }
 
 @test "retries a failed fetch twice before the third attempt succeeds" {

--- a/tests/bash/macos_homebrew_cask_update.bats
+++ b/tests/bash/macos_homebrew_cask_update.bats
@@ -42,7 +42,11 @@ case "$command_name" in
     ;;
   outdated)
     [[ ${BREW_OUTDATED_FAIL:-0} != 1 ]] || exit 65
-    [[ ! -f "$BREW_STATE/outdated-$safe_cask" ]] || printf '%s\n' "$cask"
+    [[ ${BREW_OUTDATED_EMPTY_STATUS_ONE:-0} != 1 ]] || exit 1
+    if [[ -f "$BREW_STATE/outdated-$safe_cask" ]]; then
+      printf '%s\n' "${BREW_OUTDATED_OUTPUT_OVERRIDE:-$cask}"
+      exit "${BREW_OUTDATED_EXIT_STATUS:-1}"
+    fi
     ;;
   fetch)
     succeed_on="${BREW_FETCH_SUCCEED_ON:-1}"
@@ -235,6 +239,31 @@ EOF
   [[ "$output" == *"failed to check outdated status for claude (status 65)"* ]]
   run ! grep -q '^brew fetch ' "$COMMAND_LOG"
   run ! grep -q '^brew upgrade ' "$COMMAND_LOG"
+}
+
+@test "accepts exit status zero with a matching outdated token for compatibility" {
+  install_cask claude
+  mark_outdated claude
+  run env DOTFILES_HOMEBREW_CASKS=claude BREW_OUTDATED_EXIT_STATUS=0 "$UPDATER"
+  [ "$status" -eq 0 ]
+  grep -q '^brew upgrade --cask --greedy claude$' "$COMMAND_LOG"
+}
+
+@test "rejects exit status one without an outdated token" {
+  install_cask claude
+  run env DOTFILES_HOMEBREW_CASKS=claude BREW_OUTDATED_EMPTY_STATUS_ONE=1 "$UPDATER"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed to check outdated status for claude (status 1)"* ]]
+  run ! grep -q '^brew fetch ' "$COMMAND_LOG"
+}
+
+@test "rejects exit status one with an unexpected outdated token" {
+  install_cask claude
+  mark_outdated claude
+  run env DOTFILES_HOMEBREW_CASKS=claude BREW_OUTDATED_OUTPUT_OVERRIDE=other-cask "$UPDATER"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed to check outdated status for claude (status 1)"* ]]
+  run ! grep -q '^brew fetch ' "$COMMAND_LOG"
 }
 
 @test "rejects more than three update attempts before invoking brew" {

--- a/tests/bash/macos_homebrew_cask_update.bats
+++ b/tests/bash/macos_homebrew_cask_update.bats
@@ -289,6 +289,27 @@ EOF
   run ! grep -q '^brew fetch ' "$COMMAND_LOG"
 }
 
+@test "rejects exit status zero with an unexpected outdated token" {
+  install_cask claude
+  mark_outdated claude
+  run env DOTFILES_HOMEBREW_CASKS=claude BREW_OUTDATED_EXIT_STATUS=0 \
+    BREW_OUTDATED_OUTPUT_OVERRIDE=other-cask "$UPDATER"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed to check outdated status for claude (status 0)"* ]]
+  run ! grep -q '^brew fetch ' "$COMMAND_LOG"
+  run ! grep -q '^brew upgrade ' "$COMMAND_LOG"
+}
+
+@test "rejects exit status greater than one with a matching outdated token" {
+  install_cask claude
+  mark_outdated claude
+  run env DOTFILES_HOMEBREW_CASKS=claude BREW_OUTDATED_EXIT_STATUS=65 "$UPDATER"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed to check outdated status for claude (status 65)"* ]]
+  run ! grep -q '^brew fetch ' "$COMMAND_LOG"
+  run ! grep -q '^brew upgrade ' "$COMMAND_LOG"
+}
+
 @test "rejects more than three update attempts before invoking brew" {
   install_cask claude
   mark_outdated claude


### PR DESCRIPTION
## Summary

- interpret named `brew outdated --cask --greedy <cask>` status 1 plus the expected token as a normal outdated result
- reject malformed status/output combinations, including partial output from failed commands
- normalize tap-qualified declarations such as `stablyai/orca/orca` to the short installed token only for `brew list` and stdout matching
- preserve the full declared name for `outdated`, `info`, `fetch`, and `upgrade`

## Root cause

Current Homebrew returns exit status 1 when a named cask is outdated, while the updater treated every nonzero status as a command failure. Homebrew also records a tapped cask under its short installed token, so `brew list --cask --versions stablyai/orca/orca` incorrectly reported Orca as missing.

## Impact

`nrs` can now update declared macOS desktop casks and converge instead of stopping before Docker Desktop and the remaining setup phases.

## Validation

- updater Bats: 20/20
- macOS configuration Bats: 14/14
- full Bash suite: 171/171
- Bash 3.2 syntax check: passed
- ShellCheck: passed
- pre-commit: 5/5 hooks passed
- independent task reviews and final whole-branch review: passed