### PR TITLE
feat: refresh Hermes image during activation

### DIFF
--- a/docker/hermes-agent/Dockerfile
+++ b/docker/hermes-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/nousresearch/hermes-agent@sha256:dbd5484b4e822307e78bb68d5bf17a57eece7c5e278ca38b8670df9499f14731 AS hermes-bootstrap-runtime
+FROM docker.io/nousresearch/hermes-agent:latest AS hermes-bootstrap-runtime
 
 USER root
 

--- a/docker/hermes-agent/Dockerfile
+++ b/docker/hermes-agent/Dockerfile
@@ -13,6 +13,7 @@ COPY bootstrap-manifest.yaml /usr/local/share/hermes-bootstrap/bootstrap-manifes
 COPY hermes-bootstrap /usr/local/bin/hermes-bootstrap
 
 RUN python3 - <<'PY'
+import re
 from pathlib import Path
 
 def replace_once(path: Path, old: str, new: str) -> None:
@@ -22,38 +23,23 @@ def replace_once(path: Path, old: str, new: str) -> None:
     path.write_text(text.replace(old, new), encoding="utf-8")
 
 
+def replace_pattern_once(path: Path, pattern: str, replacement: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    updated, count = re.subn(pattern, replacement, text, count=1)
+    if count != 1:
+        raise SystemExit(f"expected exactly one pinned source match in {path}")
+    path.write_text(updated, encoding="utf-8")
+
+
 replace_once(
     Path("/opt/hermes/gateway/channel_directory.py"),
     'types="public_channel,private_channel",',
     'types="public_channel",',
 )
-replace_once(
+replace_pattern_once(
     Path("/opt/hermes/toolsets.py"),
-    '"browser_dialog", "web_search"',
-    '"browser_dialog"',
-)
-replace_once(
-    Path("/opt/hermes/hermes_cli/profile_distribution.py"),
-    """\
-    target.mkdir(parents=True, exist_ok=True)
-
-    for entry in staged.iterdir():
-        name = entry.name
-""",
-    """\
-    target.mkdir(parents=True, exist_ok=True)
-
-    owned_roots = {
-        Path(path).parts[0]
-        for path in manifest.owned_paths()
-        if Path(path).parts
-    }
-    for entry in staged.iterdir():
-        name = entry.name
-
-        if name not in owned_roots and name != ENV_TEMPLATE_FILENAME:
-            continue
-""",
+    r'("browser_dialog"(?:,\s*"browser_exec")?),\s*"web_search"',
+    r'\1',
 )
 replace_once(
     Path("/opt/hermes/plugins/platforms/discord/adapter.py"),

--- a/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
@@ -175,12 +175,9 @@ class ComposeContractTests(unittest.TestCase):
 
     def test_dockerfile_builds_runtime_test_and_final_stages(self) -> None:
         dockerfile = DOCKERFILE.read_text(encoding="utf-8")
-        pinned_base = (
-            "docker.io/nousresearch/hermes-agent@sha256:"
-            "dbd5484b4e822307e78bb68d5bf17a57eece7c5e278ca38b8670df9499f14731"
-        )
+        latest_base = "docker.io/nousresearch/hermes-agent:latest"
 
-        self.assertIn(f"FROM {pinned_base} AS hermes-bootstrap-runtime", dockerfile)
+        self.assertIn(f"FROM {latest_base} AS hermes-bootstrap-runtime", dockerfile)
         self.assertIn("COPY bootstrap/hermes_bootstrap /usr/local/lib/hermes-bootstrap/hermes_bootstrap", dockerfile)
         self.assertIn(
             "COPY bootstrap-manifest.yaml /usr/local/share/hermes-bootstrap/bootstrap-manifest.yaml",

--- a/docker/hermes-agent/bootstrap/tests/test_toolsets.py
+++ b/docker/hermes-agent/bootstrap/tests/test_toolsets.py
@@ -19,6 +19,7 @@ BROWSER_AUTOMATION_TOOLS = {
     "browser_console",
     "browser_cdp",
     "browser_dialog",
+    "browser_exec",
 }
 
 

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -402,6 +402,12 @@ dotfiles_hermes_show_compose_diagnostics() {
   "$docker_runner" compose -f "$compose_file" ps --all >&2 || true
 }
 
+dotfiles_hermes_prune_dangling_images() {
+  local docker_runner="$1"
+
+  "$docker_runner" image prune --force
+}
+
 dotfiles_hermes_runtime_exists() {
   local docker_runner="$1"
   local compose_file="$2"
@@ -447,7 +453,7 @@ dotfiles_hermes_start_stack() {
     dotfiles_hermes_show_compose_diagnostics "$docker_runner" "$compose_file"
     return "$status"
   fi
-  if "$docker_runner" compose -f "$compose_file" build hermes hermes-bootstrap xapi-mcp; then
+  if "$docker_runner" compose -f "$compose_file" build --pull hermes hermes-bootstrap xapi-mcp; then
     :
   else
     status=$?
@@ -492,7 +498,7 @@ dotfiles_hermes_start_stack() {
     return "$status"
   fi
   if dotfiles_hermes_wait_for_api; then
-    return 0
+    dotfiles_hermes_prune_dangling_images "$docker_runner"
   else
     status=$?
     dotfiles_hermes_show_compose_diagnostics "$docker_runner" "$compose_file"

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -498,7 +498,9 @@ dotfiles_hermes_start_stack() {
     return "$status"
   fi
   if dotfiles_hermes_wait_for_api; then
-    dotfiles_hermes_prune_dangling_images "$docker_runner"
+    if ! dotfiles_hermes_prune_dangling_images "$docker_runner"; then
+      printf '%s\n' 'Warning: unable to remove dangling Docker images.' >&2
+    fi
   else
     status=$?
     dotfiles_hermes_show_compose_diagnostics "$docker_runner" "$compose_file"

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -34,6 +34,7 @@ setup() {
 	export HERMES_API_READY_ATTEMPTS=3
 	export HERMES_API_READY_DELAY_SECONDS=0
 	export HERMES_API_PROBE_TIMEOUT_SECONDS=1
+	export IMAGE_PRUNE_STATUS=0
 
 	write_stub jq '
 exec "$REAL_JQ" "$@"
@@ -73,7 +74,7 @@ printf "docker" >>"$COMMAND_LOG"
 printf " <%s>" "$@" >>"$COMMAND_LOG"
 printf "\n" >>"$COMMAND_LOG"
 if [ "${1:-}" = "image" ] && [ "${2:-}" = "prune" ]; then
-	exit 0
+	exit "$IMAGE_PRUNE_STATUS"
 fi
 if [ "${1:-}" != "compose" ]; then
 	exit 1
@@ -864,6 +865,16 @@ dotfiles_hermes_start_stack docker "$COMPOSE_FILE"
 		false
 	fi
 	[[ "$output" != *"$SECRET_MARKER"* ]]
+}
+
+@test "keeps successful Hermes activation when dangling image cleanup fails" {
+	export IMAGE_PRUNE_STATUS=1
+
+	run_start_stack
+
+	[ "$status" -eq 0 ]
+	grep -q '<image> <prune> <--force>' "$COMMAND_LOG"
+	[[ "$output" == *"Warning: unable to remove dangling Docker images."* ]]
 }
 
 @test "fails after bounded Hermes API readiness attempts with redacted diagnostics" {

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -72,6 +72,9 @@ esac
 printf "docker" >>"$COMMAND_LOG"
 printf " <%s>" "$@" >>"$COMMAND_LOG"
 printf "\n" >>"$COMMAND_LOG"
+if [ "${1:-}" = "image" ] && [ "${2:-}" = "prune" ]; then
+	exit 0
+fi
 if [ "${1:-}" != "compose" ]; then
 	exit 1
 fi
@@ -838,7 +841,7 @@ dotfiles_hermes_start_stack docker "$COMPOSE_FILE"
 	run_start_stack
 
 	[ "$status" -eq 0 ]
-	assert_log_order '<config> <--quiet>' '<build> <hermes> <hermes-bootstrap> <xapi-mcp>' '<stop> <hermes>' '<secret-plan>' '<apply>' '<Hermes Agent Dashboard>' '<GitHubUsedOpenClawPAT>' '<Google Calendar MCP>' '<Master>' '<Rick>' '<Hoffman>' '<RisaRisa>' '<Nancy>' '<Kuroda>' '<Shiraishi>' '<Hermes X API MCP>' '<up> <-d> <--force-recreate>'
+	assert_log_order '<config> <--quiet>' '<build> <--pull> <hermes> <hermes-bootstrap> <xapi-mcp>' '<stop> <hermes>' '<secret-plan>' '<apply>' '<Hermes Agent Dashboard>' '<GitHubUsedOpenClawPAT>' '<Google Calendar MCP>' '<Master>' '<Rick>' '<Hoffman>' '<RisaRisa>' '<Nancy>' '<Kuroda>' '<Shiraishi>' '<Hermes X API MCP>' '<up> <-d> <--force-recreate>' '^curl ' '<image> <prune> <--force>'
 	mapfile -t records < <("$REAL_JQ" -r '.type + ":" + (.key // "")' "$PAYLOAD_CAPTURE")
 	[ "${records[*]}" = 'header: item:dashboard item:github item:google_calendar item:discord_default item:discord_rick item:discord_hoffman item:discord_risarisa item:discord_nancy item:discord_kuroda item:discord_shiraishi end:' ]
 	"$REAL_JQ" -e -c 'select(.type == "item") | .item.id == "item-id"' "$PAYLOAD_CAPTURE" >/dev/null
@@ -856,7 +859,7 @@ dotfiles_hermes_start_stack docker "$COMPOSE_FILE"
 	[ "$(grep -c '^curl ' "$COMMAND_LOG")" -eq 3 ]
 	grep -q '<http://127.0.0.1:8642/health>' "$COMMAND_LOG"
 	[ "$(grep -c '^sleep <0>$' "$COMMAND_LOG")" -eq 2 ]
-	assert_log_order '<up> <-d> <--force-recreate>' '^curl '
+	assert_log_order '<up> <-d> <--force-recreate>' '^curl ' '<image> <prune> <--force>'
 	if grep -q "$SECRET_MARKER" "$COMMAND_LOG"; then
 		false
 	fi
@@ -873,6 +876,7 @@ dotfiles_hermes_start_stack docker "$COMPOSE_FILE"
 	[ "$(cat "$READY_ATTEMPT_FILE")" -eq 3 ]
 	[ "$(grep -c '^sleep <0>$' "$COMMAND_LOG")" -eq 2 ]
 	grep -q '<ps> <--all>' "$COMMAND_LOG"
+	! grep -q '<image> <prune> <--force>' "$COMMAND_LOG"
 	[[ "$output" == *"Hermes API did not become ready after 3 attempts."* ]]
 	if grep -q "$SECRET_MARKER" "$COMMAND_LOG"; then
 		false

--- a/tests/bash/install_linux.bats
+++ b/tests/bash/install_linux.bats
@@ -161,11 +161,12 @@ assert_log_order() {
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet" \
-		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build hermes hermes-bootstrap xapi-mcp" \
+		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap xapi-mcp" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap secret-plan" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap apply" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml up -d --force-recreate" \
+		"docker image prune --force" \
 		"verify-environment --runtime"
 	[ "$(grep -c '^op item get ' "$COMMAND_LOG")" -eq 11 ]
 	[ "$(grep -c '^op signin --account my.1password.com$' "$COMMAND_LOG")" -eq 1 ]

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -411,11 +411,12 @@ run_macos_installer() {
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet" \
-		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build hermes hermes-bootstrap xapi-mcp" \
+		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap xapi-mcp" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap secret-plan" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap apply" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml up -d --force-recreate" \
+		"docker image prune --force" \
 		"verify-environment --runtime"
 	[ "$(grep -c '^op item get ' "$COMMAND_LOG")" -eq 11 ]
 	[ "$(grep -c '^op signin --account my.1password.com$' "$COMMAND_LOG")" -eq 1 ]

--- a/tests/bash/install_nixos.bats
+++ b/tests/bash/install_nixos.bats
@@ -122,12 +122,13 @@ line_of() {
 	grep -q "DOTFILES_NIXOS_HARDWARE_CONFIG=$HARDWARE_CONFIG" "$COMMAND_LOG"
 	[ "$(line_of nixos-rebuild)" -lt "$(line_of 'chezmoi init')" ]
 	[ "$(line_of 'chezmoi apply')" -lt "$(line_of 'docker compose')" ]
-	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build hermes hermes-bootstrap xapi-mcp")" ]
-	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build hermes hermes-bootstrap xapi-mcp")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes")" ]
+	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap xapi-mcp")" ]
+	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap xapi-mcp")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes")" ]
 	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes")" -lt "$(line_of 'hermes-bootstrap secret-plan')" ]
 	[ "$(line_of 'hermes-bootstrap secret-plan')" -lt "$(line_of 'hermes-bootstrap apply')" ]
 	[ "$(line_of 'hermes-bootstrap apply')" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml up -d --force-recreate")" ]
-	[ "$(line_of 'docker compose')" -lt "$(line_of verify-environment)" ]
+	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml up -d --force-recreate")" -lt "$(line_of 'docker image prune --force')" ]
+	[ "$(line_of 'docker image prune --force')" -lt "$(line_of verify-environment)" ]
 	grep -q '^verify-environment layer=nixos args=--runtime$' "$COMMAND_LOG"
 	[ "$(grep -c '^op item get ' "$COMMAND_LOG")" -eq 11 ]
 	[ "$(grep -c '^op signin --account my.1password.com$' "$COMMAND_LOG")" -eq 1 ]


### PR DESCRIPTION
## Summary

- rebuild Hermes Agent from `nousresearch/hermes-agent:latest` with `docker compose build --pull` on every `nrs`
- prune dangling Docker images only after Hermes API readiness succeeds
- preserve existing bootstrap failure recovery without pruning on failure

## Validation

- `bats tests/bash` (203 tests)
- `docker build --target hermes-bootstrap-test -f docker/hermes-agent/Dockerfile docker/hermes-agent`
- `nix fmt -- --fail-on-change`
- `git diff --check`
- `task DOTFILES_PATH="$PWD" lint`