### PR TITLE
refactor(nvim): use structured lazy.nvim setup

### DIFF
--- a/chezmoi/dot_config/nvim/init.lua
+++ b/chezmoi/dot_config/nvim/init.lua
@@ -8,20 +8,6 @@ if vim.fn.has("win32") == 1 then
     vim.env.PATH = py .. "\\Scripts;" .. py .. ";" .. vim.env.PATH
 end
 
--- Bootstrap lazy.nvim
-local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
-if not vim.loop.fs_stat(lazypath) then
-    vim.fn.system({
-        "git",
-        "clone",
-        "--filter=blob:none",
-        "https://github.com/folke/lazy.nvim.git",
-        "--branch=stable",
-        lazypath,
-    })
-end
-vim.opt.rtp:prepend(lazypath)
-
 -- Leader key (before lazy)
 vim.g.mapleader = " "
 vim.g.maplocalleader = " "
@@ -31,20 +17,4 @@ require("config.options")
 require("config.keymaps")
 require("config.osc7").setup()
 
--- Load plugins
-require("lazy").setup("plugins", {
-    defaults = { lazy = true },
-    install = { colorscheme = { "catppuccin" } },
-    checker = { enabled = false },
-    performance = {
-        rtp = {
-            disabled_plugins = {
-                "gzip",
-                "tarPlugin",
-                "tohtml",
-                "tutor",
-                "zipPlugin",
-            },
-        },
-    },
-})
+require("config.lazy")

--- a/chezmoi/dot_config/nvim/lua/config/lazy.lua
+++ b/chezmoi/dot_config/nvim/lua/config/lazy.lua
@@ -1,0 +1,42 @@
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+
+if not (vim.uv or vim.loop).fs_stat(lazypath) then
+    local lazyrepo = "https://github.com/folke/lazy.nvim.git"
+    local output = vim.fn.system({
+        "git",
+        "clone",
+        "--filter=blob:none",
+        "--branch=stable",
+        lazyrepo,
+        lazypath,
+    })
+
+    if vim.v.shell_error ~= 0 then
+        vim.api.nvim_echo({
+            { "Failed to clone lazy.nvim:\n", "ErrorMsg" },
+            { output, "WarningMsg" },
+            { "\nPress any key to exit...", "WarningMsg" },
+        }, true, {})
+        vim.fn.getchar()
+        os.exit(1)
+    end
+end
+
+vim.opt.rtp:prepend(lazypath)
+
+require("lazy").setup("plugins", {
+    defaults = { lazy = true },
+    install = { colorscheme = { "catppuccin" } },
+    checker = { enabled = false },
+    performance = {
+        rtp = {
+            disabled_plugins = {
+                "gzip",
+                "tarPlugin",
+                "tohtml",
+                "tutor",
+                "zipPlugin",
+            },
+        },
+    },
+})


### PR DESCRIPTION
## Summary

- lazy.nvim の bootstrap と setup を `lua/config/lazy.lua` に分離
- `init.lua` は Windows PATH、leader、基本設定、lazy 設定の呼び出しに整理
- `vim.uv` / `vim.loop` 互換と clone 失敗時のエラー表示を追加

## Why

Neovim 設定を lazy.nvim 公式の Structured Setup 構成に合わせ、起動処理とプラグイン仕様の責務を分離するため。

## Validation

- Neovim headless smoke test: passed
- `bats tests/bash`: 51 tests passed
- `git diff --check`: passed
- Final code review: Ready to merge