### PR TITLE
fix: render SSH config templates before deployment

### DIFF
--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.ps1.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.ps1.tmpl
@@ -92,7 +92,7 @@ Write-Host "Deploying SSH configuration..."
 
 # Render ssh/config.tmpl inline (chezmoi template engine resolves this at apply time)
 $sshConfig = @'
-{{ include "ssh/config.tmpl" }}
+{{ includeTemplate "ssh/config.tmpl" . }}
 '@
 Deploy-Content $sshConfig "$HomeDir\.ssh\config"
 

--- a/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/deploy/ssh/run_always_deploy.sh.tmpl
@@ -102,7 +102,7 @@ read_op_secret() {
 echo "Deploying SSH configuration..."
 
 # Render ssh/config.tmpl inline (chezmoi template engine resolves this at apply time)
-SSH_CONFIG='{{ include "ssh/config.tmpl" }}'
+SSH_CONFIG='{{ includeTemplate "ssh/config.tmpl" . }}'
 deploy_content "$SSH_CONFIG" "$HOME_DIR/.ssh/config"
 chmod 600 "$HOME_DIR/.ssh/config"
 

--- a/chezmoi/ssh/AGENTS.md
+++ b/chezmoi/ssh/AGENTS.md
@@ -14,6 +14,6 @@
 
 ## deploy スクリプトの注意点
 
-- `config.tmpl` はテンプレートファイルなので、deploy スクリプト内で `{{ include "ssh/config.tmpl" }}` を使ってインライン展開すること。
+- `config.tmpl` はテンプレートファイルなので、deploy スクリプト内で `{{ includeTemplate "ssh/config.tmpl" . }}` を使って評価・インライン展開すること。ハッシュ計算だけは `include` で元ファイルの内容を参照する。
 - `Deploy-File` でファイルパスをコピーすると `ssh/config` を探すが存在しないため無言で失敗する。
 - Windows では Git Bash の SSH は named pipe (`//./pipe/openssh-ssh-agent`) に接続できない。`core.sshCommand = C:/Windows/System32/OpenSSH/ssh.exe` で Windows OpenSSH を使用すること。

--- a/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/SshGitconfig.Tests.ps1
@@ -20,6 +20,7 @@ BeforeAll {
     $script:sshDeployPs1 = Join-Path $script:chezmoiRoot ".chezmoiscripts/deploy/ssh/run_always_deploy.ps1.tmpl"
     $script:sshDeploySh = Join-Path $script:chezmoiRoot ".chezmoiscripts/deploy/ssh/run_always_deploy.sh.tmpl"
     $script:chezmoiToml = Join-Path $script:chezmoiRoot ".chezmoi.toml.tmpl"
+    $script:renderData = '{"chezmoi":{"os":"windows"},"op_account_personal":"test-account","op_account_work":"test-account"}'
 }
 
 Describe 'SSH config テンプレート' {
@@ -150,8 +151,18 @@ Describe 'SSH deploy スクリプト' {
             $script:ps1Content = Get-Content -Path $script:sshDeployPs1 -Raw
         }
 
-        It 'ssh/config.tmpl を include でインライン展開していること' {
-            $script:ps1Content | Should -Match 'include "ssh/config\.tmpl"' -Because "テンプレートファイルを直接コピーすると未展開のまま配置される"
+        It 'ssh/config.tmpl を includeTemplate で評価してインライン展開していること' {
+            $script:ps1Content | Should -Match 'includeTemplate "ssh/config\.tmpl" \.' -Because "include はテンプレート本文を再評価しないため、OS分岐を評価してから配置する"
+        }
+
+        It '展開後のWindows用deployスクリプトに未評価のテンプレートを残さないこと' {
+            $render = $script:ps1Content |
+                & chezmoi --source $script:chezmoiRoot --override-data $script:renderData execute-template
+            $LASTEXITCODE | Should -Be 0
+            $rendered = $render -join [Environment]::NewLine
+
+            $rendered | Should -Not -Match '\{\{'
+            $rendered | Should -Match 'IdentityAgent "//\./pipe/openssh-ssh-agent"'
         }
 
         It 'config.tmpl のハッシュが変更検出に使われていること' {
@@ -185,8 +196,28 @@ Describe 'SSH deploy スクリプト' {
             $script:shContent = Get-Content -Path $script:sshDeploySh -Raw
         }
 
-        It 'ssh/config.tmpl を include でインライン展開していること' {
-            $script:shContent | Should -Match 'include "ssh/config\.tmpl"' -Because "テンプレートファイルを直接コピーすると未展開のまま配置される"
+        It 'ssh/config.tmpl を includeTemplate で評価してインライン展開していること' {
+            $script:shContent | Should -Match 'includeTemplate "ssh/config\.tmpl" \.' -Because "include はテンプレート本文を再評価しないため、OS分岐を評価してから配置する"
+        }
+
+        It '展開後のmacOS用deployスクリプトに未評価のテンプレートを残さないこと' {
+            $render = $script:shContent |
+                & chezmoi --source $script:chezmoiRoot --override-data ($script:renderData -replace '"windows"', '"darwin"') execute-template
+            $LASTEXITCODE | Should -Be 0
+            $rendered = $render -join [Environment]::NewLine
+
+            $rendered | Should -Not -Match '\{\{'
+            $rendered | Should -Match 'IdentityAgent "~/Library/Group Containers/2BUA8C4S2C\.com\.1password/t/agent\.sock"'
+        }
+
+        It '展開後のLinux用deployスクリプトに未評価のテンプレートを残さないこと' {
+            $render = $script:shContent |
+                & chezmoi --source $script:chezmoiRoot --override-data ($script:renderData -replace '"windows"', '"linux"') execute-template
+            $LASTEXITCODE | Should -Be 0
+            $rendered = $render -join [Environment]::NewLine
+
+            $rendered | Should -Not -Match '\{\{'
+            $rendered | Should -Match 'IdentityAgent ~/.1password/agent\.sock'
         }
 
         It 'SSH config のパーミッションを 600 に設定していること' {


### PR DESCRIPTION
## Summary
- evaluate `ssh/config.tmpl` with chezmoi `includeTemplate` before deploying it
- cover Unix/macOS and Windows rendered deploy scripts with regression tests

## Validation
- targeted Pester: 42 passed
- POSIX Bats: 267 passed
- pre-commit checks: passed
- generated Unix and PowerShell scripts: syntax checks passed