### PR TITLE
feat: install Discord across supported operating systems

### DIFF
--- a/docs/superpowers/specs/2026-08-14-discord-desktop-install-design.md
+++ b/docs/superpowers/specs/2026-08-14-discord-desktop-install-design.md
@@ -1,0 +1,53 @@
+# Discord デスクトップアプリのクロスプラットフォーム導入設計
+
+## 目的
+
+既存の Nix catalog を SSOT として、dotfiles が対応する OS 全体へ Discord デスクトップアプリを宣言的に導入する。
+
+対象は Windows、Apple Silicon macOS、NixOS、Ubuntu/Debian、その他 Linux。WSL は Windows 側の Discord を利用し、WSL 内へ別の GUI アプリは導入しない。
+
+## 採用アプローチ
+
+`nix/packages/sets.nix` に Discord の catalog entry を追加し、OS ごとの適切な provider を同じエントリから導出する。
+
+| OS      | Provider                 | 実装上の扱い                                                 |
+| ------- | ------------------------ | ------------------------------------------------------------ |
+| Linux   | Nix `pkgs.discord`       | Home Manager の `home.packages` 経由で導入                   |
+| macOS   | Homebrew cask `discord`  | nix-darwin の `homebrew.casks` 経由で導入                    |
+| Windows | winget `Discord.Discord` | catalog から生成した manifest を PowerShell installer が適用 |
+
+macOS では Nix package と Homebrew cask の二重導入を避けるため、catalog entry の `pkg` は Darwin で `null`、Linux で `pkgs.discord` とする。macOS の provider metadata は明示的に `homebrew-cask`、Linux は Nix の default provider とする。
+
+Discord は GUI アプリであり、Windows manifest の `verifyCommand` は追加しない。既存の catalog 生成、provider coverage、macOS cask wiring を利用し、専用の installer logic は作らない。
+
+## 変更範囲
+
+- `nix/packages/sets.nix`
+  - `desktop` category に Discord entry を追加
+  - Nix package、winget ID、macOS cask provider を定義
+- `windows/winget/packages.json`
+  - `nix build .#winget-export` の出力から Discord entry を反映
+- `tests/bash/package_catalog.bats`
+  - Discord が Windows-only ではなく、winget と macOS cask を持つことを検証
+
+設定配布、Discord のログイン、bot token、Hermes の Discord transport は本変更の対象外とする。
+
+## 検証
+
+次を実行して、宣言と生成物の整合性を確認する。
+
+1. focused Bats test で catalog/provider metadata を検証
+2. `nix fmt` と `git diff --check` で構文・空白を検証
+3. `nix build .#winget-export` で Windows manifest を生成
+4. `nix eval` で provider coverage と Linux/macOS の package/cask wiring を確認
+5. 生成した manifest の差分を確認し、Discord が `Discord.Discord` として含まれることを確認
+
+CI の live winget install や各 OS の GUI 起動確認は、この変更のローカル完了条件には含めない。provider metadata と生成物の検証を行い、実機での反映は各 OS の既存 installer/switch 実行時に行う。
+
+## 完了条件
+
+- 既存 catalog の provider coverage を壊さない
+- Linux の Home Manager package set に Discord が含まれる
+- Apple Silicon macOS の nix-darwin cask set に `discord` が含まれる
+- Windows manifest に `Discord.Discord` が含まれる
+- focused test、Nix formatter、manifest generation、差分チェックが成功する

--- a/nix/darwin/default.nix
+++ b/nix/darwin/default.nix
@@ -134,6 +134,9 @@ in
           nrs = "~/.dotfiles/install.sh";
         };
       };
-    extraSpecialArgs = { inherit inputs; };
+    extraSpecialArgs = {
+      inherit inputs;
+      isWSL = false;
+    };
   };
 }

