### PR TITLE
fix: support Docker Desktop md5 setup on macOS

### DIFF
--- a/scripts/sh/install-macos.sh
+++ b/scripts/sh/install-macos.sh
@@ -235,12 +235,37 @@ ensure_homebrew_cask_link_directories() {
     "$HOMEBREW_CASK_CLI_PLUGIN_DIR"
 }
 
+docker_desktop_md5_link_state() {
+  local md5_binary="$1" md5_link="$2"
+  if [[ -L $md5_link && $(/usr/bin/readlink "$md5_link") == "$md5_binary" ]]; then
+    printf 'expected-link\n'
+  elif [[ -e $md5_link || -L $md5_link ]]; then
+    printf 'conflict\n'
+  else
+    printf 'missing\n'
+  fi
+}
+
+ensure_docker_desktop_md5_compatibility() {
+  local md5_binary=/sbin/md5 md5_link=/usr/local/bin/md5 state
+  [[ -x $md5_binary ]] || dotfiles_die "macOS md5 executable is unavailable: $md5_binary"
+  state="$(docker_desktop_md5_link_state "$md5_binary" "$md5_link")"
+  case "$state" in
+  expected-link) return 0 ;;
+  missing) sudo /bin/ln -s "$md5_binary" "$md5_link" ;;
+  conflict) dotfiles_die "Docker Desktop md5 compatibility path conflicts with existing entry: $md5_link" ;;
+  *) dotfiles_die "Unable to determine Docker Desktop md5 compatibility path state: $md5_link" ;;
+  esac
+}
+
 setup_docker_runtime() {
   [[ -d $DOCKER_APP ]] ||
     dotfiles_die "Docker Desktop was not installed by nix-darwin: $DOCKER_APP"
 
   local installer="$DOCKER_APP/Contents/MacOS/install"
   [[ -x $installer ]] || dotfiles_die "Docker Desktop installer not found: $installer"
+
+  ensure_docker_desktop_md5_compatibility
 
   if [[ ! -f $DOCKER_SETUP_MARKER ]]; then
     dotfiles_log "Accepting the Docker Desktop license for personal use..."

--- a/scripts/sh/install-macos.sh
+++ b/scripts/sh/install-macos.sh
@@ -246,13 +246,17 @@ docker_desktop_md5_link_state() {
   fi
 }
 
+docker_desktop_md5_binary_is_executable() {
+  [[ -x /sbin/md5 ]]
+}
+
 ensure_docker_desktop_md5_compatibility() {
   local md5_binary=/sbin/md5 md5_link=/usr/local/bin/md5 state
-  [[ -x $md5_binary ]] || dotfiles_die "macOS md5 executable is unavailable: $md5_binary"
+  docker_desktop_md5_binary_is_executable || dotfiles_die "macOS md5 executable is unavailable: $md5_binary"
   state="$(docker_desktop_md5_link_state "$md5_binary" "$md5_link")"
   case "$state" in
   expected-link) return 0 ;;
-  missing) sudo /bin/ln -s "$md5_binary" "$md5_link" ;;
+  missing) sudo /bin/ln -s /sbin/md5 /usr/local/bin/md5 ;;
   conflict) dotfiles_die "Docker Desktop md5 compatibility path conflicts with existing entry: $md5_link" ;;
   *) dotfiles_die "Unable to determine Docker Desktop md5 compatibility path state: $md5_link" ;;
   esac

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -217,6 +217,9 @@ set -euo pipefail
 
 export DOTFILES_TEST_SELECTED_INSTALLER="$0"
 . "$(dirname "$0")/install-macos-under-test.sh"
