### PR TITLE
fix: verify provenance without checkout

### DIFF
--- a/.github/workflows/ci-hermes-bootstrap.yml
+++ b/.github/workflows/ci-hermes-bootstrap.yml
@@ -38,26 +38,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Read the validated provenance commit
-        id: provenance
-        shell: bash
-        run: |
-          source_commit="$(python3 docker/hermes-agent/bootstrap/tests/verify_profile_sync_provenance.py source-commit --dotfiles-repository .)"
-          printf 'source_commit=%s\n' "$source_commit" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout provenance-pinned hermes-home
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: "rurusasu/hermes-home"
-          ref: ${{ steps.provenance.outputs.source_commit }}
-          path: hermes-home-provenance
-          token: ${{ secrets.HERMES_HOME_READ_TOKEN }}
-          persist-credentials: false
-
       - name: Verify profile-sync provenance
         env:
-          HERMES_HOME_PROVENANCE_REPOSITORY: ${{ github.workspace }}/hermes-home-provenance
-        run: python3 docker/hermes-agent/bootstrap/tests/verify_profile_sync_provenance.py verify --dotfiles-repository . --source-repository "$HERMES_HOME_PROVENANCE_REPOSITORY"
+          HERMES_HOME_READ_TOKEN: ${{ secrets.HERMES_HOME_READ_TOKEN }}
+        run: python3 docker/hermes-agent/bootstrap/tests/verify_profile_sync_provenance.py verify --dotfiles-repository . --source-url "https://github.com/rurusasu/hermes-home.git"
 
       - name: Verify provenance gate wiring
         run: python3 docker/hermes-agent/bootstrap/tests/profile_sync_provenance_gate_contract.py

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -195,7 +195,7 @@ tasks:
   hermes:bootstrap:test:
     desc: Run the Hermes bootstrap container, gh wrapper, and provenance suites
     vars:
-      PROVENANCE_REPOSITORY: '{{.HERMES_HOME_PROVENANCE_REPOSITORY | default "../hermes-home-profile-sync"}}'
+      PROVENANCE_URL: '{{.HERMES_HOME_PROVENANCE_URL | default "https://github.com/rurusasu/hermes-home.git"}}'
     preconditions:
       - sh: docker info
         msg: "Docker daemon is not running. Start Docker Desktop and try again."
@@ -206,9 +206,9 @@ tasks:
         platforms: [windows]
       - cmd: python3 docker/hermes-agent/bootstrap/tests/profile_sync_provenance_gate_contract.py
         platforms: [linux, darwin]
-      - cmd: python docker/hermes-agent/bootstrap/tests/verify_profile_sync_provenance.py verify --dotfiles-repository . --source-repository "{{.PROVENANCE_REPOSITORY}}"
+      - cmd: python docker/hermes-agent/bootstrap/tests/verify_profile_sync_provenance.py verify --dotfiles-repository . --source-url "{{.PROVENANCE_URL}}"
         platforms: [windows]
-      - cmd: python3 docker/hermes-agent/bootstrap/tests/verify_profile_sync_provenance.py verify --dotfiles-repository . --source-repository "{{.PROVENANCE_REPOSITORY}}"
+      - cmd: python3 docker/hermes-agent/bootstrap/tests/verify_profile_sync_provenance.py verify --dotfiles-repository . --source-url "{{.PROVENANCE_URL}}"
         platforms: [linux, darwin]
 
   hermes:bootstrap:config:

--- a/docker/hermes-agent/bootstrap/tests/integration/test_hermes_home_wrapper_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/integration/test_hermes_home_wrapper_contract.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import subprocess
 import tempfile
 import unittest
@@ -15,39 +14,10 @@ FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "hermes-home"
 WRAPPER = FIXTURE_ROOT / "profile_sync.sh"
 PROVENANCE = FIXTURE_ROOT / "profile_sync.provenance.json"
 ENGINE = Path("/usr/local/bin/hermes-bootstrap")
