### PR TITLE
feat: add DeepSeek Harness across platforms

### DIFF
--- a/chezmoi/.chezmoidata/pnpm_global.yaml
+++ b/chezmoi/.chezmoidata/pnpm_global.yaml
@@ -5,6 +5,7 @@
 pnpm_global_packages:
   - "@prisma/language-server"
   - "@agentclientprotocol/claude-agent-acp"
+  - "@deepseek-ai/dsh"
   - "@playwright/cli"
   - "typescript-language-server"
   - "typescript"

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -110,8 +110,8 @@ let
     };
 
     # ── dev ───────────────────────────────────────────────
-    nodejs_24 = {
-      pkg = pkgs.nodejs_24;
+    nodejs = {
+      pkg = pkgs.nodejs;
       winget = "OpenJS.NodeJS.LTS";
       category = "dev";
     };
@@ -928,6 +928,7 @@ lib.mapAttrs (_: resolve) grouped
   pnpmGlobal = [
     "@prisma/language-server"
     "@agentclientprotocol/claude-agent-acp"
+    "@deepseek-ai/dsh"
     "@playwright/cli@0.1.14"
     "playwright@1.61.0"
     "typescript-language-server"
@@ -957,6 +958,10 @@ lib.mapAttrs (_: resolve) grouped
       type = "commandExists";
       command = "claude-agent-acp";
       args = [ ];
+    };
+    "@deepseek-ai/dsh" = {
+      command = "dsh";
+      args = [ "--version" ];
     };
     "@playwright/cli" = {
       command = "playwright-cli";
@@ -1042,7 +1047,7 @@ lib.mapAttrs (_: resolve) grouped
       command = "nvim";
       args = [ "--version" ];
     };
-    nodejs_24 = {
+    nodejs = {
       command = "node";
       args = [ "--version" ];
     };

--- a/nix/tests/bootstrap-nixos.nix
+++ b/nix/tests/bootstrap-nixos.nix
@@ -65,7 +65,7 @@ pkgs.testers.runNixOSTest {
         jq
         go-task
         neovim
-        nodejs_24
+        nodejs
         python3
         go
         rustup

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -14,6 +14,24 @@ setup() {
 	grep -q 'linuxSystemModules' "$SETS"
 }
 
+@test "Node.js follows the current nixpkgs major" {
+	run awk '
+		/^    nodejs = \{/ { in_entry=1 }
+		in_entry { print }
+		in_entry && /^    };$/ { exit }
+	' "$SETS"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'pkg = pkgs.nodejs;'* ]]
+	[[ "$output" != *'nodejs_24'* ]]
+}
+
+@test "DeepSeek Harness is managed as a cross-platform pnpm package" {
+	grep -q '"@deepseek-ai/dsh"' "$SETS"
+	grep -q '"@deepseek-ai/dsh"' "$REPO_ROOT/chezmoi/.chezmoidata/pnpm_global.yaml"
+	grep -q '"@deepseek-ai/dsh"' "$REPO_ROOT/windows/pnpm/packages.json"
+	grep -q 'command = "dsh";' "$SETS"
+}
+
 @test "cross-platform applications are not classified as Windows-only" {
 	windows_only="$(sed -n '/windowsOnly = {/,/^  };/p' "$SETS")"
 	for package_id in \

--- a/windows/pnpm/packages.json
+++ b/windows/pnpm/packages.json
@@ -18,6 +18,13 @@
       }
     },
     {
+      "name": "@deepseek-ai/dsh",
+      "verifyCommand": {
+        "args": ["--version"],
+        "command": "dsh"
+      }
+    },
+    {
       "name": "@playwright/cli@0.1.14",
       "verifyCommand": {
         "args": ["--version"],


### PR DESCRIPTION
## Summary

- Add `@deepseek-ai/dsh` to the cross-platform pnpm package flow for macOS, Linux/NixOS, WSL, and Windows.
- Verify the installed CLI with `dsh --version`.
- Switch the Nix catalog from `pkgs.nodejs_24` to `pkgs.nodejs` so Node.js follows the current nixpkgs major.
- Do not distribute DeepSeek API keys; configure them in dsh Web UI as documented upstream.

## Validation

- `bats tests/bash/package_catalog.bats` — 24/24 passed
- `nix fmt -- --ci` — passed
- `nix build .#package-support-report --no-link` — passed
- Generated Windows manifests — byte-for-byte match
- Focused pre-commit — passed; Docker-only Hermes hook skipped because Docker daemon was unavailable

The full local POSIX suite had 268/284 passing; 16 existing macOS installer mock tests failed on the clean base with the same Ollama credential-file error and are unrelated to this diff.