### PR TITLE
feat: manage ChatGPT desktop with Nix

### DIFF
--- a/nix/packages/chatgpt/default.nix
+++ b/nix/packages/chatgpt/default.nix
@@ -1,0 +1,119 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  dpkg,
+  makeWrapper,
+  alsa-lib,
+  at-spi2-atk,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libGL,
+  libX11,
+  libXcomposite,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libXrandr,
+  libdrm,
+  libgbm,
+  libnotify,
+  libusb1,
+  libxcb,
+  libxkbcommon,
+  mesa,
+  nspr,
+  nss,
+  pango,
+  pulseaudio,
+  systemd,
+}:
+let
+  version = "26.818.41705";
+  sources = {
+    x86_64-linux = {
+      url = "https://persistent.oaistatic.com/codex-app-prod/linux/deb/latest/chatgpt_amd64.deb";
+      hash = "sha256-ySfJhVd73luszsx38C4UsxHZTmIwFWYh+vkleawDalU=";
+    };
+    aarch64-linux = {
+      url = "https://persistent.oaistatic.com/codex-app-prod/linux/deb/latest/chatgpt_arm64.deb";
+      hash = "sha256-Y3WtHooJT3Z5HiC58xyIhxnOz6E/Ct0sS7yAlgb3NIE=";
+    };
+  };
+  source =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "ChatGPT is unsupported on ${stdenv.hostPlatform.system}");
+  runtimeDependencies = [
+    alsa-lib
+    at-spi2-atk
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    gdk-pixbuf
+    glib
+    gtk3
+    libGL
+    libX11
+    libXcomposite
+    libXdamage
+    libXext
+    libXfixes
+    libXrandr
+    libdrm
+    libgbm
+    libnotify
+    libusb1
+    libxcb
+    libxkbcommon
+    mesa
+    nspr
+    nss
+    pango
+    pulseaudio
+    systemd
+  ];
+in
+stdenv.mkDerivation {
+  pname = "chatgpt";
+  inherit version;
+  src = fetchurl source;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    makeWrapper
+  ];
+  buildInputs = runtimeDependencies;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    dpkg-deb --extract "$src" "$out"
+    mkdir -p "$out/bin"
+    makeWrapper "$out/usr/lib/chatgpt/ChatGPT" "$out/bin/chatgpt" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeDependencies}"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Official ChatGPT desktop application for Linux";
+    homepage = "https://learn.chatgpt.com/docs/linux/linux-app";
+    license = lib.licenses.unfree;
+    mainProgram = "chatgpt";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}

--- a/nix/packages/chatgpt/default.nix
+++ b/nix/packages/chatgpt/default.nix
@@ -81,8 +81,8 @@ let
     nss
     pango
     pulseaudio
-    qt5.qtbase
-    qt6.qtbase
+    (lib.getLib qt5.qtbase)
+    (lib.getLib qt6.qtbase)
     systemd
   ];
 in

--- a/nix/packages/chatgpt/default.nix
+++ b/nix/packages/chatgpt/default.nix
@@ -41,11 +41,11 @@ let
   version = "26.818.41705";
   sources = {
     x86_64-linux = {
-      url = "https://persistent.oaistatic.com/codex-app-prod/linux/deb/latest/chatgpt_amd64.deb";
+      url = "https://persistent.oaistatic.com/codex-app-prod/linux/deb/pool/main/c/chatgpt/chatgpt_26.818.41705_amd64.deb";
       hash = "sha256-ySfJhVd73luszsx38C4UsxHZTmIwFWYh+vkleawDalU=";
     };
     aarch64-linux = {
-      url = "https://persistent.oaistatic.com/codex-app-prod/linux/deb/latest/chatgpt_arm64.deb";
+      url = "https://persistent.oaistatic.com/codex-app-prod/linux/deb/pool/main/c/chatgpt/chatgpt_26.818.41705_arm64.deb";
       hash = "sha256-Y3WtHooJT3Z5HiC58xyIhxnOz6E/Ct0sS7yAlgb3NIE=";
     };
   };
@@ -108,9 +108,12 @@ stdenv.mkDerivation {
 
   installPhase = ''
     runHook preInstall
-    dpkg-deb --extract "$src" "$out"
+    unpacked="$TMPDIR/chatgpt"
+    dpkg-deb --extract "$src" "$unpacked"
+    mkdir -p "$out"
+    cp -R "$unpacked/usr/." "$out/"
     mkdir -p "$out/bin"
-    makeWrapper "$out/usr/lib/chatgpt/ChatGPT" "$out/bin/chatgpt" \
+    makeWrapper "$out/lib/chatgpt/ChatGPT" "$out/bin/chatgpt" \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeDependencies}"
     runHook postInstall
   '';

--- a/nix/packages/chatgpt/default.nix
+++ b/nix/packages/chatgpt/default.nix
@@ -33,6 +33,8 @@
   nss,
   pango,
   pulseaudio,
+  qt5,
+  qt6,
   systemd,
 }:
 let
@@ -79,6 +81,8 @@ let
     nss
     pango
     pulseaudio
+    qt5.qtbase
+    qt6.qtbase
     systemd
   ];
 in