-DOTFILES_ROOT = Path(__file__).resolve().parents[5]
-FIXTURE_PATH = WRAPPER.relative_to(DOTFILES_ROOT)
-HERMES_HOME_ROOT = Path(
-    os.environ.get(
-        "HERMES_HOME_PROVENANCE_REPOSITORY",
-        DOTFILES_ROOT.parent / "hermes-home-profile-sync",
-    )
-)
 MODE_CONTRACT_ERROR = "wrapper provenance mode contract failed"
 
 
 class HermesHomeWrapperContractTests(unittest.TestCase):
-    def test_committed_fixture_tree_mode_is_executable(self) -> None:
-        if not self._is_git_worktree(DOTFILES_ROOT):
-            self.skipTest("committed fixture mode requires a Git worktree")
-        self._assert_committed_tree_mode(
-            DOTFILES_ROOT,
-            "HEAD",
-            FIXTURE_PATH,
-            "dotfiles fixture",
-        )
-
-    def test_committed_hermes_home_source_tree_mode_is_executable(self) -> None:
-        if not self._is_git_worktree(HERMES_HOME_ROOT):
-            self.skipTest("committed source mode requires the hermes-home worktree")
-        provenance = json.loads(PROVENANCE.read_text(encoding="ascii"))
-        self._assert_committed_tree_mode(
-            HERMES_HOME_ROOT,
-            provenance["source_commit"],
-            Path(provenance["source_path"]),
-            "hermes-home source",
-        )
-
     def test_committed_tree_mode_rejects_non_executable_source_or_fixture(
         self,
     ) -> None:
@@ -186,19 +156,6 @@ class HermesHomeWrapperContractTests(unittest.TestCase):
             check=True,
             timeout=10,
         )
-
-    @staticmethod
-    def _is_git_worktree(repository: Path) -> bool:
-        result = subprocess.run(
-            ("git", "-C", str(repository), "rev-parse", "--is-inside-work-tree"),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-            check=False,
-            timeout=10,
-        )
-        return result.returncode == 0 and result.stdout.strip() == "true"
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/docker/hermes-agent/bootstrap/tests/profile_sync_provenance_gate_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/profile_sync_provenance_gate_contract.py
@@ -41,12 +41,12 @@ class ProfileSyncProvenanceGateContractTests(unittest.TestCase):
         self.assertLess(gh_index, contract_index)
         self.assertLess(contract_index, verifier_index)
         self.assertIn(
-            "{{.HERMES_HOME_PROVENANCE_REPOSITORY "
-            '| default "../hermes-home-profile-sync"}}',
+            "{{.HERMES_HOME_PROVENANCE_URL "
+            '| default "https://github.com/rurusasu/hermes-home.git"}}',
             section,
         )
         self.assertIn(
-            '--source-repository "{{.PROVENANCE_REPOSITORY}}"',
+            '--source-url "{{.PROVENANCE_URL}}"',
             section,
         )
 
@@ -76,7 +76,7 @@ class ProfileSyncProvenanceGateContractTests(unittest.TestCase):
                 self.assertIsNotNone(re.fullmatch(trigger, changed_path))
         self.assertIsNone(re.fullmatch(trigger, "docs/hermes-agent/bootstrap.md"))
 
-    def test_workflow_checks_out_the_validated_commit_and_runs_host_gate(
+    def test_workflow_fetches_only_the_validated_blob_and_runs_host_gate(
         self,
     ) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
@@ -86,46 +86,25 @@ class ProfileSyncProvenanceGateContractTests(unittest.TestCase):
         )
         provenance = json.loads(PROVENANCE.read_text(encoding="ascii"))
 
-        self.assertEqual(len(checkout_pins), 2)
+        self.assertEqual(len(checkout_pins), 1)
         self.assertEqual(len(set(checkout_pins)), 1)
