### PR TITLE
fix: allow cask updates after app exit

### DIFF
--- a/scripts/sh/update-homebrew-casks.sh
+++ b/scripts/sh/update-homebrew-casks.sh
@@ -192,7 +192,7 @@ wait_for_app_exit() {
   local app_path="$1" attempt
 
   for ((attempt = 1; attempt <= APP_EXIT_ATTEMPTS; attempt++)); do
-    if ! "$PGREP_COMMAND" -f "$app_path/Contents/" >/dev/null 2>&1; then
+    if ! "$PGREP_COMMAND" -f "$app_path/Contents/MacOS/" >/dev/null 2>&1; then
       return 0
     fi
     ((attempt < APP_EXIT_ATTEMPTS)) && "$SLEEP_COMMAND" 1

--- a/tests/bash/macos_homebrew_cask_update.bats
+++ b/tests/bash/macos_homebrew_cask_update.bats
@@ -91,7 +91,12 @@ EOF
   cat >"$PGREP_COMMAND" <<'EOF'
 #!/usr/bin/env bash
 printf 'pgrep %s\n' "$*" >>"$COMMAND_LOG"
-[[ "$*" == *"${FAKE_RUNNING_APP:-never}"* ]] && [[ ! -f $APP_QUIT_STATE ]]
+[[ "$*" == *"${FAKE_RUNNING_APP:-never}"* ]] || exit 1
+[[ ! -f $APP_QUIT_STATE ]] && exit 0
+[[ ${FAKE_APP_HELPER_REMAINS_AFTER_QUIT:-0} == 1 ]] &&
+  [[ "$*" == *'/Contents/'* ]] &&
+  [[ "$*" != *'/Contents/MacOS/'* ]] && exit 0
+exit 1
 EOF
   cat >"$OPEN_COMMAND" <<'EOF'
 #!/usr/bin/env bash
@@ -244,6 +249,19 @@ mark_outdated() {
   grep -Fq 'tell application id "com.1password.1password" to quit' "$COMMAND_LOG"
   grep -Fq 'tell application id "com.1password.1password-launcher" to quit' "$COMMAND_LOG"
   grep -q '^brew fetch --cask 1password$' "$COMMAND_LOG"
+}
+
+@test "upgrades when an Electron helper remains after the application exits" {
+  install_cask 1password
+  mark_outdated 1password
+
+  run env DOTFILES_HOMEBREW_CASKS=1password FAKE_RUNNING_APP=/Applications/1Password.app \
+    FAKE_APP_HELPER_REMAINS_AFTER_QUIT=1 "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  grep -q '^brew fetch --cask 1password$' "$COMMAND_LOG"
+  grep -q '^brew upgrade --cask --greedy 1password$' "$COMMAND_LOG"
+  grep -q '^open -gj /Applications/1Password.app$' "$COMMAND_LOG"
 }
 
 @test "does not upgrade when a running application does not exit" {


### PR DESCRIPTION
## Summary

- wait only for the Cask app main executable to exit
- keep detecting running apps across the full App Bundle for restart behavior
- add an Electron Helper regression test

## Root cause

Electron Helper processes can remain under an App Bundle after the main application exits. The updater previously waited for every process under `Contents/`, which blocked the Cask update.

## Validation

- `bats tests/bash/macos_homebrew_cask_update.bats`
- `task test:bash DOTFILES_PATH="$PWD"`
- `bash -n scripts/sh/update-homebrew-casks.sh`
- `shellcheck scripts/sh/update-homebrew-casks.sh`
- `pre-commit run --all-files`