--- a/nix/flakes/home.nix
+++ b/nix/flakes/home.nix
@@ -15,7 +15,10 @@ let
         config.allowUnfree = true;
         overlays = [ workmuxOverlay ];
       };
-      extraSpecialArgs = { inherit inputs; };
+      extraSpecialArgs = {
+        inherit inputs;
+        isWSL = false;
+      };
       modules = [ ../home/common.nix ];
     };
 in

--- a/nix/flakes/hosts.nix
+++ b/nix/flakes/hosts.nix
@@ -31,6 +31,9 @@ in
             hostPath = ../hosts/wsl;
             homeModulePath = ../home/wsl/users.nix;
             overlays = [ workmuxOverlay ];
+            homeExtraSpecialArgs = {
+              isWSL = true;
+            };
             extraModules = [
               inputs.nixos-wsl.nixosModules.wsl
             ];

--- a/nix/flakes/hosts.nix
+++ b/nix/flakes/hosts.nix
@@ -59,6 +59,9 @@ in
             hostPath = ../hosts/linux;
             homeModulePath = ../home/linux/users.nix;
             overlays = [ workmuxOverlay ];
+            homeExtraSpecialArgs = {
+              isWSL = false;
+            };
             extraModules = [ (/. + hardwareConfig) ];
           }
         );

--- a/nix/flakes/lib/hosts.nix
+++ b/nix/flakes/lib/hosts.nix
@@ -8,6 +8,7 @@
       homeModulePath ? null,
       extraModules ? [ ],
       overlays ? [ ],
+      homeExtraSpecialArgs ? { },
     }:
     inputs.nixpkgs.lib.nixosSystem {
       specialArgs = { inherit inputs siteLib system; };
@@ -25,7 +26,11 @@
               home-manager = {
                 useGlobalPkgs = true;
                 useUserPackages = true;
-                extraSpecialArgs = { inherit inputs; };
+                extraSpecialArgs = {
+                  inherit inputs;
+                  isWSL = false;
+                }
+                // homeExtraSpecialArgs;
                 users = import homeModulePath;
               };
             }

--- a/nix/flakes/lib/hosts.nix
+++ b/nix/flakes/lib/hosts.nix
@@ -28,7 +28,6 @@
                 useUserPackages = true;
                 extraSpecialArgs = {
                   inherit inputs;
-                  isWSL = false;
                 }
                 // homeExtraSpecialArgs;
                 users = import homeModulePath;

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -9,7 +9,7 @@
   pkgs,
   lib,
   inputs ? null,
-  isWSL ? false,
+  isWSL,
   ...
 }:
 let

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -9,6 +9,7 @@
   pkgs,
   lib,
   inputs ? null,
+  isWSL ? false,
   ...
 }:
 let
@@ -29,7 +30,7 @@ in
     stateVersion = "25.05";
     # macOS installs the WezTerm GUI through Homebrew, so add its Nix terminfo
     # output separately for shells and tools that resolve TERM=wezterm.
-    packages = sets.all ++ darwinTerminfoPackages;
+    packages = sets.allWithout (lib.optional isWSL "discord") ++ darwinTerminfoPackages;
 
     sessionVariables = {
       # qmd (markdown search engine)

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -314,6 +314,17 @@ let
     };
 
     # ── desktop applications ──────────────────────────────
+    discord = {
+      pkg = if pkgs.stdenv.isDarwin then null else pkgs.discord;
+      winget = "Discord.Discord";
+      category = "desktop";
+      support = {
+        darwin = {
+          provider = "homebrew-cask";
+          cask = "discord";
+        };
+      };
+    };
     _1password-gui = {
       pkg = pkgs._1password-gui;
       winget = "AgileBits.1Password";

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -814,6 +814,9 @@ lib.mapAttrs (_: resolve) grouped
 // {
   # All packages (flat list)
   all = resolve (lib.attrNames catalog);
+  allWithout =
+    excludedNames:
+    resolve (builtins.filter (name: !(builtins.elem name excludedNames)) (lib.attrNames catalog));
 
   # Windows: nix attr name → winget PackageIdentifier
   inherit wingetMap npmMap;

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -323,6 +323,9 @@ let
           provider = "homebrew-cask";
           cask = "discord";
         };
