### PR TITLE
fix: force quit cask apps before update

### DIFF
--- a/scripts/sh/update-homebrew-casks.sh
+++ b/scripts/sh/update-homebrew-casks.sh
@@ -7,12 +7,12 @@ NIX_COMMAND="${NIX_COMMAND:-nix}"
 SLEEP_COMMAND="${SLEEP_COMMAND:-sleep}"
 JQ_COMMAND="${JQ_COMMAND:-jq}"
 PGREP_COMMAND="${PGREP_COMMAND:-pgrep}"
+PKILL_COMMAND="${PKILL_COMMAND:-pkill}"
 OPEN_COMMAND="${OPEN_COMMAND:-open}"
-PLIST_BUDDY_COMMAND="${PLIST_BUDDY_COMMAND:-/usr/libexec/PlistBuddy}"
-OSASCRIPT_COMMAND="${OSASCRIPT_COMMAND:-osascript}"
 ATTEMPTS="${DOTFILES_CASK_UPDATE_ATTEMPTS:-3}"
 BACKOFF_SECONDS="${DOTFILES_CASK_UPDATE_BACKOFF_SECONDS:-2}"
 APP_EXIT_ATTEMPTS=30
+FORCE_TERMINATE_WAIT_ATTEMPTS=10
 export HOMEBREW_NO_AUTO_UPDATE=1
 
 case "$ATTEMPTS" in
@@ -115,10 +115,9 @@ retry_command() {
 }
 
 record_running_apps() {
-  local cask="$1" app_path status app_file cask_info_file quit_identifier_file
+  local cask="$1" app_path status app_file cask_info_file
   app_file="$temporary_directory/app-paths"
   cask_info_file="$temporary_directory/cask-info"
-  quit_identifier_file="$temporary_directory/quit-identifiers"
   if "$BREW_COMMAND" info --cask "$cask" --json=v2 >"$cask_info_file"; then
     :
   else
@@ -141,92 +140,58 @@ record_running_apps() {
     return "$status"
   fi
 
-  if "$JQ_COMMAND" -r '
-      [
-        .casks[0].artifacts[]?
-        | select(has("uninstall"))
-        | .uninstall[]?
-        | select(has("quit"))
-        | .quit
-        | if type == "array" then .[] else . end
-      ]
-      | unique[]
-    ' "$cask_info_file" >"$quit_identifier_file"; then
-    :
-  else
-    status=$?
-    printf '[macos-cask-update] failed to inspect application quit identifiers for %s (status %d)\n' \
-      "$cask" "$status" >&2
-    return "$status"
-  fi
-
   while IFS= read -r app_path || [[ -n $app_path ]]; do
     [[ -n $app_path ]] || continue
     if "$PGREP_COMMAND" -f "$app_path/Contents/" >/dev/null 2>&1; then
       grep -Fxq "$app_path" "$restart_file" || printf '%s\n' "$app_path" >>"$restart_file"
-      quit_running_app "$app_path" "$quit_identifier_file" || return 1
+      force_quit_running_app "$cask" "$app_path" || return 1
     fi
   done <"$app_file"
 }
 
-application_bundle_identifier() {
-  local app_path="$1" bundle_identifier
-
-  if bundle_identifier=$("$PLIST_BUDDY_COMMAND" -c 'Print :CFBundleIdentifier' "$app_path/Contents/Info.plist"); then
-    :
-  else
-    printf '[macos-cask-update] failed to inspect application bundle identifier: %s\n' "$app_path" >&2
-    return 1
-  fi
-
-  case "$bundle_identifier" in
-  *[!A-Za-z0-9.-]* | '')
-    printf '[macos-cask-update] invalid application bundle identifier: %s\n' "$app_path" >&2
-    return 1
-    ;;
-  esac
-  printf '%s\n' "$bundle_identifier"
-}
-
 wait_for_app_exit() {
-  local app_path="$1" attempt
+  local app_path="$1" max_attempts="$2" attempt
 
-  for ((attempt = 1; attempt <= APP_EXIT_ATTEMPTS; attempt++)); do
-    if ! "$PGREP_COMMAND" -f "$app_path/Contents/MacOS/" >/dev/null 2>&1; then
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if ! "$PGREP_COMMAND" -f "$app_path/Contents/" >/dev/null 2>&1; then
       return 0
     fi
-    ((attempt < APP_EXIT_ATTEMPTS)) && "$SLEEP_COMMAND" 1
+    ((attempt < max_attempts)) && "$SLEEP_COMMAND" 1
   done
-
-  printf '[macos-cask-update] application did not exit: %s\n' "$app_path" >&2
   return 1
 }
 
