### PR TITLE
fix: start every Hermes gateway across all profiles

### DIFF
--- a/.github/e2e/bootstrap-compose.yml
+++ b/.github/e2e/bootstrap-compose.yml
@@ -10,6 +10,7 @@ services:
       - |
         printf '#!/bin/sh\nexit 0\n' >/usr/local/bin/hermes-gateway-converge
         chmod 0755 /usr/local/bin/hermes-gateway-converge
+        mkdir -p /www
         if [ -x /bin/httpd ]; then
           exec /bin/httpd -f -p 80 -h /www
         fi

--- a/.github/e2e/bootstrap-compose.yml
+++ b/.github/e2e/bootstrap-compose.yml
@@ -8,13 +8,13 @@ services:
       - /bin/sh
       - -c
       - |
-        printf '#!/bin/sh\nexit 0\n' >/usr/local/bin/hermes-gateway-converge
-        chmod 0755 /usr/local/bin/hermes-gateway-converge
         mkdir -p /www
         if [ -x /bin/httpd ]; then
           exec /bin/httpd -f -p 80 -h /www
         fi
         exec nginx -g 'daemon off;'
+    volumes:
+      - ./hermes-gateway-converge.sh:/usr/local/bin/hermes-gateway-converge:ro
 
   xapi-mcp:
     image: nginx:1.29-alpine

--- a/.github/e2e/bootstrap-compose.yml
+++ b/.github/e2e/bootstrap-compose.yml
@@ -4,6 +4,16 @@ services:
     depends_on:
       acceptance:
         condition: service_started
+    command:
+      - /bin/sh
+      - -c
+      - |
+        printf '#!/bin/sh\nexit 0\n' >/usr/local/bin/hermes-gateway-converge
+        chmod 0755 /usr/local/bin/hermes-gateway-converge
+        if [ -x /bin/httpd ]; then
+          exec /bin/httpd -f -p 80 -h /www
+        fi
+        exec nginx -g 'daemon off;'
 
   xapi-mcp:
     image: nginx:1.29-alpine

--- a/.github/e2e/hermes-gateway-converge.sh
+++ b/.github/e2e/hermes-gateway-converge.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/.github/e2e/run-bootstrap-acceptance.sh
+++ b/.github/e2e/run-bootstrap-acceptance.sh
@@ -14,6 +14,8 @@ CANONICAL_DIR="$REPO_ROOT/docker/hermes-agent"
 install -m 0644 "$FIXTURE_ROOT/bootstrap-compose.yml" "$CANONICAL_DIR/compose.yml"
 install -m 0755 "$FIXTURE_ROOT/hermes-bootstrap-fixture.sh" \
   "$CANONICAL_DIR/hermes-bootstrap-fixture.sh"
+install -m 0755 "$FIXTURE_ROOT/hermes-gateway-converge.sh" \
+  "$CANONICAL_DIR/hermes-gateway-converge.sh"
 install -m 0644 "$FIXTURE_ROOT/hindsight-health.json" \
   "$CANONICAL_DIR/hindsight-health.json"
 

--- a/docker/hermes-agent/Dockerfile
+++ b/docker/hermes-agent/Dockerfile
@@ -13,7 +13,9 @@ COPY bootstrap/hermes_bootstrap /usr/local/lib/hermes-bootstrap/hermes_bootstrap
 COPY bootstrap-manifest.yaml /usr/local/share/hermes-bootstrap/bootstrap-manifest.yaml
 COPY hermes-bootstrap /usr/local/bin/hermes-bootstrap
 COPY hindsight_acceptance.py /usr/local/bin/hermes-hindsight-acceptance
+COPY gateway_convergence.py /usr/local/bin/hermes-gateway-converge
 RUN chmod 0755 /usr/local/bin/hermes-hindsight-acceptance
+RUN chmod 0755 /usr/local/bin/hermes-gateway-converge
 
 RUN python3 - <<'PY'
 import re
@@ -143,6 +145,7 @@ COPY compose.yml /workspace/docker/hermes-agent/compose.yml
 COPY hindsight.env /workspace/docker/hermes-agent/hindsight.env
 COPY bootstrap-manifest.yaml /workspace/docker/hermes-agent/bootstrap-manifest.yaml
 COPY hindsight_acceptance.py /workspace/docker/hermes-agent/hindsight_acceptance.py
+COPY gateway_convergence.py /workspace/docker/hermes-agent/gateway_convergence.py
 COPY bootstrap/tests /workspace/docker/hermes-agent/bootstrap/tests
 
 RUN PYTHONPATH=/usr/local/lib/hermes-bootstrap /opt/hermes/.venv/bin/python -m unittest discover \

--- a/docker/hermes-agent/bootstrap/tests/test_dockerfile_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/test_dockerfile_contract.py
@@ -12,6 +12,15 @@ HINDSIGHT_CLIENT_VERSION = "0.6.1"
 
 
 class DockerfileContractTests(unittest.TestCase):
+    def test_runtime_installs_the_gateway_convergence_command(self) -> None:
+        dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "COPY gateway_convergence.py /usr/local/bin/hermes-gateway-converge",
+            dockerfile,
+        )
+        self.assertIn("chmod 0755 /usr/local/bin/hermes-gateway-converge", dockerfile)
+
     def test_runtime_installs_and_verifies_the_supported_hindsight_client(self) -> None:
         dockerfile = DOCKERFILE.read_text(encoding="utf-8")
 

