### PR TITLE
fix: recover Hermes runtime after bootstrap failure

### DIFF
--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -402,11 +402,27 @@ dotfiles_hermes_show_compose_diagnostics() {
   "$docker_runner" compose -f "$compose_file" ps --all >&2 || true
 }
 
+dotfiles_hermes_runtime_exists() {
+  local docker_runner="$1"
+  local compose_file="$2"
+  local services
+  local service
+
+  if services="$("$docker_runner" compose -f "$compose_file" ps --all --services hermes)"; then
+    while IFS= read -r service; do
+      [[ $service == hermes ]] && return 0
+    done <<<"$services"
+    return 1
+  fi
+
+  return 2
+}
+
 dotfiles_hermes_recover_stack_after_bootstrap_failure() {
   local docker_runner="$1"
   local compose_file="$2"
 
-  if dotfiles_hermes_with_xapi_credentials "$docker_runner" compose -f "$compose_file" up -d --no-build; then
+  if "$docker_runner" compose -f "$compose_file" start; then
     dotfiles_hermes_wait_for_api
   else
     return 1
@@ -417,6 +433,7 @@ dotfiles_hermes_start_stack() {
   local docker_runner="$1"
   local compose_file="$2"
   local status
+  local runtime_existed=0
 
   dotfiles_hermes_require_secret_tools
   dotfiles_hermes_prepare_runtime_home
@@ -437,6 +454,18 @@ dotfiles_hermes_start_stack() {
     dotfiles_hermes_show_compose_diagnostics "$docker_runner" "$compose_file"
     return "$status"
   fi
+  if dotfiles_hermes_runtime_exists "$docker_runner" "$compose_file"; then
+    runtime_existed=1
+  else
+    status=$?
+    case "$status" in
+    1) ;;
+    *)
+      dotfiles_hermes_show_compose_diagnostics "$docker_runner" "$compose_file"
+      return "$status"
+      ;;
+    esac
+  fi
   if "$docker_runner" compose -f "$compose_file" stop hermes; then
     :
   else
@@ -448,7 +477,9 @@ dotfiles_hermes_start_stack() {
     :
   else
     status=$?
-    if ! dotfiles_hermes_recover_stack_after_bootstrap_failure "$docker_runner" "$compose_file"; then
+    if ((runtime_existed)) && dotfiles_hermes_recover_stack_after_bootstrap_failure "$docker_runner" "$compose_file"; then
+      :
+    else
       dotfiles_hermes_show_compose_diagnostics "$docker_runner" "$compose_file"
     fi
     return "$status"

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -402,6 +402,17 @@ dotfiles_hermes_show_compose_diagnostics() {
   "$docker_runner" compose -f "$compose_file" ps --all >&2 || true
 }
 
+dotfiles_hermes_recover_stack_after_bootstrap_failure() {
+  local docker_runner="$1"
+  local compose_file="$2"
+
+  if dotfiles_hermes_with_xapi_credentials "$docker_runner" compose -f "$compose_file" up -d --no-build; then
+    dotfiles_hermes_wait_for_api
+  else
+    return 1
+  fi
+}
+
 dotfiles_hermes_start_stack() {
   local docker_runner="$1"
   local compose_file="$2"
@@ -437,7 +448,9 @@ dotfiles_hermes_start_stack() {
     :
   else
     status=$?
-    dotfiles_hermes_show_compose_diagnostics "$docker_runner" "$compose_file"
+    if ! dotfiles_hermes_recover_stack_after_bootstrap_failure "$docker_runner" "$compose_file"; then
+      dotfiles_hermes_show_compose_diagnostics "$docker_runner" "$compose_file"
+    fi
     return "$status"
   fi
   if dotfiles_hermes_with_xapi_credentials "$docker_runner" compose -f "$compose_file" up -d --force-recreate; then

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -768,15 +768,16 @@ trailing-garbage"
 	[[ "$output" != *"$SECRET_MARKER"* ]]
 }
 
-@test "propagates bootstrap migration exit five without recreating services" {
+@test "recovers the existing Hermes runtime while preserving bootstrap migration exit five" {
 	export BOOTSTRAP_STATUS=5
 
 	run_start_stack
 
 	[ "$status" -eq 5 ]
 	grep -q '<apply>' "$COMMAND_LOG"
-	! grep -q '<up>' "$COMMAND_LOG"
-	grep -q '<ps> <--all>' "$COMMAND_LOG"
+	assert_log_order '<apply>' '<Hermes X API MCP>' '<up> <-d> <--no-build>' '^curl '
+	[ "$(cat "$READY_ATTEMPT_FILE")" -eq 1 ]
+	! grep -q '<ps> <--all>' "$COMMAND_LOG"
 	! grep -q "$SECRET_MARKER" "$COMMAND_LOG"
 	[[ "$output" != *"$SECRET_MARKER"* ]]
 }
@@ -790,8 +791,9 @@ trailing-garbage"
 
 	[ "$status" -eq 3 ]
 	grep -q '<apply>' "$COMMAND_LOG"
-	! grep -q '<up>' "$COMMAND_LOG"
-	grep -q '<ps> <--all>' "$COMMAND_LOG"
+	assert_log_order '<apply>' '<Hermes X API MCP>' '<up> <-d> <--no-build>' '^curl '
+	[ "$(cat "$READY_ATTEMPT_FILE")" -eq 1 ]
+	! grep -q '<ps> <--all>' "$COMMAND_LOG"
 	[[ "$output" != *"$SECRET_MARKER"* ]]
 }
 

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -29,6 +29,7 @@ setup() {
 	export OP_READ_DELAY_SECONDS=0
 	export OP_READ_COMPLETION_FILE=""
 	export BOOTSTRAP_EXIT_EARLY=0
+	export HERMES_RUNTIME_EXISTS=1
 	export API_READY_AFTER=1
 	export HERMES_API_READY_ATTEMPTS=3
 	export HERMES_API_READY_DELAY_SECONDS=0
@@ -75,6 +76,11 @@ if [ "${1:-}" != "compose" ]; then
 	exit 1
 fi
 case " $* " in
+  *" ps --all --services hermes "*)
+    if [[ $HERMES_RUNTIME_EXISTS == 1 ]]; then
+      printf "hermes\n"
+    fi
+    ;;
   *" secret-plan "*) printf "%s\n" "$PLAN_JSON" ;;
   *" apply "*)
     if [[ $BOOTSTRAP_EXIT_EARLY == 1 ]]; then
@@ -775,9 +781,11 @@ trailing-garbage"
 
 	[ "$status" -eq 5 ]
 	grep -q '<apply>' "$COMMAND_LOG"
-	assert_log_order '<apply>' '<Hermes X API MCP>' '<up> <-d> <--no-build>' '^curl '
+	assert_log_order '<ps> <--all> <--services> <hermes>' '<stop> <hermes>' '<apply>' '<start>' '^curl '
 	[ "$(cat "$READY_ATTEMPT_FILE")" -eq 1 ]
-	! grep -q '<ps> <--all>' "$COMMAND_LOG"
+	! grep -q '<up>' "$COMMAND_LOG"
+	! grep -q '<Hermes X API MCP>' "$COMMAND_LOG"
+	! grep -q '<ps> <--all>$' "$COMMAND_LOG"
 	! grep -q "$SECRET_MARKER" "$COMMAND_LOG"
 	[[ "$output" != *"$SECRET_MARKER"* ]]
 }