-        self.assertEqual(workflow.count("persist-credentials: false"), 2)
-        provenance_checkout = workflow.split(
-            "      - name: Checkout provenance-pinned hermes-home\n",
-            maxsplit=1,
-        )[1]
-        provenance_checkout = provenance_checkout.split(
-            "\n      - name:",
-            maxsplit=1,
-        )[0]
-        self.assertIn(
-            'repository: "rurusasu/hermes-home"',
-            provenance_checkout,
-        )
-        self.assertIn(
-            "ref: ${{ steps.provenance.outputs.source_commit }}",
-            provenance_checkout,
-        )
-        self.assertIn("path: hermes-home-provenance", provenance_checkout)
-        self.assertEqual(
-            provenance_checkout.count(
-                "token: ${{ secrets.HERMES_HOME_READ_TOKEN }}"
-            ),
-            1,
-        )
+        self.assertEqual(workflow.count("persist-credentials: false"), 1)
+        self.assertNotIn("Checkout provenance-pinned hermes-home", workflow)
+        self.assertNotIn("hermes-home-provenance", workflow)
         self.assertEqual(workflow.count("secrets.HERMES_HOME_READ_TOKEN"), 1)
         self.assertNotIn(provenance["source_commit"], workflow)
-        self.assertIn("id: provenance", workflow)
-        self.assertIn(
-            f"{VERIFIER_COMMAND} source-commit --dotfiles-repository .",
-            workflow,
-        )
+        self.assertNotIn("id: provenance", workflow)
         self.assertIn(
             f"{VERIFIER_COMMAND} verify --dotfiles-repository .",
             workflow,
         )
         self.assertIn(
-            "HERMES_HOME_PROVENANCE_REPOSITORY: "
-            "${{ github.workspace }}/hermes-home-provenance",
+            "HERMES_HOME_READ_TOKEN: "
+            "${{ secrets.HERMES_HOME_READ_TOKEN }}",
+            workflow,
+        )
+        self.assertIn(
+            '--source-url "https://github.com/rurusasu/hermes-home.git"',
             workflow,
         )
         self.assertIn('"Taskfile.yml"', workflow)

--- a/docker/hermes-agent/bootstrap/tests/test_profile_sync_provenance_verifier.py
+++ b/docker/hermes-agent/bootstrap/tests/test_profile_sync_provenance_verifier.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.util
 import json
 import os
 import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 
@@ -17,6 +19,15 @@ FIXTURE_PATH = Path(
 PROVENANCE_PATH = FIXTURE_PATH.with_name("profile_sync.provenance.json")
 SOURCE_PATH = Path("scripts/profile_sync.sh")
 SOURCE_REPOSITORY = "rurusasu/hermes-home"
+
+VERIFIER_SPEC = importlib.util.spec_from_file_location(
+    "profile_sync_provenance_verifier_under_test",
+    VERIFIER,
+)
+assert VERIFIER_SPEC is not None and VERIFIER_SPEC.loader is not None
+VERIFIER_MODULE = importlib.util.module_from_spec(VERIFIER_SPEC)
+sys.modules[VERIFIER_SPEC.name] = VERIFIER_MODULE
+VERIFIER_SPEC.loader.exec_module(VERIFIER_MODULE)
 
 
 class ProfileSyncProvenanceVerifierTests(unittest.TestCase):
@@ -68,6 +79,27 @@ class ProfileSyncProvenanceVerifierTests(unittest.TestCase):
             "profile sync provenance verified\n",
         )
         self.assertEqual(result.stderr, "")
+
+    def test_accepts_matching_source_from_git_url_without_a_worktree(self) -> None:
+        result = self._verify(source_url=self.source.resolve().as_uri())
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout,
+            "profile sync provenance verified\n",
+        )
+        self.assertEqual(result.stderr, "")
+
+    def test_does_not_send_private_token_to_an_override_url(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"HERMES_HOME_READ_TOKEN": "secret-marker"},
+        ):
+            environment = VERIFIER_MODULE._source_auth_environment(
+                "https://example.invalid/hermes-home.git"
+            )
+
+        self.assertEqual(environment, {})
 
     def test_ignores_an_inherited_git_index_file_from_a_parent_hook(self) -> None:
         environment = os.environ.copy()