--- a/docker/hermes-agent/bootstrap/tests/test_gateway_convergence.py
+++ b/docker/hermes-agent/bootstrap/tests/test_gateway_convergence.py
@@ -1,0 +1,311 @@
+"""Unit tests for the in-container Hermes Gateway convergence command."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from collections.abc import Callable
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[2] / "gateway_convergence.py"
+SPEC = importlib.util.spec_from_file_location("gateway_convergence", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+gateway_convergence = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = gateway_convergence
+SPEC.loader.exec_module(gateway_convergence)
+
+
+class FakeManager:
+    def __init__(
+        self,
+        profiles: tuple[str, ...],
+        *,
+        on_start: Callable[[str], None] | None = None,
+        start_errors: dict[str, Exception] | None = None,
+    ) -> None:
+        self.profiles = profiles
+        self.started: list[str] = []
+        self.running = {f"gateway-{profile}": True for profile in profiles}
+        self.on_start = on_start
+        self.start_errors = start_errors or {}
+
+    def list_profile_gateways(self) -> list[str]:
+        return list(self.profiles)
+
+    def start(self, service_name: str) -> None:
+        self.started.append(service_name)
+        if service_name in self.start_errors:
+            raise self.start_errors[service_name]
+        if self.on_start is not None:
+            self.on_start(service_name)
+
+    def is_running(self, service_name: str) -> bool:
+        return self.running[service_name]
+
+
+def write_ready_state(root: Path, profile: str, *, discord: bool) -> None:
+    home = root if profile == "default" else root / "profiles" / profile
+    home.mkdir(parents=True, exist_ok=True)
+    state: dict[str, object] = {"desired_state": "running"}
+    if discord:
+        state["platforms"] = {"discord": {"state": "connected"}}
+    (home / "gateway_state.json").write_text(
+        json.dumps(state), encoding="utf-8"
+    )
+
+
+def write_gateway_state(root: Path, profile: str, state: dict[str, object]) -> None:
+    home = root if profile == "default" else root / "profiles" / profile
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "gateway_state.json").write_text(
+        json.dumps(state), encoding="utf-8"
+    )
+
+
+def configure_discord(root: Path, profile: str) -> None:
+    home = root if profile == "default" else root / "profiles" / profile
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text("DISCORD_BOT_TOKEN=configured\\n", encoding="utf-8")
+
+
+class FakeClock:
+    def __init__(self, on_sleep: Callable[[], None] | None = None) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+        self.on_sleep = on_sleep
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+        if self.on_sleep is not None:
+            self.on_sleep()
+
+
+class GatewayConvergenceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def test_converge_discovers_and_starts_every_registered_profile(self) -> None:
+        manager = FakeManager(("default", "future-profile"))
+        write_ready_state(self.root, "default", discord=True)
+        write_ready_state(self.root, "future-profile", discord=True)
+
+        result = gateway_convergence.converge(
+            manager,
+            self.root,
+            timeout_seconds=1.0,
+            poll_seconds=0.0,
+        )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(
+            manager.started,
+            ["gateway-default", "gateway-future-profile"],
+        )
+
+    def test_converge_starts_before_polling_for_a_profile_without_prior_state(
+        self,
+    ) -> None:
+        def write_state_when_started(service_name: str) -> None:
+            self.assertEqual(service_name, "gateway-first-start")
+            write_ready_state(self.root, "first-start", discord=False)
+
+        manager = FakeManager(("first-start",), on_start=write_state_when_started)
+
+        result = gateway_convergence.converge(
+            manager,
+            self.root,
+            timeout_seconds=1.0,
+            poll_seconds=0.0,
+        )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(manager.started, ["gateway-first-start"])
+
+    def test_converge_rejects_empty_registration_set(self) -> None:
+        manager = FakeManager(())
+
+        with self.assertRaisesRegex(ValueError, "no registered gateways"):
+            gateway_convergence.converge(
+                manager,
+                self.root,
+                timeout_seconds=1.0,
+                poll_seconds=0.0,
+            )
+
+        self.assertEqual(manager.started, [])
+
+    def test_converge_rejects_invalid_profile_before_lifecycle_dispatch(self) -> None:
+        manager = FakeManager(("invalid/profile",))
+
+        with self.assertRaisesRegex(ValueError, "invalid profile"):
+            gateway_convergence.converge(
+                manager,
+                self.root,
+                timeout_seconds=1.0,
+                poll_seconds=0.0,
+            )
+
+        self.assertEqual(manager.started, [])
+
+    def test_converge_waits_until_process_and_discord_are_ready(self) -> None:
+        manager = FakeManager(("default",))
+        manager.running["gateway-default"] = False
+        configure_discord(self.root, "default")
+        write_gateway_state(
+            self.root,
+            "default",
+            {"desired_state": "running", "platforms": {"discord": {"state": "connecting"}}},
+        )
+
+        def become_ready() -> None:
+            manager.running["gateway-default"] = True
+            write_ready_state(self.root, "default", discord=True)
+
+        clock = FakeClock(become_ready)
+        result = gateway_convergence.converge(
+            manager,
+            self.root,
+            timeout_seconds=1.0,
+            poll_seconds=0.5,
+            monotonic=clock.monotonic,
+            sleep=clock.sleep,
+        )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(clock.sleeps, [0.5])
+
+    def test_converge_does_not_require_discord_without_a_configured_token(self) -> None:
+        manager = FakeManager(("default",))
+        write_gateway_state(self.root, "default", {"desired_state": "running"})
+
+        result = gateway_convergence.converge(
+            manager,
+            self.root,
+            timeout_seconds=1.0,
+            poll_seconds=0.0,
+        )
+
+        self.assertEqual(result, 0)
+
+    def test_converge_reports_lifecycle_errors_for_all_profiles(self) -> None:
+        sentinel = "DISCORD_BOT_TOKEN=sentinel-token-value"
+        manager = FakeManager(
+            ("default", "future-profile"),
+            start_errors={
+                "gateway-default": RuntimeError(sentinel),
+                "gateway-future-profile": RuntimeError(sentinel),
+            },
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"default=lifecycle_error, future-profile=lifecycle_error",
+        ) as raised:
+            gateway_convergence.converge(
+                manager,
+                self.root,
+                timeout_seconds=1.0,
+                poll_seconds=0.0,
+            )
+
+        self.assertEqual(
+            manager.started,
+            ["gateway-default", "gateway-future-profile"],
+        )
+        self.assertNotIn(sentinel, str(raised.exception))
+
+    def test_converge_fails_immediately_for_discord_needs_attention(self) -> None:
+        sentinel = "DISCORD_BOT_TOKEN=sentinel-token-value"
+        manager = FakeManager(("default",))
+        manager.running["gateway-default"] = False
+        configure_discord(self.root, "default")
+        write_gateway_state(
+            self.root,
+            "default",
+            {
+                "desired_state": "running",
+                "platforms": {
+                    "discord": {"state": "needs_attention", "error": sentinel}
+                },
+            },
+        )
+        clock = FakeClock()
+
+        with self.assertRaisesRegex(
+            RuntimeError, r"default=discord_needs_attention"
+        ) as raised:
+            gateway_convergence.converge(
+                manager,
+                self.root,
+                timeout_seconds=1.0,
+                poll_seconds=0.5,
+                monotonic=clock.monotonic,
+                sleep=clock.sleep,
+            )
+
+        self.assertEqual(clock.sleeps, [])
+        self.assertNotIn(sentinel, str(raised.exception))
+
+    def test_converge_times_out_with_pending_profile_names(self) -> None:
+        sentinel = "DISCORD_BOT_TOKEN=sentinel-token-value"
+        manager = FakeManager(("default", "future-profile"))
+        manager.running["gateway-default"] = False
+        write_gateway_state(self.root, "default", {"desired_state": "running"})
+        write_gateway_state(
+            self.root,
+            "future-profile",
+            {"desired_state": "stopped", "error": sentinel},
+        )
+        clock = FakeClock()
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"default=process_not_running, future-profile=desired_state_not_running",
+        ) as raised:
+            gateway_convergence.converge(
+                manager,
+                self.root,
+                timeout_seconds=1.0,
+                poll_seconds=0.5,
+                monotonic=clock.monotonic,
+                sleep=clock.sleep,
+            )
+
+        self.assertEqual(clock.sleeps, [0.5, 0.5])
+        self.assertNotIn(sentinel, str(raised.exception))
+
+    def test_repeated_convergence_is_idempotent(self) -> None:
+        manager = FakeManager(("default",))
+        write_gateway_state(self.root, "default", {"desired_state": "running"})
+
+        first = gateway_convergence.converge(
+            manager,
+            self.root,
+            timeout_seconds=1.0,
+            poll_seconds=0.0,
+        )
+        second = gateway_convergence.converge(
+            manager,
+            self.root,
+            timeout_seconds=1.0,
+            poll_seconds=0.0,
+        )
+
+        self.assertEqual((first, second), (0, 0))
+        self.assertEqual(manager.started, ["gateway-default", "gateway-default"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker/hermes-agent/bootstrap/tests/test_gateway_convergence.py
+++ b/docker/hermes-agent/bootstrap/tests/test_gateway_convergence.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import json
 import sys
 import tempfile
+import types
 import unittest
 from collections.abc import Callable
 from pathlib import Path
+from unittest.mock import patch
 
 
 MODULE_PATH = Path(__file__).parents[2] / "gateway_convergence.py"
@@ -146,10 +150,10 @@ class GatewayConvergenceTests(unittest.TestCase):
 
         self.assertEqual(manager.started, [])
 
-    def test_converge_rejects_invalid_profile_before_lifecycle_dispatch(self) -> None:
+    def test_converge_sanitizes_invalid_profile_before_lifecycle_dispatch(self) -> None:
         manager = FakeManager(("invalid/profile",))
 
-        with self.assertRaisesRegex(ValueError, "invalid profile"):
+        with self.assertRaisesRegex(RuntimeError, "gateway discovery failed"):
             gateway_convergence.converge(
                 manager,
                 self.root,
@@ -305,6 +309,49 @@ class GatewayConvergenceTests(unittest.TestCase):
 
         self.assertEqual((first, second), (0, 0))
         self.assertEqual(manager.started, ["gateway-default", "gateway-default"])
+
+    def test_main_rejects_non_finite_timeout_and_poll_values(self) -> None:
+        for option, value in (
+            ("--timeout-seconds", "nan"),
+            ("--timeout-seconds", "inf"),
+            ("--poll-seconds", "nan"),
+            ("--poll-seconds", "inf"),
+        ):
+            with self.subTest(option=option, value=value):
+                with contextlib.redirect_stderr(io.StringIO()):
+                    with self.assertRaises(SystemExit) as raised:
+                        gateway_convergence.main([option, value])
+
+                self.assertEqual(raised.exception.code, 2)
+
+    def test_main_sanitizes_discovery_exception_output(self) -> None:
+        sentinel = "DISCORD_BOT_TOKEN=sentinel-token-value"
+
+        class DiscoveryFailingManager(FakeManager):
+            kind = "s6"
+
+            def list_profile_gateways(self) -> list[str]:
+                raise RuntimeError(sentinel)
+
+        manager = DiscoveryFailingManager(())
+        service_manager = types.ModuleType("hermes_cli.service_manager")
+        service_manager.get_service_manager = lambda: manager
+        hermes_cli = types.ModuleType("hermes_cli")
+        hermes_cli.service_manager = service_manager
+
+        with patch.dict(
+            sys.modules,
+            {
+                "hermes_cli": hermes_cli,
+                "hermes_cli.service_manager": service_manager,
+            },
+        ):
+            with contextlib.redirect_stderr(io.StringIO()) as stderr:
+                result = gateway_convergence.main([])
+
+        self.assertEqual(result, 1)
+        self.assertIn("gateway discovery failed", stderr.getvalue())
+        self.assertNotIn(sentinel, stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/docker/hermes-agent/bootstrap/tests/test_gateway_convergence.py
+++ b/docker/hermes-agent/bootstrap/tests/test_gateway_convergence.py
@@ -310,6 +310,50 @@ class GatewayConvergenceTests(unittest.TestCase):
         self.assertEqual((first, second), (0, 0))
         self.assertEqual(manager.started, ["gateway-default", "gateway-default"])
 
+    def test_converge_rejects_non_finite_or_out_of_range_inputs_before_dispatch(
+        self,
+    ) -> None:
+        class DispatchForbiddenManager:
+            def __init__(self) -> None:
+                self.discovery_called = False
+                self.started: list[str] = []
+
+            def list_profile_gateways(self) -> list[str]:
+                self.discovery_called = True
+                raise AssertionError("discovery must not run")
+
+            def start(self, service_name: str) -> None:
+                self.started.append(service_name)
+
+            def is_running(self, service_name: str) -> bool:
+                return False
+
+        for timeout_seconds, poll_seconds in (
+            (float("nan"), 0.0),
+            (float("inf"), 0.0),
+            (0.0, 0.0),
+            (-1.0, 0.0),
+            (1.0, float("nan")),
+            (1.0, float("inf")),
+            (1.0, -1.0),
+        ):
+            with self.subTest(
+                timeout_seconds=timeout_seconds,
+                poll_seconds=poll_seconds,
+            ):
+                manager = DispatchForbiddenManager()
+
+                with self.assertRaises(ValueError):
+                    gateway_convergence.converge(
+                        manager,
+                        self.root,
+                        timeout_seconds=timeout_seconds,
+                        poll_seconds=poll_seconds,
+                    )
+
+                self.assertFalse(manager.discovery_called)
+                self.assertEqual(manager.started, [])
+
     def test_main_rejects_non_finite_timeout_and_poll_values(self) -> None:
         for option, value in (
             ("--timeout-seconds", "nan"),

--- a/docker/hermes-agent/gateway_convergence.py
+++ b/docker/hermes-agent/gateway_convergence.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Converge every Hermes profile Gateway to its desired running state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+
+class GatewayManager(Protocol):
+    """The service-manager operations required by the convergence command."""
+
+    def list_profile_gateways(self) -> list[str]: ...
+
+    def start(self, service_name: str) -> None: ...
+
+    def is_running(self, service_name: str) -> bool: ...
+
+
+@dataclass(frozen=True)
+class GatewayTarget:
+    profile: str
+    service_name: str
+    profile_home: Path
+    discord_required: bool
+
+
+_PROFILE_NAME = re.compile(r"[a-z0-9][a-z0-9_-]*\Z")
+_MAX_PROFILE_NAME_LENGTH = 251
+
+
+def validate_profile_name(profile: str) -> None:
+    """Use Hermes validation when available, with a test-environment fallback."""
+    try:
+        from hermes_cli.service_manager import validate_profile_name as validate
+    except ModuleNotFoundError:
+        if (
+            not isinstance(profile, str)
+            or len(profile) > _MAX_PROFILE_NAME_LENGTH
+            or _PROFILE_NAME.fullmatch(profile) is None
+        ):
+            raise ValueError("invalid profile name")
+        return
+    validate(profile)
+
+
+def profile_home(root: Path, profile: str) -> Path:
+    return root if profile == "default" else root / "profiles" / profile
+
+
+def discord_is_configured(home: Path) -> bool:
+    env_path = home / ".env"
+    if not env_path.is_file():
+        return False
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key.strip() == "DISCORD_BOT_TOKEN":
+            return bool(value.strip())
+    return False
+
+
+def discover_targets(manager: GatewayManager, root: Path) -> tuple[GatewayTarget, ...]:
+    profiles = tuple(manager.list_profile_gateways())
+    if not profiles:
+        raise ValueError("no registered gateways")
+    for profile in profiles:
+        validate_profile_name(profile)
+    return tuple(
+        GatewayTarget(
+            profile=profile,
+            service_name=f"gateway-{profile}",
+            profile_home=profile_home(root, profile),
+            discord_required=discord_is_configured(profile_home(root, profile)),
+        )
+        for profile in sorted(profiles, key=lambda item: (item != "default", item))
+    )
+
+
+def _read_gateway_state(home: Path) -> dict[str, object] | None:
+    try:
+        state = json.loads((home / "gateway_state.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return state if isinstance(state, dict) else None
+
+
+def gateway_ready(manager: GatewayManager, target: GatewayTarget) -> tuple[bool, str]:
+    """Return Gateway readiness with a redacted, stable status label."""
+    try:
+        process_status = "ready" if manager.is_running(target.service_name) else "process_not_running"
+    except Exception:
+        process_status = "process_status_unavailable"
+
+    state = _read_gateway_state(target.profile_home)
+    if target.discord_required and isinstance(state, dict):
+        platforms = state.get("platforms")
+        discord = platforms.get("discord") if isinstance(platforms, dict) else None
+        discord_state = discord.get("state") if isinstance(discord, dict) else None
+        if discord_state == "needs_attention":
+            return False, "discord_needs_attention"
+    if process_status != "ready":
+        return False, process_status
+    if state is None:
+        return False, "state_unavailable"
+    if state.get("desired_state") != "running":
+        return False, "desired_state_not_running"
+    if not target.discord_required:
+        return True, "ready"
+
+    platforms = state.get("platforms")
+    discord = platforms.get("discord") if isinstance(platforms, dict) else None
+    discord_state = discord.get("state") if isinstance(discord, dict) else None
+    if discord_state != "connected":
+        return False, "discord_not_connected"
+    return True, "ready"
+
+
+def _raise_convergence_error(prefix: str, statuses: dict[str, str]) -> None:
+    summary = ", ".join(f"{profile}={status}" for profile, status in statuses.items())
+    raise RuntimeError(f"{prefix}: {summary}")
+
+
+def converge(
+    manager: GatewayManager,
+    root: Path,
+    *,
+    timeout_seconds: float,
+    poll_seconds: float,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> int:
+    """Start each Gateway and wait until every registered profile is ready."""
+    if timeout_seconds < 0:
+        raise ValueError("timeout_seconds must not be negative")
+    if poll_seconds < 0:
+        raise ValueError("poll_seconds must not be negative")
+
+    targets = discover_targets(manager, root)
+    lifecycle_failures: dict[str, str] = {}
+    for target in targets:
+        try:
+            manager.start(target.service_name)
+        except Exception:
+            lifecycle_failures[target.profile] = "lifecycle_error"
+    if lifecycle_failures:
+        _raise_convergence_error("gateway lifecycle failed", lifecycle_failures)
+
+    deadline = monotonic() + timeout_seconds
+    while True:
+        pending: dict[str, str] = {}
+        for target in targets:
+            ready, status = gateway_ready(manager, target)
+            if not ready:
+                pending[target.profile] = status
+        if not pending:
+            return 0
+        if any(status == "discord_needs_attention" for status in pending.values()):
+            _raise_convergence_error("gateway needs attention", pending)
+        now = monotonic()
+        if now >= deadline:
+            _raise_convergence_error("gateway convergence timed out", pending)
+        sleep(min(poll_seconds, deadline - now))
+
+
+def _positive_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a positive number") from error
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive number")
+    return parsed
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run convergence against the in-container s6 service manager."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--timeout-seconds", type=_positive_float, default=60.0)
+    parser.add_argument("--poll-seconds", type=_positive_float, default=1.0)
+    arguments = parser.parse_args(argv)
+
+    try:
+        from hermes_cli.service_manager import get_service_manager
+
+        manager = get_service_manager()
+    except Exception:
+        print("Hermes service manager is unavailable", file=sys.stderr)
+        return 2
+    if getattr(manager, "kind", None) != "s6":
+        print("Hermes Gateway convergence requires the s6 service manager", file=sys.stderr)
+        return 2
+
+    try:
+        return converge(
+            manager,
+            Path(os.environ.get("HERMES_HOME", "/opt/data")),
+            timeout_seconds=arguments.timeout_seconds,
+            poll_seconds=arguments.poll_seconds,
+        )
+    except (RuntimeError, ValueError) as error:
+        print(str(error), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker/hermes-agent/gateway_convergence.py
+++ b/docker/hermes-agent/gateway_convergence.py
@@ -143,10 +143,10 @@ def converge(
     sleep: Callable[[float], None] = time.sleep,
 ) -> int:
     """Start each Gateway and wait until every registered profile is ready."""
-    if timeout_seconds < 0:
-        raise ValueError("timeout_seconds must not be negative")
-    if poll_seconds < 0:
-        raise ValueError("poll_seconds must not be negative")
+    if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be a finite positive number")
+    if not math.isfinite(poll_seconds) or poll_seconds < 0:
+        raise ValueError("poll_seconds must be a finite non-negative number")
 
     try:
         targets = discover_targets(manager, root)

--- a/docker/hermes-agent/gateway_convergence.py
+++ b/docker/hermes-agent/gateway_convergence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import re
 import sys
@@ -23,6 +24,10 @@ class GatewayManager(Protocol):
     def start(self, service_name: str) -> None: ...
 
     def is_running(self, service_name: str) -> bool: ...
+
+
+class NoRegisteredGatewaysError(ValueError):
+    """Raised when s6 has no registered Gateway services."""
 
 
 @dataclass(frozen=True)
@@ -70,7 +75,7 @@ def discord_is_configured(home: Path) -> bool:
 def discover_targets(manager: GatewayManager, root: Path) -> tuple[GatewayTarget, ...]:
     profiles = tuple(manager.list_profile_gateways())
     if not profiles:
-        raise ValueError("no registered gateways")
+        raise NoRegisteredGatewaysError("no registered gateways")
     for profile in profiles:
         validate_profile_name(profile)
     return tuple(
@@ -143,7 +148,12 @@ def converge(
     if poll_seconds < 0:
         raise ValueError("poll_seconds must not be negative")
 
-    targets = discover_targets(manager, root)
+    try:
+        targets = discover_targets(manager, root)
+    except NoRegisteredGatewaysError:
+        raise
+    except Exception as error:
+        raise RuntimeError("gateway discovery failed") from error
     lifecycle_failures: dict[str, str] = {}
     for target in targets:
         try:
@@ -175,7 +185,7 @@ def _positive_float(value: str) -> float:
         parsed = float(value)
     except ValueError as error:
         raise argparse.ArgumentTypeError("must be a positive number") from error
-    if parsed <= 0:
+    if not math.isfinite(parsed) or parsed <= 0:
         raise argparse.ArgumentTypeError("must be a positive number")
     return parsed
 

--- a/docs/superpowers/specs/2026-08-17-hermes-profile-gateway-autostart-design.md
+++ b/docs/superpowers/specs/2026-08-17-hermes-profile-gateway-autostart-design.md
@@ -1,0 +1,91 @@
+# Hermes Profile Gateway Autostart Design
+
+## Goal
+
+Make the first `nrs` or supported dotfiles installation start every configured
+Hermes profile Gateway, not only `default`. Installation succeeds only after
+all registered Gateways are running and their configured Discord connections
+are connected.
+
+## Current behavior
+
+The shared bootstrap recreates the Hermes Compose stack with `gateway run` as
+the container command. Hermes redirects that command to the supervised
+`gateway-default` service. Named profile services are registered by s6, but a
+profile without a persisted `gateway_state.json` remains down until an
+operator runs `hermes -p <profile> gateway start`.
+
+Consequently, a fresh Hermes data directory starts `default` while leaving all
+named profiles stopped. Later container recreations preserve only Gateways
+that have already recorded `desired_state=running`.
+
+## Chosen approach
+
+Add one in-container Gateway convergence command to the dotfiles Hermes image.
+It discovers the runtime's registered `gateway-*` s6 services, starts every
+profile through Hermes' service-manager lifecycle, and waits for each profile
+to report:
+
+- an active supervised process;
+- `desired_state=running`; and
+- `platforms.discord.state=connected` when Discord is configured.
+
+The Unix and Windows bootstrap adapters invoke this same command after Compose
+recreates the stack. This keeps profile discovery and readiness semantics in a
+single cross-platform implementation and automatically includes profiles added
+in the future.
+
+Fixed profile lists in Shell and PowerShell are rejected because they duplicate
+configuration and can omit new profiles. Separate Compose services per profile
+are rejected because that is a larger resource and deployment redesign than
+this startup contract requires.
+
+## Components and data flow
+
+1. Bootstrap applies profile configuration and recreates the Compose stack.
+2. The existing default API readiness check confirms the container is ready for
+   lifecycle commands.
+3. The common in-container command enumerates registered s6 Gateway services.
+4. It starts each service idempotently through the Hermes service manager,
+   which records `desired_state=running` in the correct profile home.
+5. It polls supervised process state and profile Gateway state until every
+   profile is ready or the bounded timeout expires.
+6. The host bootstrap continues only after convergence succeeds.
+
+## Error handling
+
+The command validates every discovered profile name before using it. An empty
+Gateway set, lifecycle error, process exit, Discord error state, or readiness
+timeout returns nonzero and identifies the affected profile. The host bootstrap
+propagates that failure, so `nrs` and every supported installer fail closed.
+
+Gateways that started successfully are not stopped when another profile fails.
+Their persisted running state is useful for diagnosis and allows the next
+idempotent run to converge without disrupting healthy profiles. No credentials
+or token values are printed.
+
+## Platform scope
+
+The convergence implementation lives in the shared Docker image. Unix Shell
+and Windows PowerShell host adapters call the same executable after startup.
+The macOS `nrs`, Linux installers, NixOS installers, WSL setup, and Windows
+bootstrap therefore receive the same behavior without duplicating profile
+logic.
+
+## Tests
+
+Automated coverage will prove:
+
+- a fresh profile without Gateway state is started;
+- all registered profiles are discovered, including future names;
+- repeated convergence is idempotent;
+- lifecycle failures and readiness timeouts fail the command;
+- disconnected or errored Discord state fails readiness;
+- Unix and Windows adapters invoke convergence after Compose startup and
+  propagate a nonzero result;
+- the existing focused bootstrap, installer, Shell, PowerShell, formatting,
+  and lint checks remain green.
+
+Live verification will confirm all seven current profiles report supervised
+`up`, persisted `desired_state=running`, and Discord `connected`. It will not
+send Discord messages unless separately authorized.

--- a/scripts/powershell/handlers/Handler.HermesAgent.ps1
+++ b/scripts/powershell/handlers/Handler.HermesAgent.ps1
@@ -8,6 +8,7 @@ $libPath = Split-Path -Parent $PSScriptRoot
 . (Join-Path $libPath 'lib\HermesBootstrap.ps1')
 . (Join-Path $libPath 'lib\HermesXApi.ps1')
 . (Join-Path $libPath 'lib\HermesHindsight.ps1')
+. (Join-Path $libPath 'lib\HermesGateway.ps1')
 
 class HermesAgentHandler : SetupHandlerBase {
     [int]$DockerCheckTimeoutSeconds = 15
@@ -154,6 +155,13 @@ class HermesAgentHandler : SetupHandlerBase {
                 }
                 $attempts = $this.GetPositiveEnvironmentInteger('HERMES_API_READY_ATTEMPTS', 30)
                 return $this.CreateFailureResult("Hermes API did not become ready after $attempts attempts.")
+            }
+
+            try {
+                Invoke-HermesGatewayConvergence -ComposeFile $composeFile
+            }
+            catch [System.InvalidOperationException] {
+                return $this.CreateFailureResult($_.Exception.Message)
             }
 
             return $this.CreateSuccessResult("Hermes Agent started: http://127.0.0.1:9119 / browser: $($this.GetBrowserViewUrl())")

--- a/scripts/powershell/hermes-bootstrap.ps1
+++ b/scripts/powershell/hermes-bootstrap.ps1
@@ -16,6 +16,7 @@ $ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot 'lib/Invoke-ExternalCommand.ps1')
 . (Join-Path $PSScriptRoot 'lib/HermesBootstrap.ps1')
 . (Join-Path $PSScriptRoot 'lib/HermesXApi.ps1')
+. (Join-Path $PSScriptRoot 'lib/HermesGateway.ps1')
 
 function New-HermesBootstrapEntrypointResult {
     [CmdletBinding()]
@@ -322,6 +323,15 @@ function Invoke-HermesBootstrapEntrypoint {
                 return New-HermesBootstrapEntrypointResult `
                     -ExitCode 1 `
                     -Message "Hermes API did not become ready after $attempts attempts."
+            }
+
+            try {
+                Invoke-HermesGatewayConvergence -ComposeFile $paths.ComposeFile
+            }
+            catch [System.InvalidOperationException] {
+                return New-HermesBootstrapEntrypointResult `
+                    -ExitCode 1 `
+                    -Message $_.Exception.Message
             }
 
             return New-HermesBootstrapEntrypointResult -ExitCode 0 -Message 'Hermes bootstrap completed.'

--- a/scripts/powershell/lib/HermesGateway.ps1
+++ b/scripts/powershell/lib/HermesGateway.ps1
@@ -1,0 +1,18 @@
+function Invoke-HermesGatewayConvergence {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ComposeFile
+    )
+
+    $null = @(Invoke-Docker -Arguments @(
+            'compose', '-f', $ComposeFile,
+            'exec', '-T', 'hermes', '/usr/local/bin/hermes-gateway-converge'
+        ))
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw [System.InvalidOperationException]::new(
+            "Hermes profile Gateway convergence failed with exit code $exitCode."
+        )
+    }
+}

--- a/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
+++ b/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
@@ -3,6 +3,7 @@ BeforeAll {
     $script:entrypointPath = Join-Path $script:repositoryRoot 'scripts/powershell/hermes-bootstrap.ps1'
     $script:taskfilePath = Join-Path $script:repositoryRoot 'taskfiles/hermes/taskfile.yml'
 
+    . (Join-Path $script:repositoryRoot 'scripts/powershell/lib/HermesGateway.ps1')
     . $script:entrypointPath
 
     function Get-HermesTestEnvironmentVariableState {
@@ -106,6 +107,8 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             [PSCustomObject]@{ StatusCode = 200 }
         }
 
+        Mock Invoke-HermesGatewayConvergence { }
+
         Mock Start-Sleep
     }
 
@@ -203,6 +206,52 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
         }
         Should -Invoke Start-Sleep -Times 2 -Exactly -ParameterFilter { $Seconds -eq 0 }
         ($script:dockerCalls -join "`n") | Should -Not -Match 'ps --all'
+    }
+
+    It 'should converge gateways after API readiness and before reporting success' {
+        Mock Invoke-WebRequest {
+            $script:eventLog.Add('health')
+            [PSCustomObject]@{ StatusCode = 200 }
+        }
+        Mock Invoke-HermesGatewayConvergence {
+            $script:eventLog.Add('gateway-convergence')
+        }
+
+        $result = Invoke-HermesBootstrapEntrypoint `
+            -ComposeFile $script:composeFile `
+            -DataDir $script:dataDir `
+            -BrowserDataDir $script:browserDir
+        $script:eventLog.Add('success')
+
+        $result.ExitCode | Should -Be 0
+        $script:eventLog | Should -Be @(
+            'config', 'build', 'stop', 'bootstrap', 'xapi-credentials', 'up',
+            'health', 'gateway-convergence', 'success'
+        )
+        Should -Invoke Invoke-HermesGatewayConvergence -Times 1 -Exactly -ParameterFilter {
+            $ComposeFile -eq $script:composeFile
+        }
+    }
+
+    It 'should return a sanitized failure when gateway convergence fails' {
+        $secret = 'gateway-secret-output'
+        Mock Invoke-HermesGatewayConvergence {
+            $inner = [System.InvalidOperationException]::new($secret)
+            throw [System.InvalidOperationException]::new(
+                'Hermes profile Gateway convergence failed with exit code 42.',
+                $inner
+            )
+        }
+
+        $result = Invoke-HermesBootstrapEntrypoint `
+            -ComposeFile $script:composeFile `
+            -DataDir $script:dataDir `
+            -BrowserDataDir $script:browserDir
+
+        $result.ExitCode | Should -Be 1
+        $result.Message | Should -Match 'Hermes profile Gateway convergence failed'
+        $result.Message | Should -Not -Match ([regex]::Escape($secret))
+        Should -Invoke Invoke-HermesGatewayConvergence -Times 1 -Exactly
     }
 
     It 'should stop after bounded readiness attempts and print Compose diagnostics' {

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -5,6 +5,7 @@ BeforeAll {
     . $PSScriptRoot/../../lib/Invoke-ExternalCommand.ps1
     . $PSScriptRoot/../../lib/HermesBootstrap.ps1
     . $PSScriptRoot/../../lib/HermesXApi.ps1
+    . $PSScriptRoot/../../lib/HermesGateway.ps1
     function Initialize-HermesHindsightHost { }
     function Wait-HermesHindsightApi { }
     . $PSScriptRoot/../../handlers/Handler.NixOSWSL.ps1
@@ -270,6 +271,7 @@ Describe 'HermesAgentHandler' {
             $script:eventLog.Add('health')
             [PSCustomObject]@{ StatusCode = 200 }
         }
+        Mock Invoke-HermesGatewayConvergence { }
         Mock Start-Sleep { }
     }
 
@@ -572,6 +574,43 @@ Describe 'HermesAgentHandler' {
             Should -Invoke Invoke-WebRequest -Times 3 -Exactly
             Should -Invoke Start-Sleep -Times 2 -Exactly
             $script:eventLog[-1] | Should -Be 'health'
+        }
+
+        It 'converges gateways after API readiness and before reporting success' {
+            Mock Invoke-HermesGatewayConvergence {
+                $script:eventLog.Add('gateway-convergence')
+            }
+
+            $result = $handler.Apply($ctx)
+            $script:eventLog.Add('success')
+
+            $result.Success | Should -BeTrue
+            $script:eventLog | Should -Be @(
+                'config', 'hindsight-host', 'up', 'hindsight-health', 'build',
+                'stop', 'bootstrap', 'xapi-credentials', 'up', 'health',
+                'gateway-convergence', 'success'
+            )
+            Should -Invoke Invoke-HermesGatewayConvergence -Times 1 -Exactly -ParameterFilter {
+                $ComposeFile -eq $script:composeFile
+            }
+        }
+
+        It 'returns a sanitized component failure when gateway convergence fails' {
+            $secret = 'gateway-secret-output'
+            Mock Invoke-HermesGatewayConvergence {
+                $inner = [System.InvalidOperationException]::new($secret)
+                throw [System.InvalidOperationException]::new(
+                    'Hermes profile Gateway convergence failed with exit code 42.',
+                    $inner
+                )
+            }
+
+            $result = $handler.Apply($ctx)
+
+            $result.Success | Should -BeFalse
+            $result.Message | Should -Match 'Hermes profile Gateway convergence failed'
+            $result.Message | Should -Not -Match ([regex]::Escape($secret))
+            Should -Invoke Invoke-HermesGatewayConvergence -Times 1 -Exactly
         }
 
         It 'fails after bounded API readiness attempts without exposing probe errors' {

--- a/scripts/powershell/tests/lib/HermesGateway.Tests.ps1
+++ b/scripts/powershell/tests/lib/HermesGateway.Tests.ps1
@@ -1,0 +1,54 @@
+#Requires -Module Pester
+
+BeforeAll {
+    function Invoke-Docker {
+        param([string[]]$Arguments)
+        throw "Unexpected Docker invocation: $($Arguments -join ' ')"
+    }
+
+    . $PSScriptRoot/../../lib/HermesGateway.ps1
+}
+
+Describe 'Hermes Gateway convergence adapter' {
+    BeforeEach {
+        $script:dockerArguments = @()
+        $global:LASTEXITCODE = 0
+    }
+
+    It 'executes the in-container convergence command with the exact Compose arguments' {
+        Mock Invoke-Docker {
+            $script:dockerArguments = @($Arguments)
+            $global:LASTEXITCODE = 0
+            return 'converged'
+        }
+
+        $result = Invoke-HermesGatewayConvergence -ComposeFile 'C:\dotfiles\compose.yml'
+
+        $result | Should -BeNullOrEmpty
+        $script:dockerArguments | Should -Be @(
+            'compose', '-f', 'C:\dotfiles\compose.yml',
+            'exec', '-T', 'hermes', '/usr/local/bin/hermes-gateway-converge'
+        )
+    }
+
+    It 'throws a sanitized InvalidOperationException when Docker exits nonzero' {
+        $secret = 'secret-token'
+        Mock Invoke-Docker {
+            $script:dockerArguments = @($Arguments)
+            $global:LASTEXITCODE = 42
+            return "convergence failed with $secret"
+        }
+
+        $caught = $null
+        try {
+            Invoke-HermesGatewayConvergence -ComposeFile 'C:\dotfiles\compose.yml'
+        }
+        catch {
+            $caught = $_.Exception
+        }
+
+        $caught | Should -BeOfType ([System.InvalidOperationException])
+        $caught.Message | Should -Be 'Hermes profile Gateway convergence failed with exit code 42.'
+        $caught.Message | Should -Not -Match ([regex]::Escape($secret))
+    }
+}

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -503,6 +503,14 @@ dotfiles_hermes_wait_for_api() {
   return 1
 }
 
+dotfiles_hermes_converge_gateways() {
+  local docker_runner="$1"
+  local compose_file="$2"
+
+  "$docker_runner" compose -f "$compose_file" exec -T hermes \
+    /usr/local/bin/hermes-gateway-converge
+}
+
 dotfiles_hermes_show_compose_diagnostics() {
   local docker_runner="$1"
   local compose_file="$2"
@@ -628,8 +636,14 @@ dotfiles_hermes_start_stack() {
     return "$status"
   fi
   if dotfiles_hermes_wait_for_api; then
-    if ! dotfiles_hermes_prune_dangling_images "$docker_runner"; then
-      printf '%s\n' 'Warning: unable to remove dangling Docker images.' >&2
+    if dotfiles_hermes_converge_gateways "$docker_runner" "$compose_file"; then
+      if ! dotfiles_hermes_prune_dangling_images "$docker_runner"; then
+        printf '%s\n' 'Warning: unable to remove dangling Docker images.' >&2
+      fi
+    else
+      status=$?
+      dotfiles_hermes_show_compose_diagnostics "$docker_runner" "$compose_file"
+      return "$status"
     fi
   else
     status=$?

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -54,6 +54,7 @@ EOF
 	export HERMES_API_READY_DELAY_SECONDS=0
 	export HERMES_API_PROBE_TIMEOUT_SECONDS=1
 	export IMAGE_PRUNE_STATUS=0
+	export HERMES_GATEWAY_CONVERGENCE_STATUS=0
 	export UP_STATUS=0
 
 	write_stub jq '
@@ -111,6 +112,9 @@ if [ "${1:-}" != "compose" ]; then
 	exit 1
 fi
 case " $* " in
+	 *" exec -T hermes /usr/local/bin/hermes-gateway-converge "*)
+		exit "$HERMES_GATEWAY_CONVERGENCE_STATUS"
+		;;
   *" up -d --force-recreate "*)
     exit "$UP_STATUS"
     ;;
@@ -1185,6 +1189,27 @@ dotfiles_hermes_hindsight_env_value "$COMPOSE_FILE" HINDSIGHT_API_LLM_MODEL
 		false
 	fi
 	[[ "$output" != *"$SECRET_MARKER"* ]]
+}
+
+@test "converges Hermes gateways after API readiness before pruning images" {
+	run_start_stack
+
+	[ "$status" -eq 0 ]
+	assert_log_order \
+		'<http://127.0.0.1:8642/health>' \
+		'<exec> <-T> <hermes> </usr/local/bin/hermes-gateway-converge>' \
+		'<image> <prune> <--force>'
+}
+
+@test "returns the gateway convergence status with diagnostics without pruning images" {
+	export HERMES_GATEWAY_CONVERGENCE_STATUS=47
+
+	run_start_stack
+
+	[ "$status" -eq 47 ]
+	grep -q '<exec> <-T> <hermes> </usr/local/bin/hermes-gateway-converge>' "$COMMAND_LOG"
+	grep -q '<ps> <--all>' "$COMMAND_LOG"
+	! grep -q '<image> <prune> <--force>' "$COMMAND_LOG"
 }
 
 @test "keeps successful Hermes activation when dangling image cleanup fails" {

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -111,10 +111,10 @@ fi
 if [ "${1:-}" != "compose" ]; then
 	exit 1
 fi
+if [[ ${1:-} == compose && ${2:-} == -f && ${3:-} == "$COMPOSE_FILE" && ${4:-} == exec && ${5:-} == -T && ${6:-} == hermes && ${7:-} == /usr/local/bin/hermes-gateway-converge && $# -eq 7 ]]; then
+	exit "$HERMES_GATEWAY_CONVERGENCE_STATUS"
+fi
 case " $* " in
-	 *" exec -T hermes /usr/local/bin/hermes-gateway-converge "*)
-		exit "$HERMES_GATEWAY_CONVERGENCE_STATUS"
-		;;
   *" up -d --force-recreate "*)
     exit "$UP_STATUS"
     ;;
@@ -270,6 +270,17 @@ assert_log_order() {
 	local pattern line
 	for pattern in "$@"; do
 		line="$(grep -n -m 1 -- "$pattern" "$COMMAND_LOG" | cut -d: -f1)"
+		[ -n "$line" ]
+		[ "$line" -gt "$previous" ]
+		previous="$line"
+	done
+}
+
+assert_log_order_fixed() {
+	local previous=0
+	local record line
+	for record in "$@"; do
+		line="$(grep -Fxn -m 1 -- "$record" "$COMMAND_LOG" | cut -d: -f1)"
 		[ -n "$line" ]
 		[ "$line" -gt "$previous" ]
 		previous="$line"
@@ -1192,23 +1203,28 @@ dotfiles_hermes_hindsight_env_value "$COMPOSE_FILE" HINDSIGHT_API_LLM_MODEL
 }
 
 @test "converges Hermes gateways after API readiness before pruning images" {
+	local api_ready convergence image_prune
+	api_ready='curl <--fail> <--silent> <--show-error> <--max-time> <1> <http://127.0.0.1:8642/health>'
+	convergence="docker <compose> <-f> <$COMPOSE_FILE> <exec> <-T> <hermes> </usr/local/bin/hermes-gateway-converge>"
+	image_prune='docker <image> <prune> <--force>'
+
 	run_start_stack
 
 	[ "$status" -eq 0 ]
-	assert_log_order \
-		'<http://127.0.0.1:8642/health>' \
-		'<exec> <-T> <hermes> </usr/local/bin/hermes-gateway-converge>' \
-		'<image> <prune> <--force>'
+	grep -Fxq "$convergence" "$COMMAND_LOG"
+	assert_log_order_fixed "$api_ready" "$convergence" "$image_prune"
 }
 
 @test "returns the gateway convergence status with diagnostics without pruning images" {
+	local convergence diagnostics
+	convergence="docker <compose> <-f> <$COMPOSE_FILE> <exec> <-T> <hermes> </usr/local/bin/hermes-gateway-converge>"
+	diagnostics="docker <compose> <-f> <$COMPOSE_FILE> <ps> <--all>"
 	export HERMES_GATEWAY_CONVERGENCE_STATUS=47
 
 	run_start_stack
 
 	[ "$status" -eq 47 ]
-	grep -q '<exec> <-T> <hermes> </usr/local/bin/hermes-gateway-converge>' "$COMMAND_LOG"
-	grep -q '<ps> <--all>' "$COMMAND_LOG"
+	assert_log_order_fixed "$convergence" "$diagnostics"
 	! grep -q '<image> <prune> <--force>' "$COMMAND_LOG"
 }
 
@@ -1241,10 +1257,14 @@ dotfiles_hermes_hindsight_env_value "$COMPOSE_FILE" HINDSIGHT_API_LLM_MODEL
 }
 
 @test "forwards Docker calls through a function runner and retains host runtime paths" {
+	local convergence
+	convergence="runner <compose> <-f> <$COMPOSE_FILE> <exec> <-T> <hermes> </usr/local/bin/hermes-gateway-converge>"
+
 	run_start_stack_with_function_runner
 
 	[ "$status" -eq 0 ]
 	grep -q '^runner <compose> <-f> <' "$COMMAND_LOG"
+	grep -Fxq "$convergence" "$COMMAND_LOG"
 	[ -d "$TEST_HOME/.hermes/.xurl" ]
 	[ -d "$TEST_HOME/.hermes/.browser" ]
 }


### PR DESCRIPTION
Windows side Hermes gateway convergence fix: start every gateway profile on both entrypoints (Hermes bootstrap + Install).

Verified locally (darwin):
- HermesBootstrapEntrypoint.Tests.ps1: 18 passed / 0 failed / 0 skipped
- Install.Entrypoint.Tests.ps1: Windows-only gate (runs on CI windows-2025)

Draft pending CI Windows Pester run.