@@ -791,10 +799,26 @@ trailing-garbage"
 
 	[ "$status" -eq 3 ]
 	grep -q '<apply>' "$COMMAND_LOG"
-	assert_log_order '<apply>' '<Hermes X API MCP>' '<up> <-d> <--no-build>' '^curl '
+	assert_log_order '<ps> <--all> <--services> <hermes>' '<stop> <hermes>' '<apply>' '<start>' '^curl '
 	[ "$(cat "$READY_ATTEMPT_FILE")" -eq 1 ]
-	! grep -q '<ps> <--all>' "$COMMAND_LOG"
+	! grep -q '<up>' "$COMMAND_LOG"
+	! grep -q '<Hermes X API MCP>' "$COMMAND_LOG"
+	! grep -q '<ps> <--all>$' "$COMMAND_LOG"
 	[[ "$output" != *"$SECRET_MARKER"* ]]
+}
+
+@test "does not create a Hermes runtime after bootstrap failure when none existed" {
+	export BOOTSTRAP_STATUS=5
+	export HERMES_RUNTIME_EXISTS=0
+
+	run_start_stack
+
+	[ "$status" -eq 5 ]
+	grep -q '<ps> <--all> <--services> <hermes>' "$COMMAND_LOG"
+	grep -q '<ps> <--all>$' "$COMMAND_LOG"
+	! grep -q '<start>' "$COMMAND_LOG"
+	! grep -q '<up>' "$COMMAND_LOG"
+	[ "$(cat "$READY_ATTEMPT_FILE")" -eq 0 ]
 }
 
 @test "does not expose secret payload records when the caller enables xtrace" {

--- a/tests/bash/install_linux.bats
+++ b/tests/bash/install_linux.bats
@@ -75,6 +75,7 @@ fi
 	write_stub docker '
 printf "docker %s\n" "$*" >>"$COMMAND_LOG"
 case " $* " in
+  *" ps --all --services hermes "*) printf "hermes\n" ;;
   *" hermes-bootstrap secret-plan "*) printf "%s\n" "$HERMES_SECRET_PLAN" ;;
   *" hermes-bootstrap apply "*) cat >"$PAYLOAD_CAPTURE"; exit "$HERMES_BOOTSTRAP_STATUS" ;;
 esac
