### PR TITLE
feat: support native Hermes browser platforms

### DIFF
--- a/.github/e2e/bootstrap-compose.yml
+++ b/.github/e2e/bootstrap-compose.yml
@@ -5,6 +5,9 @@ services:
   xapi-mcp:
     image: nginx:1.29-alpine
 
+  chromium:
+    image: nginx:1.29-alpine
+
   acceptance:
     image: nginx:1.29-alpine
     command:

--- a/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
@@ -80,6 +80,7 @@ class ComposeContractTests(unittest.TestCase):
     def test_browser_mcp_and_novnc_share_the_compose_chromium_process(self) -> None:
         chromium = self.services["chromium"]
         browser_mcp = self.services["browser-mcp"]
+        self.assertNotIn("platform", chromium)
         self.assertEqual(
             browser_mcp["depends_on"],
             {"chromium": {"condition": "service_healthy"}},
@@ -128,6 +129,22 @@ class ComposeContractTests(unittest.TestCase):
         self.assertNotIn(
             "--disable-gpu", entrypoint_path.read_text(encoding="utf-8")
         )
+
+    def test_browser_image_selects_a_native_browser_for_each_supported_architecture(self) -> None:
+        dockerfile_path = REPOSITORY_ROOT / "docker/hermes-browser/Dockerfile"
+        entrypoint_path = REPOSITORY_ROOT / "docker/hermes-browser/entrypoint.sh"
+        if not dockerfile_path.is_file() or not entrypoint_path.is_file():
+            self.skipTest("hermes-browser source is outside the bootstrap test context")
+
+        dockerfile = dockerfile_path.read_text(encoding="utf-8")
+        entrypoint = entrypoint_path.read_text(encoding="utf-8")
+
+        self.assertIn("ARG TARGETARCH", dockerfile)
+        self.assertIn('amd64)', dockerfile)
+        self.assertIn('arm64)', dockerfile)
+        self.assertIn("apt-get install -y --no-install-recommends chromium", dockerfile)
+        self.assertIn("command -v /usr/bin/google-chrome-stable", entrypoint)
+        self.assertIn("command -v /usr/bin/chromium", entrypoint)
 
     def test_xapi_mcp_is_an_internal_shared_service(self) -> None:
         xapi = self.services.get("xapi-mcp")

--- a/docker/hermes-agent/compose.yml
+++ b/docker/hermes-agent/compose.yml
@@ -61,7 +61,6 @@ services:
       HERMES_HOME: /opt/data
 
   chromium:
-    platform: linux/amd64
     build:
       context: ../hermes-browser
       dockerfile: Dockerfile

--- a/docker/hermes-browser/Dockerfile
+++ b/docker/hermes-browser/Dockerfile
@@ -2,24 +2,39 @@ FROM debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN test "$(dpkg --print-architecture)" = "amd64" \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl \
-  && install -d -m 0755 /etc/apt/keyrings \
-  && curl -fsSL https://dl.google.com/linux/linux_signing_key.pub \
-    -o /etc/apt/keyrings/google-chrome.asc \
-  && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.asc] https://dl.google.com/linux/chrome/deb/ stable main" \
-    > /etc/apt/sources.list.d/google-chrome.list \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends google-chrome-stable fonts-noto-cjk locales socat python3-minimal xvfb x11vnc x11-utils novnc websockify \
-  && sed -i 's/^# *\(ja_JP.UTF-8 UTF-8\)/\1/' /etc/locale.gen \
-  && locale-gen \
-  && rm -rf /var/lib/apt/lists/* \
-  && groupadd --system --gid 997 hermes-browser \
-  && useradd --system --uid 997 --create-home --gid hermes-browser hermes-browser \
-  && install -d -o hermes-browser -g hermes-browser /data \
-  && sed -i 's#</body>#  <script type="module" src="app/clipboard-paste.js?v=5"></script>\n</body>#' /usr/share/novnc/vnc.html \
-  && ln -sf vnc.html /usr/share/novnc/index.html
+ARG TARGETARCH
+
+RUN set -eux; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends \
+    ca-certificates curl fonts-noto-cjk locales socat python3-minimal \
+    xvfb x11vnc x11-utils novnc websockify; \
+  case "$TARGETARCH" in \
+    amd64) \
+      install -d -m 0755 /etc/apt/keyrings; \
+      curl -fsSL https://dl.google.com/linux/linux_signing_key.pub \
+        -o /etc/apt/keyrings/google-chrome.asc; \
+      echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.asc] https://dl.google.com/linux/chrome/deb/ stable main" \
+        > /etc/apt/sources.list.d/google-chrome.list; \
+      apt-get update; \
+      apt-get install -y --no-install-recommends google-chrome-stable; \
+      ;; \
+    arm64) \
+      apt-get install -y --no-install-recommends chromium; \
+      ;; \
+    *) \
+      echo "Unsupported browser target architecture: $TARGETARCH" >&2; \
+      exit 1; \
+      ;; \
+  esac; \
+  sed -i 's/^# *\(ja_JP.UTF-8 UTF-8\)/\1/' /etc/locale.gen; \
+  locale-gen; \
+  rm -rf /var/lib/apt/lists/*; \
+  groupadd --system --gid 997 hermes-browser; \
+  useradd --system --uid 997 --create-home --gid hermes-browser hermes-browser; \
+  install -d -o hermes-browser -g hermes-browser /data; \
+  sed -i 's#</body>#  <script type="module" src="app/clipboard-paste.js?v=5"></script>\n</body>#' /usr/share/novnc/vnc.html; \
+  ln -sf vnc.html /usr/share/novnc/index.html
 
 ENV LANG=ja_JP.UTF-8 \
   LANGUAGE=ja_JP:ja \

--- a/docker/hermes-browser/entrypoint.sh
+++ b/docker/hermes-browser/entrypoint.sh
@@ -4,13 +4,22 @@ set -eu
 mkdir -p /data
 
 if ! touch /data/.hermes-browser-write-test 2>/dev/null; then
-  echo "The Google Chrome profile bind mount at /data must be writable by hermes-browser without disabling the sandbox." >&2
+  echo "The browser profile bind mount at /data must be writable by hermes-browser without disabling the sandbox." >&2
   exit 1
 fi
 
 rm -f /data/.hermes-browser-write-test
 # Remove only stale browser singleton markers from the dedicated /data profile.
 rm -f /data/SingletonLock /data/SingletonSocket /data/SingletonCookie
+
+if command -v /usr/bin/google-chrome-stable >/dev/null 2>&1; then
+  browser_binary=/usr/bin/google-chrome-stable
+elif command -v /usr/bin/chromium >/dev/null 2>&1; then
+  browser_binary=/usr/bin/chromium
+else
+  echo "No supported browser binary was found in the Hermes browser image" >&2
+  exit 1
+fi
 
 export DISPLAY="${DISPLAY:-:99}"
 display_number="${DISPLAY#*:}"
@@ -194,7 +203,7 @@ PY
 socat TCP-LISTEN:9222,fork,reuseaddr,bind=0.0.0.0 EXEC:"python3 /tmp/hermes-cdp-forwarder.py",nofork &
 cdp_pid=$!
 
-/usr/bin/google-chrome-stable \
+"$browser_binary" \
   --lang=ja \
   --disable-background-timer-throttling \
   --disable-renderer-backgrounding \

--- a/docker/hermes-browser/tests/test_runtime_contract.sh
+++ b/docker/hermes-browser/tests/test_runtime_contract.sh
@@ -17,6 +17,15 @@ if grep -Fq -- "--disable-gpu" "$entrypoint"; then
   exit 1
 fi
 
+for expression in \
+  'command -v /usr/bin/google-chrome-stable' \
+  'command -v /usr/bin/chromium'; do
+  if ! grep -Fq -- "$expression" "$entrypoint"; then
+    echo "Browser entrypoint must select an installed browser binary: $expression" >&2
+    exit 1
+  fi
+done
+
 python3 - "$repo_root/docker/hermes-browser-mcp/package.json" "$repo_root/docker/hermes-browser-mcp/package-lock.json" <<'PY'
 import json
 import sys

--- a/docs/hermes-agent/browser-mcp.md
+++ b/docs/hermes-agent/browser-mcp.md
@@ -1,17 +1,17 @@
 # Hermes Browser MCP
 
-Hermes の browser MCP は host browser ではなく、Compose 内の専用 Google Chrome container と Browser MCP container だけを使う。browser は containerized だが、noVNC を通じて表示できる。
+Hermes の browser MCP は host browser ではなく、Compose 内の専用 browser container と Browser MCP container だけを使う。browser は containerized だが、noVNC を通じて表示できる。
 ホスト PC から browser session を見る場合は noVNC を使う。既定 URL は `http://127.0.0.1:6080` で、`HERMES_BROWSER_VIEW_PORT` により host 側 port だけ変更できる。CDP `9222` と Browser MCP `8080` は引き続き host に publish しない。
 host 側の Chrome/Chromium/Brave 実行ファイル、host CDP endpoint、host Node/npm/Python は使わない。
 
 ## 構成
 
-- `chromium`: 互換性のため service 名は維持しつつ、Xvfb 上の visible Google Chrome を container 内で起動する。CDP は Compose network 内だけに公開し、noVNC viewer だけを `127.0.0.1` に公開する。
+- `chromium`: 互換性のため service 名は維持しつつ、Xvfb 上の visible browser を container 内で起動する。AMD64 では Google Chrome、ARM64 では Debian Chromium を使う。CDP は Compose network 内だけに公開し、noVNC viewer だけを `127.0.0.1` に公開する。
 - `browser-mcp`: `chrome-devtools-mcp` を `mcp-proxy` 経由で Streamable HTTP MCP として公開する。MCP要求は120秒で打ち切り、ページ単位の操作はDevToolsのpage IDでルーティングする。Chrome DevTools MCPは1.6.0、MCP proxyは6.5.5に固定する。
 - `hermes`: `browser-mcp` service 名で Browser MCP に接続する。
 
-Google Chrome container は `ja_JP.UTF-8` locale と `--lang=ja` で起動し、Chrome UI と日本語入力内容を表示できるようにする。長寿命の専用ブラウザでバックグラウンドページが凍結・破棄されると、CDPの `Runtime.enable` や `Accessibility.getFullAXTree` が停止してMCP全体のsnapshotがタイムアウトするため、背景Rendererの抑制とTabDiscardingを無効化する。
-noVNC viewer は通常の `Cmd/Ctrl+C`、`Cmd/Ctrl+X`、`Cmd/Ctrl+V` を Google Chrome 側のショートカットへ変換し、プレーンテキストの clipboard をホストと双方向に同期する。
+Browser container は `ja_JP.UTF-8` locale と `--lang=ja` で起動し、Chrome/Chromium UI と日本語入力内容を表示できるようにする。長寿命の専用ブラウザでバックグラウンドページが凍結・破棄されると、CDPの `Runtime.enable` や `Accessibility.getFullAXTree` が停止してMCP全体のsnapshotがタイムアウトするため、背景Rendererの抑制とTabDiscardingを無効化する。
+noVNC viewer は通常の `Cmd/Ctrl+C`、`Cmd/Ctrl+X`、`Cmd/Ctrl+V` を browser 側のショートカットへ変換し、プレーンテキストの clipboard をホストと双方向に同期する。
 
 Hermes から接続する内部 URL は次の固定値にする。
 
@@ -52,14 +52,14 @@ browser session を起動するため、managed profile では無効である。
 
 ## Browser profile
 
-Google Chrome の profile は専用 data directory に保存する。
+Chrome/Chromium の profile は専用 data directory に保存する。
 
 ```text
 ${HERMES_BROWSER_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes/.browser}
 ```
 
 既定では Hermes data directory 配下の `.browser` を使う。profile を消すと browser login/session/cache も消えるため、通常の Hermes home や managed profile home とは分けて扱う。
-container を更新・再作成しても、この directory は同じ `/data` に bind mount される。既存 profile は削除・初期化せず、Google Chrome で profile を登録すると Chrome が `/data` 内の設定を更新する。更新後の profile を古い Chromium へ戻す downgrade は保証しない。
+container を更新・再作成しても、この directory は同じ `/data` に bind mount される。既存 profile は削除・初期化せず、実行中の Chrome/Chromium が `/data` 内の設定を更新する。AMD64 と ARM64 の間でブラウザを切り替えた後に、profile を古いブラウザへ戻す downgrade は保証しない。
 
 ## 起動
 

--- a/scripts/powershell/handlers/Handler.HermesAgent.ps1
+++ b/scripts/powershell/handlers/Handler.HermesAgent.ps1
@@ -69,7 +69,7 @@ class HermesAgentHandler : SetupHandlerBase {
                 return $this.CreateFailureResult("Hermes Compose validation failed: $($validation.Message)")
             }
 
-            $build = $this.InvokeCompose($composeFile, @('build', 'hermes', 'hermes-bootstrap', 'xapi-mcp'))
+            $build = $this.InvokeCompose($composeFile, @('build', 'hermes', 'hermes-bootstrap', 'hermes-browser', 'xapi-mcp'))
             if (-not $build.Success) {
                 return $this.CreateFailureResult("Hermes image build failed: $($build.Message)")
             }

--- a/scripts/powershell/handlers/Handler.HermesAgent.ps1
+++ b/scripts/powershell/handlers/Handler.HermesAgent.ps1
@@ -69,7 +69,7 @@ class HermesAgentHandler : SetupHandlerBase {
                 return $this.CreateFailureResult("Hermes Compose validation failed: $($validation.Message)")
             }
 
-            $build = $this.InvokeCompose($composeFile, @('build', 'hermes', 'hermes-bootstrap', 'browser-mcp', 'xapi-mcp'))
+            $build = $this.InvokeCompose($composeFile, @('build', 'hermes', 'hermes-bootstrap', 'chromium', 'xapi-mcp'))
             if (-not $build.Success) {
                 return $this.CreateFailureResult("Hermes image build failed: $($build.Message)")
             }

--- a/scripts/powershell/handlers/Handler.HermesAgent.ps1
+++ b/scripts/powershell/handlers/Handler.HermesAgent.ps1
@@ -69,7 +69,7 @@ class HermesAgentHandler : SetupHandlerBase {
                 return $this.CreateFailureResult("Hermes Compose validation failed: $($validation.Message)")
             }
 
-            $build = $this.InvokeCompose($composeFile, @('build', 'hermes', 'hermes-bootstrap', 'hermes-browser', 'xapi-mcp'))
+            $build = $this.InvokeCompose($composeFile, @('build', 'hermes', 'hermes-bootstrap', 'browser-mcp', 'xapi-mcp'))
             if (-not $build.Success) {
                 return $this.CreateFailureResult("Hermes image build failed: $($build.Message)")
             }

--- a/scripts/powershell/hermes-bootstrap.ps1
+++ b/scripts/powershell/hermes-bootstrap.ps1
@@ -262,7 +262,7 @@ function Invoke-HermesBootstrapEntrypoint {
             if ($config.ExitCode -ne 0) { return $config }
 
             $build = Invoke-HermesBootstrapDockerPhase `
-                -Arguments @('compose', '-f', $paths.ComposeFile, 'build', 'hermes', 'hermes-bootstrap', 'browser-mcp', 'xapi-mcp') `
+                -Arguments @('compose', '-f', $paths.ComposeFile, 'build', 'hermes', 'hermes-bootstrap', 'chromium', 'xapi-mcp') `
                 -FailureMessage 'Hermes image build failed.'
             if ($build.ExitCode -ne 0) { return $build }
 

--- a/scripts/powershell/hermes-bootstrap.ps1
+++ b/scripts/powershell/hermes-bootstrap.ps1
@@ -262,7 +262,7 @@ function Invoke-HermesBootstrapEntrypoint {
             if ($config.ExitCode -ne 0) { return $config }
 
             $build = Invoke-HermesBootstrapDockerPhase `
-                -Arguments @('compose', '-f', $paths.ComposeFile, 'build', 'hermes', 'hermes-bootstrap', 'xapi-mcp') `
+                -Arguments @('compose', '-f', $paths.ComposeFile, 'build', 'hermes', 'hermes-bootstrap', 'hermes-browser', 'xapi-mcp') `
                 -FailureMessage 'Hermes image build failed.'
             if ($build.ExitCode -ne 0) { return $build }
 

--- a/scripts/powershell/hermes-bootstrap.ps1
+++ b/scripts/powershell/hermes-bootstrap.ps1
@@ -262,7 +262,7 @@ function Invoke-HermesBootstrapEntrypoint {
             if ($config.ExitCode -ne 0) { return $config }
 
             $build = Invoke-HermesBootstrapDockerPhase `
-                -Arguments @('compose', '-f', $paths.ComposeFile, 'build', 'hermes', 'hermes-bootstrap', 'hermes-browser', 'xapi-mcp') `
+                -Arguments @('compose', '-f', $paths.ComposeFile, 'build', 'hermes', 'hermes-bootstrap', 'browser-mcp', 'xapi-mcp') `
                 -FailureMessage 'Hermes image build failed.'
             if ($build.ExitCode -ne 0) { return $build }
 

--- a/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
+++ b/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
@@ -138,7 +138,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             'info',
             'compose version',
             "compose -f $script:composeFile config --quiet",
-            "compose -f $script:composeFile build hermes hermes-bootstrap browser-mcp xapi-mcp",
+            "compose -f $script:composeFile build hermes hermes-bootstrap chromium xapi-mcp",
             "compose -f $script:composeFile stop hermes",
             "compose -f $script:composeFile up -d --force-recreate"
         )

--- a/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
+++ b/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
@@ -138,7 +138,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             'info',
             'compose version',
             "compose -f $script:composeFile config --quiet",
-            "compose -f $script:composeFile build hermes hermes-bootstrap xapi-mcp",
+            "compose -f $script:composeFile build hermes hermes-bootstrap hermes-browser xapi-mcp",
             "compose -f $script:composeFile stop hermes",
             "compose -f $script:composeFile up -d --force-recreate"
         )

--- a/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
+++ b/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
@@ -138,7 +138,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             'info',
             'compose version',
             "compose -f $script:composeFile config --quiet",
-            "compose -f $script:composeFile build hermes hermes-bootstrap hermes-browser xapi-mcp",
+            "compose -f $script:composeFile build hermes hermes-bootstrap browser-mcp xapi-mcp",
             "compose -f $script:composeFile stop hermes",
             "compose -f $script:composeFile up -d --force-recreate"
         )

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -157,7 +157,7 @@ Describe 'HermesAgentHandler' {
             $browserDir | Should -Exist
             $script:dockerCalls | Should -Be @(
                 "compose -f $script:composeFile config --quiet",
-                "compose -f $script:composeFile build hermes hermes-bootstrap hermes-browser xapi-mcp",
+                "compose -f $script:composeFile build hermes hermes-bootstrap browser-mcp xapi-mcp",
                 "compose -f $script:composeFile stop hermes",
                 "compose -f $script:composeFile up -d --force-recreate"
             )

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -157,7 +157,7 @@ Describe 'HermesAgentHandler' {
             $browserDir | Should -Exist
             $script:dockerCalls | Should -Be @(
                 "compose -f $script:composeFile config --quiet",
-                "compose -f $script:composeFile build hermes hermes-bootstrap xapi-mcp",
+                "compose -f $script:composeFile build hermes hermes-bootstrap hermes-browser xapi-mcp",
                 "compose -f $script:composeFile stop hermes",
                 "compose -f $script:composeFile up -d --force-recreate"
             )

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -157,7 +157,7 @@ Describe 'HermesAgentHandler' {
             $browserDir | Should -Exist
             $script:dockerCalls | Should -Be @(
                 "compose -f $script:composeFile config --quiet",
-                "compose -f $script:composeFile build hermes hermes-bootstrap browser-mcp xapi-mcp",
+                "compose -f $script:composeFile build hermes hermes-bootstrap chromium xapi-mcp",
                 "compose -f $script:composeFile stop hermes",
                 "compose -f $script:composeFile up -d --force-recreate"
             )

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -453,7 +453,7 @@ dotfiles_hermes_start_stack() {
     dotfiles_hermes_show_compose_diagnostics "$docker_runner" "$compose_file"
     return "$status"
   fi
-  if "$docker_runner" compose -f "$compose_file" build --pull hermes hermes-bootstrap browser-mcp xapi-mcp; then
+  if "$docker_runner" compose -f "$compose_file" build --pull hermes hermes-bootstrap chromium xapi-mcp; then
     :
   else
     status=$?

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -453,7 +453,7 @@ dotfiles_hermes_start_stack() {
     dotfiles_hermes_show_compose_diagnostics "$docker_runner" "$compose_file"
     return "$status"
   fi
-  if "$docker_runner" compose -f "$compose_file" build --pull hermes hermes-bootstrap hermes-browser xapi-mcp; then
+  if "$docker_runner" compose -f "$compose_file" build --pull hermes hermes-bootstrap browser-mcp xapi-mcp; then
     :
   else
     status=$?

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -453,7 +453,7 @@ dotfiles_hermes_start_stack() {
     dotfiles_hermes_show_compose_diagnostics "$docker_runner" "$compose_file"
     return "$status"
   fi
-  if "$docker_runner" compose -f "$compose_file" build --pull hermes hermes-bootstrap xapi-mcp; then
+  if "$docker_runner" compose -f "$compose_file" build --pull hermes hermes-bootstrap hermes-browser xapi-mcp; then
     :
   else
     status=$?

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -842,7 +842,7 @@ dotfiles_hermes_start_stack docker "$COMPOSE_FILE"
 	run_start_stack
 
 	[ "$status" -eq 0 ]
-	assert_log_order '<config> <--quiet>' '<build> <--pull> <hermes> <hermes-bootstrap> <browser-mcp> <xapi-mcp>' '<stop> <hermes>' '<secret-plan>' '<apply>' '<Hermes Agent Dashboard>' '<GitHubUsedOpenClawPAT>' '<Google Calendar MCP>' '<Master>' '<Rick>' '<Hoffman>' '<RisaRisa>' '<Nancy>' '<Kuroda>' '<Shiraishi>' '<Hermes X API MCP>' '<up> <-d> <--force-recreate>' '^curl ' '<image> <prune> <--force>'
+	assert_log_order '<config> <--quiet>' '<build> <--pull> <hermes> <hermes-bootstrap> <chromium> <xapi-mcp>' '<stop> <hermes>' '<secret-plan>' '<apply>' '<Hermes Agent Dashboard>' '<GitHubUsedOpenClawPAT>' '<Google Calendar MCP>' '<Master>' '<Rick>' '<Hoffman>' '<RisaRisa>' '<Nancy>' '<Kuroda>' '<Shiraishi>' '<Hermes X API MCP>' '<up> <-d> <--force-recreate>' '^curl ' '<image> <prune> <--force>'
 	mapfile -t records < <("$REAL_JQ" -r '.type + ":" + (.key // "")' "$PAYLOAD_CAPTURE")
 	[ "${records[*]}" = 'header: item:dashboard item:github item:google_calendar item:discord_default item:discord_rick item:discord_hoffman item:discord_risarisa item:discord_nancy item:discord_kuroda item:discord_shiraishi end:' ]
 	"$REAL_JQ" -e -c 'select(.type == "item") | .item.id == "item-id"' "$PAYLOAD_CAPTURE" >/dev/null

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -842,7 +842,7 @@ dotfiles_hermes_start_stack docker "$COMPOSE_FILE"
 	run_start_stack
 
 	[ "$status" -eq 0 ]
-	assert_log_order '<config> <--quiet>' '<build> <--pull> <hermes> <hermes-bootstrap> <hermes-browser> <xapi-mcp>' '<stop> <hermes>' '<secret-plan>' '<apply>' '<Hermes Agent Dashboard>' '<GitHubUsedOpenClawPAT>' '<Google Calendar MCP>' '<Master>' '<Rick>' '<Hoffman>' '<RisaRisa>' '<Nancy>' '<Kuroda>' '<Shiraishi>' '<Hermes X API MCP>' '<up> <-d> <--force-recreate>' '^curl ' '<image> <prune> <--force>'
+	assert_log_order '<config> <--quiet>' '<build> <--pull> <hermes> <hermes-bootstrap> <browser-mcp> <xapi-mcp>' '<stop> <hermes>' '<secret-plan>' '<apply>' '<Hermes Agent Dashboard>' '<GitHubUsedOpenClawPAT>' '<Google Calendar MCP>' '<Master>' '<Rick>' '<Hoffman>' '<RisaRisa>' '<Nancy>' '<Kuroda>' '<Shiraishi>' '<Hermes X API MCP>' '<up> <-d> <--force-recreate>' '^curl ' '<image> <prune> <--force>'
 	mapfile -t records < <("$REAL_JQ" -r '.type + ":" + (.key // "")' "$PAYLOAD_CAPTURE")
 	[ "${records[*]}" = 'header: item:dashboard item:github item:google_calendar item:discord_default item:discord_rick item:discord_hoffman item:discord_risarisa item:discord_nancy item:discord_kuroda item:discord_shiraishi end:' ]
 	"$REAL_JQ" -e -c 'select(.type == "item") | .item.id == "item-id"' "$PAYLOAD_CAPTURE" >/dev/null

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -842,7 +842,7 @@ dotfiles_hermes_start_stack docker "$COMPOSE_FILE"
 	run_start_stack
 
 	[ "$status" -eq 0 ]
-	assert_log_order '<config> <--quiet>' '<build> <--pull> <hermes> <hermes-bootstrap> <xapi-mcp>' '<stop> <hermes>' '<secret-plan>' '<apply>' '<Hermes Agent Dashboard>' '<GitHubUsedOpenClawPAT>' '<Google Calendar MCP>' '<Master>' '<Rick>' '<Hoffman>' '<RisaRisa>' '<Nancy>' '<Kuroda>' '<Shiraishi>' '<Hermes X API MCP>' '<up> <-d> <--force-recreate>' '^curl ' '<image> <prune> <--force>'
+	assert_log_order '<config> <--quiet>' '<build> <--pull> <hermes> <hermes-bootstrap> <hermes-browser> <xapi-mcp>' '<stop> <hermes>' '<secret-plan>' '<apply>' '<Hermes Agent Dashboard>' '<GitHubUsedOpenClawPAT>' '<Google Calendar MCP>' '<Master>' '<Rick>' '<Hoffman>' '<RisaRisa>' '<Nancy>' '<Kuroda>' '<Shiraishi>' '<Hermes X API MCP>' '<up> <-d> <--force-recreate>' '^curl ' '<image> <prune> <--force>'
 	mapfile -t records < <("$REAL_JQ" -r '.type + ":" + (.key // "")' "$PAYLOAD_CAPTURE")
 	[ "${records[*]}" = 'header: item:dashboard item:github item:google_calendar item:discord_default item:discord_rick item:discord_hoffman item:discord_risarisa item:discord_nancy item:discord_kuroda item:discord_shiraishi end:' ]
 	"$REAL_JQ" -e -c 'select(.type == "item") | .item.id == "item-id"' "$PAYLOAD_CAPTURE" >/dev/null

--- a/tests/bash/install_linux.bats
+++ b/tests/bash/install_linux.bats
@@ -161,7 +161,7 @@ assert_log_order() {
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet" \
-		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap browser-mcp xapi-mcp" \
+		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap chromium xapi-mcp" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap secret-plan" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap apply" \

--- a/tests/bash/install_linux.bats
+++ b/tests/bash/install_linux.bats
@@ -161,7 +161,7 @@ assert_log_order() {
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet" \
-		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap xapi-mcp" \
+		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap hermes-browser xapi-mcp" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap secret-plan" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap apply" \

--- a/tests/bash/install_linux.bats
+++ b/tests/bash/install_linux.bats
@@ -161,7 +161,7 @@ assert_log_order() {
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet" \
-		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap hermes-browser xapi-mcp" \
+		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap browser-mcp xapi-mcp" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap secret-plan" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap apply" \

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -411,7 +411,7 @@ run_macos_installer() {
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet" \
-		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap browser-mcp xapi-mcp" \
+		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap chromium xapi-mcp" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap secret-plan" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap apply" \

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -411,7 +411,7 @@ run_macos_installer() {
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet" \
-		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap hermes-browser xapi-mcp" \
+		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap browser-mcp xapi-mcp" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap secret-plan" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap apply" \

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -411,7 +411,7 @@ run_macos_installer() {
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet" \
-		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap xapi-mcp" \
+		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap hermes-browser xapi-mcp" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap secret-plan" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap apply" \

--- a/tests/bash/install_nixos.bats
+++ b/tests/bash/install_nixos.bats
@@ -122,8 +122,8 @@ line_of() {
 	grep -q "DOTFILES_NIXOS_HARDWARE_CONFIG=$HARDWARE_CONFIG" "$COMMAND_LOG"
 	[ "$(line_of nixos-rebuild)" -lt "$(line_of 'chezmoi init')" ]
 	[ "$(line_of 'chezmoi apply')" -lt "$(line_of 'docker compose')" ]
-	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap browser-mcp xapi-mcp")" ]
-	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap browser-mcp xapi-mcp")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes")" ]
+	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap chromium xapi-mcp")" ]
+	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap chromium xapi-mcp")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes")" ]
 	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes")" -lt "$(line_of 'hermes-bootstrap secret-plan')" ]
 	[ "$(line_of 'hermes-bootstrap secret-plan')" -lt "$(line_of 'hermes-bootstrap apply')" ]
 	[ "$(line_of 'hermes-bootstrap apply')" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml up -d --force-recreate")" ]

--- a/tests/bash/install_nixos.bats
+++ b/tests/bash/install_nixos.bats
@@ -122,8 +122,8 @@ line_of() {
 	grep -q "DOTFILES_NIXOS_HARDWARE_CONFIG=$HARDWARE_CONFIG" "$COMMAND_LOG"
 	[ "$(line_of nixos-rebuild)" -lt "$(line_of 'chezmoi init')" ]
 	[ "$(line_of 'chezmoi apply')" -lt "$(line_of 'docker compose')" ]
-	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap hermes-browser xapi-mcp")" ]
-	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap hermes-browser xapi-mcp")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes")" ]
+	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap browser-mcp xapi-mcp")" ]
+	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap browser-mcp xapi-mcp")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes")" ]
 	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes")" -lt "$(line_of 'hermes-bootstrap secret-plan')" ]
 	[ "$(line_of 'hermes-bootstrap secret-plan')" -lt "$(line_of 'hermes-bootstrap apply')" ]
 	[ "$(line_of 'hermes-bootstrap apply')" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml up -d --force-recreate")" ]

--- a/tests/bash/install_nixos.bats
+++ b/tests/bash/install_nixos.bats
@@ -122,8 +122,8 @@ line_of() {
 	grep -q "DOTFILES_NIXOS_HARDWARE_CONFIG=$HARDWARE_CONFIG" "$COMMAND_LOG"
 	[ "$(line_of nixos-rebuild)" -lt "$(line_of 'chezmoi init')" ]
 	[ "$(line_of 'chezmoi apply')" -lt "$(line_of 'docker compose')" ]
-	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap xapi-mcp")" ]
-	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap xapi-mcp")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes")" ]
+	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap hermes-browser xapi-mcp")" ]
+	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap hermes-browser xapi-mcp")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes")" ]
 	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes")" -lt "$(line_of 'hermes-bootstrap secret-plan')" ]
 	[ "$(line_of 'hermes-bootstrap secret-plan')" -lt "$(line_of 'hermes-bootstrap apply')" ]
 	[ "$(line_of 'hermes-bootstrap apply')" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml up -d --force-recreate")" ]

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -113,13 +113,17 @@ setup() {
 	[ "$status" -eq 0 ]
 }
 
-@test "Chromium Compose service is pinned to linux amd64" {
+@test "Chromium Compose service follows the host platform" {
 	run awk '
 		/^  chromium:/ { in_chromium=1; next }
 		in_chromium && /^  [A-Za-z0-9_-]+:/ { exit }
-		in_chromium && /platform: linux\/amd64/ { found=1 }
-		END { exit(found ? 0 : 1) }
+		in_chromium && /platform:/ { found=1 }
+		END { exit(found ? 1 : 0) }
 	' "$REPO_ROOT/docker/hermes-agent/compose.yml"
+	[ "$status" -eq 0 ]
+	run grep -F 'ARG TARGETARCH' "$REPO_ROOT/docker/hermes-browser/Dockerfile"
+	[ "$status" -eq 0 ]
+	run grep -F 'arm64)' "$REPO_ROOT/docker/hermes-browser/Dockerfile"
 	[ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## Summary

- remove the hard-coded `linux/amd64` platform from the Hermes browser service
- install Google Chrome on AMD64 and Debian Chromium on ARM64
- select the installed browser binary at runtime
- document the architecture-specific browser behavior

## Root cause

Apple Silicon Docker Desktop hosts were running the browser image as `linux/amd64` because Compose forced that platform, producing the `!AMD` warning and requiring emulation.

## Validation

- `task commit -- "feat: support native Hermes browser platforms"`
- Compose contract tests: 13 run, 12 passed, 1 skipped
- Hermes browser runtime contract: passed
- ARM64 browser image build and CDP smoke test: passed
- AMD64 browser image build: passed
- both `hermes-chromium` and `browser-mcp`: healthy