@@ -485,13 +517,18 @@ class ProfileSyncProvenanceVerifierTests(unittest.TestCase):
         *,
         dotfiles: Path | None = None,
         source: Path | None = None,
+        source_url: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
+        source_arguments = (
+            ("--source-url", source_url)
+            if source_url is not None
+            else ("--source-repository", str(source or self.source))
+        )
         return self._run_verifier(
             "verify",
             "--dotfiles-repository",
             str(dotfiles or self.dotfiles),
-            "--source-repository",
-            str(source or self.source),
+            *source_arguments,
         )
 
     def _assert_failure(

--- a/docker/hermes-agent/bootstrap/tests/verify_profile_sync_provenance.py
+++ b/docker/hermes-agent/bootstrap/tests/verify_profile_sync_provenance.py
@@ -4,15 +4,17 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import json
 import os
 import re
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import NoReturn
+from typing import Mapping, NoReturn
 
 
 FIXTURE_PATH = Path(
@@ -20,6 +22,7 @@ FIXTURE_PATH = Path(
 )
 PROVENANCE_PATH = FIXTURE_PATH.with_name("profile_sync.provenance.json")
 SOURCE_REPOSITORY = "rurusasu/hermes-home"
+SOURCE_URL = "https://github.com/rurusasu/hermes-home.git"
 PROVENANCE_KEYS = frozenset(
     {
         "source_repository",
@@ -70,17 +73,10 @@ def _same_path(left: Path, right: Path) -> bool:
 def _git(
     repository: Path,
     *arguments: str,
+    extra_environment: Mapping[str, str] | None = None,
+    timeout: int = 10,
 ) -> subprocess.CompletedProcess[str]:
-    environment = os.environ.copy()
-    environment.pop("GIT_DIR", None)
-    environment.pop("GIT_INDEX_FILE", None)
-    environment.update(
-        {
-            "GIT_OPTIONAL_LOCKS": "0",
-            "LANG": "C",
-            "LC_ALL": "C",
-        }
-    )
+    environment = _git_environment(extra_environment)
     try:
         return subprocess.run(
             ("git", "-C", str(repository), *arguments),
@@ -90,10 +86,29 @@ def _git(
             stderr=subprocess.DEVNULL,
             text=True,
             check=False,
-            timeout=10,
+            timeout=timeout,
         )
     except (OSError, subprocess.SubprocessError):
         _fail("Git command could not be executed")
+
+
+def _git_environment(
+    extra_environment: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    environment = os.environ.copy()
+    environment.pop("GIT_DIR", None)
+    environment.pop("GIT_INDEX_FILE", None)
+    environment.update(
+        {
+            "GIT_OPTIONAL_LOCKS": "0",
+            "GIT_TERMINAL_PROMPT": "0",
+            "LANG": "C",
+            "LC_ALL": "C",
+        }
+    )
+    if extra_environment is not None:
+        environment.update(extra_environment)
+    return environment
 
 
 def _require_git_root(repository: Path, label: str) -> Path:
@@ -120,6 +135,7 @@ def _tree_entry(
     repository: Path,
     path: Path,
     label: str,
+    revision: str = "HEAD",
 ) -> TreeEntry:
     result = _git(
         repository,
@@ -127,7 +143,7 @@ def _tree_entry(
         "core.quotepath=false",
         "ls-tree",
         "-z",
-        "HEAD",
+        revision,
         "--",
         path.as_posix(),
     )
@@ -150,6 +166,29 @@ def _tree_entry(
         object_type=object_type,
         object_id=object_id,
     )
+
+
+def _read_git_blob(
+    repository: Path,
+    object_id: str,
+    label: str,
+    extra_environment: Mapping[str, str] | None = None,
+) -> bytes:
+    try:
+        result = subprocess.run(
+            ("git", "-C", str(repository), "cat-file", "blob", object_id),
+            env=_git_environment(extra_environment),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError):
+        _fail("Git command could not be executed")
+    if result.returncode != 0:
+        _fail(f"{label} Git blob could not be read")
+    return result.stdout
 
 
 def _require_clean(
@@ -300,9 +339,88 @@ def _git_blob_sha1(contents: bytes) -> str:
     ).hexdigest()
 
 
+def _gh_auth_token() -> str | None:
+    environment = os.environ.copy()
+    environment.pop("GH_TOKEN", None)
+    environment.pop("GITHUB_TOKEN", None)
+    try:
+        result = subprocess.run(
+            ("gh", "auth", "token", "--hostname", "github.com"),
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    token = result.stdout.strip()
+    return token if result.returncode == 0 and token else None
+
+
+def _source_auth_environment(source_url: str) -> dict[str, str]:
+    if source_url != SOURCE_URL:
+        return {}
+    token = os.environ.get("HERMES_HOME_READ_TOKEN")
+    if not token:
+        token = _gh_auth_token()
+    if not token:
+        return {}
+    credentials = base64.b64encode(
+        f"x-access-token:{token}".encode("utf-8")
+    ).decode("ascii")
+    return {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": f"http.{source_url}.extraheader",
+        "GIT_CONFIG_VALUE_0": f"AUTHORIZATION: basic {credentials}",
+    }
+
+
+def _fetch_source(
+    source_url: str,
+    provenance: Provenance,
+) -> tuple[TreeEntry, bytes]:
+    source_path = Path(*PurePosixPath(provenance.source_path).parts)
+    with tempfile.TemporaryDirectory(prefix="hermes-provenance-") as temporary:
+        repository = Path(temporary)
+        initialized = _git(repository, "init", "--bare", "--initial-branch=main")
+        if initialized.returncode != 0:
+            _fail("source Git repository could not be initialized")
+        auth_environment = _source_auth_environment(source_url)
+        fetched = _git(
+            repository,
+            "fetch",
+            "--depth=1",
+            "--filter=blob:none",
+            "--no-tags",
+            source_url,
+            provenance.source_commit,
+            extra_environment=auth_environment,
+            timeout=60,
+        )
+        if fetched.returncode != 0:
+            _fail("source commit could not be fetched")
+        source_entry = _tree_entry(
+            repository,
+            source_path,
+            "source path",
+            revision="FETCH_HEAD",
+        )
+        source_bytes = _read_git_blob(
+            repository,
+            source_entry.object_id,
+            "source path",
+            extra_environment=auth_environment,
+        )
+    return source_entry, source_bytes
+
+
 def verify(
     dotfiles_repository: Path,
-    source_repository: Path,
+    source_repository: Path | None,
+    source_url: str | None,
 ) -> None:
     dotfiles, provenance, _ = _load_dotfiles_provenance(dotfiles_repository)
     fixture_entry = _tree_entry(
@@ -312,22 +430,27 @@ def verify(
     )
     _require_clean(dotfiles, FIXTURE_PATH, "dotfiles fixture")
 
-    source = _require_git_root(source_repository, "source")
-    if _head_commit(source, "source") != provenance.source_commit:
-        _fail("source HEAD does not match provenance source_commit")
-    source_path = Path(*PurePosixPath(provenance.source_path).parts)
-    source_entry = _tree_entry(source, source_path, "source path")
-    _require_clean(source, source_path, "source path")
+    if source_url is not None:
+        source_entry, source_bytes = _fetch_source(source_url, provenance)
+    else:
+        if source_repository is None:
+            _fail("source location is missing")
+        source = _require_git_root(source_repository, "source")
+        if _head_commit(source, "source") != provenance.source_commit:
+            _fail("source HEAD does not match provenance source_commit")
+        source_path = Path(*PurePosixPath(provenance.source_path).parts)
+        source_entry = _tree_entry(source, source_path, "source path")
+        _require_clean(source, source_path, "source path")
+        source_bytes = _read_regular_file(
+            source / source_path,
+            "source path",
+        )
 
     if source_entry.mode != "100755":
         _fail("source path committed mode is not 100755")
     if fixture_entry.mode != "100755":
         _fail("dotfiles fixture committed mode is not 100755")
 
-    source_bytes = _read_regular_file(
-        source / source_path,
-        "source path",
-    )
     fixture_bytes = _read_regular_file(
         dotfiles / FIXTURE_PATH,
         "dotfiles fixture",
@@ -376,10 +499,13 @@ def _parser() -> argparse.ArgumentParser:
         type=Path,
         required=True,
     )
-    verify_parser.add_argument(
+    source = verify_parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
         "--source-repository",
         type=Path,
-        required=True,
+    )
+    source.add_argument(
+        "--source-url",
     )
     return parser
 
@@ -393,6 +519,7 @@ def main(arguments: list[str] | None = None) -> int:
             verify(
                 parsed.dotfiles_repository,
                 parsed.source_repository,
+                parsed.source_url,
             )
             print("profile sync provenance verified")
     except VerificationError as error:

--- a/docs/hermes-agent/bootstrap.md
+++ b/docs/hermes-agent/bootstrap.md
@@ -584,13 +584,15 @@ Changes under `docker/hermes-agent/`, or to `Taskfile.yml`,
 `task hermes:bootstrap:test` through the local `hermes-bootstrap-tests`
 pre-commit hook. Pull requests run the same pinned Docker stage and the `gh`
 wrapper security suite in the `Hermes Bootstrap Tests` workflow. Both paths
-also run the same host-side profile-sync provenance verifier. Locally it reads
-the sibling `hermes-home-profile-sync` worktree; GitHub Actions checks out
-`rurusasu/hermes-home` at the validated provenance commit first. That private
-checkout requires the `HERMES_HOME_READ_TOKEN` repository secret with read-only
-Contents access, and the provenance commit must already exist on the remote.
-The verifier requires clean tracked source and fixture paths, exact bytes, Git
-blob IDs, SHA-256, and committed tree mode `100755`. Task 5 integration
+also run the same host-side profile-sync provenance verifier. The verifier
+fetches the validated `rurusasu/hermes-home` commit into a temporary bare Git
+repository with blob filtering, then reads only the recorded source blob. It
+does not create a source worktree. GitHub Actions supplies the private
+repository's `HERMES_HOME_READ_TOKEN` secret with read-only Contents access;
+local runs use the authenticated GitHub CLI keyring. The provenance commit
+must already exist on the remote. The verifier requires a clean tracked
+fixture, exact bytes, Git blob IDs, SHA-256, and committed tree mode `100755`.
+Task 5 integration
 coverage is the publication gate for aggregate preflight, exact-tree deletion,
 local immutability, missing-only bootstrap install, continuation, retry, and
 result serialization.


### PR DESCRIPTION
## Summary

- Replace the required sibling `hermes-home-profile-sync` worktree with a temporary bare Git repository.
- Fetch the provenance-pinned commit with `--depth=1 --filter=blob:none` and read only the recorded source blob.
- Preserve committed mode, Git blob SHA-1, SHA-256, and exact-byte verification.
- Remove the second GitHub Actions checkout and the redundant worktree-dependent skipped tests.

## Root cause

The local and CI provenance gate required a complete `hermes-home` checkout only to inspect one immutable file. This consumed unnecessary disk/worktree resources and made local pre-commit depend on a manually maintained sibling checkout.

## Authentication

- GitHub Actions supplies the existing read-only `HERMES_HOME_READ_TOKEN`.
- Local runs use the authenticated GitHub CLI keyring.
- The private token is only attached to the canonical `https://github.com/rurusasu/hermes-home.git` URL.

## Validation

- TDD RED confirmed URL mode and no-checkout workflow expectations failed before implementation.
- `python3 -m unittest docker.hermes-agent.bootstrap.tests.test_profile_sync_provenance_verifier docker.hermes-agent.bootstrap.tests.profile_sync_provenance_gate_contract` — 19/19 passed.
- Real private URL provenance verification passed.
- `task hermes:bootstrap:test` — Docker suite, gh wrapper, contract, and remote provenance passed.
- `pre-commit run --all-files` — all hooks passed.
- `nix fmt -- --fail-on-change`, Python compile, and `git diff --check` passed.