### PR TITLE
fix: update Codex CLI across all operating systems

### DIFF
--- a/docs/superpowers/plans/2026-08-14-update-codex-cli-all-os.md
+++ b/docs/superpowers/plans/2026-08-14-update-codex-cli-all-os.md
@@ -1,0 +1,205 @@
+# Codex CLI All-OS Update Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every supported dotfiles update entry point refresh its package source before applying the environment, so macOS/Linux Codex follows updated `nixpkgs` and Windows Codex follows WinGet.
+
+**Architecture:** Add one fail-closed shell helper for `nix flake update` and call it from all four Unix installers after Nix and checkout preparation but before activation. Extend the existing Phase 1 Winget handler with a Codex-only upgrade operation that runs only when `OpenAI.Codex` is installed, treating localized no-op output as success and preserving the existing install/verify/shim path.
+
+**Tech Stack:** Bash, Bats, PowerShell, Pester, Nix flake tooling, WinGet.
+
+## Global Constraints
+
+- Unix update failure must stop before system or Home Manager activation.
+- Windows update scope is `OpenAI.Codex`; do not unconditionally upgrade every Winget package.
+- Windows Codex upgrade arguments must include `--id OpenAI.Codex`, `--exact`, `--silent`, `--accept-package-agreements`, and `--accept-source-agreements`.
+- Existing Codex portable shim, verification, and non-Codex package behavior must remain intact.
+- Do not automatically commit, push, or create a PR for generated lock/package changes.
+
+---
+
+### Task 1: Add failing Unix update-flow tests
+
+**Files:**
+
+- Modify: `tests/bash/install_macos.bats`
+- Modify: `tests/bash/install_linux.bats`
+- Modify: `tests/bash/install_nixos.bats`
+
+**Interfaces:**
+
+- Consumes: existing command-log stubs and `assert_log_order` helpers.
+- Produces: regression coverage requiring `nix flake update` before each Unix activation path and preventing activation after update failure.
+
+- [ ] **Step 1: Add success-order assertions**
+
+Update the existing successful installer tests so their Nix stubs record `flake update`, then assert the exact update entry occurs before the existing activation entry. Use the corresponding activation markers for macOS (`darwin-rebuild`), NixOS (`nixos-rebuild`), and Home Manager (`homeConfigurations`).
+
+```bash
+assert_log_order \
+  "nix flake update" \
+  "switch --flake .#ubuntu --sudo"
+```
+
+- [ ] **Step 2: Add update-failure tests**
+
+Make each test Nix stub return a non-zero status for exactly `flake update`, run the installer, assert a non-zero status, and assert the activation marker is absent.
+
+```bash
+if [[ $* == "flake update" ]]; then
+  exit 41
+fi
+```
+
+- [ ] **Step 3: Run the focused tests to verify they fail**
+
+Run `bats tests/bash/install_macos.bats tests/bash/install_linux.bats tests/bash/install_nixos.bats`. Expected: the new update-order assertions fail because the installers do not yet invoke `nix flake update`.
+
+- [ ] **Step 4: Commit the red tests**
+
+```bash
+git add tests/bash/install_macos.bats tests/bash/install_linux.bats tests/bash/install_nixos.bats
+git commit -m "test: require flake updates before Unix activation"
+```
+
+### Task 2: Implement the shared Unix flake update helper
+
+**Files:**
+
+- Create: `scripts/sh/update-flake.sh`
+- Modify: `scripts/sh/install-macos.sh`
+- Modify: `scripts/sh/install-linux.sh`
+- Modify: `scripts/sh/install-nixos.sh`
+- Modify: `scripts/sh/install-home-manager.sh`
+
+**Interfaces:**
+
+- Consumes: `ROOT`, `dotfiles_have`, `dotfiles_log`, and `dotfiles_die` from `install-common.sh`.
+- Produces: `dotfiles_update_flake <repo-root>`; it returns success only after `nix flake update` succeeds.
+
+- [ ] **Step 1: Add the minimal helper**
+
+Create a sourced shell helper with this contract:
+
+```bash
+dotfiles_update_flake() {
+  local root="$1"
+  dotfiles_have nix || dotfiles_die "Nix is required to update flake inputs."
+  dotfiles_log "Updating Nix flake inputs..."
+  (
+    cd "$root" || dotfiles_die "Unable to enter dotfiles checkout: $root"
+    nix flake update
+  ) || dotfiles_die "Nix flake input update failed."
+}
+```
+
+- [ ] **Step 2: Source and call the helper from every Unix installer**
+
+Source `update-flake.sh` after `install-common.sh`, then call `dotfiles_update_flake "$ROOT"` in `main` after `dotfiles_link_checkout "$ROOT"` and before `apply_darwin_system`, `apply_linux_system`, `apply_nixos_system`, or `activate_home_manager`.
+
+- [ ] **Step 3: Run the focused Bash tests to verify they pass**
+
+Run `bats tests/bash/install_macos.bats tests/bash/install_linux.bats tests/bash/install_nixos.bats`. Expected: all focused installer tests pass, including the new ordering and fail-closed cases.
+
+- [ ] **Step 4: Commit the Unix implementation**
+
+```bash
+git add scripts/sh/update-flake.sh scripts/sh/install-macos.sh scripts/sh/install-linux.sh scripts/sh/install-nixos.sh scripts/sh/install-home-manager.sh
+git commit -m "fix: update flake inputs before Unix activation"
+```
+
+### Task 3: Add failing Windows Codex upgrade tests
+
+**Files:**
+
+- Modify: `scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1`
+
+**Interfaces:**
+
+- Consumes: existing `WingetHandler`, Pester mocks, and package JSON fixtures.
+- Produces: tests for installed Codex upgrade, missing Codex install fallback, no-op success, and real upgrade failure.
+
+- [ ] **Step 1: Add an installed-Codex fixture and upgrade argument assertion**
+
+Add a Pester test whose mocked package list contains `OpenAI.Codex`, whose installed list contains `OpenAI.Codex`, and whose `Invoke-Winget` mock captures the `upgrade` invocation. Assert the captured arguments contain:
+
+```powershell
+"upgrade", "--id", "OpenAI.Codex", "--exact", "--silent",
+"--accept-package-agreements", "--accept-source-agreements"
+```
+
+- [ ] **Step 2: Add no-op and failure cases**
+
+Add one test returning the existing localized no-update messages with a non-zero exit code and assert success. Add another returning an unrelated upgrade error and assert `SetupResult.Success` is `$false`.
+
+- [ ] **Step 3: Run the focused Pester test to verify it fails**
+
+Run `pwsh -NoProfile -Command "Invoke-Pester -Path ./scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1 -Output Detailed"`. Expected: the new tests fail because `WingetHandler` has no explicit Codex upgrade call.
+
+- [ ] **Step 4: Commit the red Windows tests**
+
+```bash
+git add scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
+git commit -m "test: require explicit Windows Codex upgrades"
+```
+
+### Task 4: Implement the Windows Codex upgrade path
+
+**Files:**
+
+- Modify: `scripts/powershell/handlers/Handler.Winget.ps1`
+
+**Interfaces:**
+
+- Consumes: parsed Winget package objects and the existing installed-ID discovery.
+- Produces: a Codex-only upgrade before normal package processing, with no-op success and failure propagation through `SetupResult`.
+
+- [ ] **Step 1: Add a Codex upgrade method**
+
+Implement a private method that accepts the parsed Codex package object and invokes `Invoke-Winget` with the exact upgrade arguments. Treat output matching the existing `IsAlreadyInstalledInstallFailure` no-op messages as successful; return `$false` for all other non-zero exits.
+
+- [ ] **Step 2: Invoke it only for installed `OpenAI.Codex`**
+
+After `$installedIds` is obtained and before normal install/verification processing, find the exact package ID. If it is installed, run the method. On failure, return `CreateFailureResult` immediately; on success, refresh the process PATH and portable link before the normal verification loop. If it is not installed, skip the explicit upgrade and let existing install behavior handle it.
+
+- [ ] **Step 3: Run the focused Pester test to verify it passes**
+
+Run `pwsh -NoProfile -Command "Invoke-Pester -Path ./scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1 -Output Detailed"`. Expected: the focused Winget handler suite passes with zero failed tests.
+
+- [ ] **Step 4: Commit the Windows implementation**
+
+```bash
+git add scripts/powershell/handlers/Handler.Winget.ps1
+git commit -m "fix: explicitly upgrade Codex with winget"
+```
+
+### Task 5: Run complete validation and inspect the final diff
+
+**Files:**
+
+- Inspect: all changed files and commits from Tasks 1–4.
+- Observe: `flake.lock` and generated Windows package metadata as runtime update outputs; do not edit them directly in this feature change.
+
+- [ ] **Step 1: Run all Bash tests**
+
+Run `bats tests/bash`. Expected: exit code 0 and no failed tests.
+
+- [ ] **Step 2: Run all PowerShell tests and analyzer**
+
+Run `pwsh -NoProfile -Command "& ./scripts/powershell/tests/Invoke-Tests.ps1 -MinimumCoverage 0"`. Expected: exit code 0 and no failed Pester tests or analyzer errors.
+
+- [ ] **Step 3: Run formatting checks**
+
+Run `nix fmt -- --fail-on-change`. Expected: formatter exits 0 without modifying files.
+
+- [ ] **Step 4: Review status and diff**
+
+Run:
+
+```bash
+git status --short --branch
+git diff main...HEAD --stat
+git diff main...HEAD -- scripts/sh tests/bash scripts/powershell/handlers/Handler.Winget.ps1 scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
+```
+
+Confirm only the approved Unix update flow, Windows Codex update flow, tests, and the already-committed design/plan artifacts are present.