-quit_running_app() {
-  local app_path="$1" quit_identifier_file="$2" bundle_identifier quit_identifier
+send_app_signal() {
+  local cask="$1" app_path="$2" signal="$3"
 
-  while IFS= read -r quit_identifier || [[ -n $quit_identifier ]]; do
-    [[ -n $quit_identifier ]] || continue
-    case "$quit_identifier" in
-    *[!A-Za-z0-9.-]* | '')
-      printf '[macos-cask-update] invalid application quit identifier: %s\n' "$app_path" >&2
-      return 1
-      ;;
-    esac
-    if ! "$OSASCRIPT_COMMAND" -e "tell application id \"$quit_identifier\" to quit"; then
-      printf '[macos-cask-update] failed to request application exit: %s\n' "$app_path" >&2
-      return 1
-    fi
-  done <"$quit_identifier_file"
-
-  bundle_identifier="$(application_bundle_identifier "$app_path")" || return 1
-  if ! grep -Fxq "$bundle_identifier" "$quit_identifier_file"; then
-    if ! "$OSASCRIPT_COMMAND" -e "tell application id \"$bundle_identifier\" to quit"; then
-      printf '[macos-cask-update] failed to request application exit: %s\n' "$app_path" >&2
-      return 1
-    fi
+  if "$PKILL_COMMAND" "-$signal" -f "$app_path/Contents/"; then
+    return 0
   fi
-  wait_for_app_exit "$app_path"
+
+  if ! "$PGREP_COMMAND" -f "$app_path/Contents/" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  printf '[macos-cask-update] failed to send %s to cask %s application: %s\n' \
+    "$signal" "$cask" "$app_path" >&2
+  return 1
+}
+
+force_quit_running_app() {
+  local cask="$1" app_path="$2"
+
+  send_app_signal "$cask" "$app_path" TERM || return 1
+  if wait_for_app_exit "$app_path" "$FORCE_TERMINATE_WAIT_ATTEMPTS"; then
+    return 0
+  fi
+
+  send_app_signal "$cask" "$app_path" KILL || return 1
+  if wait_for_app_exit "$app_path" "$APP_EXIT_ATTEMPTS"; then
+    return 0
+  fi
+
+  printf '[macos-cask-update] application did not exit: %s\n' "$app_path" >&2
+  return 1
 }
 
 reopen_apps() {

--- a/scripts/sh/update-homebrew-casks.sh
+++ b/scripts/sh/update-homebrew-casks.sh
@@ -7,7 +7,8 @@ NIX_COMMAND="${NIX_COMMAND:-nix}"
 SLEEP_COMMAND="${SLEEP_COMMAND:-sleep}"
 JQ_COMMAND="${JQ_COMMAND:-jq}"
 PGREP_COMMAND="${PGREP_COMMAND:-pgrep}"
-PKILL_COMMAND="${PKILL_COMMAND:-pkill}"
+PS_COMMAND="${PS_COMMAND:-ps}"
+KILL_COMMAND="${KILL_COMMAND:-/bin/kill}"
 OPEN_COMMAND="${OPEN_COMMAND:-open}"
 ATTEMPTS="${DOTFILES_CASK_UPDATE_ATTEMPTS:-3}"
 BACKOFF_SECONDS="${DOTFILES_CASK_UPDATE_BACKOFF_SECONDS:-2}"
@@ -142,18 +143,34 @@ record_running_apps() {
 
   while IFS= read -r app_path || [[ -n $app_path ]]; do
     [[ -n $app_path ]] || continue
-    if "$PGREP_COMMAND" -f "$app_path/Contents/" >/dev/null 2>&1; then
+    if app_is_running "$app_path"; then
       grep -Fxq "$app_path" "$restart_file" || printf '%s\n' "$app_path" >>"$restart_file"
       force_quit_running_app "$cask" "$app_path" || return 1
     fi
   done <"$app_file"
 }
 
+app_process_ids() {
+  local app_path="$1" process_id executable
+
+  while IFS= read -r process_id || [[ -n $process_id ]]; do
+    [[ $process_id =~ ^[0-9]+$ ]] || continue
+    executable="$("$PS_COMMAND" -p "$process_id" -o comm= 2>/dev/null)" || continue
+    [[ $executable == "$app_path/Contents/"* ]] && printf '%s\n' "$process_id"
+  done < <("$PGREP_COMMAND" -f "$app_path/Contents/" 2>/dev/null || true)
+}
+
+app_is_running() {
+  local app_path="$1" process_ids
+  process_ids="$(app_process_ids "$app_path")"
+  [[ -n $process_ids ]]
+}
+
 wait_for_app_exit() {
   local app_path="$1" max_attempts="$2" attempt
 
   for ((attempt = 1; attempt <= max_attempts; attempt++)); do
-    if ! "$PGREP_COMMAND" -f "$app_path/Contents/" >/dev/null 2>&1; then
+    if ! app_is_running "$app_path"; then
       return 0
     fi
     ((attempt < max_attempts)) && "$SLEEP_COMMAND" 1
@@ -162,13 +179,19 @@ wait_for_app_exit() {
 }
 
 send_app_signal() {
-  local cask="$1" app_path="$2" signal="$3"
+  local cask="$1" app_path="$2" signal="$3" process_id
+  local -a process_ids=()
 
-  if "$PKILL_COMMAND" "-$signal" -f "$app_path/Contents/"; then
+  while IFS= read -r process_id || [[ -n $process_id ]]; do
+    [[ -n $process_id ]] && process_ids+=("$process_id")
+  done < <(app_process_ids "$app_path")
+
+  ((${#process_ids[@]} > 0)) || return 0
+  if "$KILL_COMMAND" "-$signal" "${process_ids[@]}"; then
     return 0
   fi
 
-  if ! "$PGREP_COMMAND" -f "$app_path/Contents/" >/dev/null 2>&1; then
+  if ! app_is_running "$app_path"; then
     return 0
   fi
 

--- a/tests/bash/macos_homebrew_cask_update.bats
+++ b/tests/bash/macos_homebrew_cask_update.bats
@@ -18,13 +18,10 @@ setup() {
   JQ_COMMAND="$(command -v jq)"
   export JQ_COMMAND
   export PGREP_COMMAND="$TEST_BIN/pgrep"
+  export PKILL_COMMAND="$TEST_BIN/pkill"
   export OPEN_COMMAND="$TEST_BIN/open"
-  export PLIST_BUDDY_COMMAND="$TEST_BIN/PlistBuddy"
-  export OSASCRIPT_COMMAND="$TEST_BIN/osascript"
-  APP_QUIT_STATE="$BATS_TEST_TMPDIR/app-quit-state"
-  APP_QUIT_IDENTIFIERS="$BATS_TEST_TMPDIR/app-quit-identifiers"
-  export APP_QUIT_STATE
-  export APP_QUIT_IDENTIFIERS
+  APP_PROCESS_EXITED_STATE="$BATS_TEST_TMPDIR/app-process-exited"
+  export APP_PROCESS_EXITED_STATE
   export DOTFILES_CASK_UPDATE_BACKOFF_SECONDS=2
 
   cat >"$BREW_COMMAND" <<'EOF'
@@ -68,9 +65,11 @@ case "$command_name" in
     [[ ${BREW_INFO_FAIL:-0} != 1 ]] || exit 66
     cask="${2:-}"
     if [[ $cask == claude ]]; then
-      printf '%s\n' '{"casks":[{"artifacts":[{"uninstall":[{"quit":["com.anthropic.claudefordesktop"]}]},{"app":["Claude.app"],"target":"/Applications/Claude.app"}]}]}'
+      printf '%s\n' '{"casks":[{"artifacts":[{"app":["Claude.app"],"target":"/Applications/Claude.app"}]}]}'
     elif [[ $cask == 1password ]]; then
-      printf '%s\n' '{"casks":[{"artifacts":[{"uninstall":[{"quit":["com.1password.1password","com.1password.1password-launcher"]}]},{"app":["1Password.app"],"target":"/Applications/1Password.app"}]}]}'
+      printf '%s\n' '{"casks":[{"artifacts":[{"app":["1Password.app"],"target":"/Applications/1Password.app"}]}]}'
+    elif [[ $cask == thebrowsercompany-dia ]]; then
+      printf '%s\n' '{"casks":[{"artifacts":[{"app":["Dia.app"],"target":"/Applications/Dia.app"}]}]}'
     else
       printf '%s\n' '{"casks":[{"artifacts":[]}]}'
     fi
@@ -92,40 +91,34 @@ EOF
 #!/usr/bin/env bash
 printf 'pgrep %s\n' "$*" >>"$COMMAND_LOG"
 [[ "$*" == *"${FAKE_RUNNING_APP:-never}"* ]] || exit 1
-[[ ! -f $APP_QUIT_STATE ]] && exit 0
-[[ ${FAKE_APP_HELPER_REMAINS_AFTER_QUIT:-0} == 1 ]] &&
-  [[ "$*" == *'/Contents/'* ]] &&
-  [[ "$*" != *'/Contents/MacOS/'* ]] && exit 0
-exit 1
+[[ ! -f $APP_PROCESS_EXITED_STATE ]]
+EOF
+  cat >"$PKILL_COMMAND" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'pkill %s\n' "$*" >>"$COMMAND_LOG"
+[[ "$*" == *"${FAKE_RUNNING_APP:-never}"* ]] || exit 1
+[[ ! -f $APP_PROCESS_EXITED_STATE ]] || exit 1
+
+case "$*" in
+*-TERM*)
+  if [[ ${FAKE_APP_EXITS_DURING_TERM:-0} == 1 ]]; then
+    : >"$APP_PROCESS_EXITED_STATE"
+    exit 1
+  fi
+  [[ ${FAKE_APP_IGNORES_TERM:-0} == 1 ]] || : >"$APP_PROCESS_EXITED_STATE"
+  ;;
+*-KILL*)
+  [[ ${FAKE_APP_IGNORES_KILL:-0} == 1 ]] || : >"$APP_PROCESS_EXITED_STATE"
+  ;;
+*) exit 64 ;;
+esac
 EOF
   cat >"$OPEN_COMMAND" <<'EOF'
 #!/usr/bin/env bash
 printf 'open %s\n' "$*" >>"$COMMAND_LOG"
 EOF
-  cat >"$PLIST_BUDDY_COMMAND" <<'EOF'
-#!/usr/bin/env bash
-printf 'PlistBuddy %s\n' "$*" >>"$COMMAND_LOG"
-printf '%s\n' 'com.anthropic.claudefordesktop'
-EOF
-cat >"$OSASCRIPT_COMMAND" <<'EOF'
-#!/usr/bin/env bash
-printf 'osascript %s\n' "$*" >>"$COMMAND_LOG"
-printf '%s\n' "$*" >>"$APP_QUIT_IDENTIFIERS"
-if [[ ${FAKE_APP_IGNORES_QUIT:-0} != 1 ]]; then
-  if [[ -z ${FAKE_REQUIRED_QUIT_IDENTIFIERS:-} ]]; then
-    : >"$APP_QUIT_STATE"
-  else
-    all_identifiers_seen=1
-    for required_identifier in $FAKE_REQUIRED_QUIT_IDENTIFIERS; do
-      grep -Fq "$required_identifier" "$APP_QUIT_IDENTIFIERS" || all_identifiers_seen=0
-    done
-    ((all_identifiers_seen)) && : >"$APP_QUIT_STATE"
-  fi
-fi
-exit 0
-EOF
-  chmod +x "$BREW_COMMAND" "$NIX_COMMAND" "$SLEEP_COMMAND" "$PGREP_COMMAND" "$OPEN_COMMAND" \
-    "$PLIST_BUDDY_COMMAND" "$OSASCRIPT_COMMAND"
+  chmod +x "$BREW_COMMAND" "$NIX_COMMAND" "$SLEEP_COMMAND" "$PGREP_COMMAND" "$PKILL_COMMAND" "$OPEN_COMMAND"
 }
 
 install_cask() {
@@ -217,64 +210,92 @@ mark_outdated() {
   [ "$upgrade_line" -lt "$open_line" ]
 }
 
-@test "quits a running application before upgrading and reopens it after the update" {
+@test "sends TERM to a running application before upgrading and reopens it after the update" {
   install_cask claude
   mark_outdated claude
 
   run env DOTFILES_HOMEBREW_CASKS=claude FAKE_RUNNING_APP=/Applications/Claude.app "$UPDATER"
 
   [ "$status" -eq 0 ]
-  grep -Fq 'osascript -e tell application id "com.anthropic.claudefordesktop" to quit' "$COMMAND_LOG"
+  grep -q '^pkill -TERM -f /Applications/Claude.app/Contents/$' "$COMMAND_LOG"
   grep -q '^open -gj /Applications/Claude.app$' "$COMMAND_LOG"
   initial_pgrep_line="$(grep -n -m1 '^pgrep ' "$COMMAND_LOG" | cut -d: -f1)"
-  quit_line="$(grep -n -m1 '^osascript ' "$COMMAND_LOG" | cut -d: -f1)"
+  terminate_line="$(grep -n -m1 '^pkill -TERM ' "$COMMAND_LOG" | cut -d: -f1)"
   exit_check_line="$(grep -n '^pgrep ' "$COMMAND_LOG" | sed -n '2p' | cut -d: -f1)"
   fetch_line="$(grep -n -m1 '^brew fetch ' "$COMMAND_LOG" | cut -d: -f1)"
   upgrade_line="$(grep -n -m1 '^brew upgrade ' "$COMMAND_LOG" | cut -d: -f1)"
   open_line="$(grep -n -m1 '^open ' "$COMMAND_LOG" | cut -d: -f1)"
-  [ "$initial_pgrep_line" -lt "$quit_line" ]
-  [ "$quit_line" -lt "$exit_check_line" ]
+  [ "$initial_pgrep_line" -lt "$terminate_line" ]
+  [ "$terminate_line" -lt "$exit_check_line" ]
   [ "$exit_check_line" -lt "$fetch_line" ]
   [ "$upgrade_line" -lt "$open_line" ]
 }
 
-@test "quits every identifier supplied by cask metadata before upgrading" {
+@test "force kills an application helper that remains after TERM" {
   install_cask 1password
   mark_outdated 1password
 
   run env DOTFILES_HOMEBREW_CASKS=1password FAKE_RUNNING_APP=/Applications/1Password.app \
-    FAKE_REQUIRED_QUIT_IDENTIFIERS='com.1password.1password com.1password.1password-launcher' "$UPDATER"
+    FAKE_APP_IGNORES_TERM=1 "$UPDATER"
 
   [ "$status" -eq 0 ]
-  grep -Fq 'tell application id "com.1password.1password" to quit' "$COMMAND_LOG"
-  grep -Fq 'tell application id "com.1password.1password-launcher" to quit' "$COMMAND_LOG"
-  grep -q '^brew fetch --cask 1password$' "$COMMAND_LOG"
-}
-
-@test "upgrades when an Electron helper remains after the application exits" {
-  install_cask 1password
-  mark_outdated 1password
-
-  run env DOTFILES_HOMEBREW_CASKS=1password FAKE_RUNNING_APP=/Applications/1Password.app \
-    FAKE_APP_HELPER_REMAINS_AFTER_QUIT=1 "$UPDATER"
-
-  [ "$status" -eq 0 ]
+  grep -q '^pkill -KILL -f /Applications/1Password.app/Contents/$' "$COMMAND_LOG"
   grep -q '^brew fetch --cask 1password$' "$COMMAND_LOG"
   grep -q '^brew upgrade --cask --greedy 1password$' "$COMMAND_LOG"
   grep -q '^open -gj /Applications/1Password.app$' "$COMMAND_LOG"
 }
 
-@test "does not upgrade when a running application does not exit" {
+@test "does not upgrade when an application survives KILL" {
   install_cask claude
   mark_outdated claude
 
   run env DOTFILES_HOMEBREW_CASKS=claude FAKE_RUNNING_APP=/Applications/Claude.app \
-    FAKE_APP_IGNORES_QUIT=1 "$UPDATER"
+    FAKE_APP_IGNORES_TERM=1 FAKE_APP_IGNORES_KILL=1 "$UPDATER"
 
   [ "$status" -ne 0 ]
   [[ "$output" == *"application did not exit: /Applications/Claude.app"* ]]
+  grep -q '^pkill -KILL -f /Applications/Claude.app/Contents/$' "$COMMAND_LOG"
   run ! grep -q '^brew fetch ' "$COMMAND_LOG"
   run ! grep -q '^brew upgrade ' "$COMMAND_LOG"
+}
+
+@test "force kills an app that ignores TERM before upgrading and reopening it" {
+  install_cask thebrowsercompany-dia
+  mark_outdated thebrowsercompany-dia
+
+  run env DOTFILES_HOMEBREW_CASKS=thebrowsercompany-dia \
+    FAKE_RUNNING_APP=/Applications/Dia.app FAKE_APP_IGNORES_TERM=1 "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  grep -q '^pkill -TERM -f /Applications/Dia.app/Contents/$' "$COMMAND_LOG"
+  grep -q '^pkill -KILL -f /Applications/Dia.app/Contents/$' "$COMMAND_LOG"
+  grep -q '^brew fetch --cask thebrowsercompany-dia$' "$COMMAND_LOG"
+  grep -q '^brew upgrade --cask --greedy thebrowsercompany-dia$' "$COMMAND_LOG"
+  grep -q '^open -gj /Applications/Dia.app$' "$COMMAND_LOG"
+}
+
+@test "does not KILL an app that exits after TERM" {
+  install_cask claude
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude FAKE_RUNNING_APP=/Applications/Claude.app "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  grep -q '^pkill -TERM -f /Applications/Claude.app/Contents/$' "$COMMAND_LOG"
+  run ! grep -q '^pkill -KILL -f /Applications/Claude.app/Contents/$' "$COMMAND_LOG"
+}
+
+@test "continues when an app exits while TERM is being sent" {
+  install_cask claude
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude FAKE_RUNNING_APP=/Applications/Claude.app \
+    FAKE_APP_EXITS_DURING_TERM=1 "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  grep -q '^pkill -TERM -f /Applications/Claude.app/Contents/$' "$COMMAND_LOG"
+  grep -q '^brew fetch --cask claude$' "$COMMAND_LOG"
+  run ! grep -q '^pkill -KILL -f /Applications/Claude.app/Contents/$' "$COMMAND_LOG"
 }
 
 @test "reopens a running application after upgrade retries are exhausted" {

--- a/tests/bash/macos_homebrew_cask_update.bats
+++ b/tests/bash/macos_homebrew_cask_update.bats
@@ -19,6 +19,8 @@ setup() {
   export JQ_COMMAND
   export PGREP_COMMAND="$TEST_BIN/pgrep"
   export PKILL_COMMAND="$TEST_BIN/pkill"
+  export PS_COMMAND="$TEST_BIN/ps"
+  export KILL_COMMAND="$TEST_BIN/kill"
   export OPEN_COMMAND="$TEST_BIN/open"
   APP_PROCESS_EXITED_STATE="$BATS_TEST_TMPDIR/app-process-exited"
   export APP_PROCESS_EXITED_STATE
@@ -91,7 +93,8 @@ EOF
 #!/usr/bin/env bash
 printf 'pgrep %s\n' "$*" >>"$COMMAND_LOG"
 [[ "$*" == *"${FAKE_RUNNING_APP:-never}"* ]] || exit 1
-[[ ! -f $APP_PROCESS_EXITED_STATE ]]
+[[ ! -f $APP_PROCESS_EXITED_STATE ]] || exit 1
+printf '%s\n' "${FAKE_PROCESS_ID:-4242}"
 EOF
   cat >"$PKILL_COMMAND" <<'EOF'
 #!/usr/bin/env bash
@@ -114,11 +117,38 @@ case "$*" in
 *) exit 64 ;;
 esac
 EOF
+  cat >"$PS_COMMAND" <<'EOF'
+#!/usr/bin/env bash
+printf 'ps %s\n' "$*" >>"$COMMAND_LOG"
+[[ ! -f $APP_PROCESS_EXITED_STATE ]] || exit 1
+printf '%s\n' "${FAKE_PROCESS_EXECUTABLE:-${FAKE_RUNNING_APP:-}/Contents/MacOS/app}"
+EOF
+  cat >"$KILL_COMMAND" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'kill %s\n' "$*" >>"$COMMAND_LOG"
+[[ ! -f $APP_PROCESS_EXITED_STATE ]] || exit 1
+
+case "$*" in
+*-TERM*)
+  if [[ ${FAKE_APP_EXITS_DURING_TERM:-0} == 1 ]]; then
+    : >"$APP_PROCESS_EXITED_STATE"
+    exit 1
+  fi
+  [[ ${FAKE_APP_IGNORES_TERM:-0} == 1 ]] || : >"$APP_PROCESS_EXITED_STATE"
+  ;;
+*-KILL*)
+  [[ ${FAKE_APP_IGNORES_KILL:-0} == 1 ]] || : >"$APP_PROCESS_EXITED_STATE"
+  ;;
+*) exit 64 ;;
+esac
+EOF
   cat >"$OPEN_COMMAND" <<'EOF'
 #!/usr/bin/env bash
 printf 'open %s\n' "$*" >>"$COMMAND_LOG"
 EOF
-  chmod +x "$BREW_COMMAND" "$NIX_COMMAND" "$SLEEP_COMMAND" "$PGREP_COMMAND" "$PKILL_COMMAND" "$OPEN_COMMAND"
+  chmod +x "$BREW_COMMAND" "$NIX_COMMAND" "$SLEEP_COMMAND" "$PGREP_COMMAND" "$PKILL_COMMAND" \
+    "$PS_COMMAND" "$KILL_COMMAND" "$OPEN_COMMAND"
 }
 
 install_cask() {
@@ -217,17 +247,15 @@ mark_outdated() {
   run env DOTFILES_HOMEBREW_CASKS=claude FAKE_RUNNING_APP=/Applications/Claude.app "$UPDATER"
 
   [ "$status" -eq 0 ]
-  grep -q '^pkill -TERM -f /Applications/Claude.app/Contents/$' "$COMMAND_LOG"
+  grep -q '^kill -TERM 4242$' "$COMMAND_LOG"
   grep -q '^open -gj /Applications/Claude.app$' "$COMMAND_LOG"
   initial_pgrep_line="$(grep -n -m1 '^pgrep ' "$COMMAND_LOG" | cut -d: -f1)"
-  terminate_line="$(grep -n -m1 '^pkill -TERM ' "$COMMAND_LOG" | cut -d: -f1)"
-  exit_check_line="$(grep -n '^pgrep ' "$COMMAND_LOG" | sed -n '2p' | cut -d: -f1)"
+  terminate_line="$(grep -n -m1 '^kill -TERM ' "$COMMAND_LOG" | cut -d: -f1)"
   fetch_line="$(grep -n -m1 '^brew fetch ' "$COMMAND_LOG" | cut -d: -f1)"
   upgrade_line="$(grep -n -m1 '^brew upgrade ' "$COMMAND_LOG" | cut -d: -f1)"
   open_line="$(grep -n -m1 '^open ' "$COMMAND_LOG" | cut -d: -f1)"
   [ "$initial_pgrep_line" -lt "$terminate_line" ]
-  [ "$terminate_line" -lt "$exit_check_line" ]
-  [ "$exit_check_line" -lt "$fetch_line" ]
+  [ "$terminate_line" -lt "$fetch_line" ]
   [ "$upgrade_line" -lt "$open_line" ]
 }
 
@@ -239,7 +267,7 @@ mark_outdated() {
     FAKE_APP_IGNORES_TERM=1 "$UPDATER"
 
   [ "$status" -eq 0 ]
-  grep -q '^pkill -KILL -f /Applications/1Password.app/Contents/$' "$COMMAND_LOG"
+  grep -q '^kill -KILL 4242$' "$COMMAND_LOG"
   grep -q '^brew fetch --cask 1password$' "$COMMAND_LOG"
   grep -q '^brew upgrade --cask --greedy 1password$' "$COMMAND_LOG"
   grep -q '^open -gj /Applications/1Password.app$' "$COMMAND_LOG"
@@ -254,7 +282,7 @@ mark_outdated() {
 
   [ "$status" -ne 0 ]
   [[ "$output" == *"application did not exit: /Applications/Claude.app"* ]]
-  grep -q '^pkill -KILL -f /Applications/Claude.app/Contents/$' "$COMMAND_LOG"
+  grep -q '^kill -KILL 4242$' "$COMMAND_LOG"
   run ! grep -q '^brew fetch ' "$COMMAND_LOG"
   run ! grep -q '^brew upgrade ' "$COMMAND_LOG"
 }
@@ -267,8 +295,8 @@ mark_outdated() {
     FAKE_RUNNING_APP=/Applications/Dia.app FAKE_APP_IGNORES_TERM=1 "$UPDATER"
 
   [ "$status" -eq 0 ]
-  grep -q '^pkill -TERM -f /Applications/Dia.app/Contents/$' "$COMMAND_LOG"
-  grep -q '^pkill -KILL -f /Applications/Dia.app/Contents/$' "$COMMAND_LOG"
+  grep -q '^kill -TERM 4242$' "$COMMAND_LOG"
+  grep -q '^kill -KILL 4242$' "$COMMAND_LOG"
   grep -q '^brew fetch --cask thebrowsercompany-dia$' "$COMMAND_LOG"
   grep -q '^brew upgrade --cask --greedy thebrowsercompany-dia$' "$COMMAND_LOG"
   grep -q '^open -gj /Applications/Dia.app$' "$COMMAND_LOG"
@@ -281,8 +309,24 @@ mark_outdated() {
   run env DOTFILES_HOMEBREW_CASKS=claude FAKE_RUNNING_APP=/Applications/Claude.app "$UPDATER"
 
   [ "$status" -eq 0 ]
-  grep -q '^pkill -TERM -f /Applications/Claude.app/Contents/$' "$COMMAND_LOG"
-  run ! grep -q '^pkill -KILL -f /Applications/Claude.app/Contents/$' "$COMMAND_LOG"
+  grep -q '^kill -TERM 4242$' "$COMMAND_LOG"
+  run ! grep -q '^kill -KILL ' "$COMMAND_LOG"
+}
+
+@test "does not signal a process that only has an app bundle path in its arguments" {
+  install_cask claude
+  mark_outdated claude
+
+  run env DOTFILES_HOMEBREW_CASKS=claude FAKE_RUNNING_APP=/Applications/Claude.app \
+    FAKE_PROCESS_EXECUTABLE=/usr/bin/codesign "$UPDATER"
+
+  [ "$status" -eq 0 ]
+  grep -q '^ps -p ' "$COMMAND_LOG"
+  run ! grep -q '^pkill ' "$COMMAND_LOG"
+  run ! grep -q '^kill ' "$COMMAND_LOG"
+  run ! grep -q '^open ' "$COMMAND_LOG"
+  grep -q '^brew fetch --cask claude$' "$COMMAND_LOG"
+  grep -q '^brew upgrade --cask --greedy claude$' "$COMMAND_LOG"
 }
 
 @test "continues when an app exits while TERM is being sent" {
@@ -293,9 +337,9 @@ mark_outdated() {
     FAKE_APP_EXITS_DURING_TERM=1 "$UPDATER"
 
   [ "$status" -eq 0 ]
-  grep -q '^pkill -TERM -f /Applications/Claude.app/Contents/$' "$COMMAND_LOG"
+  grep -q '^kill -TERM 4242$' "$COMMAND_LOG"
   grep -q '^brew fetch --cask claude$' "$COMMAND_LOG"
-  run ! grep -q '^pkill -KILL -f /Applications/Claude.app/Contents/$' "$COMMAND_LOG"
+  run ! grep -q '^kill -KILL ' "$COMMAND_LOG"
 }
 
 @test "reopens a running application after upgrade retries are exhausted" {


### PR DESCRIPTION
## What changed

- Force-terminate every running app bundle belonging to an outdated Homebrew Cask before its update.
- Use `TERM`, wait up to 10 seconds, then use `KILL` only for remaining `<App>.app/Contents/` processes.
- Reopen apps that were running before the update, whether the Cask update succeeds or fails.

## Why

Dia can cancel AppleScript `quit` requests while its internal agent or Sparkle updater is running, which stops `nrs` Cask updates. The updater now uses non-interactive process signals instead of AppleScript and Cask-specific quit metadata.

## Validation

- `bats tests/bash/macos_homebrew_cask_update.bats` (26 tests)
- `task test:bash DOTFILES_PATH="$PWD"` (210 tests)
- `bash -n scripts/sh/update-homebrew-casks.sh`
- `shellcheck scripts/sh/update-homebrew-casks.sh`
- `pre-commit run --files scripts/sh/update-homebrew-casks.sh tests/bash/macos_homebrew_cask_update.bats`
- `git diff --check`