### PR TITLE
fix: approve dsh native pnpm builds

### DIFF
--- a/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl
@@ -23,17 +23,29 @@ fi
 FAILED=0
 INSTALLED=0
 SKIPPED=0
+PNPM_BUILD_ARGS=()
 
 {{ range .pnpm_global_packages -}}
 # {{ . }}
 PKG_NAME="{{ . }}"
+if [ "$PKG_NAME" = "@deepseek-ai/dsh" ]; then
+  PNPM_BUILD_ARGS=(
+    "--allow-build=@deepseek-ai/dsh-subprocess-local"
+    "--allow-build=@google/genai"
+    "--allow-build=koffi"
+    "--allow-build=node-pty"
+    "--allow-build=protobufjs"
+  )
+else
+  PNPM_BUILD_ARGS=()
+fi
 PKG_DIR="${PKG_NAME#@*/}"  # scoped package → scope removed for dir check
 if [ -n "$GLOBAL_ROOT" ] && [ -d "$GLOBAL_ROOT/$PKG_NAME" ]; then
   echo "  スキップ (インストール済み): $PKG_NAME"
   SKIPPED=$((SKIPPED + 1))
 else
   echo "  インストール中: $PKG_NAME"
-  if pnpm add -g "$PKG_NAME"; then
+  if pnpm add -g "${PNPM_BUILD_ARGS[@]}" "$PKG_NAME"; then
     echo "  ✓ $PKG_NAME"
     INSTALLED=$((INSTALLED + 1))
   else

--- a/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl
@@ -40,10 +40,22 @@ else
   PNPM_BUILD_ARGS=()
 fi
 PKG_DIR="${PKG_NAME#@*/}"  # scoped package → scope removed for dir check
+INSTALL_REQUIRED=1
+REMOVE_FAILED=0
 if [ -n "$GLOBAL_ROOT" ] && [ -d "$GLOBAL_ROOT/$PKG_NAME" ]; then
-  echo "  スキップ (インストール済み): $PKG_NAME"
-  SKIPPED=$((SKIPPED + 1))
-else
+  if [ "$PKG_NAME" = "@deepseek-ai/dsh" ]; then
+    echo "  再インストール (native build approval を適用): $PKG_NAME"
+    if ! pnpm remove -g "$PKG_NAME"; then
+      echo "  ✗ $PKG_NAME の既存インストール削除に失敗しました"
+      REMOVE_FAILED=1
+    fi
+  else
+    echo "  スキップ (インストール済み): $PKG_NAME"
+    SKIPPED=$((SKIPPED + 1))
+    INSTALL_REQUIRED=0
+  fi
+fi
+if [ "$INSTALL_REQUIRED" -eq 1 ] && [ "$REMOVE_FAILED" -eq 0 ]; then
   echo "  インストール中: $PKG_NAME"
   if pnpm add -g "${PNPM_BUILD_ARGS[@]}" "$PKG_NAME"; then
     echo "  ✓ $PKG_NAME"
@@ -52,6 +64,8 @@ else
     echo "  ✗ $PKG_NAME のインストールに失敗しました"
     FAILED=$((FAILED + 1))
   fi
+elif [ "$REMOVE_FAILED" -eq 1 ]; then
+  FAILED=$((FAILED + 1))
 fi
 
 {{ end -}}

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -990,6 +990,13 @@ lib.mapAttrs (_: resolve) grouped
 
   # Extra pnpm install arguments for packages that need approved native builds.
   pnpmInstallArgs = {
+    "@deepseek-ai/dsh" = [
+      "--allow-build=@deepseek-ai/dsh-subprocess-local"
+      "--allow-build=@google/genai"
+      "--allow-build=koffi"
+      "--allow-build=node-pty"
+      "--allow-build=protobufjs"
+    ];
     "@google/gemini-cli" = [
       "--allow-build=@github/keytar"
       "--allow-build=node-pty"

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -32,6 +32,20 @@ setup() {
 	grep -q 'command = "dsh";' "$SETS"
 }
 
+@test "DeepSeek Harness native builds are pre-approved for pnpm global installs" {
+	for build_package in \
+		"@deepseek-ai/dsh-subprocess-local" \
+		"@google/genai" \
+		koffi \
+		node-pty \
+		protobufjs; do
+		grep -q -- "--allow-build=$build_package" "$SETS"
+		grep -q -- "--allow-build=$build_package" "$REPO_ROOT/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl"
+		grep -q -- "--allow-build=$build_package" "$REPO_ROOT/windows/pnpm/packages.json"
+	done
+	grep -q 'pnpm add -g.*PNPM_BUILD_ARGS' "$REPO_ROOT/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl"
+}
+
 @test "cross-platform applications are not classified as Windows-only" {
 	windows_only="$(sed -n '/windowsOnly = {/,/^  };/p' "$SETS")"
 	for package_id in \

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -46,6 +46,10 @@ setup() {
 	grep -q 'pnpm add -g.*PNPM_BUILD_ARGS' "$REPO_ROOT/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl"
 }
 
+@test "DeepSeek Harness is reinstalled when the native build approval changes" {
+	grep -q 'pnpm remove -g.*PKG_NAME' "$REPO_ROOT/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl"
+}
+
 @test "cross-platform applications are not classified as Windows-only" {
 	windows_only="$(sed -n '/windowsOnly = {/,/^  };/p' "$SETS")"
 	for package_id in \

--- a/windows/pnpm/packages.json
+++ b/windows/pnpm/packages.json
@@ -18,6 +18,13 @@
       }
     },
     {
+      "installArgs": [
+        "--allow-build=@deepseek-ai/dsh-subprocess-local",
+        "--allow-build=@google/genai",
+        "--allow-build=koffi",
+        "--allow-build=node-pty",
+        "--allow-build=protobufjs"
+      ],
       "name": "@deepseek-ai/dsh",
       "verifyCommand": {
         "args": ["--version"],


### PR DESCRIPTION
## Description

`@deepseek-ai/dsh` のグローバルpnpmインストール時に、依存パッケージのビルド承認プロンプトが表示されないようにする。Nixのpnpm install argsをSSOTとして、Unixのchezmoiインストーラーと生成済みWindowsマニフェストへ反映する。

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change or documentation update

## Checklist

- [x] Self-review completed
- [x] Added regression coverage
- [x] Relevant local tests pass
- [x] Generated Windows manifest matches Nix output

## Validation

- `bats tests/bash/package_catalog.bats` — 25/25 passed
- `pre-commit run --files ...` — passed
- `nix build .#winget-export --no-link` — generated pnpm manifest matches
- Full `task test` reached 148 successful cases, then was interrupted because `install_macos.bats` entered a live `ollama pull qwen3.6:35b` path; no assertion failure occurred before that external wait.