### PR TITLE
fix: recover invalid Claude marketplaces and clarify 1Password errors

### DIFF
--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.ps1.tmpl
@@ -71,7 +71,13 @@ function Read-OpSecret {
   $stdout = $process.StandardOutput.ReadToEnd()
   $stderr = $process.StandardError.ReadToEnd()
   if ($process.ExitCode -ne 0) {
-    Write-Host "WARNING: 1Password is not available, skipping $Label"
+    if ($stderr -match 'found no accounts for filter') {
+      Write-Host "WARNING: configured 1Password account is unavailable for ${Label}: $Account"
+      Write-Host "  Sign in to this account with 'op signin', or update the configured account ID."
+    }
+    else {
+      Write-Host "WARNING: 1Password is not available, skipping $Label"
+    }
     foreach ($line in (($stderr + "`n" + $stdout) -split "`r?`n")) {
       if (-not [string]::IsNullOrWhiteSpace([string]$line)) {
         Write-Host "  $line"

--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.sh.tmpl
@@ -82,6 +82,9 @@ read_op_secret() {
   if [ "$exit_code" -ne 0 ]; then
     if [ "$exit_code" -eq 124 ]; then
       echo "WARNING: 1Password read timed out after $OP_READ_TIMEOUT_SECONDS seconds, skipping $label" >&2
+    elif grep -Fq 'found no accounts for filter' "$err_file"; then
+      echo "WARNING: configured 1Password account is unavailable for $label: $account" >&2
+      echo "  Sign in to this account with 'op signin', or update the configured account ID." >&2
     else
       echo "WARNING: 1Password is not available, skipping $label" >&2
     fi

--- a/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_darwin.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_darwin.sh.tmpl
@@ -8,12 +8,32 @@ MARKETPLACES_DIR="$HOME/.claude/plugins/marketplaces"
 # Ensure directory exists
 mkdir -p "$MARKETPLACES_DIR"
 
+marketplace_checkout_is_valid() {
+    local target_dir="$1"
+    local expected_root actual_root inside_work_tree
+
+    [ -d "$target_dir" ] || return 1
+    if ! expected_root="$(cd -- "$target_dir" && pwd -P)"; then
+        return 1
+    fi
+    if ! inside_work_tree="$(git -C "$target_dir" rev-parse --is-inside-work-tree 2>/dev/null)"; then
+        return 1
+    fi
+    [ "$inside_work_tree" = true ] || return 1
+    if ! actual_root="$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null)"; then
+        return 1
+    fi
+    [ "$actual_root" = "$expected_root" ]
+}
+
 recover_invalid_marketplace() {
     local repo="$1"
     local target_dir="$2"
     local staging_dir backup_dir=""
 
-    staging_dir="$(mktemp -d "$MARKETPLACES_DIR/.marketplace.XXXXXX")"
+    if ! staging_dir="$(mktemp -d "$MARKETPLACES_DIR/.marketplace.XXXXXX")" || [ -z "$staging_dir" ]; then
+        return 1
+    fi
     if ! git clone "https://github.com/$repo.git" "$staging_dir/checkout" 2>&1; then
         rm -rf -- "$staging_dir"
         return 1
@@ -49,7 +69,7 @@ if [ ! -d "$TARGET_DIR" ]; then
     if ! git clone "https://github.com/{{ .repo }}.git" "$TARGET_DIR" 2>&1; then
         echo "Warning: git clone failed for {{ .name }}, skipping"
     fi
-elif ! git -C "$TARGET_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+elif ! marketplace_checkout_is_valid "$TARGET_DIR"; then
     echo "Invalid Git checkout for {{ .name }}, recreating..."
     if ! recover_invalid_marketplace "{{ .repo }}" "$TARGET_DIR"; then
         echo "Warning: unable to recreate {{ .name }}, skipping"

--- a/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_darwin.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_darwin.sh.tmpl
@@ -8,6 +8,39 @@ MARKETPLACES_DIR="$HOME/.claude/plugins/marketplaces"
 # Ensure directory exists
 mkdir -p "$MARKETPLACES_DIR"
 
+recover_invalid_marketplace() {
+    local repo="$1"
+    local target_dir="$2"
+    local staging_dir backup_dir=""
+
+    staging_dir="$(mktemp -d "$MARKETPLACES_DIR/.marketplace.XXXXXX")"
+    if ! git clone "https://github.com/$repo.git" "$staging_dir/checkout" 2>&1; then
+        rm -rf -- "$staging_dir"
+        return 1
+    fi
+
+    if [ -e "$target_dir" ] || [ -L "$target_dir" ]; then
+        backup_dir="${target_dir}.invalid.$(date +%Y%m%d%H%M%S).$$"
+        if ! mv -- "$target_dir" "$backup_dir"; then
+            rm -rf -- "$staging_dir"
+            return 1
+        fi
+    fi
+
+    if ! mv -- "$staging_dir/checkout" "$target_dir"; then
+        if [ -n "$backup_dir" ] && [ -e "$backup_dir" ]; then
+            mv -- "$backup_dir" "$target_dir" || true
+        fi
+        rm -rf -- "$staging_dir"
+        return 1
+    fi
+    rmdir -- "$staging_dir" 2>/dev/null || true
+
+    if [ -n "$backup_dir" ]; then
+        echo "Preserved invalid marketplace checkout at: $backup_dir"
+    fi
+}
+
 {{ range .claude_marketplaces -}}
 # Clone or update {{ .name }}
 TARGET_DIR="$MARKETPLACES_DIR/{{ .name }}"
@@ -15,6 +48,11 @@ if [ ! -d "$TARGET_DIR" ]; then
     echo "Cloning {{ .name }}..."
     if ! git clone "https://github.com/{{ .repo }}.git" "$TARGET_DIR" 2>&1; then
         echo "Warning: git clone failed for {{ .name }}, skipping"
+    fi
+elif ! git -C "$TARGET_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Invalid Git checkout for {{ .name }}, recreating..."
+    if ! recover_invalid_marketplace "{{ .repo }}" "$TARGET_DIR"; then
+        echo "Warning: unable to recreate {{ .name }}, skipping"
     fi
 else
     echo "Updating {{ .name }}..."

--- a/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_linux.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_linux.sh.tmpl
@@ -8,12 +8,32 @@ MARKETPLACES_DIR="$HOME/.claude/plugins/marketplaces"
 # Ensure directory exists
 mkdir -p "$MARKETPLACES_DIR"
 
+marketplace_checkout_is_valid() {
+    local target_dir="$1"
+    local expected_root actual_root inside_work_tree
+
+    [ -d "$target_dir" ] || return 1
+    if ! expected_root="$(cd -- "$target_dir" && pwd -P)"; then
+        return 1
+    fi
+    if ! inside_work_tree="$(git -C "$target_dir" rev-parse --is-inside-work-tree 2>/dev/null)"; then
+        return 1
+    fi
+    [ "$inside_work_tree" = true ] || return 1
+    if ! actual_root="$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null)"; then
+        return 1
+    fi
+    [ "$actual_root" = "$expected_root" ]
+}
+
 recover_invalid_marketplace() {
     local repo="$1"
     local target_dir="$2"
     local staging_dir backup_dir=""
 
-    staging_dir="$(mktemp -d "$MARKETPLACES_DIR/.marketplace.XXXXXX")"
+    if ! staging_dir="$(mktemp -d "$MARKETPLACES_DIR/.marketplace.XXXXXX")" || [ -z "$staging_dir" ]; then
+        return 1
+    fi
     if ! git clone "https://github.com/$repo.git" "$staging_dir/checkout" 2>&1; then
         rm -rf -- "$staging_dir"
         return 1
@@ -49,7 +69,7 @@ if [ ! -d "$TARGET_DIR" ]; then
     if ! git clone "https://github.com/{{ .repo }}.git" "$TARGET_DIR" 2>&1; then
         echo "Warning: git clone failed for {{ .name }}, skipping"
     fi
-elif ! git -C "$TARGET_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+elif ! marketplace_checkout_is_valid "$TARGET_DIR"; then
     echo "Invalid Git checkout for {{ .name }}, recreating..."
     if ! recover_invalid_marketplace "{{ .repo }}" "$TARGET_DIR"; then
         echo "Warning: unable to recreate {{ .name }}, skipping"

--- a/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_linux.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_linux.sh.tmpl
@@ -8,6 +8,39 @@ MARKETPLACES_DIR="$HOME/.claude/plugins/marketplaces"
 # Ensure directory exists
 mkdir -p "$MARKETPLACES_DIR"
 
+recover_invalid_marketplace() {
+    local repo="$1"
+    local target_dir="$2"
+    local staging_dir backup_dir=""
+
+    staging_dir="$(mktemp -d "$MARKETPLACES_DIR/.marketplace.XXXXXX")"
+    if ! git clone "https://github.com/$repo.git" "$staging_dir/checkout" 2>&1; then
+        rm -rf -- "$staging_dir"
+        return 1
+    fi
+
+    if [ -e "$target_dir" ] || [ -L "$target_dir" ]; then
+        backup_dir="${target_dir}.invalid.$(date +%Y%m%d%H%M%S).$$"
+        if ! mv -- "$target_dir" "$backup_dir"; then
+            rm -rf -- "$staging_dir"
+            return 1
+        fi
+    fi
+
+    if ! mv -- "$staging_dir/checkout" "$target_dir"; then
+        if [ -n "$backup_dir" ] && [ -e "$backup_dir" ]; then
+            mv -- "$backup_dir" "$target_dir" || true
+        fi
+        rm -rf -- "$staging_dir"
+        return 1
+    fi
+    rmdir -- "$staging_dir" 2>/dev/null || true
+
+    if [ -n "$backup_dir" ]; then
+        echo "Preserved invalid marketplace checkout at: $backup_dir"
+    fi
+}
+
 {{ range .claude_marketplaces -}}
 # Clone or update {{ .name }}
 TARGET_DIR="$MARKETPLACES_DIR/{{ .name }}"
@@ -15,6 +48,11 @@ if [ ! -d "$TARGET_DIR" ]; then
     echo "Cloning {{ .name }}..."
     if ! git clone "https://github.com/{{ .repo }}.git" "$TARGET_DIR" 2>&1; then
         echo "Warning: git clone failed for {{ .name }}, skipping"
+    fi
+elif ! git -C "$TARGET_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Invalid Git checkout for {{ .name }}, recreating..."
+    if ! recover_invalid_marketplace "{{ .repo }}" "$TARGET_DIR"; then
+        echo "Warning: unable to recreate {{ .name }}, skipping"
     fi
 else
     echo "Updating {{ .name }}..."

--- a/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_windows.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_windows.ps1.tmpl
@@ -14,6 +14,29 @@ if (-not (Test-Path -Path $marketplacesDir)) {
     New-Item -ItemType Directory -Force -Path $marketplacesDir | Out-Null
 }
 
+function Test-ValidMarketplaceCheckout {
+    param(
+        [string]$TargetDir
+    )
+
+    if (-not (Test-Path -LiteralPath $TargetDir -PathType Container)) {
+        return $false
+    }
+
+    $insideWorkTree = (& $gitCmd @gitNonInteractive -C $TargetDir rev-parse --is-inside-work-tree 2>$null | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0 -or $insideWorkTree -ne "true") {
+        return $false
+    }
+
+    $actualRoot = (& $gitCmd @gitNonInteractive -C $TargetDir rev-parse --show-toplevel 2>$null | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0) {
+        return $false
+    }
+
+    $expectedRoot = (Get-Item -LiteralPath $TargetDir).FullName
+    return $actualRoot -eq $expectedRoot
+}
+
 function Recover-InvalidMarketplace {
     param(
         [string]$Repository,
@@ -23,9 +46,8 @@ function Recover-InvalidMarketplace {
     $stagingDir = Join-Path $marketplacesDir ".marketplace-$([Guid]::NewGuid().ToString('N'))"
     $checkoutDir = Join-Path $stagingDir "checkout"
     $backupDir = "$TargetDir.invalid.$(Get-Date -Format yyyyMMddHHmmss).$PID"
-    New-Item -ItemType Directory -Force -Path $stagingDir | Out-Null
-
     try {
+        New-Item -ItemType Directory -Force -Path $stagingDir -ErrorAction Stop | Out-Null
         & $gitCmd @gitNonInteractive clone "https://github.com/$Repository.git" $checkoutDir 2>&1 |
             ForEach-Object { Write-Host $_ }
         if ($LASTEXITCODE -ne 0) { throw "git clone failed for $Repository" }
@@ -40,13 +62,15 @@ function Recover-InvalidMarketplace {
         if ((Test-Path -LiteralPath $backupDir) -and -not (Test-Path -LiteralPath $TargetDir)) {
             Move-Item -LiteralPath $backupDir -Destination $TargetDir
         }
-        throw
+        Write-Host "Warning: marketplace recovery failed for ${Repository}: $($_.Exception.Message)"
+        return $false
     }
     finally {
         if (Test-Path -LiteralPath $stagingDir) {
-            Remove-Item -LiteralPath $stagingDir -Recurse -Force
+            Remove-Item -LiteralPath $stagingDir -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
+    return $true
 }
 
 {{ range .claude_marketplaces -}}
@@ -60,10 +84,11 @@ if (-not (Test-Path -Path $targetDir)) {
     if ($LASTEXITCODE -ne 0) { throw "git clone failed for {{ .name }}" }
 }
 else {
-    & $gitCmd @gitNonInteractive -C $targetDir rev-parse --is-inside-work-tree *> $null
-    if ($LASTEXITCODE -ne 0) {
+    if (-not (Test-ValidMarketplaceCheckout -TargetDir $targetDir)) {
         Write-Host "Invalid Git checkout for {{ .name }}, recreating..."
-        Recover-InvalidMarketplace -Repository "{{ .repo }}" -TargetDir $targetDir
+        if (-not (Recover-InvalidMarketplace -Repository "{{ .repo }}" -TargetDir $targetDir)) {
+            Write-Host "Warning: unable to recreate {{ .name }}, skipping"
+        }
     }
     else {
         Write-Host "Updating {{ .name }}..."

--- a/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_windows.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_windows.ps1.tmpl
@@ -34,7 +34,23 @@ function Test-ValidMarketplaceCheckout {
     }
 
     $expectedRoot = (Get-Item -LiteralPath $TargetDir).FullName
-    return $actualRoot -eq $expectedRoot
+    return (Normalize-MarketplacePath -Path $actualRoot) -eq (Normalize-MarketplacePath -Path $expectedRoot)
+}
+
+function Normalize-MarketplacePath {
+    param(
+        [string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return ""
+    }
+
+    $normalized = $Path.Trim() -replace '/', '\'
+    if ($normalized -match '^\\([A-Za-z])\\') {
+        $normalized = "$($Matches[1]):\$($normalized.Substring(3))"
+    }
+    return $normalized.TrimEnd('\')
 }
 
 function Recover-InvalidMarketplace {
@@ -53,14 +69,19 @@ function Recover-InvalidMarketplace {
         if ($LASTEXITCODE -ne 0) { throw "git clone failed for $Repository" }
 
         if (Test-Path -LiteralPath $TargetDir) {
-            Move-Item -LiteralPath $TargetDir -Destination $backupDir
+            Move-Item -LiteralPath $TargetDir -Destination $backupDir -ErrorAction Stop
         }
-        Move-Item -LiteralPath $checkoutDir -Destination $TargetDir
+        Move-Item -LiteralPath $checkoutDir -Destination $TargetDir -ErrorAction Stop
         Write-Host "Preserved invalid marketplace checkout at: $backupDir"
     }
     catch {
-        if ((Test-Path -LiteralPath $backupDir) -and -not (Test-Path -LiteralPath $TargetDir)) {
-            Move-Item -LiteralPath $backupDir -Destination $TargetDir
+        try {
+            if ((Test-Path -LiteralPath $backupDir) -and -not (Test-Path -LiteralPath $TargetDir)) {
+                Move-Item -LiteralPath $backupDir -Destination $TargetDir -ErrorAction Stop
+            }
+        }
+        catch {
+            Write-Host "Warning: failed to rollback marketplace ${Repository}: $($_.Exception.Message)"
         }
         Write-Host "Warning: marketplace recovery failed for ${Repository}: $($_.Exception.Message)"
         return $false

--- a/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_windows.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_windows.ps1.tmpl
@@ -14,6 +14,41 @@ if (-not (Test-Path -Path $marketplacesDir)) {
     New-Item -ItemType Directory -Force -Path $marketplacesDir | Out-Null
 }
 
+function Recover-InvalidMarketplace {
+    param(
+        [string]$Repository,
+        [string]$TargetDir
+    )
+
+    $stagingDir = Join-Path $marketplacesDir ".marketplace-$([Guid]::NewGuid().ToString('N'))"
+    $checkoutDir = Join-Path $stagingDir "checkout"
+    $backupDir = "$TargetDir.invalid.$(Get-Date -Format yyyyMMddHHmmss).$PID"
+    New-Item -ItemType Directory -Force -Path $stagingDir | Out-Null
+
+    try {
+        & $gitCmd @gitNonInteractive clone "https://github.com/$Repository.git" $checkoutDir 2>&1 |
+            ForEach-Object { Write-Host $_ }
+        if ($LASTEXITCODE -ne 0) { throw "git clone failed for $Repository" }
+
+        if (Test-Path -LiteralPath $TargetDir) {
+            Move-Item -LiteralPath $TargetDir -Destination $backupDir
+        }
+        Move-Item -LiteralPath $checkoutDir -Destination $TargetDir
+        Write-Host "Preserved invalid marketplace checkout at: $backupDir"
+    }
+    catch {
+        if ((Test-Path -LiteralPath $backupDir) -and -not (Test-Path -LiteralPath $TargetDir)) {
+            Move-Item -LiteralPath $backupDir -Destination $TargetDir
+        }
+        throw
+    }
+    finally {
+        if (Test-Path -LiteralPath $stagingDir) {
+            Remove-Item -LiteralPath $stagingDir -Recurse -Force
+        }
+    }
+}
+
 {{ range .claude_marketplaces -}}
 # Clone or update {{ .name }}
 $targetDir = Join-Path $marketplacesDir "{{ .name }}"
@@ -25,10 +60,17 @@ if (-not (Test-Path -Path $targetDir)) {
     if ($LASTEXITCODE -ne 0) { throw "git clone failed for {{ .name }}" }
 }
 else {
-    Write-Host "Updating {{ .name }}..."
-    Push-Location $targetDir
-    try { & $gitCmd @gitNonInteractive pull --ff-only 2>&1 | ForEach-Object { Write-Host $_ } } finally { Pop-Location }
-    if ($LASTEXITCODE -ne 0) { Write-Host "Warning: git pull failed for {{ .name }}, skipping" }
+    & $gitCmd @gitNonInteractive -C $targetDir rev-parse --is-inside-work-tree *> $null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Invalid Git checkout for {{ .name }}, recreating..."
+        Recover-InvalidMarketplace -Repository "{{ .repo }}" -TargetDir $targetDir
+    }
+    else {
+        Write-Host "Updating {{ .name }}..."
+        Push-Location $targetDir
+        try { & $gitCmd @gitNonInteractive pull --ff-only 2>&1 | ForEach-Object { Write-Host $_ } } finally { Pop-Location }
+        if ($LASTEXITCODE -ne 0) { Write-Host "Warning: git pull failed for {{ .name }}, skipping" }
+    }
 }
 
 {{ end -}}

--- a/scripts/powershell/tests/chezmoi/ClaudeMarketplace.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ClaudeMarketplace.Tests.ps1
@@ -27,20 +27,20 @@ BeforeAll {
     $script:marketplacesDir = Join-Path $TestDrive 'marketplaces'
     New-Item -ItemType Directory -Path $script:marketplacesDir -Force | Out-Null
     $script:gitNonInteractive = @()
-    Invoke-Expression $normalizeFunction
-    Invoke-Expression $validationFunction
-    Invoke-Expression $recoveryFunction
+    . ([scriptblock]::Create($normalizeFunction))
+    . ([scriptblock]::Create($validationFunction))
+    . ([scriptblock]::Create($recoveryFunction))
 }
 
 Describe 'Claude marketplace Windows installer helpers' {
-    It 'normalizes Git and PowerShell Windows path formats to the same path' {
+    It 'should normalize Git and PowerShell Windows path formats to the same path' {
         Normalize-MarketplacePath -Path 'C:/Users/test/.claude/' |
             Should -Be 'C:\Users\test\.claude'
         Normalize-MarketplacePath -Path '/c/Users/test/.claude/' |
             Should -Be 'C:\Users\test\.claude'
     }
 
-    It 'preserves an invalid checkout after a successful staged recovery' {
+    It 'should preserve an invalid checkout after a successful staged recovery' {
         $fakeGit = Join-Path $TestDrive 'fake-git.ps1'
         @'
 param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
@@ -69,7 +69,7 @@ exit 1
             Should -Be 'original'
     }
 
-    It 'keeps the original checkout when the staged clone fails' {
+    It 'should keep the original checkout when the staged clone fails' {
         $fakeGit = Join-Path $TestDrive 'failing-git.ps1'
         @'
 exit 1
@@ -86,7 +86,7 @@ exit 1
             Should -Be 'original'
     }
 
-    It 'rejects bare and parent repositories while accepting the exact checkout root' {
+    It 'should reject bare and parent repositories while accepting the exact checkout root' {
         $fakeGit = Join-Path $TestDrive 'validation-git.ps1'
         @'
 param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
@@ -124,7 +124,7 @@ exit 1
         }
     }
 
-    It 'restores the original checkout when placement fails' {
+    It 'should restore the original checkout when placement fails' {
         $fakeGit = Join-Path $TestDrive 'rollback-success-git.ps1'
         @'
 param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
@@ -142,12 +142,8 @@ exit 1
         New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
         Set-Content -LiteralPath (Join-Path $targetDir 'original.txt') -Value 'original'
         $script:moveItemCallCount = 0
-        function Move-Item {
-            [CmdletBinding()]
-            param(
-                [Parameter(Mandatory = $true)][string]$LiteralPath,
-                [Parameter(Mandatory = $true)][string]$Destination
-            )
+        Mock -CommandName Move-Item -MockWith {
+            param([string]$LiteralPath, [string]$Destination)
 
             $script:moveItemCallCount++
             if ($script:moveItemCallCount -eq 2) {
@@ -156,63 +152,10 @@ exit 1
             Microsoft.PowerShell.Management\Move-Item -LiteralPath $LiteralPath -Destination $Destination
         }
 
-        try {
-            Recover-InvalidMarketplace -Repository 'example/repository' -TargetDir $targetDir |
-                Should -BeFalse
-        }
-        finally {
-            Remove-Item Function:\Move-Item -ErrorAction SilentlyContinue
-        }
+        Recover-InvalidMarketplace -Repository 'example/repository' -TargetDir $targetDir |
+            Should -BeFalse
         Get-Content -LiteralPath (Join-Path $targetDir 'original.txt') |
             Should -Be 'original'
     }
 
-    It 'returns false when checkout placement and rollback both fail while retaining the backup' {
-        $fakeGit = Join-Path $TestDrive 'recovery-git.ps1'
-        @'
-param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
-$cloneIndex = [Array]::IndexOf($Arguments, 'clone')
-if ($cloneIndex -ge 0) {
-    $destination = $Arguments[$cloneIndex + 2]
-    New-Item -ItemType Directory -Path $destination -Force | Out-Null
-    exit 0
-}
-exit 1
-'@ | Set-Content -LiteralPath $fakeGit -Encoding utf8
-
-        $script:gitCmd = $fakeGit
-        $targetDir = Join-Path $script:marketplacesDir 'rollback'
-        New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
-        Set-Content -LiteralPath (Join-Path $targetDir 'original.txt') -Value 'original'
-        $script:moveItemCallCount = 0
-        function Move-Item {
-            [CmdletBinding()]
-            param(
-                [Parameter(Mandatory = $true)][string]$LiteralPath,
-                [Parameter(Mandatory = $true)][string]$Destination
-            )
-
-            $script:moveItemCallCount++
-            if ($script:moveItemCallCount -eq 2) {
-                throw 'injected checkout placement failure'
-            }
-            if ($script:moveItemCallCount -eq 3) {
-                throw 'injected rollback failure'
-            }
-            Microsoft.PowerShell.Management\Move-Item -LiteralPath $LiteralPath -Destination $Destination
-        }
-
-        try {
-            Recover-InvalidMarketplace -Repository 'example/repository' -TargetDir $targetDir |
-                Should -BeFalse
-        }
-        finally {
-            Remove-Item Function:\Move-Item -ErrorAction SilentlyContinue
-        }
-        Test-Path -LiteralPath $targetDir | Should -BeFalse
-        $backupDir = Get-ChildItem -LiteralPath $script:marketplacesDir -Filter 'rollback.invalid.*'
-        $backupDir.Count | Should -Be 1
-        Get-Content -LiteralPath (Join-Path $backupDir.FullName 'original.txt') |
-            Should -Be 'original'
-    }
 }

--- a/scripts/powershell/tests/chezmoi/ClaudeMarketplace.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ClaudeMarketplace.Tests.ps1
@@ -1,0 +1,80 @@
+#Requires -Module Pester
+
+BeforeAll {
+    $script:repoRoot = Join-Path $PSScriptRoot '../../../..'
+    $script:chezmoiRoot = Join-Path $script:repoRoot 'chezmoi'
+    $templatePath = Join-Path $script:chezmoiRoot '.chezmoiscripts/run_always_install-claude-plugins_windows.ps1.tmpl'
+    $rendered = (Get-Content -LiteralPath $templatePath -Raw |
+            & chezmoi --source $script:chezmoiRoot --override-data '{"chezmoi":{"os":"windows"}}' execute-template) -join [Environment]::NewLine
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Failed to render the Windows Claude marketplace installer template.'
+    }
+
+    $normalizeFunction = [regex]::Match($rendered, '(?s)function Normalize-MarketplacePath \{.*?\n\}').Value
+    $recoveryFunction = [regex]::Match(
+        $rendered,
+        '(?s)function Recover-InvalidMarketplace \{.*?\n\}(?=\r?\n\r?\n# Clone or update)'
+    ).Value
+    if ([string]::IsNullOrWhiteSpace($normalizeFunction) -or [string]::IsNullOrWhiteSpace($recoveryFunction)) {
+        throw 'Failed to extract marketplace helper functions from the rendered installer.'
+    }
+
+    $script:marketplacesDir = Join-Path $TestDrive 'marketplaces'
+    New-Item -ItemType Directory -Path $script:marketplacesDir -Force | Out-Null
+    $script:gitNonInteractive = @()
+    Invoke-Expression $normalizeFunction
+    Invoke-Expression $recoveryFunction
+}
+
+Describe 'Claude marketplace Windows installer helpers' {
+    It 'normalizes Git and PowerShell Windows path formats to the same path' {
+        Normalize-MarketplacePath -Path 'C:/Users/test/.claude/' |
+            Should -Be 'C:\Users\test\.claude'
+        Normalize-MarketplacePath -Path '/c/Users/test/.claude/' |
+            Should -Be 'C:\Users\test\.claude'
+    }
+
+    It 'preserves an invalid checkout after a successful staged recovery' {
+        $fakeGit = Join-Path $TestDrive 'fake-git.ps1'
+        @'
+param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+$cloneIndex = [Array]::IndexOf($Arguments, 'clone')
+if ($cloneIndex -ge 0) {
+    $destination = $Arguments[$cloneIndex + 2]
+    New-Item -ItemType Directory -Path $destination -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $destination 'recovered.txt') -Value 'recovered'
+    exit 0
+}
+exit 1
+'@ | Set-Content -LiteralPath $fakeGit -Encoding utf8
+
+        $script:gitCmd = $fakeGit
+        $targetDir = Join-Path $script:marketplacesDir 'invalid'
+        New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $targetDir 'original.txt') -Value 'original'
+
+        Recover-InvalidMarketplace -Repository 'example/repository' -TargetDir $targetDir |
+            Should -BeTrue
+        Test-Path -LiteralPath (Join-Path $targetDir 'recovered.txt') |
+            Should -BeTrue
+        @(Get-ChildItem -LiteralPath $script:marketplacesDir -Filter 'invalid.invalid.*').Count |
+            Should -Be 1
+    }
+
+    It 'keeps the original checkout when the staged clone fails' {
+        $fakeGit = Join-Path $TestDrive 'failing-git.ps1'
+        @'
+exit 1
+'@ | Set-Content -LiteralPath $fakeGit -Encoding utf8
+
+        $script:gitCmd = $fakeGit
+        $targetDir = Join-Path $script:marketplacesDir 'still-invalid'
+        New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $targetDir 'original.txt') -Value 'original'
+
+        Recover-InvalidMarketplace -Repository 'example/repository' -TargetDir $targetDir |
+            Should -BeFalse
+        Get-Content -LiteralPath (Join-Path $targetDir 'original.txt') |
+            Should -Be 'original'
+    }
+}

--- a/scripts/powershell/tests/chezmoi/ClaudeMarketplace.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ClaudeMarketplace.Tests.ps1
@@ -124,7 +124,50 @@ exit 1
         }
     }
 
-    It 'rolls back after checkout placement fails and returns false if rollback also fails' {
+    It 'restores the original checkout when placement fails' {
+        $fakeGit = Join-Path $TestDrive 'rollback-success-git.ps1'
+        @'
+param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+$cloneIndex = [Array]::IndexOf($Arguments, 'clone')
+if ($cloneIndex -ge 0) {
+    $destination = $Arguments[$cloneIndex + 2]
+    New-Item -ItemType Directory -Path $destination -Force | Out-Null
+    exit 0
+}
+exit 1
+'@ | Set-Content -LiteralPath $fakeGit -Encoding utf8
+
+        $script:gitCmd = $fakeGit
+        $targetDir = Join-Path $script:marketplacesDir 'rollback-success'
+        New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $targetDir 'original.txt') -Value 'original'
+        $script:moveItemCallCount = 0
+        function Move-Item {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory = $true)][string]$LiteralPath,
+                [Parameter(Mandatory = $true)][string]$Destination
+            )
+
+            $script:moveItemCallCount++
+            if ($script:moveItemCallCount -eq 2) {
+                throw 'injected checkout placement failure'
+            }
+            Microsoft.PowerShell.Management\Move-Item -LiteralPath $LiteralPath -Destination $Destination
+        }
+
+        try {
+            Recover-InvalidMarketplace -Repository 'example/repository' -TargetDir $targetDir |
+                Should -BeFalse
+        }
+        finally {
+            Remove-Item Function:\Move-Item -ErrorAction SilentlyContinue
+        }
+        Get-Content -LiteralPath (Join-Path $targetDir 'original.txt') |
+            Should -Be 'original'
+    }
+
+    It 'returns false when checkout placement and rollback both fail while retaining the backup' {
         $fakeGit = Join-Path $TestDrive 'recovery-git.ps1'
         @'
 param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
@@ -167,5 +210,9 @@ exit 1
             Remove-Item Function:\Move-Item -ErrorAction SilentlyContinue
         }
         Test-Path -LiteralPath $targetDir | Should -BeFalse
+        $backupDir = Get-ChildItem -LiteralPath $script:marketplacesDir -Filter 'rollback.invalid.*'
+        $backupDir.Count | Should -Be 1
+        Get-Content -LiteralPath (Join-Path $backupDir.FullName 'original.txt') |
+            Should -Be 'original'
     }
 }

--- a/scripts/powershell/tests/chezmoi/ClaudeMarketplace.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ClaudeMarketplace.Tests.ps1
@@ -11,11 +11,16 @@ BeforeAll {
     }
 
     $normalizeFunction = [regex]::Match($rendered, '(?s)function Normalize-MarketplacePath \{.*?\n\}').Value
+    $validationFunction = [regex]::Match($rendered, '(?s)function Test-ValidMarketplaceCheckout \{.*?\n\}').Value
     $recoveryFunction = [regex]::Match(
         $rendered,
         '(?s)function Recover-InvalidMarketplace \{.*?\n\}(?=\r?\n\r?\n# Clone or update)'
     ).Value
-    if ([string]::IsNullOrWhiteSpace($normalizeFunction) -or [string]::IsNullOrWhiteSpace($recoveryFunction)) {
+    if (
+        [string]::IsNullOrWhiteSpace($normalizeFunction) -or
+        [string]::IsNullOrWhiteSpace($validationFunction) -or
+        [string]::IsNullOrWhiteSpace($recoveryFunction)
+    ) {
         throw 'Failed to extract marketplace helper functions from the rendered installer.'
     }
 
@@ -23,6 +28,7 @@ BeforeAll {
     New-Item -ItemType Directory -Path $script:marketplacesDir -Force | Out-Null
     $script:gitNonInteractive = @()
     Invoke-Expression $normalizeFunction
+    Invoke-Expression $validationFunction
     Invoke-Expression $recoveryFunction
 }
 
@@ -57,8 +63,10 @@ exit 1
             Should -BeTrue
         Test-Path -LiteralPath (Join-Path $targetDir 'recovered.txt') |
             Should -BeTrue
-        @(Get-ChildItem -LiteralPath $script:marketplacesDir -Filter 'invalid.invalid.*').Count |
-            Should -Be 1
+        $backupDir = Get-ChildItem -LiteralPath $script:marketplacesDir -Filter 'invalid.invalid.*'
+        $backupDir.Count | Should -Be 1
+        Get-Content -LiteralPath (Join-Path $backupDir.FullName 'original.txt') |
+            Should -Be 'original'
     }
 
     It 'keeps the original checkout when the staged clone fails' {
@@ -76,5 +84,88 @@ exit 1
             Should -BeFalse
         Get-Content -LiteralPath (Join-Path $targetDir 'original.txt') |
             Should -Be 'original'
+    }
+
+    It 'rejects bare and parent repositories while accepting the exact checkout root' {
+        $fakeGit = Join-Path $TestDrive 'validation-git.ps1'
+        @'
+param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+if ($Arguments -contains '--is-inside-work-tree') {
+    Write-Output $env:FAKE_GIT_INSIDE
+    exit 0
+}
+if ($Arguments -contains '--show-toplevel') {
+    Write-Output $env:FAKE_GIT_ROOT
+    exit 0
+}
+exit 1
+'@ | Set-Content -LiteralPath $fakeGit -Encoding utf8
+
+        $script:gitCmd = $fakeGit
+        $targetDir = Join-Path $script:marketplacesDir 'checkout'
+        New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+        $oldInside = $env:FAKE_GIT_INSIDE
+        $oldRoot = $env:FAKE_GIT_ROOT
+        try {
+            $env:FAKE_GIT_INSIDE = 'true'
+            $env:FAKE_GIT_ROOT = (Get-Item -LiteralPath $targetDir).FullName -replace '\\', '/'
+            Test-ValidMarketplaceCheckout -TargetDir $targetDir | Should -BeTrue
+
+            $env:FAKE_GIT_INSIDE = 'false'
+            Test-ValidMarketplaceCheckout -TargetDir $targetDir | Should -BeFalse
+
+            $env:FAKE_GIT_INSIDE = 'true'
+            $env:FAKE_GIT_ROOT = (Get-Item -LiteralPath $script:marketplacesDir).FullName
+            Test-ValidMarketplaceCheckout -TargetDir $targetDir | Should -BeFalse
+        }
+        finally {
+            $env:FAKE_GIT_INSIDE = $oldInside
+            $env:FAKE_GIT_ROOT = $oldRoot
+        }
+    }
+
+    It 'rolls back after checkout placement fails and returns false if rollback also fails' {
+        $fakeGit = Join-Path $TestDrive 'recovery-git.ps1'
+        @'
+param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+$cloneIndex = [Array]::IndexOf($Arguments, 'clone')
+if ($cloneIndex -ge 0) {
+    $destination = $Arguments[$cloneIndex + 2]
+    New-Item -ItemType Directory -Path $destination -Force | Out-Null
+    exit 0
+}
+exit 1
+'@ | Set-Content -LiteralPath $fakeGit -Encoding utf8
+
+        $script:gitCmd = $fakeGit
+        $targetDir = Join-Path $script:marketplacesDir 'rollback'
+        New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $targetDir 'original.txt') -Value 'original'
+        $script:moveItemCallCount = 0
+        function Move-Item {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory = $true)][string]$LiteralPath,
+                [Parameter(Mandatory = $true)][string]$Destination
+            )
+
+            $script:moveItemCallCount++
+            if ($script:moveItemCallCount -eq 2) {
+                throw 'injected checkout placement failure'
+            }
+            if ($script:moveItemCallCount -eq 3) {
+                throw 'injected rollback failure'
+            }
+            Microsoft.PowerShell.Management\Move-Item -LiteralPath $LiteralPath -Destination $Destination
+        }
+
+        try {
+            Recover-InvalidMarketplace -Repository 'example/repository' -TargetDir $targetDir |
+                Should -BeFalse
+        }
+        finally {
+            Remove-Item Function:\Move-Item -ErrorAction SilentlyContinue
+        }
+        Test-Path -LiteralPath $targetDir | Should -BeFalse
     }
 }

--- a/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
@@ -179,7 +179,7 @@ Describe 'SSH deploy スクリプト' {
             $script:ps1Content | Should -Match 'timed out after \$OpReadTimeoutSeconds seconds' -Because "timeout should take the non-fatal skip path"
         }
 
-        It '設定済みアカウントがCLIにない場合に復旧方法を表示すること' {
+        It 'should 設定済みアカウントがCLIにない場合に復旧方法を表示すること' {
             $script:ps1Content | Should -Match 'configured 1Password account.*\$Account' -Because "missing account UUID should be distinguishable from a missing item"
             $script:ps1Content | Should -Match 'sign in.*update.*account' -Because "the warning should explain how to repair the account configuration"
         }
@@ -212,7 +212,7 @@ Describe 'SSH deploy スクリプト' {
             $script:shContent | Should -Match 'timed out after \$OP_READ_TIMEOUT_SECONDS seconds' -Because "timeout should take the non-fatal skip path"
         }
 
-        It '設定済みアカウントがCLIにない場合に復旧方法を表示すること' {
+        It 'should 設定済みアカウントがCLIにない場合に復旧方法を表示すること' {
             $script:shContent | Should -Match 'configured 1Password account.*\$account' -Because "missing account UUID should be distinguishable from a missing item"
             $script:shContent | Should -Match 'sign in.*update.*account' -Because "the warning should explain how to repair the account configuration"
         }

--- a/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
@@ -178,6 +178,11 @@ Describe 'SSH deploy スクリプト' {
             $script:ps1Content | Should -Match 'Kill\(' -Because "timed-out Windows op reads should be terminated"
             $script:ps1Content | Should -Match 'timed out after \$OpReadTimeoutSeconds seconds' -Because "timeout should take the non-fatal skip path"
         }
+
+        It '設定済みアカウントがCLIにない場合に復旧方法を表示すること' {
+            $script:ps1Content | Should -Match 'configured 1Password account.*\$Account' -Because "missing account UUID should be distinguishable from a missing item"
+            $script:ps1Content | Should -Match 'sign in.*update.*account' -Because "the warning should explain how to repair the account configuration"
+        }
     }
 
     Context 'Linux/macOS (sh.tmpl)' {
@@ -205,6 +210,11 @@ Describe 'SSH deploy スクリプト' {
             $script:shContent | Should -Match 'OP_READ_TIMEOUT_SECONDS=60' -Because "WSL op.exe reads can exceed 20 seconds after app auth"
             $script:shContent | Should -Match 'timeout|gtimeout' -Because "Unix op read should be bounded"
             $script:shContent | Should -Match 'timed out after \$OP_READ_TIMEOUT_SECONDS seconds' -Because "timeout should take the non-fatal skip path"
+        }
+
+        It '設定済みアカウントがCLIにない場合に復旧方法を表示すること' {
+            $script:shContent | Should -Match 'configured 1Password account.*\$account' -Because "missing account UUID should be distinguishable from a missing item"
+            $script:shContent | Should -Match 'sign in.*update.*account' -Because "the warning should explain how to repair the account configuration"
         }
     }
 }

--- a/tests/bash/chezmoi_script_portability.bats
+++ b/tests/bash/chezmoi_script_portability.bats
@@ -12,3 +12,17 @@ setup() {
 
 	[ -z "$violations" ]
 }
+
+@test "Claude marketplace installers recover invalid checkouts" {
+	for template in \
+		"$REPO_ROOT/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_darwin.sh.tmpl" \
+		"$REPO_ROOT/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_linux.sh.tmpl"; do
+		grep -Fq 'git -C "$TARGET_DIR" rev-parse --is-inside-work-tree' "$template"
+		grep -Fq 'mktemp -d' "$template"
+		grep -Fq '.invalid.$(date +%Y%m%d%H%M%S)' "$template"
+	done
+
+	windows_template="$REPO_ROOT/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_windows.ps1.tmpl"
+	grep -Fq 'rev-parse --is-inside-work-tree' "$windows_template"
+	grep -Fq '.invalid.$(Get-Date -Format yyyyMMddHHmmss)' "$windows_template"
+}

--- a/tests/bash/chezmoi_script_portability.bats
+++ b/tests/bash/chezmoi_script_portability.bats
@@ -17,12 +17,16 @@ setup() {
 	for template in \
 		"$REPO_ROOT/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_darwin.sh.tmpl" \
 		"$REPO_ROOT/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_linux.sh.tmpl"; do
-		grep -Fq 'git -C "$TARGET_DIR" rev-parse --is-inside-work-tree' "$template"
+		grep -Fq 'marketplace_checkout_is_valid()' "$template"
+		grep -Fq 'rev-parse --show-toplevel' "$template"
 		grep -Fq 'mktemp -d' "$template"
+		grep -Fq 'if ! staging_dir=' "$template"
 		grep -Fq '.invalid.$(date +%Y%m%d%H%M%S)' "$template"
 	done
 
 	windows_template="$REPO_ROOT/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_windows.ps1.tmpl"
-	grep -Fq 'rev-parse --is-inside-work-tree' "$windows_template"
+	grep -Fq 'Test-ValidMarketplaceCheckout' "$windows_template"
+	grep -Fq 'rev-parse --show-toplevel' "$windows_template"
+	grep -Fq 'if (-not (Recover-InvalidMarketplace' "$windows_template"
 	grep -Fq '.invalid.$(Get-Date -Format yyyyMMddHHmmss)' "$windows_template"
 }

--- a/tests/bash/chezmoi_script_portability.bats
+++ b/tests/bash/chezmoi_script_portability.bats
@@ -26,7 +26,12 @@ setup() {
 
 	windows_template="$REPO_ROOT/chezmoi/.chezmoiscripts/run_always_install-claude-plugins_windows.ps1.tmpl"
 	grep -Fq 'Test-ValidMarketplaceCheckout' "$windows_template"
+	grep -Fq 'Normalize-MarketplacePath' "$windows_template"
+	grep -Fq -- "-replace '/', '\\'" "$windows_template"
 	grep -Fq 'rev-parse --show-toplevel' "$windows_template"
 	grep -Fq 'if (-not (Recover-InvalidMarketplace' "$windows_template"
+	grep -Fq 'Move-Item -LiteralPath $TargetDir -Destination $backupDir -ErrorAction Stop' "$windows_template"
+	grep -Fq 'Move-Item -LiteralPath $checkoutDir -Destination $TargetDir -ErrorAction Stop' "$windows_template"
+	grep -Fq 'failed to rollback marketplace' "$windows_template"
 	grep -Fq '.invalid.$(Get-Date -Format yyyyMMddHHmmss)' "$windows_template"
 }


### PR DESCRIPTION
## Summary
- Recover non-Git Claude marketplace directories with a staged clone and timestamped backup on Unix and Windows.
- Explain how to repair a missing configured 1Password account during SSH key deployment.
- Add regression coverage for the marketplace and account-diagnostic contracts.

## Validation
- `task test` (Bats 268/268)
- Pester chezmoi SSH tests (42/42)
- targeted pre-commit hooks
- Bash/PowerShell syntax validation and ShellCheck
- Live macOS marketplace recovery verified

Unrelated existing `flake.lock` changes are intentionally excluded.