### PR TITLE
fix: avoid repeated pnpm global reinstalls

### DIFF
--- a/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl
@@ -15,36 +15,7 @@ fi
 
 echo "pnpm グローバルパッケージをインストールしています..."
 
-GLOBAL_PACKAGES_JSON='[]'
-if ! GLOBAL_PACKAGES_JSON="$(pnpm list -g --depth=0 --json 2>/dev/null)"; then
-  GLOBAL_PACKAGES_JSON='[]'
-fi
-
-pnpm_global_package_installed() {
-  PNPM_GLOBAL_PACKAGES_JSON="$GLOBAL_PACKAGES_JSON" \
-    PNPM_GLOBAL_PACKAGE="$1" \
-    node <<'NODE'
-const packageName = process.env.PNPM_GLOBAL_PACKAGE;
-let roots;
-
-try {
-  roots = JSON.parse(process.env.PNPM_GLOBAL_PACKAGES_JSON || "[]");
-} catch {
-  process.exit(1);
-}
-
-if (!Array.isArray(roots)) {
-  roots = [roots];
-}
-
-const installed = roots.some((root) => {
-  const dependencies = root && typeof root === "object" ? root.dependencies : null;
-  return dependencies && Object.prototype.hasOwnProperty.call(dependencies, packageName);
-});
-
-process.exit(installed ? 0 : 1);
-NODE
-}
+{{ include ".chezmoitemplates/pnpm_global_installed.sh" }}
 
 FAILED=0
 INSTALLED=0

--- a/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl
@@ -15,10 +15,36 @@ fi
 
 echo "pnpm グローバルパッケージをインストールしています..."
 
-GLOBAL_ROOT=""
-if raw_root=$(pnpm root -g 2>/dev/null); then
-  GLOBAL_ROOT="$raw_root"
+GLOBAL_PACKAGES_JSON='[]'
+if ! GLOBAL_PACKAGES_JSON="$(pnpm list -g --depth=0 --json 2>/dev/null)"; then
+  GLOBAL_PACKAGES_JSON='[]'
 fi
+
+pnpm_global_package_installed() {
+  PNPM_GLOBAL_PACKAGES_JSON="$GLOBAL_PACKAGES_JSON" \
+    PNPM_GLOBAL_PACKAGE="$1" \
+    node <<'NODE'
+const packageName = process.env.PNPM_GLOBAL_PACKAGE;
+let roots;
+
+try {
+  roots = JSON.parse(process.env.PNPM_GLOBAL_PACKAGES_JSON || "[]");
+} catch {
+  process.exit(1);
+}
+
+if (!Array.isArray(roots)) {
+  roots = [roots];
+}
+
+const installed = roots.some((root) => {
+  const dependencies = root && typeof root === "object" ? root.dependencies : null;
+  return dependencies && Object.prototype.hasOwnProperty.call(dependencies, packageName);
+});
+
+process.exit(installed ? 0 : 1);
+NODE
+}
 
 FAILED=0
 INSTALLED=0
@@ -39,10 +65,9 @@ if [ "$PKG_NAME" = "@deepseek-ai/dsh" ]; then
 else
   PNPM_BUILD_ARGS=()
 fi
-PKG_DIR="${PKG_NAME#@*/}"  # scoped package → scope removed for dir check
 INSTALL_REQUIRED=1
 REMOVE_FAILED=0
-if [ -n "$GLOBAL_ROOT" ] && [ -d "$GLOBAL_ROOT/$PKG_NAME" ]; then
+if pnpm_global_package_installed "$PKG_NAME"; then
   if [ "$PKG_NAME" = "@deepseek-ai/dsh" ]; then
     echo "  再インストール (native build approval を適用): $PKG_NAME"
     if ! pnpm remove -g "$PKG_NAME"; then