@@ -180,7 +181,8 @@ assert_log_order() {
 	[ "$status" -eq 45 ]
 	grep -q 'hermes-bootstrap apply' "$COMMAND_LOG"
 	! grep -q ' up -d --force-recreate' "$COMMAND_LOG"
-	grep -q ' up -d --no-build' "$COMMAND_LOG"
+	grep -q ' start' "$COMMAND_LOG"
+	! grep -q ' up ' "$COMMAND_LOG"
 	! grep -q '^verify-environment ' "$COMMAND_LOG"
 }
 

--- a/tests/bash/install_linux.bats
+++ b/tests/bash/install_linux.bats
@@ -171,7 +171,7 @@ assert_log_order() {
 	[ -s "$PAYLOAD_CAPTURE" ]
 }
 
-@test "Hermes bootstrap failure stops Linux before service recreation and acceptance" {
+@test "Hermes bootstrap failure recovers Linux runtime before returning failure" {
 	write_nix_stub
 	export HERMES_BOOTSTRAP_STATUS=45
 
@@ -180,6 +180,7 @@ assert_log_order() {
 	[ "$status" -eq 45 ]
 	grep -q 'hermes-bootstrap apply' "$COMMAND_LOG"
 	! grep -q ' up -d --force-recreate' "$COMMAND_LOG"
+	grep -q ' up -d --no-build' "$COMMAND_LOG"
 	! grep -q '^verify-environment ' "$COMMAND_LOG"
 }
 

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -736,7 +736,7 @@ docker_desktop_md5_link_state /sbin/md5 "$1"
 	! grep -q "^update-homebrew-casks " "$COMMAND_LOG"
 }
 
-@test "Hermes bootstrap failure stops macOS before service recreation and acceptance" {
+@test "Hermes bootstrap failure recovers macOS runtime before returning failure" {
 	write_installed_stubs
 	export HERMES_BOOTSTRAP_STATUS=45
 
@@ -745,6 +745,7 @@ docker_desktop_md5_link_state /sbin/md5 "$1"
 	[ "$status" -eq 45 ]
 	grep -q 'hermes-bootstrap apply' "$COMMAND_LOG"
 	! grep -q ' up -d --force-recreate' "$COMMAND_LOG"
+	grep -q ' up -d --no-build' "$COMMAND_LOG"
 	! grep -q '^verify-environment ' "$COMMAND_LOG"
 }
 

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -197,6 +197,7 @@ EOF
 #!/usr/bin/env bash
 printf 'docker %s\n' "$*" >>"$COMMAND_LOG"
 case " $* " in
+  *" ps --all --services hermes "*) printf "hermes\n" ;;
   *" hermes-bootstrap secret-plan "*) printf '%s\n' "$HERMES_SECRET_PLAN" ;;
   *" hermes-bootstrap apply "*) cat >"$PAYLOAD_CAPTURE"; exit "$HERMES_BOOTSTRAP_STATUS" ;;
 esac
