### PR TITLE
fix: declare oMLX custom Homebrew tap

### DIFF
--- a/nix/hosts/darwin/default.nix
+++ b/nix/hosts/darwin/default.nix
@@ -117,6 +117,12 @@ in
     enable = true;
     brews = sets.darwinBrews;
     casks = sets.darwinCasks;
+    taps = [
+      {
+        name = "jundot/omlx";
+        clone_target = "https://github.com/jundot/omlx";
+      }
+    ];
     # nix-darwin installs and upgrades declared casks through Homebrew Bundle.
     greedyCasks = true;
     onActivation = {

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -149,6 +149,20 @@ setup() {
 	[ "$status" -eq 0 ]
 }
 
+@test "Darwin taps oMLX from its nonstandard upstream repository" {
+	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
+
+	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex \
+		nix eval --impure --json --no-write-lock-file --expr "
+			let config = (builtins.getFlake (toString $REPO_ROOT)).darwinConfigurations.macos.config;
+			in config.homebrew.taps
+		"
+
+	[ "$status" -eq 0 ]
+	run jq -e 'any(.[]; .name == "jundot/omlx" and .clone_target == "https://github.com/jundot/omlx")' <<<"$output"
+	[ "$status" -eq 0 ]
+}
+
 @test "Home Manager exposes Apple Silicon package manager and Docker paths" {
 	run awk '
 		/sessionPath = \[/ { in_darwin=1 }


### PR DESCRIPTION
## Summary

- declare the official oMLX repository as the custom clone target for the `jundot/omlx` tap
- keep the fully qualified formula trusted during nix-darwin activation
- add a regression test for the evaluated Homebrew tap configuration

## Testing

- `bats tests/bash` (293 passed)
- `nix fmt -- nix/hosts/darwin/default.nix tests/bash/macos_config.bats`
- evaluated the generated Brewfile and confirmed `tap "jundot/omlx", "https://github.com/jundot/omlx"`
- `git diff --check`