### PR TITLE
fix: handle GitHub bootstrap username prompts

### DIFF
--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/git.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/git.py
@@ -196,7 +196,13 @@ def _create_askpass(workdir: Path) -> Path:
         os.fchmod(descriptor, 0o700)
         with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
             descriptor = -1
-            handle.write("#!/bin/sh\nexec printf '%s\\n' \"$HERMES_BOOTSTRAP_GITHUB_TOKEN\"\n")
+            handle.write(
+                "#!/bin/sh\n"
+                "case \"${1-}\" in\n"
+                "  *[Uu]sername*) exec printf '%s\\n' 'x-access-token' ;;\n"
+                "  *) exec printf '%s\\n' \"$HERMES_BOOTSTRAP_GITHUB_TOKEN\" ;;\n"
+                "esac\n"
+            )
             handle.flush()
             os.fsync(handle.fileno())
         return path

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/git.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/git.py
@@ -199,7 +199,7 @@ def _create_askpass(workdir: Path) -> Path:
             handle.write(
                 "#!/bin/sh\n"
                 "case \"${1-}\" in\n"
-                "  *[Uu]sername*) exec printf '%s\\n' 'x-access-token' ;;\n"
+                "  [Uu]sername*) exec printf '%s\\n' 'x-access-token' ;;\n"
                 "  *) exec printf '%s\\n' \"$HERMES_BOOTSTRAP_GITHUB_TOKEN\" ;;\n"
                 "esac\n"
             )

--- a/docker/hermes-agent/bootstrap/tests/test_repositories.py
+++ b/docker/hermes-agent/bootstrap/tests/test_repositories.py
@@ -19,6 +19,7 @@ from unittest import mock
 
 import hermes_bootstrap.repositories as repositories_module
 from hermes_bootstrap.errors import MigrationError, RepositoryError
+from hermes_bootstrap.git import _create_askpass
 from hermes_bootstrap.github import GitAuth
 from hermes_bootstrap.models import BootstrapManifest, SharedRepository
 from hermes_bootstrap.payload import SecretRedactor
@@ -170,6 +171,32 @@ class RepositoryTests(unittest.TestCase):
         self.assertNotIn(result.working_tree, transaction.snapshots)
         self.assertNotIn(repo.legacy_target, transaction.snapshots)
         self.assertFalse(os.path.lexists(repo.legacy_target))
+
+    def test_github_askpass_uses_token_username_for_username_prompt(self) -> None:
+        askpass = _create_askpass(self.root)
+        environment = {"HERMES_BOOTSTRAP_GITHUB_TOKEN": self.auth.token}
+        try:
+            username = subprocess.run(
+                (str(askpass), "Username for 'https://github.com':"),
+                check=True,
+                env=environment,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            password = subprocess.run(
+                (str(askpass), "Password for 'https://github.com':"),
+                check=True,
+                env=environment,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        finally:
+            askpass.unlink()
+
+        self.assertEqual(username.stdout, "x-access-token\n")
+        self.assertEqual(password.stdout, f"{self.auth.token}\n")
 
     def test_initial_publication_release_failure_rolls_back_and_can_retry(self) -> None:
         repo = self.repository()

--- a/docker/hermes-agent/bootstrap/tests/test_repositories.py
+++ b/docker/hermes-agent/bootstrap/tests/test_repositories.py
@@ -185,7 +185,7 @@ class RepositoryTests(unittest.TestCase):
                 text=True,
             )
             password = subprocess.run(
-                (str(askpass), "Password for 'https://github.com':"),
+                (str(askpass), "Password for 'https://myusername@github.com':"),
                 check=True,
                 env=environment,
                 stdout=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- return x-access-token for GitHub username prompts and the bootstrap token for password prompts
- add a regression test for the askpass contract

## Validation
- Hermes bootstrap container suite: 630 tests passed, 3 skipped
- Hindsight provider gate: passed
- Live Hermes bootstrap with the task8 data root: applied

The local macOS Docker Desktop gh-wrapper shell test is environment-sensitive; the required Linux GitHub Actions workflow is the merge gate.