@@ -93,6 +97,11 @@ stdenv.mkDerivation {
     makeWrapper
   ];
   buildInputs = runtimeDependencies;
+
+  autoPatchelfIgnoreMissingDeps = [
+    "libc.musl-x86_64.so.1"
+    "libc.musl-aarch64.so.1"
+  ];
 
   dontConfigure = true;
   dontBuild = true;

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -5,6 +5,7 @@
 #   - catalog categories (core, dev, terminal, editors, llm, …) → lists of derivations
 #   - all                → flat list of all derivations
 #   - wingetMap          → nix attr name → winget PackageIdentifier
+#   - msstoreMap         → nix attr name → Microsoft Store Product ID
 #   - npmMap             → nix attr name → npm package spec
 #   - pnpmGlobal         → cross-platform pnpm global package names
 #   - npmVerify          → catalog attr name → { command, args } for npm verification
@@ -331,6 +332,20 @@ let
       pkg = pkgs.codex;
       winget = "OpenAI.Codex";
       category = "llm";
+    };
+    chatgpt = {
+      pkg = if pkgs.stdenv.hostPlatform.isLinux then pkgs.callPackage ./chatgpt { } else null;
+      msstore = "9NT1R1C2HH7J";
+      category = "desktop";
+      support = {
+        darwin = {
+          provider = "homebrew-cask";
+          cask = "chatgpt";
+        };
+        linux = {
+          provider = "nix";
+        };
+      };
     };
     ollama = {
       pkg = if pkgs.stdenv.hostPlatform.isDarwin then null else pkgs.ollama;
@@ -767,6 +782,8 @@ let
       windows =
         if (entry.winget or null) != null then
           { provider = "winget"; }
+        else if (entry.msstore or null) != null then
+          { provider = "msstore"; }
         else if (entry.npm or null) != null then
           { provider = "npm"; }
         else
@@ -818,7 +835,6 @@ let
       mkWindowsOnlySupport "winget" "Windows compiler toolchain";
     "Microsoft.WindowsTerminal" = mkWindowsOnlySupport "winget" "Windows shell host";
     "Microsoft.WSL" = mkWindowsOnlySupport "winget" "Windows subsystem component";
-    "9NT1R1C2HH7J" = mkWindowsOnlySupport "msstore" "Windows Store application";
     "9PLM9XGG6VKS" = mkWindowsOnlySupport "msstore" "Windows Store desktop application";
   };
 
@@ -840,6 +856,7 @@ let
 
   # Extract winget mappings (non-null only)
   wingetMap = lib.filterAttrs (_: v: v != null) (lib.mapAttrs (_: v: v.winget or null) catalog);
+  msstoreMap = lib.filterAttrs (_: v: v != null) (lib.mapAttrs (_: v: v.msstore or null) catalog);
   npmMap = lib.filterAttrs (_: v: v != null) (lib.mapAttrs (_: v: v.npm or null) catalog);
 
   supportReport = lib.mapAttrs (_: entry: entry.support) catalog // windowsOnlySupport;
@@ -883,7 +900,7 @@ lib.mapAttrs (_: resolve) grouped
     resolve (builtins.filter (name: !(builtins.elem name excludedNames)) (lib.attrNames catalog));
 
   # Windows: nix attr name → winget PackageIdentifier
-  inherit wingetMap npmMap;
+  inherit wingetMap msstoreMap npmMap;
 
   inherit
     supportReport