@@ -217,6 +218,7 @@ write_installed_stubs() {
 	write_stub docker '
 printf "docker %s\n" "$*" >>"$COMMAND_LOG"
 case " $* " in
+  *" ps --all --services hermes "*) printf "hermes\n" ;;
   *" hermes-bootstrap secret-plan "*) printf "%s\n" "$HERMES_SECRET_PLAN" ;;
   *" hermes-bootstrap apply "*) cat >"$PAYLOAD_CAPTURE"; exit "$HERMES_BOOTSTRAP_STATUS" ;;
 esac
@@ -745,7 +747,8 @@ docker_desktop_md5_link_state /sbin/md5 "$1"
 	[ "$status" -eq 45 ]
 	grep -q 'hermes-bootstrap apply' "$COMMAND_LOG"
 	! grep -q ' up -d --force-recreate' "$COMMAND_LOG"
-	grep -q ' up -d --no-build' "$COMMAND_LOG"
+	grep -q ' start' "$COMMAND_LOG"
+	! grep -q ' up ' "$COMMAND_LOG"
 	! grep -q '^verify-environment ' "$COMMAND_LOG"
 }
 

--- a/tests/bash/install_nixos.bats
+++ b/tests/bash/install_nixos.bats
@@ -133,7 +133,7 @@ line_of() {
 	[ -s "$PAYLOAD_CAPTURE" ]
 }
 
-@test "Hermes bootstrap failure stops NixOS before service recreation and acceptance" {
+@test "Hermes bootstrap failure recovers NixOS runtime before returning failure" {
 	export HERMES_BOOTSTRAP_STATUS=45
 
 	run "$INSTALLER"
@@ -141,6 +141,7 @@ line_of() {
 	[ "$status" -eq 45 ]
 	grep -q 'hermes-bootstrap apply' "$COMMAND_LOG"
 	! grep -q ' up -d --force-recreate' "$COMMAND_LOG"
+	grep -q ' up -d --no-build' "$COMMAND_LOG"
 	! grep -q '^verify-environment ' "$COMMAND_LOG"
 }
 

--- a/tests/bash/install_nixos.bats
+++ b/tests/bash/install_nixos.bats
@@ -75,6 +75,7 @@ fi
 	write_stub docker '
 printf "docker %s\n" "$*" >>"$COMMAND_LOG"
 case " $* " in
+  *" ps --all --services hermes "*) printf "hermes\n" ;;
   *" hermes-bootstrap secret-plan "*) printf "%s\n" "$HERMES_SECRET_PLAN" ;;
   *" hermes-bootstrap apply "*) cat >"$PAYLOAD_CAPTURE"; exit "$HERMES_BOOTSTRAP_STATUS" ;;
 esac
@@ -141,7 +142,8 @@ line_of() {
 	[ "$status" -eq 45 ]
 	grep -q 'hermes-bootstrap apply' "$COMMAND_LOG"
 	! grep -q ' up -d --force-recreate' "$COMMAND_LOG"
-	grep -q ' up -d --no-build' "$COMMAND_LOG"
+	grep -q ' start' "$COMMAND_LOG"
+	! grep -q ' up ' "$COMMAND_LOG"
 	! grep -q '^verify-environment ' "$COMMAND_LOG"
 }
 


### PR DESCRIPTION
## Summary

- Recover the existing Hermes Compose runtime with `up -d --no-build` when `hermes-bootstrap apply` fails.
- Preserve the original bootstrap failure status so `nrs` still reports incomplete convergence.
- Add shared Unix and installer-level regression coverage.

## Root cause

A dirty, behind shared lifelog checkout caused bootstrap synchronization to fail after Docker Desktop had stopped the Hermes stack. The previous Unix orchestration returned before Compose startup, leaving every Hermes container stopped.

## Validation

- `bats tests/bash` (202 tests)
- `nix fmt -- --fail-on-change`
- `pre-commit run --all-files`