--- a/docs/superpowers/specs/2026-08-14-update-codex-cli-all-os-design.md
+++ b/docs/superpowers/specs/2026-08-14-update-codex-cli-all-os-design.md
@@ -1,0 +1,62 @@
+# Codex CLI の全 OS 更新経路統一
+
+## 目的
+
+`nrs` を実行したときに、Codex CLI を含む依存パッケージが各 OS の最新定義へ追従するようにする。現在の macOS 経路は `nix-darwin switch` のみを実行し、`flake.lock` を更新しないため、ロック済みの古い `nixpkgs` に含まれる Codex が継続して使われる。
+
+## 対象範囲
+
+- macOS: `install.sh` から呼ばれる `install-macos.sh`
+- NixOS: `install.sh` から呼ばれる `install-nixos.sh`
+- Debian/Ubuntu: `install.sh` から呼ばれる `install-linux.sh`
+- Linux のユーザー専用 Home Manager 経路: `install-home-manager.sh`
+- Windows: `install.cmd` / PowerShell の Phase 1 Winget 経路
+
+Windows は Nix の `flake.lock` を使わないため、`OpenAI.Codex` を含む Winget パッケージの更新経路を明示的に保証する。
+
+## 設計
+
+### Unix 系の共通更新処理
+
+`scripts/sh/update-flake.sh` を追加し、次を一元化する。
+
+1. `nix` が利用可能であることを確認する。
+2. リポジトリのルートで `nix flake update` を実行する。
+3. 失敗した場合は `dotfiles_die` 相当のエラーで終了し、後続の再構築・Home Manager 適用を行わない。
+
+各 Unix インストーラーは、Nix の準備と checkout のリンク確立後、システムまたは Home Manager の build/apply より前に共通処理を呼ぶ。これにより `flake.lock` 更新が成功した状態だけを後続処理へ渡す。
+
+既存の prebuilt NixOS E2E 経路でも更新処理の契約は維持するが、テストでは Nix コマンドをスタブ化する。更新処理の失敗時に `nixos-rebuild`、`darwin-rebuild`、System Manager、Home Manager が呼ばれないことを回帰テストで確認する。
+
+### Windows の Codex 更新処理
+
+Winget の通常 import はインストール済みパッケージにも latest を選ばせる既存契約を持つが、Codex の更新要求を明確にするため、Winget ハンドラーに更新対象の明示的な処理を追加する。
+
+- `OpenAI.Codex` がパッケージ定義に存在する場合、`winget upgrade --id OpenAI.Codex --exact --silent --accept-package-agreements --accept-source-agreements` を実行する。
+- 更新対象が未インストールの場合は既存の install 処理に委ねる。
+- upgrade が「更新なし」を返すケースは成功として扱う。
+- 実際の更新失敗は Phase 1 の失敗として返し、後続 Phase へ進ませない。
+- 既存の portable shim 更新、Codex の `verifyCommand`、他パッケージの install/verify 動作は維持する。
+
+Windows の処理は `OpenAI.Codex` に限定し、全 Winget パッケージを無条件に upgrade する変更は行わない。これにより、既存のインストール契約とユーザーが明示した Codex 更新要求を分離する。
+
+## エラー処理
+
+- Unix: `nix flake update` の非ゼロ終了を即時エラーとし、再構築を実行しない。
+- Windows: Codex の明示的 upgrade が、更新なし以外の失敗を返した場合は Phase 1 を失敗させる。
+- ロックファイルや生成済み Windows パッケージ一覧は、実行結果として Git 差分に現れる。自動 commit や push は行わない。
+
+## テスト方針
+
+- Bash の各 Unix インストーラーテストで、更新コマンドが build/apply より先に呼ばれることを確認する。
+- Bash で更新コマンドが失敗した場合、後続の build/apply が呼ばれないことを確認する。
+- PowerShell の Winget ハンドラーテストで、インストール済み Codex に対する明示的 upgrade、未インストール Codex の install フォールバック、更新なしの成功、更新失敗の Phase 1 失敗を確認する。
+- 既存の Bash / PowerShell テスト、Nix formatter、PowerShell analyzer を実行する。
+
+## 非対象
+
+- Codex CLI のバージョンをリポジトリ内で固定すること
+- Codex の配布元を変更すること
+- Homebrew cask の更新方式を変更すること
+- Windows の全パッケージを無条件に upgrade すること
+- 更新後の自動 commit、push、PR 作成

