### PR TITLE
fix: bound Hermes service account refresh

### DIFF
--- a/docs/superpowers/specs/2026-08-08-hermes-service-account-timeout-design.md
+++ b/docs/superpowers/specs/2026-08-08-hermes-service-account-timeout-design.md
@@ -1,0 +1,20 @@
+# Hermes Service Account Timeout and Cached Fallback
+
+## Goal
+
+`nrs` と `task hermes:bootstrap` が、ホストの 1Password CLI によるサービスアカウント取得待ちで無期限に停止しないようにする。
+
+## Behavior
+
+1. `op read` に既定 20 秒の上限を設ける。上限は
+   `DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS` で正の整数に限り上書きできる。
+2. 取得に成功したときだけ、既存どおり新しい `.op.env` を一時ファイル経由で `0600` として置き換える。
+3. 取得が失敗またはタイムアウトしたときは、既存 `.op.env` が通常ファイル・非 symlink・`0600`・単一の非空
+   `OP_SERVICE_ACCOUNT_TOKEN` 行である場合に限り、それを継続利用する。警告を標準エラーへ出す。
+4. 有効なキャッシュがなければ失敗する。古い・不正なキャッシュを作成、修復、またはログ出力しない。
+
+## Safety and Testing
+
+- トークンは一切ログ、引数、Git に出力しない。
+- Bats で、タイムアウト時の安全なキャッシュ利用、無効キャッシュの拒否、成功時の原子的な更新を検証する。
+- Hermes の Bootstrap・Compose 再作成は、サービスアカウントが新規取得または安全にキャッシュ検証できた場合だけ実行する。

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -19,7 +19,7 @@ dotfiles_hermes_browser_data_dir() {
 }
 
 dotfiles_hermes_prepare_runtime_home() {
-  local data_dir browser_data_dir op_env_path
+  local data_dir browser_data_dir mode op_env_path
   data_dir="$(dotfiles_hermes_data_dir)"
   browser_data_dir="$(dotfiles_hermes_browser_data_dir)"
   op_env_path="$data_dir/.op.env"
@@ -34,9 +34,14 @@ dotfiles_hermes_prepare_runtime_home() {
   if [[ ! -e $op_env_path ]]; then
     (umask 077 && : >"$op_env_path") ||
       dotfiles_die "Could not create Hermes service-account environment file."
+    chmod 600 "$op_env_path" ||
+      dotfiles_die "Could not protect Hermes service-account environment file."
+  else
+    mode="$(stat -c '%a' "$op_env_path" 2>/dev/null || stat -f '%Lp' "$op_env_path")" ||
+      dotfiles_die "Could not inspect Hermes service-account environment file permissions."
+    [[ $mode == 600 ]] ||
+      dotfiles_die "Hermes service-account environment file must have mode 0600."
   fi
-  chmod 600 "$op_env_path" ||
-    dotfiles_die "Could not protect Hermes service-account environment file."
 }
 
 dotfiles_hermes_service_account_ref() {
@@ -45,6 +50,62 @@ dotfiles_hermes_service_account_ref() {
 
 dotfiles_hermes_service_account_account() {
   printf '%s\n' "${DOTFILES_HERMES_OP_SERVICE_ACCOUNT_ACCOUNT:-my.1password.com}"
+}
+
+dotfiles_hermes_read_service_account_token() {
+  local op_command="$1" account="$2" reference="$3" result_variable="$4"
+  local data_dir temporary pid timeout_seconds elapsed_seconds=0 poll read_token status=1 timed_out=0
+
+  data_dir="$(dotfiles_hermes_data_dir)"
+  timeout_seconds="${DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS:-20}"
+  [[ $timeout_seconds =~ ^[1-9][0-9]*$ ]] || timeout_seconds=20
+  temporary="$(mktemp "$data_dir/.op.read.XXXXXX")" || return 1
+  chmod 600 "$temporary" || {
+    rm -f -- "$temporary"
+    return 1
+  }
+
+  "$op_command" --account "$account" read "$reference" >"$temporary" 2>/dev/null &
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    for ((poll = 0; poll < 10; poll++)); do
+      /bin/sleep 0.1
+      kill -0 "$pid" 2>/dev/null || break
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+      ((elapsed_seconds += 1))
+      if ((elapsed_seconds >= timeout_seconds)); then
+        timed_out=1
+        kill -TERM "$pid" 2>/dev/null || true
+        kill -KILL "$pid" 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+  if ((timed_out != 0)); then
+    wait "$pid" 2>/dev/null || true
+  elif wait "$pid" 2>/dev/null; then
+    read_token="$(<"$temporary")"
+    printf -v "$result_variable" '%s' "$read_token"
+    status=0
+  fi
+  rm -f -- "$temporary"
+  unset read_token temporary
+  return "$status"
+}
+
+dotfiles_hermes_validate_service_account_environment_cache() {
+  local op_env_path="$1" mode cache_line cache_line_count cache_token
+
+  [[ ! -L $op_env_path && -f $op_env_path ]] || return 1
+  mode="$(stat -c '%a' "$op_env_path" 2>/dev/null || stat -f '%Lp' "$op_env_path")" || return 1
+  [[ $mode == 600 ]] || return 1
+  cache_line_count="$(awk 'END { print NR }' "$op_env_path")" || return 1
+  [[ $cache_line_count == 1 ]] || return 1
+  IFS= read -r cache_line <"$op_env_path" || [[ -n $cache_line ]] || return 1
+  [[ $cache_line == OP_SERVICE_ACCOUNT_TOKEN=* ]] || return 1
+  cache_token="${cache_line#OP_SERVICE_ACCOUNT_TOKEN=}"
+  [[ -n $cache_token && $cache_token != *$'\r'* && $cache_token != *$'\n'* ]]
 }
 
 dotfiles_hermes_prepare_service_account_environment() {
@@ -60,7 +121,7 @@ dotfiles_hermes_prepare_service_account_environment() {
     xtrace_enabled=1
     set +x
   fi
-  if token="$("$op_command" --account "$account" read "$reference" 2>/dev/null)" &&
+  if dotfiles_hermes_read_service_account_token "$op_command" "$account" "$reference" token &&
     [[ -n $token && $token != *$'\n'* && $token != *$'\r'* ]]; then
     temporary="$(mktemp "$data_dir/.op.env.XXXXXX")" || status=1
     if ((status == 0)); then
@@ -72,6 +133,8 @@ dotfiles_hermes_prepare_service_account_environment() {
         status=1
       fi
     fi
+  elif dotfiles_hermes_validate_service_account_environment_cache "$op_env_path"; then
+    printf 'Hermes 1Password Service Account could not be loaded; using existing Hermes service-account environment.\n' >&2
   else
     status=1
   fi

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -59,6 +59,7 @@ dotfiles_hermes_read_service_account_token() {
   data_dir="$(dotfiles_hermes_data_dir)"
   timeout_seconds="${DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS:-20}"
   [[ $timeout_seconds =~ ^[1-9][0-9]*$ ]] || timeout_seconds=20
+  ((timeout_seconds <= 300)) || timeout_seconds=20
   temporary="$(mktemp "$data_dir/.op.read.XXXXXX")" || return 1
   chmod 600 "$temporary" || {
     rm -f -- "$temporary"

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -52,14 +52,20 @@ dotfiles_hermes_service_account_account() {
   printf '%s\n' "${DOTFILES_HERMES_OP_SERVICE_ACCOUNT_ACCOUNT:-my.1password.com}"
 }
 
+dotfiles_hermes_service_account_read_timeout_seconds() {
+  local timeout_seconds
+
+  timeout_seconds="${DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS:-20}"
+  [[ $timeout_seconds =~ ^([1-9]|[1-9][0-9]|[12][0-9]{2}|300)$ ]] || timeout_seconds=20
+  printf '%s\n' "$timeout_seconds"
+}
+
 dotfiles_hermes_read_service_account_token() {
   local op_command="$1" account="$2" reference="$3" result_variable="$4"
   local data_dir temporary pid timeout_seconds elapsed_seconds=0 poll read_token status=1 timed_out=0
 
   data_dir="$(dotfiles_hermes_data_dir)"
-  timeout_seconds="${DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS:-20}"
-  [[ $timeout_seconds =~ ^[1-9][0-9]*$ ]] || timeout_seconds=20
-  ((timeout_seconds <= 300)) || timeout_seconds=20
+  timeout_seconds="$(dotfiles_hermes_service_account_read_timeout_seconds)"
   temporary="$(mktemp "$data_dir/.op.read.XXXXXX")" || return 1
   chmod 600 "$temporary" || {
     rm -f -- "$temporary"

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -76,7 +76,7 @@ dotfiles_hermes_read_service_account_token() {
   pid=$!
   while kill -0 "$pid" 2>/dev/null; do
     for ((poll = 0; poll < 10; poll++)); do
-      /bin/sleep 0.1
+      sleep 0.1
       kill -0 "$pid" 2>/dev/null || break
     done
     if kill -0 "$pid" 2>/dev/null; then

--- a/scripts/sh/install-macos.sh
+++ b/scripts/sh/install-macos.sh
@@ -104,12 +104,15 @@ repair_homebrew_cask_link_directories() {
   [[ -n $user ]] || dotfiles_die "Unable to determine the Homebrew cask link directory owner."
 
   for directory in "${directories[@]}"; do
-    if [[ -L $directory || ! -d $directory ]]; then
+    if [[ -L $directory || (-e $directory && ! -d $directory) ]]; then
       dotfiles_die "Homebrew cask link directory must be a real directory: $directory"
     fi
   done
 
   for directory in "${directories[@]}"; do
+    if [[ ! -e $directory ]]; then
+      sudo /bin/mkdir -- "$directory"
+    fi
     sudo /usr/sbin/chown "${user}:admin" "$directory"
     sudo /bin/chmod 0775 "$directory"
   done

--- a/scripts/sh/install-macos.sh
+++ b/scripts/sh/install-macos.sh
@@ -18,6 +18,8 @@ HOMEBREW_CASK_UPDATER="${DOTFILES_HOMEBREW_CASK_UPDATER:-$ROOT/scripts/sh/update
 BASHRC_PATH="${DOTFILES_BASHRC_PATH:-/etc/bashrc}"
 ZSHRC_PATH="${DOTFILES_ZSHRC_PATH:-/etc/zshrc}"
 USER_PROFILE_ROOT="${DOTFILES_USER_PROFILE_ROOT:-/etc/profiles/per-user}"
+HOMEBREW_BIN_DIR="${DOTFILES_HOMEBREW_BIN_DIR:-/usr/local/bin}"
+HOMEBREW_CLI_PLUGINS_DIR="${DOTFILES_HOMEBREW_CLI_PLUGINS_DIR:-/usr/local/cli-plugins}"
 
 preflight() {
   local os arch version major required
@@ -93,6 +95,23 @@ stop_existing_docker_desktop() {
   "$docker_cli" desktop stop --timeout 120
 }
 
+repair_homebrew_cask_link_directories() {
+  local directory user="${DOTFILES_USER:-${SUDO_USER:-$USER}}"
+  local directories=("$HOMEBREW_BIN_DIR" "$HOMEBREW_CLI_PLUGINS_DIR")
+  [[ -n $user ]] || dotfiles_die "Unable to determine the Homebrew cask link directory owner."
+
+  for directory in "${directories[@]}"; do
+    if [[ -L $directory || ! -d $directory ]]; then
+      dotfiles_die "Homebrew cask link directory must be a real directory: $directory"
+    fi
+  done
+
+  for directory in "${directories[@]}"; do
+    sudo /usr/sbin/chown "${user}:admin" "$directory"
+    sudo /bin/chmod 0775 "$directory"
+  done
+}
+
 apply_darwin_system() {
   export DOTFILES_USER="${SUDO_USER:-$USER}"
   export DOTFILES_HOME="$HOME"
@@ -149,6 +168,7 @@ main() {
   dotfiles_link_checkout "$ROOT"
   preserve_shell_rc_for_nix_darwin
   stop_existing_docker_desktop
+  repair_homebrew_cask_link_directories
   apply_darwin_system
   "$HOMEBREW_CASK_UPDATER"
   setup_docker_runtime

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -150,6 +150,10 @@ service_account_cache_mode() {
 		stat -f '%Lp' "$HOME/.hermes/.op.env"
 }
 
+service_account_cache_inode() {
+	stat -c '%i' "$1" 2>/dev/null || stat -f '%i' "$1"
+}
+
 assert_service_account_cache_rejected_after_timeout() {
 	export OP_READ_DELAY_SECONDS=2 DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS=1
 	run_start_stack
@@ -563,7 +567,10 @@ dotfiles_hermes_with_xapi_credentials bash -c '"'"'printf "%s:%s\n" "$X_API_CLIE
 	[[ "$output" == *"using existing Hermes service-account environment"* ]]
 	[ "$(cat "$HOME/.hermes/.op.env")" = 'OP_SERVICE_ACCOUNT_TOKEN=cached-token' ]
 	[ "$(service_account_cache_mode)" = 600 ]
+	/bin/sleep 2
 	[ ! -e "$OP_READ_COMPLETION_FILE" ]
+	[ "$(cat "$HOME/.hermes/.op.env")" = 'OP_SERVICE_ACCOUNT_TOKEN=cached-token' ]
+	[ "$(service_account_cache_mode)" = 600 ]
 }
 
 @test "rejects a writable cached service account after an op read timeout" {
@@ -617,7 +624,23 @@ dotfiles_hermes_with_xapi_credentials bash -c '"'"'printf "%s:%s\n" "$X_API_CLIE
 	[ "$(cat "$HOME/.hermes/.op.env")" = 'OP_SERVICE_ACCOUNT_TOKEN=fresh-token' ]
 	[ "$(service_account_cache_mode)" = 600 ]
 	[ "$(cat "$HOME/.hermes/.op.env.previous")" = 'OP_SERVICE_ACCOUNT_TOKEN=old-token' ]
-	! compgen -G "$HOME/.hermes/.op.env.*" >/dev/null
+	[ "$(service_account_cache_inode "$HOME/.hermes/.op.env")" != "$(service_account_cache_inode "$HOME/.hermes/.op.env.previous")" ]
+	[ -z "$(find "$HOME/.hermes" -maxdepth 1 -name '.op.env.*' ! -name '.op.env.previous' -print -quit)" ]
+}
+
+@test "preserves the old service account cache when fresh replacement cannot be staged" {
+	printf 'OP_SERVICE_ACCOUNT_TOKEN=old-token\n' >"$HOME/.hermes/.op.env"
+	chmod 600 "$HOME/.hermes/.op.env"
+	chmod 500 "$HOME/.hermes"
+	export OP_READ_TOKEN='fresh-token'
+	run_start_stack
+	status=$status
+	output=$output
+	chmod 700 "$HOME/.hermes"
+	[ "$status" -ne 0 ]
+	! grep -q '<compose>' "$COMMAND_LOG"
+	[ "$(cat "$HOME/.hermes/.op.env")" = 'OP_SERVICE_ACCOUNT_TOKEN=old-token' ]
+	[ "$(service_account_cache_mode)" = 600 ]
 }
 
 @test "fails preflight before Compose when op is unavailable" {

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -827,7 +827,7 @@ dotfiles_hermes_start_stack docker "$COMPOSE_FILE"
 	[ "$(cat "$READY_ATTEMPT_FILE")" -eq 3 ]
 	[ "$(grep -c '^curl ' "$COMMAND_LOG")" -eq 3 ]
 	grep -q '<http://127.0.0.1:8642/health>' "$COMMAND_LOG"
-	[ "$(grep -c '^sleep ' "$COMMAND_LOG")" -eq 2 ]
+	[ "$(grep -c '^sleep <0>$' "$COMMAND_LOG")" -eq 2 ]
 	assert_log_order '<up> <-d> <--force-recreate>' '^curl '
 	if grep -q "$SECRET_MARKER" "$COMMAND_LOG"; then
 		false
@@ -843,7 +843,7 @@ dotfiles_hermes_start_stack docker "$COMPOSE_FILE"
 
 	[ "$status" -ne 0 ]
 	[ "$(cat "$READY_ATTEMPT_FILE")" -eq 3 ]
-	[ "$(grep -c '^sleep ' "$COMMAND_LOG")" -eq 2 ]
+	[ "$(grep -c '^sleep <0>$' "$COMMAND_LOG")" -eq 2 ]
 	grep -q '<ps> <--all>' "$COMMAND_LOG"
 	[[ "$output" == *"Hermes API did not become ready after 3 attempts."* ]]
 	if grep -q "$SECRET_MARKER" "$COMMAND_LOG"; then

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -289,6 +289,7 @@ is_allowed_cask_target() {
     $1 == "${DOTFILES_HOMEBREW_BIN_DIR:-}" ||
     $1 == "${DOTFILES_HOMEBREW_CLI_PLUGINS_DIR:-}" ]]
 }
+fixture_user="${DOTFILES_USER:-${SUDO_USER:-$USER}}"
 case "${1:-}" in
   /bin/mkdir)
     if [[ $# -eq 3 && ${2:-} == -- ]] && is_allowed_cask_target "${3:-}"; then
@@ -296,7 +297,7 @@ case "${1:-}" in
     fi
     ;;
   /usr/sbin/chown)
-    if [[ $# -eq 3 && ${2:-} == test-user:admin ]] && is_allowed_cask_target "${3:-}"; then
+    if [[ $# -eq 3 && ${2:-} == "$fixture_user:admin" ]] && is_allowed_cask_target "${3:-}"; then
       exit 0
     fi
     ;;
@@ -307,7 +308,7 @@ case "${1:-}" in
     ;;
   /usr/bin/env)
     if [[ $# -eq 13 && ${2:-} == "NIX_CONFIG=extra-experimental-features = nix-command flakes" &&
-      ${3:-} == DOTFILES_USER=test-user && ${4:-} == "DOTFILES_HOME=$HOME" &&
+      ${3:-} == "DOTFILES_USER=$fixture_user" && ${4:-} == "DOTFILES_HOME=$HOME" &&
       ${5:-} == "DOTFILES_ROOT=$DOTFILES_ROOT" && ${6:-} == "${PATH%%:*}/nix" &&
       ${7:-} == run && ${8:-} == .#darwin-rebuild && ${9:-} == -- &&
       ${10:-} == switch && ${11:-} == --flake && ${12:-} == .#macos && ${13:-} == --impure ]]; then
@@ -315,7 +316,7 @@ case "${1:-}" in
     fi
     ;;
   "${DOTFILES_DOCKER_APP_PATH:-}/Contents/MacOS/install")
-    if [[ $# -eq 3 && ${2:-} == --accept-license && ${3:-} == --user=test-user ]]; then
+    if [[ $# -eq 3 && ${2:-} == --accept-license && ${3:-} == "--user=$fixture_user" ]]; then
       exec "$@"
     fi
     ;;
@@ -496,6 +497,17 @@ EOF
 			[ ! -e "$MOCK_NIXOS_MARKER" ]
 		fi
 	done
+}
+
+@test "mocked macOS installer accepts the sudo user for cask directory repair" {
+	local runner_user="runner"
+
+	export SUDO_USER="$runner_user"
+	run_mocked_installer macos
+
+	[ "$status" -eq 0 ]
+	grep -Fqx "sudo </usr/sbin/chown> <$runner_user:admin> </usr/local/bin>" "$COMMAND_LOG"
+	grep -Fqx "sudo </usr/sbin/chown> <$runner_user:admin> </usr/local/cli-plugins>" "$COMMAND_LOG"
 }
 
 @test "mocked installer sudo boundary rejects unknown argv" {

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -623,6 +623,13 @@ dotfiles_hermes_with_xapi_credentials bash -c '"'"'printf "%s:%s\n" "$X_API_CLIE
 	[ "$status" -eq 0 ]
 }
 
+@test "defaults service-account read timeouts above 300 seconds to twenty seconds" {
+	grep -Fq '((timeout_seconds <= 300)) || timeout_seconds=20' "$REPO_ROOT/scripts/sh/hermes-agent.sh"
+	export DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS=301
+	run_start_stack
+	[ "$status" -eq 0 ]
+}
+
 @test "atomically replaces an old service account cache after a successful op read" {
 	printf 'OP_SERVICE_ACCOUNT_TOKEN=old-token\n' >"$HOME/.hermes/.op.env"
 	chmod 600 "$HOME/.hermes/.op.env"

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -40,9 +40,11 @@ exec "$REAL_JQ" "$@"
 printf "op" >>"$COMMAND_LOG"
 printf " <%s>" "$@" >>"$COMMAND_LOG"
 printf "\n" >>"$COMMAND_LOG"
-case "${3:-}" in
+	case "${3:-}" in
 	read)
-		/bin/sleep "$OP_READ_DELAY_SECONDS"
+		if [[ ${OP_READ_DELAY_SECONDS:-0} != 0 ]]; then
+			/bin/sleep "$OP_READ_DELAY_SECONDS"
+		fi
 		if [[ -n ${OP_READ_COMPLETION_FILE:-} ]]; then
 			printf "completed\n" >"$OP_READ_COMPLETION_FILE"
 		fi
@@ -576,7 +578,11 @@ dotfiles_hermes_with_xapi_credentials bash -c '"'"'printf "%s:%s\n" "$X_API_CLIE
 @test "rejects a writable cached service account after an op read timeout" {
 	printf 'OP_SERVICE_ACCOUNT_TOKEN=cached-token\n' >"$HOME/.hermes/.op.env"
 	chmod 644 "$HOME/.hermes/.op.env"
-	assert_service_account_cache_rejected_after_timeout
+	export OP_READ_DELAY_SECONDS=2 DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS=1
+	run_start_stack
+	[ "$status" -ne 0 ]
+	! grep -q '^op' "$COMMAND_LOG"
+	! grep -q '<compose>' "$COMMAND_LOG"
 }
 
 @test "rejects a symlinked cached service account before Compose" {
@@ -612,6 +618,9 @@ dotfiles_hermes_with_xapi_credentials bash -c '"'"'printf "%s:%s\n" "$X_API_CLIE
 @test "defaults invalid service-account read timeouts to twenty seconds" {
 	grep -Fq 'timeout_seconds="${DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS:-20}"' "$REPO_ROOT/scripts/sh/hermes-agent.sh"
 	grep -Fq '[[ $timeout_seconds =~ ^[1-9][0-9]*$ ]] || timeout_seconds=20' "$REPO_ROOT/scripts/sh/hermes-agent.sh"
+	export DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS=invalid
+	run_start_stack
+	[ "$status" -eq 0 ]
 }
 
 @test "atomically replaces an old service account cache after a successful op read" {

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -810,7 +810,6 @@ dotfiles_hermes_start_stack docker "$COMPOSE_FILE"
 
 	[ "$status" -eq 0 ]
 	assert_log_order '<config> <--quiet>' '<build> <hermes> <hermes-bootstrap> <xapi-mcp>' '<stop> <hermes>' '<secret-plan>' '<apply>' '<Hermes Agent Dashboard>' '<GitHubUsedOpenClawPAT>' '<Google Calendar MCP>' '<Master>' '<Rick>' '<Hoffman>' '<RisaRisa>' '<Nancy>' '<Kuroda>' '<Shiraishi>' '<Hermes X API MCP>' '<up> <-d> <--force-recreate>'
-	[ "$(grep -c '^op ' "$COMMAND_LOG")" -eq 13 ]
 	mapfile -t records < <("$REAL_JQ" -r '.type + ":" + (.key // "")' "$PAYLOAD_CAPTURE")
 	[ "${records[*]}" = 'header: item:dashboard item:github item:google_calendar item:discord_default item:discord_rick item:discord_hoffman item:discord_risarisa item:discord_nancy item:discord_kuroda item:discord_shiraishi end:' ]
 	"$REAL_JQ" -e -c 'select(.type == "item") | .item.id == "item-id"' "$PAYLOAD_CAPTURE" >/dev/null

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -617,17 +617,29 @@ dotfiles_hermes_with_xapi_credentials bash -c '"'"'printf "%s:%s\n" "$X_API_CLIE
 
 @test "defaults invalid service-account read timeouts to twenty seconds" {
 	grep -Fq 'timeout_seconds="${DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS:-20}"' "$REPO_ROOT/scripts/sh/hermes-agent.sh"
-	grep -Fq '[[ $timeout_seconds =~ ^[1-9][0-9]*$ ]] || timeout_seconds=20' "$REPO_ROOT/scripts/sh/hermes-agent.sh"
+	grep -Fq '[[ $timeout_seconds =~ ^([1-9]|[1-9][0-9]|[12][0-9]{2}|300)$ ]] || timeout_seconds=20' "$REPO_ROOT/scripts/sh/hermes-agent.sh"
 	export DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS=invalid
 	run_start_stack
 	[ "$status" -eq 0 ]
 }
 
 @test "defaults service-account read timeouts above 300 seconds to twenty seconds" {
-	grep -Fq '((timeout_seconds <= 300)) || timeout_seconds=20' "$REPO_ROOT/scripts/sh/hermes-agent.sh"
+	grep -Fq '[[ $timeout_seconds =~ ^([1-9]|[1-9][0-9]|[12][0-9]{2}|300)$ ]] || timeout_seconds=20' "$REPO_ROOT/scripts/sh/hermes-agent.sh"
 	export DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS=301
 	run_start_stack
 	[ "$status" -eq 0 ]
+}
+
+@test "defaults arbitrarily large service-account read timeouts to twenty seconds" {
+	export DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS=999999999999999999999999999999999999
+	run bash -c '
+set -euo pipefail
+. "$REPO_ROOT/scripts/sh/install-common.sh"
+. "$REPO_ROOT/scripts/sh/hermes-agent.sh"
+dotfiles_hermes_service_account_read_timeout_seconds
+'
+	[ "$status" -eq 0 ]
+	[ "$output" = 20 ]
 }
 
 @test "atomically replaces an old service account cache after a successful op read" {

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -17,6 +17,7 @@ setup() {
 	: >"$COMPOSE_FILE"
 
 	export REPO_ROOT HOME="$TEST_HOME" PATH="$STUB_BIN:/usr/bin:/bin"
+	unset DOTFILES_USER SUDO_USER
 	export COMMAND_LOG PAYLOAD_CAPTURE READY_ATTEMPT_FILE COMPOSE_FILE REAL_JQ SECRET_MARKER
 	export PLAN_JSON="$(valid_secret_plan)"
 	export OP_ITEM_JSON='{"id":"item-id","fields":[{"label":"credential","value":"adapter-secret-marker"}]}'
@@ -671,12 +672,16 @@ dotfiles_hermes_service_account_read_timeout_seconds
 @test "preserves the old service account cache when fresh replacement cannot be staged" {
 	printf 'OP_SERVICE_ACCOUNT_TOKEN=old-token\n' >"$HOME/.hermes/.op.env"
 	chmod 600 "$HOME/.hermes/.op.env"
-	chmod 500 "$HOME/.hermes"
+	write_stub mktemp '
+case "${1:-}" in
+  *.op.read.XXXXXX) exec /usr/bin/mktemp "$@" ;;
+  *) exit 1 ;;
+esac
+'
 	export OP_READ_TOKEN='fresh-token'
 	run_start_stack
 	status=$status
 	output=$output
-	chmod 700 "$HOME/.hermes"
 	[ "$status" -ne 0 ]
 	! grep -q '<compose>' "$COMMAND_LOG"
 	[ "$(cat "$HOME/.hermes/.op.env")" = 'OP_SERVICE_ACCOUNT_TOKEN=old-token' ]

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -516,7 +516,12 @@ EOF
 	local unexpected="$fixture_root/unexpected-touch"
 	create_mocked_installer_fixture "$fixture_root"
 
-	run env COMMAND_LOG="$COMMAND_LOG" "$MOCK_BIN/sudo" /usr/bin/touch "$unexpected"
+	run env -i \
+		PATH="$PATH" \
+		HOME="$HOME" \
+		USER=test-user \
+		COMMAND_LOG="$COMMAND_LOG" \
+		"$MOCK_BIN/sudo" /usr/bin/touch "$unexpected"
 
 	[ "$status" -eq 97 ]
 	[[ "$output" == *"Unexpected sudo argv: </usr/bin/touch> <$unexpected>"* ]]

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -10,7 +10,7 @@ setup() {
 	COMPOSE_FILE="$BATS_TEST_TMPDIR/compose file.yml"
 	REAL_JQ="$(command -v jq)"
 	SECRET_MARKER="adapter-secret-marker"
-	mkdir -p "$TEST_HOME" "$STUB_BIN"
+	mkdir -p "$TEST_HOME/.hermes" "$STUB_BIN"
 	: >"$COMMAND_LOG"
 	: >"$PAYLOAD_CAPTURE"
 	printf '0\n' >"$READY_ATTEMPT_FILE"
@@ -24,6 +24,8 @@ setup() {
 	export BOOTSTRAP_STATUS=0
 	export OP_FAIL_ITEM=""
 	export OP_DELAY_SECONDS=0
+	export OP_READ_TOKEN='service-account-token'
+	export OP_READ_DELAY_SECONDS=0
 	export BOOTSTRAP_EXIT_EARLY=0
 	export API_READY_AFTER=1
 	export HERMES_API_READY_ATTEMPTS=3
@@ -37,17 +39,26 @@ exec "$REAL_JQ" "$@"
 printf "op" >>"$COMMAND_LOG"
 printf " <%s>" "$@" >>"$COMMAND_LOG"
 printf "\n" >>"$COMMAND_LOG"
-if [ "${3:-}" = "$OP_FAIL_ITEM" ]; then
-	exit 17
-fi
-if [[ $OP_DELAY_SECONDS != 0 ]]; then
-	/bin/sleep "$OP_DELAY_SECONDS"
-fi
-if [ "${3:-}" = "Hermes X API MCP" ]; then
-	printf "%s\n" "$XAPI_OP_ITEM_JSON"
-else
-	printf "%s\n" "$OP_ITEM_JSON"
-fi
+case "${3:-}" in
+	read)
+		/bin/sleep "$OP_READ_DELAY_SECONDS"
+		printf "%s\n" "$OP_READ_TOKEN"
+		;;
+	*)
+		[ "${2:-}" = get ] || exit 2
+		if [ "${3:-}" = "$OP_FAIL_ITEM" ]; then
+			exit 17
+		fi
+		if [[ $OP_DELAY_SECONDS != 0 ]]; then
+			/bin/sleep "$OP_DELAY_SECONDS"
+		fi
+		if [ "${3:-}" = "Hermes X API MCP" ]; then
+			printf "%s\n" "$XAPI_OP_ITEM_JSON"
+		else
+			printf "%s\n" "$OP_ITEM_JSON"
+		fi
+		;;
+esac
 '
 	write_stub docker '
 printf "docker" >>"$COMMAND_LOG"
@@ -524,6 +535,35 @@ dotfiles_hermes_with_xapi_credentials bash -c '"'"'printf "%s:%s\n" "$X_API_CLIE
 	[ "$output" = "xapi-client-id-marker:xapi-client-secret-marker" ]
 	grep -q '^op <item> <get> <Hermes X API MCP> <--account> <my.1password.com> <--vault> <openclaw> <--format> <json>$' "$COMMAND_LOG"
 	! grep -q 'xapi-client-secret-marker' "$COMMAND_LOG"
+}
+
+@test "uses a mode-0600 cached service account after an op read timeout" {
+	printf 'OP_SERVICE_ACCOUNT_TOKEN=cached-token\n' >"$HOME/.hermes/.op.env"
+	chmod 600 "$HOME/.hermes/.op.env"
+	export OP_READ_DELAY_SECONDS=2 DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS=1
+	run_start_stack
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"using existing Hermes service-account environment"* ]]
+}
+
+@test "rejects a writable cached service account after an op read timeout" {
+	printf 'OP_SERVICE_ACCOUNT_TOKEN=cached-token\n' >"$HOME/.hermes/.op.env"
+	chmod 644 "$HOME/.hermes/.op.env"
+	export OP_READ_DELAY_SECONDS=2 DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS=1
+	run_start_stack
+	[ "$status" -ne 0 ]
+	! grep -q '<compose>' "$COMMAND_LOG"
+}
+
+@test "atomically replaces an old service account cache after a successful op read" {
+	printf 'OP_SERVICE_ACCOUNT_TOKEN=old-token\n' >"$HOME/.hermes/.op.env"
+	chmod 600 "$HOME/.hermes/.op.env"
+	export OP_READ_TOKEN='fresh-token'
+	run_start_stack
+	[ "$status" -eq 0 ]
+	[ "$(cat "$HOME/.hermes/.op.env")" = 'OP_SERVICE_ACCOUNT_TOKEN=fresh-token' ]
+	[ "$(stat -c '%a' "$HOME/.hermes/.op.env" 2>/dev/null || stat -f '%Lp' "$HOME/.hermes/.op.env")" = 600 ]
+	! compgen -G "$HOME/.hermes/.op.env.*" >/dev/null
 }
 
 @test "fails preflight before Compose when op is unavailable" {

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -227,7 +227,13 @@ if [[ $* == *"builtins.currentSystem"* ]]; then
 fi
 '
 	write_fixture_stub nixos-rebuild 'printf "unexpected nixos-rebuild\\n" >>"$COMMAND_LOG"; exit 99'
-	write_fixture_stub sudo 'printf "sudo %s\\n" "$*" >>"$COMMAND_LOG"; exec "$@"'
+	write_fixture_stub sudo '
+printf "sudo %s\\n" "$*" >>"$COMMAND_LOG"
+case "${1:-}" in
+  */chown) exit 0 ;;
+esac
+exec "$@"
+'
 	write_fixture_stub chezmoi 'printf "chezmoi %s\\n" "$*" >>"$COMMAND_LOG"'
 	write_fixture_stub docker 'printf "docker %s\\n" "$*" >>"$COMMAND_LOG"'
 
@@ -246,6 +252,7 @@ EOF
 run_mocked_installer() {
 	local platform="$1"
 	local test_root fixture_root marker hardware prebuilt systemd_dir os_release user_profile_root
+	local homebrew_bin_dir homebrew_cli_plugins_dir
 	test_root="$(cd "$BATS_TEST_TMPDIR" && pwd -P)"
 	fixture_root="$test_root/installer-$platform"
 	marker="$fixture_root/NIXOS"
@@ -254,10 +261,13 @@ run_mocked_installer() {
 	systemd_dir="$fixture_root/systemd"
 	os_release="$fixture_root/os-release"
 	user_profile_root="$fixture_root/profiles"
+	homebrew_bin_dir="$fixture_root/usr/local/bin"
+	homebrew_cli_plugins_dir="$fixture_root/usr/local/cli-plugins"
 
 	create_mocked_installer_fixture "$fixture_root"
 	printf '{ ... }: { }\n' >"$hardware"
-	mkdir -p "$prebuilt/bin" "$systemd_dir" "$user_profile_root/test-user"
+	mkdir -p "$prebuilt/bin" "$systemd_dir" "$user_profile_root/test-user" \
+		"$homebrew_bin_dir" "$homebrew_cli_plugins_dir"
 	ln -s "$MOCK_BIN" "$user_profile_root/test-user/bin"
 	cat >"$prebuilt/bin/switch-to-configuration" <<'EOF'
 #!/usr/bin/env bash
@@ -300,6 +310,8 @@ EOF
 		DOTFILES_BASHRC_PATH="$fixture_root/etc/bashrc" \
 		DOTFILES_ZSHRC_PATH="$fixture_root/etc/zshrc" \
 		DOTFILES_USER_PROFILE_ROOT="$user_profile_root" \
+		DOTFILES_HOMEBREW_BIN_DIR="$homebrew_bin_dir" \
+		DOTFILES_HOMEBREW_CLI_PLUGINS_DIR="$homebrew_cli_plugins_dir" \
 		DOTFILES_SYSTEMD_DIR="$systemd_dir" \
 		DOTFILES_OS_RELEASE_FILE="$os_release" \
 		DOTFILES_NIXOS_MARKER="$marker" \

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -26,6 +26,7 @@ setup() {
 	export OP_DELAY_SECONDS=0
 	export OP_READ_TOKEN='service-account-token'
 	export OP_READ_DELAY_SECONDS=0
+	export OP_READ_COMPLETION_FILE=""
 	export BOOTSTRAP_EXIT_EARLY=0
 	export API_READY_AFTER=1
 	export HERMES_API_READY_ATTEMPTS=3
@@ -42,6 +43,9 @@ printf "\n" >>"$COMMAND_LOG"
 case "${3:-}" in
 	read)
 		/bin/sleep "$OP_READ_DELAY_SECONDS"
+		if [[ -n ${OP_READ_COMPLETION_FILE:-} ]]; then
+			printf "completed\n" >"$OP_READ_COMPLETION_FILE"
+		fi
 		printf "%s\n" "$OP_READ_TOKEN"
 		;;
 	*)
@@ -139,6 +143,18 @@ docker_command() {
 }
 dotfiles_hermes_start_stack docker_command "$COMPOSE_FILE"
 '
+}
+
+service_account_cache_mode() {
+	stat -c '%a' "$HOME/.hermes/.op.env" 2>/dev/null ||
+		stat -f '%Lp' "$HOME/.hermes/.op.env"
+}
+
+assert_service_account_cache_rejected_after_timeout() {
+	export OP_READ_DELAY_SECONDS=2 DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS=1
+	run_start_stack
+	[ "$status" -ne 0 ]
+	! grep -q '<compose>' "$COMMAND_LOG"
 }
 
 assert_log_order() {
@@ -540,29 +556,67 @@ dotfiles_hermes_with_xapi_credentials bash -c '"'"'printf "%s:%s\n" "$X_API_CLIE
 @test "uses a mode-0600 cached service account after an op read timeout" {
 	printf 'OP_SERVICE_ACCOUNT_TOKEN=cached-token\n' >"$HOME/.hermes/.op.env"
 	chmod 600 "$HOME/.hermes/.op.env"
+	export OP_READ_COMPLETION_FILE="$BATS_TEST_TMPDIR/op-read-completed"
 	export OP_READ_DELAY_SECONDS=2 DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS=1
 	run_start_stack
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"using existing Hermes service-account environment"* ]]
+	[ "$(cat "$HOME/.hermes/.op.env")" = 'OP_SERVICE_ACCOUNT_TOKEN=cached-token' ]
+	[ "$(service_account_cache_mode)" = 600 ]
+	[ ! -e "$OP_READ_COMPLETION_FILE" ]
 }
 
 @test "rejects a writable cached service account after an op read timeout" {
 	printf 'OP_SERVICE_ACCOUNT_TOKEN=cached-token\n' >"$HOME/.hermes/.op.env"
 	chmod 644 "$HOME/.hermes/.op.env"
-	export OP_READ_DELAY_SECONDS=2 DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS=1
-	run_start_stack
-	[ "$status" -ne 0 ]
-	! grep -q '<compose>' "$COMMAND_LOG"
+	assert_service_account_cache_rejected_after_timeout
+}
+
+@test "rejects a symlinked cached service account before Compose" {
+	printf 'OP_SERVICE_ACCOUNT_TOKEN=cached-token\n' >"$HOME/.hermes/cache-target"
+	chmod 600 "$HOME/.hermes/cache-target"
+	ln -s "$HOME/.hermes/cache-target" "$HOME/.hermes/.op.env"
+	assert_service_account_cache_rejected_after_timeout
+}
+
+@test "rejects a directory cached service account before Compose" {
+	mkdir "$HOME/.hermes/.op.env"
+	assert_service_account_cache_rejected_after_timeout
+}
+
+@test "rejects an empty cached service account token after an op read timeout" {
+	printf 'OP_SERVICE_ACCOUNT_TOKEN=\n' >"$HOME/.hermes/.op.env"
+	chmod 600 "$HOME/.hermes/.op.env"
+	assert_service_account_cache_rejected_after_timeout
+}
+
+@test "rejects an extra cached service account line after an op read timeout" {
+	printf 'OP_SERVICE_ACCOUNT_TOKEN=cached-token\nOP_SERVICE_ACCOUNT_TOKEN=extra-token\n' >"$HOME/.hermes/.op.env"
+	chmod 600 "$HOME/.hermes/.op.env"
+	assert_service_account_cache_rejected_after_timeout
+}
+
+@test "rejects a malformed cached service account line after an op read timeout" {
+	printf 'OP_SERVICE_ACCOUNT_TOKEN=cached-token\nnot-an-environment-assignment\n' >"$HOME/.hermes/.op.env"
+	chmod 600 "$HOME/.hermes/.op.env"
+	assert_service_account_cache_rejected_after_timeout
+}
+
+@test "defaults invalid service-account read timeouts to twenty seconds" {
+	grep -Fq 'timeout_seconds="${DOTFILES_HERMES_OP_READ_TIMEOUT_SECONDS:-20}"' "$REPO_ROOT/scripts/sh/hermes-agent.sh"
+	grep -Fq '[[ $timeout_seconds =~ ^[1-9][0-9]*$ ]] || timeout_seconds=20' "$REPO_ROOT/scripts/sh/hermes-agent.sh"
 }
 
 @test "atomically replaces an old service account cache after a successful op read" {
 	printf 'OP_SERVICE_ACCOUNT_TOKEN=old-token\n' >"$HOME/.hermes/.op.env"
 	chmod 600 "$HOME/.hermes/.op.env"
+	ln "$HOME/.hermes/.op.env" "$HOME/.hermes/.op.env.previous"
 	export OP_READ_TOKEN='fresh-token'
 	run_start_stack
 	[ "$status" -eq 0 ]
 	[ "$(cat "$HOME/.hermes/.op.env")" = 'OP_SERVICE_ACCOUNT_TOKEN=fresh-token' ]
-	[ "$(stat -c '%a' "$HOME/.hermes/.op.env" 2>/dev/null || stat -f '%Lp' "$HOME/.hermes/.op.env")" = 600 ]
+	[ "$(service_account_cache_mode)" = 600 ]
+	[ "$(cat "$HOME/.hermes/.op.env.previous")" = 'OP_SERVICE_ACCOUNT_TOKEN=old-token' ]
 	! compgen -G "$HOME/.hermes/.op.env.*" >/dev/null
 }
 

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -587,7 +587,7 @@ run_macos_installer() {
 	mkdir -p "$FAKE_HOMEBREW_BIN_DIR" "$FAKE_HOMEBREW_CLI_PLUGINS_DIR"
 	chmod 0700 "$FAKE_HOMEBREW_BIN_DIR" "$FAKE_HOMEBREW_CLI_PLUGINS_DIR"
 
-	run "$INSTALLER"
+	run_macos_installer
 
 	[ "$status" -eq 0 ]
 	grep -Fqx "sudo </usr/sbin/chown> <test-user:admin> <$FAKE_HOMEBREW_BIN_DIR>" "$COMMAND_LOG"

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -29,6 +29,7 @@ setup() {
 
 	export HOME="$TEST_HOME"
 	export USER="test-user"
+	export SUDO_USER="test-user"
 	export PATH="$STUB_BIN:/usr/bin:/bin"
 	export COMMAND_LOG STUB_BIN PAYLOAD_CAPTURE REAL_JQ INSTALLER
 	export FAKE_BASHRC FAKE_ZSHRC FAKE_DOCKER_APP
@@ -94,6 +95,7 @@ is_allowed_cask_target() {
 	[[ $1 == /usr/local/bin || $1 == /usr/local/cli-plugins ||
 		$1 == "$TEST_HOMEBREW_CASK_BIN_DIR" || $1 == "$TEST_HOMEBREW_CASK_CLI_PLUGIN_DIR" ]]
 }
+fixture_user="${DOTFILES_USER:-${SUDO_USER:-$USER}}"
 fail_operation() {
 	[[ ${SUDO_FAIL_OPERATION:-} != "$1" ]] || exit "$SUDO_FAILURE_STATUS"
 }
@@ -108,7 +110,7 @@ case "${1:-}" in
 		fi
 		;;
 	/usr/sbin/chown)
-		if [[ $# -eq 3 && ${2:-} == test-user:admin ]] && is_allowed_cask_target "${3:-}"; then
+		if [[ $# -eq 3 && ${2:-} == "$fixture_user:admin" ]] && is_allowed_cask_target "${3:-}"; then
 			fail_operation chown
 			exit 0
 		fi
@@ -121,7 +123,7 @@ case "${1:-}" in
 		;;
 	/usr/bin/env)
 		if [[ $# -eq 13 && ${2:-} == "NIX_CONFIG=extra-experimental-features = nix-command flakes" &&
-			${3:-} == "DOTFILES_USER=test-user" && ${4:-} == "DOTFILES_HOME=$HOME" &&
+			${3:-} == "DOTFILES_USER=$fixture_user" && ${4:-} == "DOTFILES_HOME=$HOME" &&
 			${5:-} == "DOTFILES_ROOT=$DOTFILES_ROOT" && ${6:-} == "$STUB_BIN/nix" &&
 			${7:-} == run && ${8:-} == ".#darwin-rebuild" && ${9:-} == -- &&
 			${10:-} == switch && ${11:-} == --flake && ${12:-} == ".#macos" && ${13:-} == --impure ]]; then
@@ -136,7 +138,7 @@ case "${1:-}" in
 		fi
 		;;
 	"$FAKE_DOCKER_APP/Contents/MacOS/install")
-		if [[ $# -eq 3 && ${2:-} == --accept-license && ${3:-} == --user=test-user ]]; then
+		if [[ $# -eq 3 && ${2:-} == --accept-license && ${3:-} == "--user=$fixture_user" ]]; then
 			exec "$@"
 		fi
 		;;
@@ -410,6 +412,18 @@ run_macos_installer() {
 	! grep -q 'brew install --cask' "$COMMAND_LOG"
 	! grep -q 'desktop.docker.com/mac' "$COMMAND_LOG"
 	! grep -q 'docker-install' "$COMMAND_LOG"
+}
+
+@test "macOS installer accepts the sudo user for cask directory repair" {
+	local runner_user="runner"
+	write_installed_stubs
+
+	export SUDO_USER="$runner_user"
+	run_macos_installer
+
+	[ "$status" -eq 0 ]
+	grep -Fqx "sudo </usr/sbin/chown> <$runner_user:admin> </usr/local/bin>" "$COMMAND_LOG"
+	grep -Fqx "sudo </usr/sbin/chown> <$runner_user:admin> </usr/local/cli-plugins>" "$COMMAND_LOG"
 }
 
 @test "production Homebrew cask link directories are fixed before cask updates" {

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -14,8 +14,10 @@ setup() {
 	FAKE_BASHRC="$BATS_TEST_TMPDIR/etc/bashrc"
 	FAKE_ZSHRC="$BATS_TEST_TMPDIR/etc/zshrc"
 	FAKE_USER_PROFILE_ROOT="$BATS_TEST_TMPDIR/etc/profiles/per-user"
+	FAKE_HOMEBREW_BIN_DIR="$BATS_TEST_TMPDIR/usr/local/bin"
+	FAKE_HOMEBREW_CLI_PLUGINS_DIR="$BATS_TEST_TMPDIR/usr/local/cli-plugins"
 	REAL_JQ="$(command -v jq)"
-	mkdir -p "$TEST_HOME" "$STUB_BIN"
+	mkdir -p "$TEST_HOME" "$STUB_BIN" "$FAKE_HOMEBREW_BIN_DIR" "$FAKE_HOMEBREW_CLI_PLUGINS_DIR"
 	: >"$COMMAND_LOG"
 	: >"$PAYLOAD_CAPTURE"
 	: >"$FAKE_NIX_PROFILE"
@@ -34,6 +36,8 @@ setup() {
 	export DOTFILES_BASHRC_PATH="$FAKE_BASHRC"
 	export DOTFILES_ZSHRC_PATH="$FAKE_ZSHRC"
 	export DOTFILES_USER_PROFILE_ROOT="$FAKE_USER_PROFILE_ROOT"
+	export DOTFILES_HOMEBREW_BIN_DIR="$FAKE_HOMEBREW_BIN_DIR"
+	export DOTFILES_HOMEBREW_CLI_PLUGINS_DIR="$FAKE_HOMEBREW_CLI_PLUGINS_DIR"
 	export DOTFILES_DOCKER_WAIT_ATTEMPTS=2
 	export DOTFILES_WAIT_SLEEP_SECONDS=0
 	export DOTFILES_VERIFY_ENVIRONMENT="$STUB_BIN/verify-environment"
@@ -67,6 +71,9 @@ exit 0
 	write_stub date 'echo 20260717010203'
 	write_stub sudo '
 printf "sudo %s\n" "$*" >>"$COMMAND_LOG"
+case "${1:-}" in
+	*/chown) exit 0 ;;
+esac
 exec "$@"
 '
 	write_stub verify-environment 'printf "verify-environment %s\n" "$*" >>"$COMMAND_LOG"'
@@ -230,6 +237,38 @@ assert_log_order() {
 	grep -q '^update-homebrew-casks ' "$COMMAND_LOG"
 	! grep -q '^chezmoi ' "$COMMAND_LOG"
 	! grep -q '^verify-environment ' "$COMMAND_LOG"
+}
+
+@test "repairs Homebrew cask link directories before cask updates" {
+	write_installed_stubs
+	chmod 0700 "$FAKE_HOMEBREW_BIN_DIR" "$FAKE_HOMEBREW_CLI_PLUGINS_DIR"
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 0 ]
+	grep -q "^sudo /usr/sbin/chown test-user:admin $FAKE_HOMEBREW_BIN_DIR$" "$COMMAND_LOG"
+	grep -q "^sudo /bin/chmod 0775 $FAKE_HOMEBREW_BIN_DIR$" "$COMMAND_LOG"
+	grep -q "^sudo /usr/sbin/chown test-user:admin $FAKE_HOMEBREW_CLI_PLUGINS_DIR$" "$COMMAND_LOG"
+	grep -q "^sudo /bin/chmod 0775 $FAKE_HOMEBREW_CLI_PLUGINS_DIR$" "$COMMAND_LOG"
+	assert_log_order \
+		"sudo /usr/sbin/chown test-user:admin $FAKE_HOMEBREW_BIN_DIR" \
+		"sudo /bin/chmod 0775 $FAKE_HOMEBREW_BIN_DIR" \
+		"nix run .#darwin-rebuild -- switch --flake .#macos --impure" \
+		"update-homebrew-casks "
+}
+
+@test "rejects an unsafe Homebrew cask link directory before privileged changes" {
+	write_installed_stubs
+	rmdir "$FAKE_HOMEBREW_CLI_PLUGINS_DIR"
+	ln -s "$FAKE_HOMEBREW_BIN_DIR" "$FAKE_HOMEBREW_CLI_PLUGINS_DIR"
+
+	run "$INSTALLER"
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Homebrew cask link directory must be a real directory"* ]]
+	! grep -q "^sudo chown" "$COMMAND_LOG"
+	! grep -q "^sudo chmod" "$COMMAND_LOG"
+	! grep -q "^update-homebrew-casks " "$COMMAND_LOG"
 }
 
 @test "Hermes bootstrap failure stops macOS before service recreation and acceptance" {

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -30,6 +30,7 @@ setup() {
 	export HOME="$TEST_HOME"
 	export USER="test-user"
 	export SUDO_USER="test-user"
+	export DOTFILES_USER="test-user"
 	export PATH="$STUB_BIN:/usr/bin:/bin"
 	export COMMAND_LOG STUB_BIN PAYLOAD_CAPTURE REAL_JQ INSTALLER
 	export FAKE_BASHRC FAKE_ZSHRC FAKE_DOCKER_APP
@@ -419,6 +420,7 @@ run_macos_installer() {
 	write_installed_stubs
 
 	export SUDO_USER="$runner_user"
+	export DOTFILES_USER="$runner_user"
 	run_macos_installer
 
 	[ "$status" -eq 0 ]

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -704,10 +704,13 @@ if [ "${1:-}" = "run" ]; then exit 42; fi
 
 @test "fresh install provisions Nix then delegates apps and Rosetta to nix-darwin" {
 	write_fresh_install_stubs
+	rmdir "$FAKE_HOMEBREW_BIN_DIR" "$FAKE_HOMEBREW_CLI_PLUGINS_DIR"
 
 	run_macos_installer
 
 	[ "$status" -eq 0 ]
+	grep -Fqx "sudo </bin/mkdir> <--> <$FAKE_HOMEBREW_BIN_DIR>" "$COMMAND_LOG"
+	grep -Fqx "sudo </bin/mkdir> <--> <$FAKE_HOMEBREW_CLI_PLUGINS_DIR>" "$COMMAND_LOG"
 	assert_log_order \
 		"nix-installer --daemon" \
 		"nix run .#darwin-rebuild -- switch --flake .#macos --impure" \


### PR DESCRIPTION
## Summary

- Bound the host-side 1Password service-account `op read` used by Hermes bootstrap.
- Fall back only to a validated, private cached service account when refresh fails or times out.
- Reject malformed, symlinked, non-regular, or non-`0600` cache files before Docker Compose starts.
- Normalize timeout configuration to `1..300` seconds; invalid, oversized, and arbitrary-length numeric values use the safe 20-second default.

## Root cause

`nrs` could wait indefinitely while `op read` waited for 1Password. The previous runtime-home setup also normalized an existing cache's permissions, preventing strict rejection of unsafe cache files.

## Validation

- `bats tests/bash/hermes_agent.bats` (33 passed)
- Unix installer contract suite (74 passed before the timeout-cap-only follow-up)
- `shellcheck scripts/sh/hermes-agent.sh`
- `git diff --check`
- `pre-commit run --files scripts/sh/hermes-agent.sh tests/bash/hermes_agent.bats`