@@ -1241,7 +1258,6 @@ lib.mapAttrs (_: resolve) grouped
       "Microsoft.WSL"
     ];
     msstore = [
-      "9NT1R1C2HH7J"
       "9PLM9XGG6VKS"
     ];
     npm = [

--- a/nix/packages/winget.nix
+++ b/nix/packages/winget.nix
@@ -190,7 +190,20 @@ let
 
   wingetPackages = wingetFromMap ++ wingetFromWindowsOnly;
 
-  msstorePackages = map (
+  msstoreFromMap = lib.mapAttrsToList (
+    name: id:
+    attachSkipInstall sets.wingetSkipInstall name (
+      attachCiSkipInstall sets.wingetCiSkipInstall name (
+        attachSkipInstall sets.wingetSkipInstall id (
+          attachCiSkipInstall sets.wingetCiSkipInstall id (
+            attachVerify sets.msstoreVerifyById id { PackageIdentifier = id; }
+          )
+        )
+      )
+    )
+  ) sets.msstoreMap;
+
+  msstorePackagesWindowsOnly = map (
     id:
     attachSkipInstall sets.wingetSkipInstall id (
       attachCiSkipInstall sets.wingetCiSkipInstall id (
@@ -198,6 +211,8 @@ let
       )
     )
   ) sets.windowsOnly.msstore;
+
+  msstorePackages = msstoreFromMap ++ msstorePackagesWindowsOnly;
 
   # --- pnpm ---
   pnpmFromGlobal = map (

--- a/scripts/powershell/tests/PackageCatalog.Tests.ps1
+++ b/scripts/powershell/tests/PackageCatalog.Tests.ps1
@@ -447,6 +447,7 @@ Describe 'Package catalog consistency' {
                 'Google.Chrome'
                 'Microsoft.VisualStudioCode'
                 'OpenAI.Codex'
+                '9NT1R1C2HH7J'
                 'Oven-sh.Bun'
                 'zig.zig'
             ) | ForEach-Object {

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -180,8 +180,8 @@ setup() {
 }
 
 @test "ChatGPT Linux package supplies Qt runtimes and ignores optional musl modules" {
-	grep -q '^    qt5\.qtbase$' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
-	grep -q '^    qt6\.qtbase$' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
+	grep -q '^    (lib\.getLib qt5\.qtbase)$' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
+	grep -q '^    (lib\.getLib qt6\.qtbase)$' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
 	grep -q 'autoPatchelfIgnoreMissingDeps' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
 	grep -q 'libc\.musl-x86_64\.so\.1' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
 	grep -q 'libc\.musl-aarch64\.so\.1' "$REPO_ROOT/nix/packages/chatgpt/default.nix"

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -160,6 +160,25 @@ setup() {
 	[[ "$output" == *'args = [ "--version" ];'* ]]
 }
 
+@test "ChatGPT desktop has native Linux, Darwin cask, and Microsoft Store providers" {
+	run awk '
+		/^    chatgpt = \{/ { in_entry=1 }
+		in_entry { print }
+		in_entry && /^    \};/ { exit }
+	' "$SETS"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'pkg = if pkgs.stdenv.hostPlatform.isLinux then pkgs.callPackage ./chatgpt { } else null;'* ]]
+	[[ "$output" == *'msstore = "9NT1R1C2HH7J";'* ]]
+	[[ "$output" == *'cask = "chatgpt"'* ]]
+	[[ "$output" == *'provider = "nix"'* ]]
+}
+
+@test "ChatGPT Linux package is wired as a reproducible Nix derivation" {
+	[ -f "$REPO_ROOT/nix/packages/chatgpt/default.nix" ]
+	grep -q 'persistent.oaistatic.com/codex-app-prod/linux/deb' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
+	grep -q 'sha256-' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
+}
+
 @test "Darwin evaluation installs WezTerm terminfo and excludes the broken cask" {
 	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
 

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -179,6 +179,14 @@ setup() {
 	grep -q 'sha256-' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
 }
 
+@test "ChatGPT Linux package supplies Qt runtimes and ignores optional musl modules" {
+	grep -q '^    qt5\.qtbase$' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
+	grep -q '^    qt6\.qtbase$' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
+	grep -q 'autoPatchelfIgnoreMissingDeps' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
+	grep -q 'libc\.musl-x86_64\.so\.1' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
+	grep -q 'libc\.musl-aarch64\.so\.1' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
+}
+
 @test "Darwin evaluation installs WezTerm terminfo and excludes the broken cask" {
 	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
 

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -175,7 +175,9 @@ setup() {
 
 @test "ChatGPT Linux package is wired as a reproducible Nix derivation" {
 	[ -f "$REPO_ROOT/nix/packages/chatgpt/default.nix" ]
-	grep -q 'persistent.oaistatic.com/codex-app-prod/linux/deb' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
+	grep -q 'persistent.oaistatic.com/codex-app-prod/linux/deb/pool/main/c/chatgpt/chatgpt_26.818.41705_amd64.deb' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
+	grep -q 'persistent.oaistatic.com/codex-app-prod/linux/deb/pool/main/c/chatgpt/chatgpt_26.818.41705_arm64.deb' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
+	! grep -q '/latest/chatgpt_' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
 	grep -q 'sha256-' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
 }
 
@@ -185,6 +187,11 @@ setup() {
 	grep -q 'autoPatchelfIgnoreMissingDeps' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
 	grep -q 'libc\.musl-x86_64\.so\.1' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
 	grep -q 'libc\.musl-aarch64\.so\.1' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
+}
+
+@test "ChatGPT Linux package uses the normal Nix output layout" {
+	grep -q 'cp -R "\$unpacked/usr/." "\$out/"' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
+	grep -q 'makeWrapper "\$out/lib/chatgpt/ChatGPT"' "$REPO_ROOT/nix/packages/chatgpt/default.nix"
 }
 
 @test "Darwin evaluation installs WezTerm terminfo and excludes the broken cask" {


### PR DESCRIPTION
## Summary
- add the official ChatGPT Linux desktop package as a Nix derivation for x86_64-linux and aarch64-linux
- register ChatGPT across the Nix catalog, macOS Homebrew cask, and Windows Microsoft Store
- keep generated Windows package exports unchanged while deriving the Microsoft Store mapping from the catalog

## Validation
- `nix fmt -- --ci`
- `nix flake check --no-build --all-systems`
- `bats tests/bash/package_catalog.bats`
- `pwsh -NoProfile -File ./scripts/powershell/tests/Invoke-Tests.ps1 -Path ./scripts/powershell/tests/PackageCatalog.Tests.ps1 -MinimumCoverage 0`
- generated Windows exports match committed files
- Linux package build was not run locally because this macOS host has no Linux builder
- local pre-commit Docker hook was skipped because Docker Desktop is not running; GitHub Actions must verify it