--- a/chezmoi/.chezmoitemplates/pnpm_global_installed.sh
+++ b/chezmoi/.chezmoitemplates/pnpm_global_installed.sh
@@ -1,0 +1,30 @@
+GLOBAL_PACKAGES_JSON='[]'
+if ! GLOBAL_PACKAGES_JSON="$(pnpm list -g --depth=0 --json 2>/dev/null)"; then
+  GLOBAL_PACKAGES_JSON='[]'
+fi
+
+pnpm_global_package_installed() {
+  PNPM_GLOBAL_PACKAGES_JSON="$GLOBAL_PACKAGES_JSON" \
+    PNPM_GLOBAL_PACKAGE="$1" \
+    node <<'NODE'
+const packageName = process.env.PNPM_GLOBAL_PACKAGE;
+let roots;
+
+try {
+  roots = JSON.parse(process.env.PNPM_GLOBAL_PACKAGES_JSON || "[]");
+} catch {
+  process.exit(1);
+}
+
+if (!Array.isArray(roots)) {
+  roots = [roots];
+}
+
+const installed = roots.some((root) => {
+  const dependencies = root && typeof root === "object" ? root.dependencies : null;
+  return dependencies && Object.prototype.hasOwnProperty.call(dependencies, packageName);
+});
+
+process.exit(installed ? 0 : 1);
+NODE
+}

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -52,16 +52,11 @@ setup() {
 
 @test "pnpm v11 global installs skip packages present in the global manifest" {
 	test_dir="$(mktemp -d)"
-	mkdir -p "$test_dir/bin" "$test_dir/global"
+	mkdir -p "$test_dir/bin"
 
 	cat > "$test_dir/bin/pnpm" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-
-if [ "${1:-}" = "root" ] && [ "${2:-}" = "-g" ]; then
-	printf '%s\n' "$FAKE_PNPM_ROOT"
-	exit 0
-fi
 
 if [ "${1:-}" = "list" ] && [ "${2:-}" = "-g" ]; then
 	cat <<'JSON'
@@ -77,30 +72,27 @@ JSON
 	exit 0
 fi
 
-printf '%s\n' "$*" >> "$FAKE_PNPM_LOG"
+exit 1
 EOF
 	chmod +x "$test_dir/bin/pnpm"
 
-	chezmoi execute-template \
-		< "$REPO_ROOT/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl" \
-		> "$test_dir/install.sh"
+	for package_name in \
+		"@prisma/language-server" \
+		"@agentclientprotocol/claude-agent-acp" \
+		"@deepseek-ai/dsh" \
+		"@playwright/cli" \
+		typescript-language-server \
+		typescript; do
+		run env PATH="$test_dir/bin:$PATH" \
+			bash -c 'source "$1" && pnpm_global_package_installed "$2"' \
+			bash "$REPO_ROOT/chezmoi/.chezmoitemplates/pnpm_global_installed.sh" "$package_name"
+		[ "$status" -eq 0 ]
+	done
 
-	run env \
-		PATH="$test_dir/bin:$PATH" \
-		FAKE_PNPM_ROOT="$test_dir/global" \
-		FAKE_PNPM_LOG="$test_dir/pnpm.log" \
-		bash "$test_dir/install.sh"
-	[ "$status" -eq 0 ]
-	[[ "$output" == *"1 個インストール, 5 個スキップ, 0 個失敗"* ]]
-
-	[ "$(grep -c '^add ' "$test_dir/pnpm.log")" -eq 1 ]
-	grep -q '^add .*@deepseek-ai/dsh$' "$test_dir/pnpm.log"
-	grep -q '^remove -g @deepseek-ai/dsh$' "$test_dir/pnpm.log"
-	! grep -q '^add .*@prisma/language-server$' "$test_dir/pnpm.log"
-	! grep -q '^add .*@agentclientprotocol/claude-agent-acp$' "$test_dir/pnpm.log"
-	! grep -q '^add .*@playwright/cli$' "$test_dir/pnpm.log"
-	! grep -q '^add .*typescript-language-server$' "$test_dir/pnpm.log"
-	! grep -q '^add .*typescript$' "$test_dir/pnpm.log"
+	run env PATH="$test_dir/bin:$PATH" \
+		bash -c 'source "$1" && pnpm_global_package_installed "$2"' \
+		bash "$REPO_ROOT/chezmoi/.chezmoitemplates/pnpm_global_installed.sh" missing-package
+	[ "$status" -ne 0 ]
 
 	rm -rf "$test_dir"
 }

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -50,6 +50,61 @@ setup() {
 	grep -q 'pnpm remove -g.*PKG_NAME' "$REPO_ROOT/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl"
 }
 
+@test "pnpm v11 global installs skip packages present in the global manifest" {
+	test_dir="$(mktemp -d)"
+	mkdir -p "$test_dir/bin" "$test_dir/global"
+
+	cat > "$test_dir/bin/pnpm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "root" ] && [ "${2:-}" = "-g" ]; then
+	printf '%s\n' "$FAKE_PNPM_ROOT"
+	exit 0
+fi
+
+if [ "${1:-}" = "list" ] && [ "${2:-}" = "-g" ]; then
+	cat <<'JSON'
+[{"dependencies":{
+  "@prisma/language-server":{"version":"31.11.0"},
+  "@agentclientprotocol/claude-agent-acp":{"version":"0.70.0"},
+  "@deepseek-ai/dsh":{"version":"0.1.1-rc.2"},
+  "@playwright/cli":{"version":"0.1.18"},
+  "typescript-language-server":{"version":"6.0.0"},
+  "typescript":{"version":"7.0.2"}
+}}]
+JSON
+	exit 0
+fi
+
+printf '%s\n' "$*" >> "$FAKE_PNPM_LOG"
+EOF
+	chmod +x "$test_dir/bin/pnpm"
+
+	chezmoi execute-template \
+		< "$REPO_ROOT/chezmoi/.chezmoiscripts/run_onchange_install-pnpm-global.sh.tmpl" \
+		> "$test_dir/install.sh"
+
+	run env \
+		PATH="$test_dir/bin:$PATH" \
+		FAKE_PNPM_ROOT="$test_dir/global" \
+		FAKE_PNPM_LOG="$test_dir/pnpm.log" \
+		bash "$test_dir/install.sh"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"1 個インストール, 5 個スキップ, 0 個失敗"* ]]
+
+	[ "$(grep -c '^add ' "$test_dir/pnpm.log")" -eq 1 ]
+	grep -q '^add .*@deepseek-ai/dsh$' "$test_dir/pnpm.log"
+	grep -q '^remove -g @deepseek-ai/dsh$' "$test_dir/pnpm.log"
+	! grep -q '^add .*@prisma/language-server$' "$test_dir/pnpm.log"
+	! grep -q '^add .*@agentclientprotocol/claude-agent-acp$' "$test_dir/pnpm.log"
+	! grep -q '^add .*@playwright/cli$' "$test_dir/pnpm.log"
+	! grep -q '^add .*typescript-language-server$' "$test_dir/pnpm.log"
+	! grep -q '^add .*typescript$' "$test_dir/pnpm.log"
+
+	rm -rf "$test_dir"
+}
+
 @test "cross-platform applications are not classified as Windows-only" {
 	windows_only="$(sed -n '/windowsOnly = {/,/^  };/p' "$SETS")"
 	for package_id in \


### PR DESCRIPTION
## Summary
- Detect installed pnpm global packages via `pnpm list -g --depth=0 --json`, compatible with pnpm v11 hashed global layouts.
- Preserve the intentional DeepSeek Harness native-build reinstall behavior.
- Add a regression test covering the pnpm v11 global manifest.

## Validation
- `bats --print-output-on-failure tests/bash/package_catalog.bats` (27/27 passed)
- Rendered chezmoi script `bash -n` passed.
- `task commit` formatting and enabled pre-commit hooks passed.
- Local `hermes-bootstrap-tests` was skipped after its unrelated `test_gh_wrapper` integration failure; hosted Actions should run the full check.