### PR TITLE
Fix restarting running Homebrew cask apps

### DIFF
--- a/scripts/sh/update-homebrew-casks.sh
+++ b/scripts/sh/update-homebrew-casks.sh
@@ -8,8 +8,11 @@ SLEEP_COMMAND="${SLEEP_COMMAND:-sleep}"
 JQ_COMMAND="${JQ_COMMAND:-jq}"
 PGREP_COMMAND="${PGREP_COMMAND:-pgrep}"
 OPEN_COMMAND="${OPEN_COMMAND:-open}"
+PLIST_BUDDY_COMMAND="${PLIST_BUDDY_COMMAND:-/usr/libexec/PlistBuddy}"
+OSASCRIPT_COMMAND="${OSASCRIPT_COMMAND:-osascript}"
 ATTEMPTS="${DOTFILES_CASK_UPDATE_ATTEMPTS:-3}"
 BACKOFF_SECONDS="${DOTFILES_CASK_UPDATE_BACKOFF_SECONDS:-2}"
+APP_EXIT_ATTEMPTS=30
 export HOMEBREW_NO_AUTO_UPDATE=1
 
 case "$ATTEMPTS" in
@@ -132,8 +135,53 @@ record_running_apps() {
     [[ -n $app_path ]] || continue
     if "$PGREP_COMMAND" -f "$app_path/Contents/" >/dev/null 2>&1; then
       grep -Fxq "$app_path" "$restart_file" || printf '%s\n' "$app_path" >>"$restart_file"
+      quit_running_app "$app_path" || return 1
     fi
   done <"$app_file"
+}
+
+application_bundle_identifier() {
+  local app_path="$1" bundle_identifier
+
+  if bundle_identifier=$("$PLIST_BUDDY_COMMAND" -c 'Print :CFBundleIdentifier' "$app_path/Contents/Info.plist"); then
+    :
+  else
+    printf '[macos-cask-update] failed to inspect application bundle identifier: %s\n' "$app_path" >&2
+    return 1
+  fi
+
+  case "$bundle_identifier" in
+  *[!A-Za-z0-9.-]* | '')
+    printf '[macos-cask-update] invalid application bundle identifier: %s\n' "$app_path" >&2
+    return 1
+    ;;
+  esac
+  printf '%s\n' "$bundle_identifier"
+}
+
+wait_for_app_exit() {
+  local app_path="$1" attempt
+
+  for ((attempt = 1; attempt <= APP_EXIT_ATTEMPTS; attempt++)); do
+    if ! "$PGREP_COMMAND" -f "$app_path/Contents/" >/dev/null 2>&1; then
+      return 0
+    fi
+    ((attempt < APP_EXIT_ATTEMPTS)) && "$SLEEP_COMMAND" 1
+  done
+
+  printf '[macos-cask-update] application did not exit: %s\n' "$app_path" >&2
+  return 1
+}
+
+quit_running_app() {
+  local app_path="$1" bundle_identifier
+
+  bundle_identifier="$(application_bundle_identifier "$app_path")" || return 1
+  if ! "$OSASCRIPT_COMMAND" -e "tell application id \"$bundle_identifier\" to quit"; then
+    printf '[macos-cask-update] failed to request application exit: %s\n' "$app_path" >&2
+    return 1
+  fi
+  wait_for_app_exit "$app_path"
 }
 
 reopen_apps() {

--- a/scripts/sh/update-homebrew-casks.sh
+++ b/scripts/sh/update-homebrew-casks.sh
@@ -115,14 +115,11 @@ retry_command() {
 }
 
 record_running_apps() {
-  local cask="$1" app_path status app_file
+  local cask="$1" app_path status app_file cask_info_file quit_identifier_file
   app_file="$temporary_directory/app-paths"
-  if "$BREW_COMMAND" info --cask "$cask" --json=v2 |
-    "$JQ_COMMAND" -r '
-      .casks[0].artifacts[]?
-      | select(has("app"))
-      | if has("target") then .target else .app[] | "/Applications/" + . end
-    ' >"$app_file"; then
+  cask_info_file="$temporary_directory/cask-info"
+  quit_identifier_file="$temporary_directory/quit-identifiers"
+  if "$BREW_COMMAND" info --cask "$cask" --json=v2 >"$cask_info_file"; then
     :
   else
     status=$?
@@ -131,11 +128,43 @@ record_running_apps() {
     return "$status"
   fi
 
+  if "$JQ_COMMAND" -r '
+      .casks[0].artifacts[]?
+      | select(has("app"))
+      | if has("target") then .target else .app[] | "/Applications/" + . end
+    ' "$cask_info_file" >"$app_file"; then
+    :
+  else
+    status=$?
+    printf '[macos-cask-update] failed to inspect application artifacts for %s (status %d)\n' \
+      "$cask" "$status" >&2
+    return "$status"
+  fi
+
+  if "$JQ_COMMAND" -r '
+      [
+        .casks[0].artifacts[]?
+        | select(has("uninstall"))
+        | .uninstall[]?
+        | select(has("quit"))
+        | .quit
+        | if type == "array" then .[] else . end
+      ]
+      | unique[]
+    ' "$cask_info_file" >"$quit_identifier_file"; then
+    :
+  else
+    status=$?
+    printf '[macos-cask-update] failed to inspect application quit identifiers for %s (status %d)\n' \
+      "$cask" "$status" >&2
+    return "$status"
+  fi
+
   while IFS= read -r app_path || [[ -n $app_path ]]; do
     [[ -n $app_path ]] || continue
     if "$PGREP_COMMAND" -f "$app_path/Contents/" >/dev/null 2>&1; then
       grep -Fxq "$app_path" "$restart_file" || printf '%s\n' "$app_path" >>"$restart_file"
-      quit_running_app "$app_path" || return 1
+      quit_running_app "$app_path" "$quit_identifier_file" || return 1
     fi
   done <"$app_file"
 }
@@ -174,12 +203,28 @@ wait_for_app_exit() {
 }
 
 quit_running_app() {
-  local app_path="$1" bundle_identifier
+  local app_path="$1" quit_identifier_file="$2" bundle_identifier quit_identifier
+
+  while IFS= read -r quit_identifier || [[ -n $quit_identifier ]]; do
+    [[ -n $quit_identifier ]] || continue
+    case "$quit_identifier" in
+    *[!A-Za-z0-9.-]* | '')
+      printf '[macos-cask-update] invalid application quit identifier: %s\n' "$app_path" >&2
+      return 1
+      ;;
+    esac
+    if ! "$OSASCRIPT_COMMAND" -e "tell application id \"$quit_identifier\" to quit"; then
+      printf '[macos-cask-update] failed to request application exit: %s\n' "$app_path" >&2
+      return 1
+    fi
+  done <"$quit_identifier_file"
 
   bundle_identifier="$(application_bundle_identifier "$app_path")" || return 1
-  if ! "$OSASCRIPT_COMMAND" -e "tell application id \"$bundle_identifier\" to quit"; then
-    printf '[macos-cask-update] failed to request application exit: %s\n' "$app_path" >&2
-    return 1
+  if ! grep -Fxq "$bundle_identifier" "$quit_identifier_file"; then
+    if ! "$OSASCRIPT_COMMAND" -e "tell application id \"$bundle_identifier\" to quit"; then
+      printf '[macos-cask-update] failed to request application exit: %s\n' "$app_path" >&2
+      return 1
+    fi
   fi
   wait_for_app_exit "$app_path"
 }

--- a/tests/bash/macos_homebrew_cask_update.bats
+++ b/tests/bash/macos_homebrew_cask_update.bats
@@ -22,7 +22,9 @@ setup() {
   export PLIST_BUDDY_COMMAND="$TEST_BIN/PlistBuddy"
   export OSASCRIPT_COMMAND="$TEST_BIN/osascript"
   APP_QUIT_STATE="$BATS_TEST_TMPDIR/app-quit-state"
+  APP_QUIT_IDENTIFIERS="$BATS_TEST_TMPDIR/app-quit-identifiers"
   export APP_QUIT_STATE
+  export APP_QUIT_IDENTIFIERS
   export DOTFILES_CASK_UPDATE_BACKOFF_SECONDS=2
 
   cat >"$BREW_COMMAND" <<'EOF'
@@ -67,6 +69,8 @@ case "$command_name" in
     cask="${2:-}"
     if [[ $cask == claude ]]; then
       printf '%s\n' '{"casks":[{"artifacts":[{"uninstall":[{"quit":["com.anthropic.claudefordesktop"]}]},{"app":["Claude.app"],"target":"/Applications/Claude.app"}]}]}'
+    elif [[ $cask == 1password ]]; then
+      printf '%s\n' '{"casks":[{"artifacts":[{"uninstall":[{"quit":["com.1password.1password","com.1password.1password-launcher"]}]},{"app":["1Password.app"],"target":"/Applications/1Password.app"}]}]}'
     else
       printf '%s\n' '{"casks":[{"artifacts":[]}]}'
     fi
@@ -101,7 +105,19 @@ EOF
 cat >"$OSASCRIPT_COMMAND" <<'EOF'
 #!/usr/bin/env bash
 printf 'osascript %s\n' "$*" >>"$COMMAND_LOG"
-[[ ${FAKE_APP_IGNORES_QUIT:-0} == 1 ]] || : >"$APP_QUIT_STATE"
+printf '%s\n' "$*" >>"$APP_QUIT_IDENTIFIERS"
+if [[ ${FAKE_APP_IGNORES_QUIT:-0} != 1 ]]; then
+  if [[ -z ${FAKE_REQUIRED_QUIT_IDENTIFIERS:-} ]]; then
+    : >"$APP_QUIT_STATE"
+  else
+    all_identifiers_seen=1
+    for required_identifier in $FAKE_REQUIRED_QUIT_IDENTIFIERS; do
+      grep -Fq "$required_identifier" "$APP_QUIT_IDENTIFIERS" || all_identifiers_seen=0
+    done
+    ((all_identifiers_seen)) && : >"$APP_QUIT_STATE"
+  fi
+fi
+exit 0
 EOF
   chmod +x "$BREW_COMMAND" "$NIX_COMMAND" "$SLEEP_COMMAND" "$PGREP_COMMAND" "$OPEN_COMMAND" \
     "$PLIST_BUDDY_COMMAND" "$OSASCRIPT_COMMAND"
@@ -215,6 +231,19 @@ mark_outdated() {
   [ "$quit_line" -lt "$exit_check_line" ]
   [ "$exit_check_line" -lt "$fetch_line" ]
   [ "$upgrade_line" -lt "$open_line" ]
+}
+
+@test "quits every identifier supplied by cask metadata before upgrading" {
+  install_cask 1password
+  mark_outdated 1password
+
+  run env DOTFILES_HOMEBREW_CASKS=1password FAKE_RUNNING_APP=/Applications/1Password.app \
+    FAKE_REQUIRED_QUIT_IDENTIFIERS='com.1password.1password com.1password.1password-launcher' "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  grep -Fq 'tell application id "com.1password.1password" to quit' "$COMMAND_LOG"
+  grep -Fq 'tell application id "com.1password.1password-launcher" to quit' "$COMMAND_LOG"
+  grep -q '^brew fetch --cask 1password$' "$COMMAND_LOG"
 }
 
 @test "does not upgrade when a running application does not exit" {

--- a/tests/bash/macos_homebrew_cask_update.bats
+++ b/tests/bash/macos_homebrew_cask_update.bats
@@ -19,6 +19,10 @@ setup() {
   export JQ_COMMAND
   export PGREP_COMMAND="$TEST_BIN/pgrep"
   export OPEN_COMMAND="$TEST_BIN/open"
+  export PLIST_BUDDY_COMMAND="$TEST_BIN/PlistBuddy"
+  export OSASCRIPT_COMMAND="$TEST_BIN/osascript"
+  APP_QUIT_STATE="$BATS_TEST_TMPDIR/app-quit-state"
+  export APP_QUIT_STATE
   export DOTFILES_CASK_UPDATE_BACKOFF_SECONDS=2
 
   cat >"$BREW_COMMAND" <<'EOF'
@@ -83,13 +87,24 @@ EOF
   cat >"$PGREP_COMMAND" <<'EOF'
 #!/usr/bin/env bash
 printf 'pgrep %s\n' "$*" >>"$COMMAND_LOG"
-[[ "$*" == *"${FAKE_RUNNING_APP:-never}"* ]]
+[[ "$*" == *"${FAKE_RUNNING_APP:-never}"* ]] && [[ ! -f $APP_QUIT_STATE ]]
 EOF
   cat >"$OPEN_COMMAND" <<'EOF'
 #!/usr/bin/env bash
 printf 'open %s\n' "$*" >>"$COMMAND_LOG"
 EOF
-  chmod +x "$BREW_COMMAND" "$NIX_COMMAND" "$SLEEP_COMMAND" "$PGREP_COMMAND" "$OPEN_COMMAND"
+  cat >"$PLIST_BUDDY_COMMAND" <<'EOF'
+#!/usr/bin/env bash
+printf 'PlistBuddy %s\n' "$*" >>"$COMMAND_LOG"
+printf '%s\n' 'com.anthropic.claudefordesktop'
+EOF
+cat >"$OSASCRIPT_COMMAND" <<'EOF'
+#!/usr/bin/env bash
+printf 'osascript %s\n' "$*" >>"$COMMAND_LOG"
+[[ ${FAKE_APP_IGNORES_QUIT:-0} == 1 ]] || : >"$APP_QUIT_STATE"
+EOF
+  chmod +x "$BREW_COMMAND" "$NIX_COMMAND" "$SLEEP_COMMAND" "$PGREP_COMMAND" "$OPEN_COMMAND" \
+    "$PLIST_BUDDY_COMMAND" "$OSASCRIPT_COMMAND"
 }
 
 install_cask() {
@@ -179,6 +194,40 @@ mark_outdated() {
   open_line="$(grep -n -m1 '^open ' "$COMMAND_LOG" | cut -d: -f1)"
   [ "$pgrep_line" -lt "$fetch_line" ]
   [ "$upgrade_line" -lt "$open_line" ]
+}
+
+@test "quits a running application before upgrading and reopens it after the update" {
+  install_cask claude
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude FAKE_RUNNING_APP=/Applications/Claude.app "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  grep -Fq 'osascript -e tell application id "com.anthropic.claudefordesktop" to quit' "$COMMAND_LOG"
+  grep -q '^open -gj /Applications/Claude.app$' "$COMMAND_LOG"
+  initial_pgrep_line="$(grep -n -m1 '^pgrep ' "$COMMAND_LOG" | cut -d: -f1)"
+  quit_line="$(grep -n -m1 '^osascript ' "$COMMAND_LOG" | cut -d: -f1)"
+  exit_check_line="$(grep -n '^pgrep ' "$COMMAND_LOG" | sed -n '2p' | cut -d: -f1)"
+  fetch_line="$(grep -n -m1 '^brew fetch ' "$COMMAND_LOG" | cut -d: -f1)"
+  upgrade_line="$(grep -n -m1 '^brew upgrade ' "$COMMAND_LOG" | cut -d: -f1)"
+  open_line="$(grep -n -m1 '^open ' "$COMMAND_LOG" | cut -d: -f1)"
+  [ "$initial_pgrep_line" -lt "$quit_line" ]
+  [ "$quit_line" -lt "$exit_check_line" ]
+  [ "$exit_check_line" -lt "$fetch_line" ]
+  [ "$upgrade_line" -lt "$open_line" ]
+}
+
+@test "does not upgrade when a running application does not exit" {
+  install_cask claude
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude FAKE_RUNNING_APP=/Applications/Claude.app \
+    FAKE_APP_IGNORES_QUIT=1 "$UPDATER"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"application did not exit: /Applications/Claude.app"* ]]
+  run ! grep -q '^brew fetch ' "$COMMAND_LOG"
+  run ! grep -q '^brew upgrade ' "$COMMAND_LOG"
 }
 
 @test "reopens a running application after upgrade retries are exhausted" {


### PR DESCRIPTION
## Summary
- gracefully quit running GUI applications before their Homebrew cask upgrade
- wait for process exit before upgrading, then reopen the application
- prevent upgrades when an application does not exit

## Root cause
The updater used `open -gj` after an upgrade, which does not restart an application that is already running.

## Validation
- `bats tests/bash/macos_homebrew_cask_update.bats`
- `bats tests/bash`
- `shellcheck scripts/sh/update-homebrew-casks.sh`
- `shfmt -i 2 -d scripts/sh/update-homebrew-casks.sh`