+        linux = {
+          provider = "nix";
+        };
       };
     };
     _1password-gui = {

--- a/nix/system-manager/default.nix
+++ b/nix/system-manager/default.nix
@@ -60,6 +60,9 @@ in
     useUserPackages = true;
     backupFileExtension = "hm-backup";
     users.${user} = import ../home/common.nix;
-    extraSpecialArgs = { inherit inputs; };
+    extraSpecialArgs = {
+      inherit inputs;
+      isWSL = false;
+    };
   };
 }

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -95,6 +95,12 @@ setup() {
 	[[ "$output" == *'cask = "discord"'* ]]
 }
 
+@test "WSL excludes the native Discord package" {
+	run grep -n -A3 'homeExtraSpecialArgs' "$REPO_ROOT/nix/flakes/hosts.nix"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'isWSL = true;'* ]]
+}
+
 @test "generated Windows manifest contains Discord" {
 	command -v jq >/dev/null 2>&1 || skip "jq is not available in this test environment"
 	run jq -e '

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -95,6 +95,15 @@ setup() {
 	[[ "$output" == *'cask = "discord"'* ]]
 }
 
+@test "generated Windows manifest contains Discord" {
+	command -v jq >/dev/null 2>&1 || skip "jq is not available in this test environment"
+	run jq -e '
+		[.Sources[] | select(.SourceDetails.Name == "winget") | .Packages[]
+		 | select(.PackageIdentifier == "Discord.Discord")] | length == 1
+	' "$REPO_ROOT/windows/winget/packages.json"
+	[ "$status" -eq 0 ]
+}
+
 @test "WezTerm uses the nightly Homebrew cask on Darwin and Nix on Linux" {
 	run awk '
 		/wezterm = \{/ { in_entry=1 }

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -85,6 +85,16 @@ setup() {
 	[[ "$output" == *'cask = "thebrowsercompany-dia"'* ]]
 }
 
+@test "Discord is a cross-platform desktop package" {
+	run grep -n -A12 '^    discord = {' "$SETS"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'pkg = if pkgs.stdenv.isDarwin then null else pkgs.discord;'* ]]
+	[[ "$output" == *'winget = "Discord.Discord";'* ]]
+	[[ "$output" == *'category = "desktop";'* ]]
+	[[ "$output" == *'provider = "homebrew-cask";'* ]]
+	[[ "$output" == *'cask = "discord"'* ]]
+}
+
 @test "WezTerm uses the nightly Homebrew cask on Darwin and Nix on Linux" {
 	run awk '
 		/wezterm = \{/ { in_entry=1 }

--- a/windows/winget/packages.json
+++ b/windows/winget/packages.json
@@ -53,6 +53,9 @@
           }
         },
         {
+          "PackageIdentifier": "Discord.Discord"
+        },
+        {
           "PackageIdentifier": "Docker.DockerDesktop"
         },
         {


### PR DESCRIPTION
## Summary

- Add Discord to the Nix package catalog for Linux, macOS, and Windows.
- Use the macOS Homebrew cask, Linux Nix provider, and Windows Winget package.
- Regenerate the Winget manifest and add catalog/generated-output regression coverage.

## Validation

- `bats tests/bash/package_catalog.bats` — 14/14 passed
- `nix build .#winget-export` — passed
- Generated Discord uniqueness check — passed
- `nix build .#package-support-report` — passed; provider errors empty
- `nix fmt` — 0 files changed
- `git diff --check` — passed

## Note

The direct cross-system `nix eval` remains blocked by the pre-existing `pkgs.workmux` attribute missing from the pinned nixpkgs import; the flake support-report build passes.