--- a/scripts/powershell/handlers/Handler.Winget.ps1
+++ b/scripts/powershell/handlers/Handler.Winget.ps1
@@ -202,9 +202,28 @@ class WingetHandler : SetupHandlerBase {
             # 正規表現で検出できないパッケージ（ARP エントリ等）は個別チェックにフォールバック
             $installedIds = $this.GetInstalledPackageIds()
 
-            # 通常実行ではインストール済みも含めて winget install を流し、
-            # winget 側の install-or-upgrade 動作で latest を選ばせる。
+            # 通常実行ではインストール済みも含めて更新する。
+            # Codex だけは明示的な upgrade を先に行い、他のパッケージは
+            # 既存の winget install-or-upgrade 動作を維持する。
             $verifyCommandOnly = $ctx.GetOption("WingetVerifyCommandOnly", $false)
+            $explicitlyUpdatedIds = @()
+            $updated = 0
+            if (-not $verifyCommandOnly) {
+                $codex = @($packages | Where-Object { $_.Id -eq "OpenAI.Codex" }) | Select-Object -First 1
+                if ($null -ne $codex) {
+                    $codexInstalled = $codex.Id -in $installedIds
+                    if (-not $codexInstalled) {
+                        $codexInstalled = $this.IsPackageInstalled($codex.Id)
+                    }
+                    if ($codexInstalled) {
+                        if (-not $this.UpgradeInstalledCodex($codex)) {
+                            return $this.CreateFailureResult("$($codex.Id) のアップグレードに失敗しました")
+                        }
+                        $explicitlyUpdatedIds += $codex.Id
+                        $updated++
+                    }
+                }
+            }
             $toInstall = @()
             $skipped = 0
             $verified = 0
@@ -253,6 +272,9 @@ class WingetHandler : SetupHandlerBase {
                 }
 
                 if ($pkg.Id -in $installedIds -or $this.IsPackageInstalled($pkg.Id)) {
+                    if ($pkg.Id -in $explicitlyUpdatedIds -and (-not $pkg.VerifyCommand -or $verificationPassed)) {
+                        continue
+                    }
                     if ($pkg.VerifyCommand -and $verificationPassed) {
                         $toInstall += [PSCustomObject]@{
                             Id                    = $pkg.Id
@@ -340,6 +362,7 @@ class WingetHandler : SetupHandlerBase {
                 if ($verified -gt 0) { $parts += "$verified 個検証済み" }
                 if ($verifyFailed -gt 0) { $parts += "$verifyFailed 個検証失敗" }
                 if ($deferred -gt 0) { $parts += "$deferred 個管理者フェーズ待ち" }
+                if ($updated -gt 0) { $parts += "$updated 個更新済み" }
                 $parts += "$skipped 個スキップ"
                 if ($verifyFailed -gt 0) {
                     return $this.CreateFailureResult($parts -join ", ")
@@ -437,6 +460,7 @@ class WingetHandler : SetupHandlerBase {
             if ($failed -gt 0) { $parts += "$failed 個失敗" }
             if ($verified -gt 0) { $parts += "$verified 個検証済み" }
             if ($deferred -gt 0) { $parts += "$deferred 個管理者フェーズ待ち" }
+            if ($updated -gt 0) { $parts += "$updated 個更新済み" }
             $parts += "$skipped 個スキップ"
             $message = $parts -join ", "
             if ($failed -gt 0 -or $verifyFailed -gt 0) {
@@ -462,6 +486,35 @@ class WingetHandler : SetupHandlerBase {
         $text -match '新しいパッケージ バージョンはありません' -or
         $text -match 'バージョン番号を特定できません' -or
         $text -match '別のバージョンが既にインストールされています'
+    }
+
+    hidden [bool] UpgradeInstalledCodex([object]$pkg) {
+        $upgradeArgs = @(
+            "upgrade", "--id", $pkg.Id, "--exact",
+            "--silent",
+            "--accept-package-agreements",
+            "--accept-source-agreements",
+            "--disable-interactivity"
+        )
+        $this.Log("Codex CLI を更新しています: $($pkg.Id)")
+        $upgradeOutput = @(Invoke-Winget -Arguments $upgradeArgs)
+        $exitCode = $LASTEXITCODE
+        foreach ($line in $upgradeOutput) {
+            if (-not [string]::IsNullOrWhiteSpace([string]$line)) {
+                $this.Log("  $line", "Gray")
+            }
+        }
+
+        if ($exitCode -eq 0) {
+            return $true
+        }
+        if ($this.IsAlreadyInstalledInstallFailure($upgradeOutput)) {
+            $this.Log("✓ $($pkg.Id) は最新版です (winget upgrade は no-op)", "Green")
+            return $true
+        }
+
+        $this.LogWarning("✗ $($pkg.Id) のアップグレードに失敗しました")
+        return $false
     }
 
     hidden [void] LogSkippedInstall([object]$pkg) {

--- a/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Winget.Tests.ps1
@@ -306,6 +306,147 @@ Describe 'WingetHandler' {
         }
     }
 
+    Context 'Apply - import mode: Codex upgrade' {
+        BeforeEach {
+            Mock Get-ExternalCommand { return @{ Source = "C:\winget.exe" } }
+            Mock Test-PathExist { return $true }
+            Mock Get-JsonContent {
+                return [PSCustomObject]@{
+                    Sources = @(
+                        [PSCustomObject]@{
+                            SourceDetails = [PSCustomObject]@{ Name = "winget" }
+                            Packages      = @(
+                                [PSCustomObject]@{ PackageIdentifier = "OpenAI.Codex" }
+                            )
+                        }
+                    )
+                }
+            }
+            $script:upgradeArgs = $null
+            $script:installCalled = $false
+        }
+
+        It 'should explicitly upgrade an installed Codex package without calling install' {
+            Mock Invoke-Winget {
+                param($Arguments)
+                if ($Arguments -contains "list" -and $Arguments -notcontains "--id") {
+                    $global:LASTEXITCODE = 0
+                    return @(
+                        "Name       Id           Version Source"
+                        "---------------------------------------"
+                        "Codex      OpenAI.Codex 0.144.4 winget"
+                    )
+                }
+                if ($Arguments -contains "upgrade") {
+                    $script:upgradeArgs = $Arguments
+                    $global:LASTEXITCODE = 0
+                    return @("Successfully upgraded")
+                }
+                if ($Arguments -contains "install") {
+                    $script:installCalled = $true
+                }
+                $global:LASTEXITCODE = 0
+            }
+
+            $ctx.Options["WingetMode"] = "import"
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $script:upgradeArgs | Should -Contain "upgrade"
+            $script:upgradeArgs | Should -Contain "--id"
+            $script:upgradeArgs | Should -Contain "OpenAI.Codex"
+            $script:upgradeArgs | Should -Contain "--exact"
+            $script:upgradeArgs | Should -Contain "--silent"
+            $script:upgradeArgs | Should -Contain "--accept-package-agreements"
+            $script:upgradeArgs | Should -Contain "--accept-source-agreements"
+            $script:installCalled | Should -Be $false
+        }
+
+        It 'should treat an already-latest Codex upgrade as success' {
+            Mock Invoke-Winget {
+                param($Arguments)
+                if ($Arguments -contains "list" -and $Arguments -notcontains "--id") {
+                    $global:LASTEXITCODE = 0
+                    return @(
+                        "Name       Id           Version Source"
+                        "---------------------------------------"
+                        "Codex      OpenAI.Codex 0.144.4 winget"
+                    )
+                }
+                if ($Arguments -contains "upgrade") {
+                    $script:upgradeArgs = $Arguments
+                    $global:LASTEXITCODE = 1
+                    return @("No available upgrade found")
+                }
+                if ($Arguments -contains "install") {
+                    $script:installCalled = $true
+                }
+                $global:LASTEXITCODE = 0
+            }
+
+            $ctx.Options["WingetMode"] = "import"
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $script:upgradeArgs | Should -Contain "upgrade"
+            $script:installCalled | Should -Be $false
+        }
+
+        It 'should return failure when the Codex upgrade fails' {
+            Mock Invoke-Winget {
+                param($Arguments)
+                if ($Arguments -contains "list" -and $Arguments -notcontains "--id") {
+                    $global:LASTEXITCODE = 0
+                    return @(
+                        "Name       Id           Version Source"
+                        "---------------------------------------"
+                        "Codex      OpenAI.Codex 0.144.4 winget"
+                    )
+                }
+                if ($Arguments -contains "upgrade") {
+                    $script:upgradeArgs = $Arguments
+                    $global:LASTEXITCODE = 17
+                    return @("Network failure")
+                }
+                if ($Arguments -contains "install") {
+                    $script:installCalled = $true
+                }
+                $global:LASTEXITCODE = 0
+            }
+
+            $ctx.Options["WingetMode"] = "import"
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $false
+            $result.Message | Should -Match "OpenAI.Codex"
+            $script:installCalled | Should -Be $false
+        }
+
+        It 'should use the existing install path when Codex is not installed' {
+            Mock Invoke-Winget {
+                param($Arguments)
+                if ($Arguments -contains "list") {
+                    $global:LASTEXITCODE = 1
+                    return @()
+                }
+                if ($Arguments -contains "upgrade") {
+                    $script:upgradeArgs = $Arguments
+                }
+                if ($Arguments -contains "install") {
+                    $script:installCalled = $true
+                }
+                $global:LASTEXITCODE = 0
+            }
+
+            $ctx.Options["WingetMode"] = "import"
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -Be $true
+            $script:upgradeArgs | Should -BeNullOrEmpty
+            $script:installCalled | Should -Be $true
+        }
+    }
+
     Context 'Apply - import mode: installed package verification fails' {
         BeforeEach {
             $script:verifyCalls = 0

--- a/scripts/sh/install-home-manager.sh
+++ b/scripts/sh/install-home-manager.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 export DOTFILES_LOG_PREFIX="home-manager-install"
 # shellcheck source=/dev/null
 . "$ROOT/scripts/sh/install-common.sh"
+. "$ROOT/scripts/sh/update-flake.sh"
 
 ensure_opt_in() {
   [[ ${DOTFILES_ALLOW_USER_ONLY:-0} == "1" ]] ||
@@ -71,6 +72,7 @@ main() {
   ensure_nix
   dotfiles_link_checkout "$ROOT"
   capture_user_identity
+  dotfiles_update_flake "$ROOT"
   activate_home_manager
   apply_chezmoi
   printf 'User-only setup complete; Docker/systemd were not configured.\n'

--- a/scripts/sh/install-linux.sh
+++ b/scripts/sh/install-linux.sh
@@ -6,6 +6,7 @@ export DOTFILES_ROOT="$ROOT"
 export DOTFILES_LOG_PREFIX="linux-install"
 # shellcheck source=/dev/null
 . "$ROOT/scripts/sh/install-common.sh"
+. "$ROOT/scripts/sh/update-flake.sh"
 # shellcheck source=/dev/null
 . "$ROOT/scripts/sh/hermes-agent.sh"
 
@@ -126,6 +127,7 @@ main() {
   ensure_nix
   dotfiles_link_checkout "$ROOT"
   capture_host_identity
+  dotfiles_update_flake "$ROOT"
   apply_linux_system
   apply_chezmoi
   dotfiles_hermes_start_stack docker_command "$DOTFILES_ROOT/docker/hermes-agent/compose.yml"

--- a/scripts/sh/install-macos.sh
+++ b/scripts/sh/install-macos.sh
@@ -6,6 +6,7 @@ export DOTFILES_ROOT="$ROOT"
 export DOTFILES_LOG_PREFIX="macos-install"
 # shellcheck source=/dev/null
 . "$ROOT/scripts/sh/install-common.sh"
+. "$ROOT/scripts/sh/update-flake.sh"
 # shellcheck source=/dev/null
 . "$ROOT/scripts/sh/hermes-agent.sh"
 
@@ -297,6 +298,7 @@ main() {
   ensure_command_line_tools
   ensure_nix
   dotfiles_link_checkout "$ROOT"
+  dotfiles_update_flake "$ROOT"
   preserve_shell_rc_for_nix_darwin
   stop_existing_docker_desktop
   repair_homebrew_cask_link_directories

--- a/scripts/sh/install-nixos.sh
+++ b/scripts/sh/install-nixos.sh
@@ -6,6 +6,7 @@ export DOTFILES_ROOT="$ROOT"
 export DOTFILES_LOG_PREFIX="nixos-install"
 # shellcheck source=/dev/null
 . "$ROOT/scripts/sh/install-common.sh"
+. "$ROOT/scripts/sh/update-flake.sh"
 # shellcheck source=/dev/null
 . "$ROOT/scripts/sh/hermes-agent.sh"
 
@@ -103,6 +104,7 @@ main() {
   preflight
   dotfiles_link_checkout "$ROOT"
   capture_host_identity
+  dotfiles_update_flake "$ROOT"
   apply_nixos_system
   apply_chezmoi
   dotfiles_hermes_start_stack docker_command "$DOTFILES_ROOT/docker/hermes-agent/compose.yml"

--- a/scripts/sh/update-flake.sh
+++ b/scripts/sh/update-flake.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+dotfiles_update_flake() {
+  local root="$1"
+
+  dotfiles_have nix || dotfiles_die "Nix is required to update flake inputs."
+  dotfiles_log "Updating Nix flake inputs..."
+  if (
+    cd "$root" || dotfiles_die "Unable to enter dotfiles checkout: $root"
+    nix flake update
+  ); then
+    return 0
+  else
+    local status=$?
+    dotfiles_log "Nix flake input update failed."
+    exit "$status"
+  fi
+}

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -216,6 +216,7 @@ create_mocked_installer_fixture() {
 	MOCK_REPO="$(cd "$MOCK_REPO" && pwd -P)"
 	cp "$REPO_ROOT/install.sh" "$MOCK_REPO/install.sh"
 	cp "$REPO_ROOT/scripts/sh/install-common.sh" "$MOCK_REPO/scripts/sh/install-common.sh"
+	cp "$REPO_ROOT/scripts/sh/update-flake.sh" "$MOCK_REPO/scripts/sh/update-flake.sh"
 	for installer in install-macos.sh install-linux.sh install-nixos.sh; do
 		cp "$REPO_ROOT/scripts/sh/$installer" "$MOCK_REPO/scripts/sh/$installer"
 	done

--- a/tests/bash/install_linux.bats
+++ b/tests/bash/install_linux.bats
@@ -157,6 +157,7 @@ assert_log_order() {
 	[ "$status" -eq 0 ]
 	grep -q 'user=test-user home=.* uid=1000 gid=1000 group=users system=x86_64-linux args=run .#system-manager -- --nix-option pure-eval false switch --flake .#ubuntu --sudo' "$COMMAND_LOG"
 	assert_log_order \
+		"args=flake update" \
 		"switch --flake .#ubuntu --sudo" \
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
@@ -260,6 +261,18 @@ EOF
 	! grep -q '^docker compose ' "$COMMAND_LOG"
 }
 
+@test "Linux stops before System Manager when flake update fails" {
+	write_nix_stub
+	cat >>"$STUB_BIN/nix" <<'EOF'
+if [[ $* == "flake update" ]]; then exit 41; fi
+EOF
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 41 ]
+	! grep -q 'switch --flake' "$COMMAND_LOG"
+}
+
 @test "invalid existing user identity is rejected before System Manager" {
 	write_nix_stub
 	write_stub id '
@@ -330,6 +343,7 @@ fi
 	[ "$status" -eq 0 ]
 	grep -q 'build --impure --no-link --print-out-paths .*homeConfigurations.*x86_64-linux.*activationPackage' "$COMMAND_LOG"
 	assert_log_order \
+		"nix flake update" \
 		"homeConfigurations" \
 		"home-manager-activate" \
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
@@ -337,4 +351,21 @@ fi
 	! grep -q '^docker ' "$COMMAND_LOG"
 	! grep -q '^verify-environment ' "$COMMAND_LOG"
 	[[ "$output" == *"User-only setup complete; Docker/systemd were not configured."* ]]
+}
+
+@test "Home Manager fallback stops before activation when flake update fails" {
+	export DOTFILES_ALLOW_USER_ONLY=1
+	write_stub nix '
+printf "nix %s\n" "$*" >>"$COMMAND_LOG"
+if [[ $* == "eval --impure --raw --expr builtins.currentSystem" ]]; then
+	printf x86_64-linux
+elif [[ $* == "flake update" ]]; then
+	exit 41
+fi
+'
+
+	run "$FALLBACK_INSTALLER"
+
+	[ "$status" -eq 41 ]
+	! grep -q 'homeConfigurations' "$COMMAND_LOG"
 }

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -405,6 +405,7 @@ run_macos_installer() {
 	[ "$status" -eq 0 ]
 	grep -Fqx "sudo </usr/bin/env> <NIX_CONFIG=extra-experimental-features = nix-command flakes> <DOTFILES_USER=test-user> <DOTFILES_HOME=$TEST_HOME> <DOTFILES_ROOT=$REPO_ROOT> <$STUB_BIN/nix> <run> <.#darwin-rebuild> <--> <switch> <--flake> <.#macos> <--impure>" "$COMMAND_LOG"
 	assert_log_order \
+		"nix flake update" \
 		"nix run .#darwin-rebuild -- switch --flake .#macos --impure" \
 		"update-homebrew-casks " \
 		"docker info" \
@@ -424,6 +425,19 @@ run_macos_installer() {
 	! grep -q 'brew install --cask' "$COMMAND_LOG"
 	! grep -q 'desktop.docker.com/mac' "$COMMAND_LOG"
 	! grep -q 'docker-install' "$COMMAND_LOG"
+}
+
+@test "macOS stops before nix-darwin when flake update fails" {
+	write_installed_stubs
+	write_stub nix '
+printf "nix %s\n" "$*" >>"$COMMAND_LOG"
+if [[ $* == "flake update" ]]; then exit 41; fi
+'
+
+	run_macos_installer
+
+	[ "$status" -eq 41 ]
+	! grep -q 'nix run .#darwin-rebuild' "$COMMAND_LOG"
 }
 
 @test "Docker Desktop md5 compatibility ensure uses fixed paths for all states" {

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -877,6 +877,7 @@ if [ "${1:-}" = "run" ]; then exit 42; fi
 		"$HOME/.dotfiles/docker/hermes-agent"
 	cp "$INSTALLER" "$HOME/.dotfiles/scripts/sh/install-macos.sh"
 	cp "$COMMON_INSTALLER" "$HOME/.dotfiles/scripts/sh/install-common.sh"
+	cp "$REPO_ROOT/scripts/sh/update-flake.sh" "$HOME/.dotfiles/scripts/sh/update-flake.sh"
 	cp "$HERMES_INSTALLER" "$HOME/.dotfiles/scripts/sh/hermes-agent.sh"
 	touch \
 		"$HOME/.dotfiles/flake.nix" \

--- a/tests/bash/install_nixos.bats
+++ b/tests/bash/install_nixos.bats
@@ -120,6 +120,7 @@ line_of() {
 	[ "$status" -eq 0 ]
 	grep -q "nixos-rebuild user=test-user home=$HOME uid=1000 gid=1000 group=users args=switch --flake $REPO_ROOT#linux --impure" "$COMMAND_LOG"
 	grep -q "DOTFILES_NIXOS_HARDWARE_CONFIG=$HARDWARE_CONFIG" "$COMMAND_LOG"
+	[ "$(line_of 'nix flake update')" -lt "$(line_of nixos-rebuild)" ]
 	[ "$(line_of nixos-rebuild)" -lt "$(line_of 'chezmoi init')" ]
 	[ "$(line_of 'chezmoi apply')" -lt "$(line_of 'docker compose')" ]
 	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap xapi-mcp")" ]
@@ -186,6 +187,22 @@ exit 42
 	[ "$status" -eq 42 ]
 	! grep -q '^chezmoi ' "$COMMAND_LOG"
 	! grep -q '^docker ' "$COMMAND_LOG"
+}
+
+@test "NixOS stops before rebuild when flake update fails" {
+	write_stub nix '
+printf "nix %s\n" "$*" >>"$COMMAND_LOG"
+if [[ $* == "eval --impure --raw --expr builtins.currentSystem" ]]; then
+	printf x86_64-linux
+elif [[ $* == "flake update" ]]; then
+	exit 41
+fi
+'
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 41 ]
+	! grep -q '^nixos-rebuild ' "$COMMAND_LOG"
 }
 
 @test "NixOS Compose failure stops before acceptance" {


### PR DESCRIPTION
## Summary

- Update Nix flake inputs before activation on macOS, Ubuntu/Debian, NixOS, and the Home Manager fallback path.
- Explicitly run `winget upgrade` for an installed `OpenAI.Codex` package on Windows.
- Treat localized already-latest upgrade results as success and propagate real upgrade failures.

## Root cause

The macOS update path activated nix-darwin without refreshing flake inputs, so the locked Codex package could remain unchanged. Windows relied on the generic install-or-upgrade behavior, which did not reliably update the Codex CLI.

## Validation

- Winget Pester suite: 62 passed.
- Unix installer Bats suites for macOS, Linux, and NixOS: 52 passed.
- Bash and PowerShell syntax checks passed.
- pre-commit checks passed.