+ensure_docker_desktop_md5_compatibility() {
+  :
+}
 homebrew_cask_link_parent_metadata() {
   printf '0 755\n'
 }

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -353,6 +353,9 @@ run_macos_installer_for_host() {
 	run bash -c '
 set -euo pipefail
 . "$INSTALLER"
+ensure_docker_desktop_md5_compatibility() {
+  :
+}
 homebrew_cask_link_parent_metadata() {
   printf "%s\n" "$TEST_HOMEBREW_PARENT_METADATA"
 }
@@ -415,27 +418,75 @@ run_macos_installer() {
 	[ "$(grep -c '^op item get ' "$COMMAND_LOG")" -eq 11 ]
 	[ "$(grep -c '^op signin --account my.1password.com$' "$COMMAND_LOG")" -eq 1 ]
 	[ -s "$PAYLOAD_CAPTURE" ]
-	[ "$(grep -Fxc 'sudo </bin/ln> <-s> </sbin/md5> </usr/local/bin/md5>' "$COMMAND_LOG")" -eq 1 ]
 	! grep -q 'brew install --cask' "$COMMAND_LOG"
 	! grep -q 'desktop.docker.com/mac' "$COMMAND_LOG"
 	! grep -q 'docker-install' "$COMMAND_LOG"
 }
 
-@test "Docker Desktop md5 compatibility link state accepts the expected link" {
-	local path="$BATS_TEST_TMPDIR/md5"
-	ln -s /sbin/md5 "$path"
+@test "Docker Desktop md5 compatibility ensure uses fixed paths for all states" {
+	write_docker_app
 
 	run bash -c '
 set -euo pipefail
 . "$INSTALLER"
-docker_desktop_md5_link_state /sbin/md5 "$1"
-' bash "$path"
+docker_desktop_md5_binary_is_executable() { return 1; }
+ensure_docker_desktop_md5_compatibility
+' bash
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"macOS md5 executable is unavailable: /sbin/md5"* ]]
+
+	: >"$COMMAND_LOG"
+	run bash -c '
+set -euo pipefail
+. "$INSTALLER"
+docker_desktop_md5_binary_is_executable() { :; }
+docker_desktop_md5_link_state() {
+  [[ $1 == /sbin/md5 && $2 == /usr/local/bin/md5 ]] || exit 91
+  printf "expected-link\\n"
+}
+ensure_docker_desktop_md5_compatibility
+' bash
 
 	[ "$status" -eq 0 ]
-	[ "$output" = expected-link ]
+	! grep -q '^sudo ' "$COMMAND_LOG"
+
+	: >"$COMMAND_LOG"
+	run bash -c '
+set -euo pipefail
+. "$INSTALLER"
+docker_desktop_md5_binary_is_executable() { :; }
+docker_desktop_md5_link_state() {
+  [[ $1 == /sbin/md5 && $2 == /usr/local/bin/md5 ]] || exit 91
+  printf "missing\\n"
+}
+ensure_docker_desktop_md5_compatibility
+' bash
+
+	[ "$status" -eq 0 ]
+	[ "$(grep -Fxc 'sudo </bin/ln> <-s> </sbin/md5> </usr/local/bin/md5>' "$COMMAND_LOG")" -eq 1 ]
+	[ "$(grep -c '^sudo ' "$COMMAND_LOG")" -eq 1 ]
+
+	: >"$COMMAND_LOG"
+	run bash -c '
+set -euo pipefail
+. "$INSTALLER"
+docker_desktop_md5_binary_is_executable() { :; }
+docker_desktop_md5_link_state() {
+  [[ $1 == /sbin/md5 && $2 == /usr/local/bin/md5 ]] || exit 91
+  printf "conflict\\n"
+}
+setup_docker_runtime
+' bash
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Docker Desktop md5 compatibility path conflicts with existing entry: /usr/local/bin/md5"* ]]
+	! grep -q '^sudo ' "$COMMAND_LOG"
+	! grep -q '^docker-install ' "$COMMAND_LOG"
+	! grep -q '^docker desktop start ' "$COMMAND_LOG"
 }
 
