### PR TITLE
fix: update flake inputs during install

### DIFF
--- a/.github/workflows/ci-bootstrap-e2e-linux.yml
+++ b/.github/workflows/ci-bootstrap-e2e-linux.yml
@@ -31,6 +31,9 @@ concurrency:
 
 env:
   TESTED_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  # Bootstrap E2E must remain reproducible. Production installs update all
+  # flake inputs by default; these tests exercise the committed lock file.
+  DOTFILES_SKIP_FLAKE_UPDATE: "1"
 
 jobs:
   ubuntu:
@@ -162,7 +165,7 @@ jobs:
 
           # The variables below must expand inside the Debian machine.
           # shellcheck disable=SC2016
-          bootstrap='cd /workspace; ./.github/e2e/run-bootstrap-acceptance.sh'
+          bootstrap='export DOTFILES_SKIP_FLAKE_UPDATE=1; cd /workspace; ./.github/e2e/run-bootstrap-acceptance.sh'
           # shellcheck disable=SC2016
           verify='export PATH=/run/system-manager/sw/bin:/etc/profiles/per-user/dotfiles/bin:$HOME/.nix-profile/bin:$PATH; cd /workspace; ./scripts/sh/verify-environment.sh --runtime'
           run_inside "$bootstrap"

--- a/nix/tests/bootstrap-nixos.nix
+++ b/nix/tests/bootstrap-nixos.nix
@@ -95,7 +95,7 @@ pkgs.testers.runNixOSTest {
     machine.succeed("cp -r ${dotfilesSource} /home/nixos/dotfiles")
     machine.succeed("chmod -R u+w /home/nixos/dotfiles && chown -R nixos:users /home/nixos/dotfiles")
 
-    install = "su - nixos -c 'env DOTFILES_NIXOS_PREBUILT_SYSTEM=${nodes.machine.system.build.toplevel} DOTFILES_NIXOS_HARDWARE_CONFIG=/etc/nixos/hardware-configuration.nix DOTFILES_CHECKOUT_TARGET=/home/nixos/dotfiles /home/nixos/dotfiles/.github/e2e/run-bootstrap-acceptance.sh'"
+    install = "su - nixos -c 'env DOTFILES_SKIP_FLAKE_UPDATE=1 DOTFILES_NIXOS_PREBUILT_SYSTEM=${nodes.machine.system.build.toplevel} DOTFILES_NIXOS_HARDWARE_CONFIG=/etc/nixos/hardware-configuration.nix DOTFILES_CHECKOUT_TARGET=/home/nixos/dotfiles /home/nixos/dotfiles/.github/e2e/run-bootstrap-acceptance.sh'"
     machine.succeed(install)
     machine.succeed(install)
     machine.succeed("su - nixos -c 'export PATH=/run/current-system/sw/bin:/etc/profiles/per-user/nixos/bin:$HOME/.nix-profile/bin:$PATH; cd /home/nixos/dotfiles; DOTFILES_VERIFY_SYSTEM_LAYER=nixos ./scripts/sh/verify-environment.sh --runtime'")

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -96,10 +96,12 @@ Describe 'Package catalog consistency' {
             $taskfile = Get-Content -LiteralPath (Join-Path $script:repoRoot "Taskfile.yml") -Raw
             $updateScript = Get-Content -LiteralPath (Join-Path $script:repoRoot "scripts/sh/update.sh") -Raw
             $postInstallScript = Get-Content -LiteralPath (Join-Path $script:repoRoot "scripts/sh/nixos-wsl-postinstall.sh") -Raw
+            $commonInstallScript = Get-Content -LiteralPath (Join-Path $script:repoRoot "scripts/sh/install-common.sh") -Raw
 
             $taskfile | Should -Match 'nix flake update && sudo nixos-rebuild switch --flake \. --impure'
             $updateScript | Should -Match 'nix flake update --flake ~/.dotfiles'
-            $postInstallScript | Should -Match 'nix flake update --flake "\$TARGET_DIR"'
+            $commonInstallScript | Should -Match 'nix flake update --flake "\$flake_root"'
+            $postInstallScript | Should -Match 'dotfiles_update_flake "\$TARGET_DIR"'
         }
 
         It 'should use nixpkgs gwq and keep it out of Windows package providers' {

--- a/scripts/sh/install-common.sh
+++ b/scripts/sh/install-common.sh
@@ -42,6 +42,24 @@ dotfiles_load_nix() {
   fi
 }
 
+dotfiles_update_flake() {
+  local flake_root="${1:-${DOTFILES_ROOT:-}}"
+  if [[ ${DOTFILES_SKIP_FLAKE_UPDATE:-0} == 1 ]]; then
+    dotfiles_log "Skipping flake input update."
+    return 0
+  fi
+  [[ -n $flake_root ]] || dotfiles_die "A flake root is required for input updates."
+  [[ -f $flake_root/flake.nix ]] || dotfiles_die "Flake configuration is missing: $flake_root/flake.nix"
+  dotfiles_have nix || dotfiles_die "Nix is required to update flake inputs."
+
+  dotfiles_log "Updating flake inputs..."
+  (
+    cd "$flake_root" || exit 1
+    NIX_CONFIG="experimental-features = nix-command flakes" \
+      nix flake update --flake "$flake_root"
+  )
+}
+
 dotfiles_canonical_directory() {
   (
     cd "$1" || exit 1

--- a/scripts/sh/install-home-manager.sh
+++ b/scripts/sh/install-home-manager.sh
@@ -70,6 +70,7 @@ main() {
   [[ $(uname -s) == "Linux" ]] || dotfiles_die "Linux is required."
   ensure_nix
   dotfiles_link_checkout "$ROOT"
+  dotfiles_update_flake "$ROOT"
   capture_user_identity
   activate_home_manager
   apply_chezmoi

--- a/scripts/sh/install-linux.sh
+++ b/scripts/sh/install-linux.sh
@@ -125,6 +125,7 @@ main() {
   ensure_systemd
   ensure_nix
   dotfiles_link_checkout "$ROOT"
+  dotfiles_update_flake "$ROOT"
   capture_host_identity
   apply_linux_system
   apply_chezmoi

--- a/scripts/sh/install-macos.sh
+++ b/scripts/sh/install-macos.sh
@@ -297,6 +297,7 @@ main() {
   ensure_command_line_tools
   ensure_nix
   dotfiles_link_checkout "$ROOT"
+  dotfiles_update_flake "$ROOT"
   preserve_shell_rc_for_nix_darwin
   stop_existing_docker_desktop
   repair_homebrew_cask_link_directories

--- a/scripts/sh/install-nixos.sh
+++ b/scripts/sh/install-nixos.sh
@@ -102,6 +102,7 @@ docker_command() {
 main() {
   preflight
   dotfiles_link_checkout "$ROOT"
+  dotfiles_update_flake "$ROOT"
   capture_host_identity
   apply_nixos_system
   apply_chezmoi

--- a/scripts/sh/nixos-wsl-postinstall.sh
+++ b/scripts/sh/nixos-wsl-postinstall.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=/dev/null
+. "$SCRIPT_ROOT/install-common.sh"
+
 usage() {
   cat <<'USAGE'
 Usage: nixos-wsl-postinstall.sh [options]
@@ -307,8 +311,7 @@ fi
 
 if [[ $SKIP_FLAKE_UPDATE -eq 0 ]]; then
   # Update flake inputs so first install uses the latest Nix sources.
-  NIX_CONFIG="experimental-features = nix-command flakes" \
-    nix flake update --flake "$TARGET_DIR"
+  dotfiles_update_flake "$TARGET_DIR"
 else
   echo "Skipping flake update."
 fi

--- a/tests/bash/install_linux.bats
+++ b/tests/bash/install_linux.bats
@@ -157,6 +157,7 @@ assert_log_order() {
 	[ "$status" -eq 0 ]
 	grep -q 'user=test-user home=.* uid=1000 gid=1000 group=users system=x86_64-linux args=run .#system-manager -- --nix-option pure-eval false switch --flake .#ubuntu --sudo' "$COMMAND_LOG"
 	assert_log_order \
+		"args=flake update --flake $REPO_ROOT" \
 		"switch --flake .#ubuntu --sudo" \
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
@@ -171,6 +172,35 @@ assert_log_order() {
 	[ "$(grep -c '^op item get ' "$COMMAND_LOG")" -eq 11 ]
 	[ "$(grep -c '^op signin --account my.1password.com$' "$COMMAND_LOG")" -eq 1 ]
 	[ -s "$PAYLOAD_CAPTURE" ]
+}
+
+@test "flake update failure stops Linux activation" {
+	write_stub nix '
+printf "nix %s\n" "$*" >>"$COMMAND_LOG"
+if [[ $* == flake\ update\ --flake\ * ]]; then
+  exit 42
+fi
+if [[ $* == "eval --impure --raw --expr builtins.currentSystem" ]]; then
+  printf x86_64-linux
+fi
+'
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 42 ]
+	! grep -q 'switch --flake' "$COMMAND_LOG"
+	! grep -q '^chezmoi ' "$COMMAND_LOG"
+}
+
+@test "flake update can be skipped for offline test environments" {
+	export DOTFILES_SKIP_FLAKE_UPDATE=1
+	write_nix_stub
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 0 ]
+	! grep -q 'args=flake update --flake' "$COMMAND_LOG"
+	grep -q 'switch --flake .#ubuntu --sudo' "$COMMAND_LOG"
 }
 
 @test "Hermes bootstrap failure recovers Linux runtime before returning failure" {
@@ -330,6 +360,7 @@ fi
 	[ "$status" -eq 0 ]
 	grep -q 'build --impure --no-link --print-out-paths .*homeConfigurations.*x86_64-linux.*activationPackage' "$COMMAND_LOG"
 	assert_log_order \
+		"nix flake update --flake $REPO_ROOT" \
 		"homeConfigurations" \
 		"home-manager-activate" \
 		"chezmoi init --source $REPO_ROOT/chezmoi" \

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -405,6 +405,7 @@ run_macos_installer() {
 	[ "$status" -eq 0 ]
 	grep -Fqx "sudo </usr/bin/env> <NIX_CONFIG=extra-experimental-features = nix-command flakes> <DOTFILES_USER=test-user> <DOTFILES_HOME=$TEST_HOME> <DOTFILES_ROOT=$REPO_ROOT> <$STUB_BIN/nix> <run> <.#darwin-rebuild> <--> <switch> <--flake> <.#macos> <--impure>" "$COMMAND_LOG"
 	assert_log_order \
+		"nix flake update --flake $REPO_ROOT" \
 		"nix run .#darwin-rebuild -- switch --flake .#macos --impure" \
 		"update-homebrew-casks " \
 		"docker info" \

--- a/tests/bash/install_nixos.bats
+++ b/tests/bash/install_nixos.bats
@@ -120,6 +120,7 @@ line_of() {
 	[ "$status" -eq 0 ]
 	grep -q "nixos-rebuild user=test-user home=$HOME uid=1000 gid=1000 group=users args=switch --flake $REPO_ROOT#linux --impure" "$COMMAND_LOG"
 	grep -q "DOTFILES_NIXOS_HARDWARE_CONFIG=$HARDWARE_CONFIG" "$COMMAND_LOG"
+	[ "$(line_of 'nix flake update --flake')" -lt "$(line_of nixos-rebuild)" ]
 	[ "$(line_of nixos-rebuild)" -lt "$(line_of 'chezmoi init')" ]
 	[ "$(line_of 'chezmoi apply')" -lt "$(line_of 'docker compose')" ]
 	[ "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet")" -lt "$(line_of "docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap chromium xapi-mcp")" ]


### PR DESCRIPTION
## Summary

- update all flake inputs before OS configuration activation
- share the update behavior across macOS, Linux, NixOS, Home Manager, and WSL postinstall
- stop installation when flake update fails

## Why

`nrs` previously reapplied the existing `flake.lock` without refreshing flake inputs, so Nix-managed packages could remain on stale versions such as Codex 0.144.4.

## Validation

- Bats: 92/92 passed
- PowerShell package contract tests: 41/41 passed
- PowerShell Nix rebuild tests: 42/42 passed
- Bash syntax, ShellCheck error scan, and git diff check passed
- pre-commit hooks passed
