### PR TITLE
chore: remove oMLX from Darwin packages

### DIFF
--- a/nix/hosts/darwin/default.nix
+++ b/nix/hosts/darwin/default.nix
@@ -117,12 +117,6 @@ in
     enable = true;
     brews = sets.darwinBrews;
     casks = sets.darwinCasks;
-    taps = [
-      {
-        name = "jundot/omlx";
-        clone_target = "https://github.com/jundot/omlx";
-      }
-    ];
     # nix-darwin installs and upgrades declared casks through Homebrew Bundle.
     greedyCasks = true;
     onActivation = {

--- a/nix/hosts/darwin/default.nix
+++ b/nix/hosts/darwin/default.nix
@@ -36,6 +36,22 @@ in
       runAsUser /usr/bin/defaults write -g NSUserKeyEquivalents -dict-add "Zoom" "@^m"
       runAsUser /usr/bin/defaults write -g NSUserKeyEquivalents -dict-add "拡大／縮小" "@^m"
     '';
+    activationScripts.removeLegacyOmlx.text = ''
+      brew="/opt/homebrew/bin/brew"
+      if [ -x "$brew" ]; then
+        uid="$(id -u -- ${lib.escapeShellArg user})"
+        runAsUser() {
+          launchctl asuser "$uid" sudo --user=${lib.escapeShellArg user} --set-home -- "$@"
+        }
+
+        if runAsUser "$brew" list --formula --versions omlx >/dev/null 2>&1; then
+          runAsUser "$brew" uninstall --formula omlx
+        fi
+        if runAsUser "$brew" tap | ${lib.getExe pkgs.gnugrep} --fixed-strings --line-regexp --quiet "jundot/omlx"; then
+          runAsUser "$brew" untap jundot/omlx
+        fi
+      fi
+    '';
   };
 
   system.defaults.CustomUserPreferences."com.apple.symbolichotkeys".AppleSymbolicHotKeys = {

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -357,21 +357,6 @@ let
         };
       };
     };
-    omlx = {
-      category = "llm";
-      support = {
-        windows = {
-          unsupported = "oMLX requires Apple Silicon macOS";
-        };
-        darwin = {
-          provider = "homebrew-formula";
-          formula = "jundot/omlx/omlx";
-        };
-        linux = {
-          unsupported = "oMLX requires Apple Silicon macOS";
-        };
-      };
-    };
     workmux = {
       pkg = pkgs.workmux;
       winget = null;

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -163,6 +163,22 @@ setup() {
 	[ "$status" -eq 0 ]
 }
 
+@test "Darwin removes legacy oMLX installations during activation" {
+	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
+
+	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex \
+		nix eval --impure --raw --no-write-lock-file --expr "
+			let config = (builtins.getFlake (toString $REPO_ROOT)).darwinConfigurations.macos.config;
+			in config.system.activationScripts.removeLegacyOmlx.text
+		"
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'list --formula --versions omlx'* ]]
+	[[ "$output" == *'uninstall --formula omlx'* ]]
+	[[ "$output" == *'untap jundot/omlx'* ]]
+	[[ "$output" == *'sudo --user=codex --set-home'* ]]
+}
+
 @test "Home Manager exposes Apple Silicon package manager and Docker paths" {
 	run awk '
 		/sessionPath = \[/ { in_darwin=1 }

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -135,31 +135,31 @@ setup() {
 	[ "$status" -eq 0 ]
 }
 
-@test "Darwin declares the oMLX Homebrew formula" {
+@test "Darwin excludes the oMLX Homebrew formula" {
 	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
 
 	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex \
 		nix eval --impure --json --no-write-lock-file --expr "
 			let config = (builtins.getFlake (toString $REPO_ROOT)).darwinConfigurations.macos.config;
 			in config.homebrew.brews
-		"
+	"
 
 	[ "$status" -eq 0 ]
-	run jq -e 'any(.[]; .name == "jundot/omlx/omlx")' <<<"$output"
+	run jq -e 'all(.[]; .name != "jundot/omlx/omlx" and .name != "omlx")' <<<"$output"
 	[ "$status" -eq 0 ]
 }
 
-@test "Darwin taps oMLX from its nonstandard upstream repository" {
+@test "Darwin excludes the oMLX Homebrew tap" {
 	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
 
 	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex \
 		nix eval --impure --json --no-write-lock-file --expr "
 			let config = (builtins.getFlake (toString $REPO_ROOT)).darwinConfigurations.macos.config;
 			in config.homebrew.taps
-		"
+	"
 
 	[ "$status" -eq 0 ]
-	run jq -e 'any(.[]; .name == "jundot/omlx" and .clone_target == "https://github.com/jundot/omlx")' <<<"$output"
+	run jq -e 'all(.[]; .name != "jundot/omlx")' <<<"$output"
 	[ "$status" -eq 0 ]
 }
 

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -253,34 +253,6 @@ EOF
 	[[ "$output" == *'args = [ "--version" ];'* ]]
 }
 
-@test "oMLX is a Darwin Homebrew formula with reviewed non-Darwin support" {
-	run awk '
-		/^    omlx = \{/ { in_entry=1 }
-		in_entry { print }
-		in_entry && /^    };$/ { exit }
-	' "$SETS"
-	[ "$status" -eq 0 ]
-	[[ "$output" == *'category = "llm";'* ]]
-	[[ "$output" == *'provider = "homebrew-formula";'* ]]
-	[[ "$output" == *'formula = "jundot/omlx/omlx";'* ]]
-	local entry="$output"
-	run awk '
-		/^        windows = \{/ { in_platform=1 }
-		in_platform { print }
-		in_platform && /^        };$/ { exit }
-	' <<<"$entry"
-	[ "$status" -eq 0 ]
-	[[ "$output" == *'unsupported = "oMLX requires Apple Silicon macOS";'* ]]
-
-	run awk '
-		/^        linux = \{/ { in_platform=1 }
-		in_platform { print }
-		in_platform && /^        };$/ { exit }
-	' <<<"$entry"
-	[ "$status" -eq 0 ]
-	[[ "$output" == *'unsupported = "oMLX requires Apple Silicon macOS";'* ]]
-}
-
 @test "ChatGPT desktop has native Linux, Darwin cask, and Microsoft Store providers" {
 	run awk '
 		/^    chatgpt = \{/ { in_entry=1 }


### PR DESCRIPTION
## Summary

- remove the oMLX Homebrew formula from the Darwin package catalog
- remove the jundot/omlx Homebrew tap
- keep Ollama as the local LLM hosting service and add negative regression checks for oMLX

## Validation

- bats tests/bash (292/292)
- nix build --no-link .#checks.aarch64-darwin.package-provider-coverage
- nix fmt -- --fail-on-change nix/hosts/darwin/default.nix nix/packages/sets.nix tests/bash/macos_config.bats tests/bash/package_catalog.bats
- pre-commit run --all-files