-@test "Docker Desktop md5 compatibility path rejects a regular file" {
+@test "Docker Desktop md5 compatibility link state rejects a regular file without replacing it" {
 	local path="$BATS_TEST_TMPDIR/md5"
 	touch "$path"
 
@@ -447,20 +498,12 @@ docker_desktop_md5_link_state /sbin/md5 "$1"
 
 	[ "$status" -eq 0 ]
 	[ "$output" = conflict ]
-
-	run bash -c '
-set -euo pipefail
-. "$INSTALLER"
-docker_desktop_md5_link_state() { printf "conflict\n"; }
-ensure_docker_desktop_md5_compatibility
-' bash
-
-	[ "$status" -ne 0 ]
-	[[ "$output" == *"Docker Desktop md5 compatibility path conflicts with existing entry:"* ]]
+	[ -f "$path" ]
 }
 
-@test "Docker Desktop md5 compatibility path rejects a link to another target" {
+@test "Docker Desktop md5 compatibility link state rejects a link to an existing different target" {
 	local path="$BATS_TEST_TMPDIR/md5" target="$BATS_TEST_TMPDIR/other-md5"
+	touch "$target"
 	ln -s "$target" "$path"
 
 	run bash -c '
@@ -471,30 +514,24 @@ docker_desktop_md5_link_state /sbin/md5 "$1"
 
 	[ "$status" -eq 0 ]
 	[ "$output" = conflict ]
-
-	run bash -c '
-set -euo pipefail
-. "$INSTALLER"
-docker_desktop_md5_link_state() { printf "conflict\n"; }
-ensure_docker_desktop_md5_compatibility
-' bash
-
-	[ "$status" -ne 0 ]
-	[[ "$output" == *"Docker Desktop md5 compatibility path conflicts with existing entry:"* ]]
+	[ -L "$path" ]
+	[ "$(/usr/bin/readlink "$path")" = "$target" ]
 }
 
-@test "Docker Desktop md5 compatibility conflict stops before Docker startup" {
+@test "Docker Desktop md5 compatibility link state rejects a dangling link without replacing it" {
+	local path="$BATS_TEST_TMPDIR/md5" target="$BATS_TEST_TMPDIR/missing-md5"
+	ln -s "$target" "$path"
+
 	run bash -c '
 set -euo pipefail
 . "$INSTALLER"
-docker_desktop_md5_link_state() { printf "conflict\n"; }
-ensure_docker_desktop_md5_compatibility
-docker desktop start --timeout 120
-' bash
+docker_desktop_md5_link_state /sbin/md5 "$1"
+' bash "$path"
 
-	[ "$status" -ne 0 ]
-	[[ "$output" == *"Docker Desktop md5 compatibility path conflicts with existing entry:"* ]]
-	! grep -q '^docker desktop start' "$COMMAND_LOG"
+	[ "$status" -eq 0 ]
+	[ "$output" = conflict ]
+	[ -L "$path" ]
+	[ "$(/usr/bin/readlink "$path")" = "$target" ]
 }
 
 @test "macOS installer accepts the sudo user for cask directory repair" {
@@ -512,7 +549,7 @@ docker desktop start --timeout 120
 
 @test "production Homebrew cask link directories are fixed before cask updates" {
 	write_installed_stubs
-	local expected_sudo_count=10 target
+	local expected_sudo_count=9 target
 
 	run_macos_installer
 
@@ -539,7 +576,6 @@ docker desktop start --timeout 120
 		"sudo </usr/sbin/chown> <test-user:admin> </usr/local/cli-plugins>" \
 		"sudo </bin/chmod> <0775> </usr/local/cli-plugins>" \
 		"update-homebrew-casks " \
-		"sudo </bin/ln> <-s> </sbin/md5> </usr/local/bin/md5>" \
 		"docker info"
 }
 

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -122,6 +122,11 @@ case "${1:-}" in
 			exit 0
 		fi
 		;;
+	/bin/ln)
+		if [[ $# -eq 4 && ${2:-} == -s && ${3:-} == /sbin/md5 && ${4:-} == /usr/local/bin/md5 ]]; then
+			exit 0
+		fi
+		;;
 	/usr/bin/env)
 		if [[ $# -eq 13 && ${2:-} == "NIX_CONFIG=extra-experimental-features = nix-command flakes" &&
 			${3:-} == "DOTFILES_USER=$fixture_user" && ${4:-} == "DOTFILES_HOME=$HOME" &&
@@ -410,9 +415,86 @@ run_macos_installer() {
 	[ "$(grep -c '^op item get ' "$COMMAND_LOG")" -eq 11 ]
 	[ "$(grep -c '^op signin --account my.1password.com$' "$COMMAND_LOG")" -eq 1 ]
 	[ -s "$PAYLOAD_CAPTURE" ]
+	[ "$(grep -Fxc 'sudo </bin/ln> <-s> </sbin/md5> </usr/local/bin/md5>' "$COMMAND_LOG")" -eq 1 ]
 	! grep -q 'brew install --cask' "$COMMAND_LOG"
 	! grep -q 'desktop.docker.com/mac' "$COMMAND_LOG"
 	! grep -q 'docker-install' "$COMMAND_LOG"
+}
+
+@test "Docker Desktop md5 compatibility link state accepts the expected link" {
+	local path="$BATS_TEST_TMPDIR/md5"
+	ln -s /sbin/md5 "$path"
+
+	run bash -c '
+set -euo pipefail
+. "$INSTALLER"
+docker_desktop_md5_link_state /sbin/md5 "$1"
+' bash "$path"
+
+	[ "$status" -eq 0 ]
+	[ "$output" = expected-link ]
+}
+
+@test "Docker Desktop md5 compatibility path rejects a regular file" {
+	local path="$BATS_TEST_TMPDIR/md5"
+	touch "$path"
+
+	run bash -c '
+set -euo pipefail
+. "$INSTALLER"
+docker_desktop_md5_link_state /sbin/md5 "$1"
+' bash "$path"
+
+	[ "$status" -eq 0 ]
+	[ "$output" = conflict ]
+
+	run bash -c '
+set -euo pipefail
+. "$INSTALLER"
+docker_desktop_md5_link_state() { printf "conflict\n"; }
+ensure_docker_desktop_md5_compatibility
+' bash
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Docker Desktop md5 compatibility path conflicts with existing entry:"* ]]
+}
+
+@test "Docker Desktop md5 compatibility path rejects a link to another target" {
+	local path="$BATS_TEST_TMPDIR/md5" target="$BATS_TEST_TMPDIR/other-md5"
+	ln -s "$target" "$path"
+
+	run bash -c '
+set -euo pipefail
+. "$INSTALLER"
+docker_desktop_md5_link_state /sbin/md5 "$1"
+' bash "$path"
+
+	[ "$status" -eq 0 ]
+	[ "$output" = conflict ]
+
+	run bash -c '
+set -euo pipefail
+. "$INSTALLER"
+docker_desktop_md5_link_state() { printf "conflict\n"; }
+ensure_docker_desktop_md5_compatibility
+' bash
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Docker Desktop md5 compatibility path conflicts with existing entry:"* ]]
+}
+
+@test "Docker Desktop md5 compatibility conflict stops before Docker startup" {
+	run bash -c '
+set -euo pipefail
+. "$INSTALLER"
+docker_desktop_md5_link_state() { printf "conflict\n"; }
+ensure_docker_desktop_md5_compatibility
+docker desktop start --timeout 120
+' bash
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Docker Desktop md5 compatibility path conflicts with existing entry:"* ]]
+	! grep -q '^docker desktop start' "$COMMAND_LOG"
 }
 
 @test "macOS installer accepts the sudo user for cask directory repair" {
@@ -430,7 +512,7 @@ run_macos_installer() {
 
 @test "production Homebrew cask link directories are fixed before cask updates" {
 	write_installed_stubs
-	local expected_sudo_count=9 target
+	local expected_sudo_count=10 target
 
 	run_macos_installer
 
@@ -456,7 +538,9 @@ run_macos_installer() {
 		"sudo </bin/chmod> <0775> </usr/local/bin>" \
 		"sudo </usr/sbin/chown> <test-user:admin> </usr/local/cli-plugins>" \
 		"sudo </bin/chmod> <0775> </usr/local/cli-plugins>" \
-		"update-homebrew-casks "
+		"update-homebrew-casks " \
+		"sudo </bin/ln> <-s> </sbin/md5> </usr/local/bin/md5>" \
+		"docker info"
 }
 
 @test "Linux harness stubs macOS-only parent inspection" {


### PR DESCRIPTION
## Summary
- make macOS nrs repair Docker Desktop's missing md5 command path before engine startup
- preserve existing md5 entries and fail safely on conflicts
- add host-independent macOS installer coverage for expected, missing, conflicting, and dangling link states

## Root cause
Docker Desktop 4.86.0 runs md5 from an AppleScript shell whose PATH omits /sbin, while macOS provides md5 at /sbin/md5.

## Validation
- bats tests/bash/install_macos.bats (29/29)
- nix fmt -- --fail-on-change
- git diff --check
- task lint (including Hermes Bootstrap tests)