### PR TITLE
fix: gate macOS optional runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ Windows、macOS、NixOS、Ubuntu、Debian を 1 コマンドで収束させる�
 
 ## クイックスタート
 
-clone 後、OS ごとの入口を 1 回実行します。Full support の installer は Nix、OS パッケージ、Home Manager、chezmoi、Docker Compose を適用し、最後に runtime acceptance を実行します。途中で失敗した場合も同じコマンドを再実行できます。
+clone 後、OS ごとの入口を 1 回実行します。installer は Nix、OS パッケージ、
+Home Manager、chezmoi と明示的に選択した optional profile を適用します。
+Docker profile では最後に runtime acceptance も実行します。途中で失敗した場合も
+同じコマンドを再実行できます。
 
 ### Windows
 
@@ -48,9 +51,8 @@ Hindsight、Hermes、Chrome、Discord、Chromium/browser-mcp は導入しませ�
 
 ### macOS (Apple Silicon)
 
-macOS 26 以降の Apple Silicon Mac で実行します。Docker Desktop と Nix の
-システムコンポーネントを導入するため、初回は管理者パスワードの入力と
-Docker Desktop のライセンス確認が必要です。
+macOS 26 以降の Apple Silicon Mac で実行します。Nix のシステムコンポーネントを
+導入するため、初回は管理者パスワードの入力が必要です。
 
 ```bash
 git clone https://github.com/rurusasu/dotfiles.git
@@ -58,7 +60,20 @@ cd dotfiles
 ./install.sh
 ```
 
-Nix installer と nix-darwin がシステムを収束させ、nix-homebrew が Homebrew formula と Docker Desktop cask を管理します。Home Manager、chezmoi、Docker Compose、runtime acceptance まで同じコマンド内で実行します。macOS では WSL や NixOS を導入しません。
+引数なしでは core 環境だけを適用し、Ollama、Docker Desktop、Hindsight、
+Hermes、Chrome、Discord は install/update/起動の対象にしません。必要な構成だけを
+明示的に追加します。`--with-docker` と `--with-hermes` の runtime は、chezmoi と
+editor 同期が完了してから起動します。
+
+```bash
+./install.sh --with-ollama # Ollama のみ
+./install.sh --with-docker # Ollama + Docker + 独立 Hindsight
+./install.sh --with-hermes # 上記 + Hermes + Chrome + Discord + browser-mcp
+```
+
+Nix installer と nix-darwin がシステムを収束させ、nix-homebrew が選択した
+Homebrew formula/cask を管理します。Home Manager と chezmoi も同じコマンド内で
+適用します。macOS では WSL や NixOS を導入しません。
 
 Tart CLI もこの macOS activation で導入されますが、約25GBの VM image は通常の `./install.sh` では取得しません。大容量ダウンロードを開始するタイミングを分離するため、初回だけ次を実行します。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,7 +124,7 @@ Hermes gateway は稼働を継続します。
 ```
 nix/packages/sets.nix (SSOT)
 ├── Home Manager ───────── macOS / NixOS / Ubuntu / Debian CLI
-├── darwinCasks ────────── nix-homebrew casks
+├── darwinCasksForInstallFeatures ── profile-filtered nix-homebrew casks
 ├── darwinBrews ────────── nix-homebrew formulas
 ├── linuxSystemModules ─── NixOS / System Manager packages and services
 ├── wingetMap + npmMap ─── generated Windows manifests

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,15 +56,15 @@ dotfiles/
 
 ## セットアップフロー
 
-| Platform      | Entrypoint                                | System layer                             | User layer             | Runtime        |
-| ------------- | ----------------------------------------- | ---------------------------------------- | ---------------------- | -------------- |
-| Windows       | `install.cmd`                             | PowerShell handlers, winget, NixOS-WSL   | Home Manager + chezmoi | Docker Desktop |
-| macOS ARM64   | `./install.sh`                            | nix-darwin + nix-homebrew                | Home Manager + chezmoi | Docker Desktop |
-| Ubuntu/Debian | `./install.sh`                            | System Manager                           | Home Manager + chezmoi | rootful Docker |
-| NixOS         | `./install.sh`                            | NixOS generation + host hardware profile | Home Manager + chezmoi | rootful Docker |
-| Other Linux   | `DOTFILES_ALLOW_USER_ONLY=1 ./install.sh` | none                                     | Home Manager only      | not managed    |
+| Platform      | Entrypoint                                | System layer                             | User layer             | Runtime                                                        |
+| ------------- | ----------------------------------------- | ---------------------------------------- | ---------------------- | -------------------------------------------------------------- |
+| Windows       | `install.cmd`                             | PowerShell handlers, winget, NixOS-WSL   | Home Manager + chezmoi | Docker Desktop                                                 |
+| macOS ARM64   | `./install.sh`                            | nix-darwin + nix-homebrew                | Home Manager + chezmoi | optional profile: Ollama / Docker Desktop / Hindsight / Hermes |
+| Ubuntu/Debian | `./install.sh`                            | System Manager                           | Home Manager + chezmoi | rootful Docker                                                 |
+| NixOS         | `./install.sh`                            | NixOS generation + host hardware profile | Home Manager + chezmoi | rootful Docker                                                 |
+| Other Linux   | `DOTFILES_ALLOW_USER_ONLY=1 ./install.sh` | none                                     | Home Manager only      | not managed                                                    |
 
-Full support の共通フローは `preflight → Nix/bootstrap → system switch → Home Manager → chezmoi → Compose → runtime acceptance` です。失敗時はその phase で停止し、同じ入口を再実行します。
+Full support の共通フローは `preflight → Nix/bootstrap → system switch → Home Manager → chezmoi → Compose → runtime acceptance` です。macOS の `Compose → runtime acceptance` は `--with-docker` または `--with-hermes` を指定した場合だけ実行します。失敗時はその phase で停止し、同じ入口を再実行します。
 
 ## 役割分担
 

--- a/docs/nix/package-management.md
+++ b/docs/nix/package-management.md
@@ -4,16 +4,19 @@
 
 `nix/packages/sets.nix` の catalog が全プラットフォームの package provider を一元管理します。Home Manager だけを SSOT とするのではなく、1 つの catalog から OS ごとの実装を導出します。
 
-| Catalog output        | Consumer                            | Platform                     |
-| --------------------- | ----------------------------------- | ---------------------------- |
-| `all` / category sets | `nix/home/common.nix`               | macOS、NixOS、Ubuntu、Debian |
-| `darwinCasks`         | nix-homebrew in nix-darwin          | macOS                        |
-| `linuxSystemModules`  | NixOS / System Manager modules      | Linux                        |
-| `wingetMap`, `npmMap` | `nix/packages/winget.nix`           | Windows                      |
-| `supportReport`       | `package-support-report` derivation | CI and review                |
-| `providerErrors`      | flake check                         | all platforms                |
+| Catalog output                  | Consumer                            | Platform                     |
+| ------------------------------- | ----------------------------------- | ---------------------------- |
+| `all` / category sets           | `nix/home/common.nix`               | macOS、NixOS、Ubuntu、Debian |
+| `darwinCasksForInstallFeatures` | nix-homebrew in nix-darwin          | macOS                        |
+| `linuxSystemModules`            | NixOS / System Manager modules      | Linux                        |
+| `wingetMap`, `npmMap`           | `nix/packages/winget.nix`           | Windows                      |
+| `supportReport`                 | `package-support-report` derivation | CI and review                |
+| `providerErrors`                | flake check                         | all platforms                |
 
 Windows だけに存在する GUI や OS component は `windowsOnlySupport` に置き、macOS/Linux で対応しない理由を必ず記録します。クロスプラットフォームのツールを理由なしに Windows-only へ入れることはできません。
+
+macOS caskで`installFeature`を持つpackageは、installerが解決したprofileを
+`darwinCasksForInstallFeatures`へ渡した場合だけHomebrew Bundleへ含まれます。
 
 ## Provider の追加
 

--- a/nix/hosts/darwin/default.nix
+++ b/nix/hosts/darwin/default.nix
@@ -10,6 +10,13 @@ let
   sets = import ../../packages/sets.nix {
     inherit pkgs lib;
   };
+  withHermes = builtins.getEnv "DOTFILES_WITH_HERMES" == "1";
+  withDocker = withHermes || builtins.getEnv "DOTFILES_WITH_DOCKER" == "1";
+  withOllama = withDocker || builtins.getEnv "DOTFILES_WITH_OLLAMA" == "1";
+  installFeatures =
+    lib.optionals withOllama [ "WithOllama" ]
+    ++ lib.optionals withDocker [ "WithDocker" ]
+    ++ lib.optionals withHermes [ "WithHermes" ];
 in
 {
   assertions = [
@@ -132,7 +139,7 @@ in
   homebrew = {
     enable = true;
     brews = sets.darwinBrews;
-    casks = sets.darwinCasks;
+    casks = sets.darwinCasksForInstallFeatures installFeatures;
     # nix-darwin installs and upgrades declared casks through Homebrew Bundle.
     greedyCasks = true;
     onActivation = {

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -831,6 +831,19 @@ let
   darwinCasks = lib.mapAttrsToList (_: entry: entry.support.darwin.cask) (
     lib.filterAttrs (_: entry: entry.support.darwin ? cask) catalog
   );
+  darwinCasksForInstallFeatures =
+    enabledFeatures:
+    lib.mapAttrsToList (_: entry: entry.support.darwin.cask) (
+      lib.filterAttrs (
+        _: entry:
+        entry.support.darwin ? cask
+        && (
+          !(entry ? installFeature)
+          || entry.installFeature == null
+          || builtins.elem entry.installFeature enabledFeatures
+        )
+      ) catalog
+    );
   darwinBrews = lib.mapAttrsToList (_: entry: entry.support.darwin.formula) (
     lib.filterAttrs (_: entry: entry.support.darwin ? formula) catalog
   );
@@ -887,6 +900,7 @@ lib.mapAttrs (_: resolve) grouped
   inherit
     supportReport
     darwinCasks
+    darwinCasksForInstallFeatures
     darwinBrews
     linuxSystemModules
     providerErrors

--- a/scripts/sh/install-macos.sh
+++ b/scripts/sh/install-macos.sh
@@ -12,6 +12,10 @@ HINDSIGHT_COMPOSE_FILE="$DOTFILES_ROOT/docker/hindsight/compose.yml"
 DOCKER_APP="${DOTFILES_DOCKER_APP_PATH:-/Applications/Docker.app}"
 DOCKER_SETUP_MARKER="${DOTFILES_DOCKER_SETUP_MARKER:-$HOME/.config/dotfiles/docker-desktop-installed}"
 DOCKER_WAIT_ATTEMPTS="${DOTFILES_DOCKER_WAIT_ATTEMPTS:-120}"
+OLLAMA_APP="${DOTFILES_OLLAMA_APP_PATH:-/Applications/Ollama.app}"
+OLLAMA_API_URL="${DOTFILES_OLLAMA_API_URL:-http://127.0.0.1:11434/api/version}"
+OLLAMA_WAIT_ATTEMPTS="${DOTFILES_OLLAMA_WAIT_ATTEMPTS:-60}"
+OPEN_COMMAND="${DOTFILES_OPEN_COMMAND:-/usr/bin/open}"
 VERIFY_ENVIRONMENT="${DOTFILES_VERIFY_ENVIRONMENT:-$ROOT/scripts/sh/verify-environment.sh}"
 readonly HOMEBREW_CASK_PARENT_DIR=/usr/local
 readonly HOMEBREW_CASK_BIN_DIR=/usr/local/bin
@@ -409,6 +413,24 @@ setup_docker_runtime() {
   docker compose version >/dev/null
 }
 
+ollama_api_is_ready() {
+  curl --fail --silent --show-error --max-time 2 "$OLLAMA_API_URL" >/dev/null
+}
+
+setup_ollama_runtime() {
+  [[ -d $OLLAMA_APP ]] || dotfiles_die "Ollama was not installed by nix-darwin: $OLLAMA_APP"
+  [[ -x $OPEN_COMMAND ]] || dotfiles_die "macOS open command is unavailable: $OPEN_COMMAND"
+  dotfiles_have curl || dotfiles_die "curl is required to verify Ollama."
+
+  if ollama_api_is_ready; then
+    return 0
+  fi
+
+  dotfiles_log "Starting Ollama..."
+  "$OPEN_COMMAND" -gj -a "$OLLAMA_APP"
+  dotfiles_wait_for "$OLLAMA_WAIT_ATTEMPTS" "Ollama API" ollama_api_is_ready
+}
+
 apply_chezmoi() {
   dotfiles_have chezmoi || dotfiles_die "chezmoi is unavailable after nix-darwin activation."
   chezmoi init --source "$ROOT/chezmoi"
@@ -432,6 +454,9 @@ main() {
   dotfiles_install_herdr
   ensure_homebrew_cask_link_directories
   apply_chezmoi
+  if ((DOTFILES_WITH_OLLAMA == 1)); then
+    setup_ollama_runtime
+  fi
   if ((DOTFILES_WITH_DOCKER == 1)); then
     setup_docker_runtime
     if ((DOTFILES_WITH_HERMES == 1)); then

--- a/scripts/sh/install-macos.sh
+++ b/scripts/sh/install-macos.sh
@@ -8,6 +8,7 @@ export DOTFILES_LOG_PREFIX="macos-install"
 . "$ROOT/scripts/sh/install-common.sh"
 
 COMPOSE_FILE="$DOTFILES_ROOT/docker/hermes-agent/compose.yml"
+HINDSIGHT_COMPOSE_FILE="$DOTFILES_ROOT/docker/hindsight/compose.yml"
 DOCKER_APP="${DOTFILES_DOCKER_APP_PATH:-/Applications/Docker.app}"
 DOCKER_SETUP_MARKER="${DOTFILES_DOCKER_SETUP_MARKER:-$HOME/.config/dotfiles/docker-desktop-installed}"
 DOCKER_WAIT_ATTEMPTS="${DOTFILES_DOCKER_WAIT_ATTEMPTS:-120}"
@@ -27,6 +28,43 @@ ZSHRC_PATH="${DOTFILES_ZSHRC_PATH:-/etc/zshrc}"
 USER_PROFILE_ROOT="${DOTFILES_USER_PROFILE_ROOT:-/etc/profiles/per-user}"
 HOMEBREW_BIN_DIR="${DOTFILES_HOMEBREW_BIN_DIR:-/usr/local/bin}"
 HOMEBREW_CLI_PLUGINS_DIR="${DOTFILES_HOMEBREW_CLI_PLUGINS_DIR:-/usr/local/cli-plugins}"
+DOTFILES_WITH_OLLAMA=0
+DOTFILES_WITH_DOCKER=0
+DOTFILES_WITH_HERMES=0
+
+usage() {
+  cat <<'EOF'
+Usage: ./install.sh [--with-ollama | --with-docker | --with-hermes]
+
+  --with-ollama  Install and update Ollama.
+  --with-docker  Include Ollama, Docker Desktop, and independent Hindsight.
+  --with-hermes  Include the Docker profile, Hermes, Chrome, and Discord.
+EOF
+}
+
+resolve_install_profile() {
+  while (($# > 0)); do
+    case "$1" in
+    --with-ollama) DOTFILES_WITH_OLLAMA=1 ;;
+    --with-docker) DOTFILES_WITH_DOCKER=1 ;;
+    --with-hermes) DOTFILES_WITH_HERMES=1 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *) dotfiles_die "Unknown argument: $1" ;;
+    esac
+    shift
+  done
+
+  if ((DOTFILES_WITH_HERMES == 1)); then
+    DOTFILES_WITH_DOCKER=1
+  fi
+  if ((DOTFILES_WITH_DOCKER == 1)); then
+    DOTFILES_WITH_OLLAMA=1
+  fi
+  export DOTFILES_WITH_OLLAMA DOTFILES_WITH_DOCKER DOTFILES_WITH_HERMES
+}
 
 preflight() {
   local os arch version major required
@@ -40,11 +78,19 @@ preflight() {
   [[ $major =~ ^[0-9]+$ ]] || dotfiles_die "Unable to parse macOS version: $version"
   ((major >= 26)) || dotfiles_die "macOS 26 or later is required (detected $version)."
 
-  for required in \
-    "$ROOT/flake.nix" \
-    "$ROOT/chezmoi" \
-    "$COMPOSE_FILE" \
-    "$VERIFY_ENVIRONMENT"; do
+  local -a required_paths=(
+    "$ROOT/flake.nix"
+    "$ROOT/chezmoi"
+    "$VERIFY_ENVIRONMENT"
+  )
+  if ((DOTFILES_WITH_DOCKER == 1)); then
+    required_paths+=("$HINDSIGHT_COMPOSE_FILE")
+  fi
+  if ((DOTFILES_WITH_HERMES == 1)); then
+    required_paths+=("$COMPOSE_FILE")
+  fi
+
+  for required in "${required_paths[@]}"; do
     [[ -e $required ]] || dotfiles_die "Required repository path is missing: $required"
   done
 }
@@ -135,6 +181,9 @@ apply_darwin_system() {
       "DOTFILES_USER=$DOTFILES_USER" \
       "DOTFILES_HOME=$DOTFILES_HOME" \
       "DOTFILES_ROOT=$DOTFILES_ROOT" \
+      "DOTFILES_WITH_OLLAMA=$DOTFILES_WITH_OLLAMA" \
+      "DOTFILES_WITH_DOCKER=$DOTFILES_WITH_DOCKER" \
+      "DOTFILES_WITH_HERMES=$DOTFILES_WITH_HERMES" \
       "$nix_bin" run .#darwin-rebuild -- switch --flake .#macos --impure
   )
 
@@ -367,22 +416,34 @@ apply_chezmoi() {
 }
 
 main() {
+  resolve_install_profile "$@"
   preflight
   ensure_command_line_tools
   ensure_nix
   dotfiles_link_checkout "$ROOT"
   dotfiles_update_flake "$ROOT"
   preserve_shell_rc_for_nix_darwin
-  stop_existing_docker_desktop
+  if ((DOTFILES_WITH_DOCKER == 1)); then
+    stop_existing_docker_desktop
+  fi
   repair_homebrew_cask_link_directories
   migrate_unmanaged_wezterm_install
   apply_darwin_system
   dotfiles_install_herdr
   ensure_homebrew_cask_link_directories
-  setup_docker_runtime
   apply_chezmoi
-  dotfiles_run_task hermes:bootstrap
-  "$VERIFY_ENVIRONMENT" --runtime
+  if ((DOTFILES_WITH_DOCKER == 1)); then
+    setup_docker_runtime
+    if ((DOTFILES_WITH_HERMES == 1)); then
+      dotfiles_run_task hermes:bootstrap
+      DOTFILES_COMPOSE_FILE="$COMPOSE_FILE" "$VERIFY_ENVIRONMENT" --runtime
+    else
+      dotfiles_run_task hindsight:up
+      DOTFILES_COMPOSE_FILE="$HINDSIGHT_COMPOSE_FILE" "$VERIFY_ENVIRONMENT" --runtime
+    fi
+  else
+    "$VERIFY_ENVIRONMENT"
+  fi
   dotfiles_log "macOS setup complete."
 }
 

--- a/scripts/sh/verify-environment.sh
+++ b/scripts/sh/verify-environment.sh
@@ -41,29 +41,35 @@ required=(
   python3
   go
   rustup
-  docker
 )
 
 case "$platform" in
 darwin) required+=(brew darwin-rebuild) ;;
 linux)
-  required+=(systemctl)
+  required+=(systemctl docker)
   [[ $system_layer == "nixos" ]] && required+=(nixos-rebuild)
   ;;
 *) fail "unsupported verification platform: $platform" ;;
 esac
 
+if ((runtime == 1)); then
+  required+=(docker)
+fi
+
 for command_name in "${required[@]}"; do
   command -v "$command_name" >/dev/null 2>&1 || fail "missing command: $command_name"
 done
 
-[[ -f $COMPOSE_FILE ]] || fail "missing Compose file: $COMPOSE_FILE"
-docker compose version >/dev/null || fail "Docker Compose is unavailable"
-docker info >/dev/null || fail "Docker engine is unavailable"
 chezmoi apply --dry-run >/dev/null || fail "chezmoi dry-run failed"
 if ! chezmoi verify --exclude=scripts >/dev/null; then
   chezmoi diff --exclude=scripts --no-pager --color=false >&2 || true
   fail "chezmoi target state differs"
+fi
+
+if [[ $platform == "linux" ]] || ((runtime == 1)); then
+  [[ -f $COMPOSE_FILE ]] || fail "missing Compose file: $COMPOSE_FILE"
+  docker compose version >/dev/null || fail "Docker Compose is unavailable"
+  docker info >/dev/null || fail "Docker engine is unavailable"
 fi
 
 if [[ $platform == "linux" ]]; then

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -312,9 +312,10 @@ create_mocked_installer_fixture() {
 	MOCK_REPO="$fixture_root/installer-repo"
 	MOCK_BIN="$fixture_root/installer-bin"
 	MOCK_DOCKER_APP="$fixture_root/Docker.app"
+	MOCK_OLLAMA_APP="$fixture_root/Ollama.app"
 	mkdir -p "$MOCK_REPO/scripts/sh" "$MOCK_REPO/chezmoi" \
 		"$MOCK_REPO/docker/hermes-agent" "$MOCK_REPO/docker/hindsight" \
-		"$MOCK_BIN" "$MOCK_DOCKER_APP/Contents/MacOS" \
+		"$MOCK_BIN" "$MOCK_OLLAMA_APP" "$MOCK_DOCKER_APP/Contents/MacOS" \
 		"$MOCK_DOCKER_APP/Contents/Resources/bin"
 	MOCK_REPO="$(cd "$MOCK_REPO" && pwd -P)"
 	cp "$REPO_ROOT/install.sh" "$MOCK_REPO/install.sh"
@@ -448,6 +449,8 @@ printf "\\n" >&2
 exit 97
 '
 	write_fixture_stub chezmoi 'printf "chezmoi %s\\n" "$*" >>"$COMMAND_LOG"'
+	write_fixture_stub curl 'printf "curl %s\\n" "$*" >>"$COMMAND_LOG"'
+	write_fixture_stub open 'printf "open %s\\n" "$*" >>"$COMMAND_LOG"'
 	write_fixture_stub docker 'printf "docker %s\\n" "$*" >>"$COMMAND_LOG"'
 	write_fixture_stub task 'printf "task %s\\n" "$*" >>"$COMMAND_LOG"'
 
@@ -522,6 +525,8 @@ EOF
 		DOTFILES_CHECKOUT_TARGET="$fixture_root/checkout" \
 		DOTFILES_NIX_PROFILE_SCRIPT="$fixture_root/nix-daemon.sh" \
 		DOTFILES_DOCKER_APP_PATH="$MOCK_DOCKER_APP" \
+		DOTFILES_OLLAMA_APP_PATH="$MOCK_OLLAMA_APP" \
+		DOTFILES_OPEN_COMMAND="$MOCK_BIN/open" \
 		DOTFILES_TASK_COMMAND="$MOCK_BIN/task" \
 		DOTFILES_DOCKER_SETUP_MARKER="$fixture_root/docker-setup" \
 		DOTFILES_HOMEBREW_CASK_BIN_DIR="$fixture_root/untrusted/bin" \

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -313,7 +313,8 @@ create_mocked_installer_fixture() {
 	MOCK_BIN="$fixture_root/installer-bin"
 	MOCK_DOCKER_APP="$fixture_root/Docker.app"
 	mkdir -p "$MOCK_REPO/scripts/sh" "$MOCK_REPO/chezmoi" \
-		"$MOCK_REPO/docker/hermes-agent" "$MOCK_BIN" "$MOCK_DOCKER_APP/Contents/MacOS" \
+		"$MOCK_REPO/docker/hermes-agent" "$MOCK_REPO/docker/hindsight" \
+		"$MOCK_BIN" "$MOCK_DOCKER_APP/Contents/MacOS" \
 		"$MOCK_DOCKER_APP/Contents/Resources/bin"
 	MOCK_REPO="$(cd "$MOCK_REPO" && pwd -P)"
 	cp "$REPO_ROOT/install.sh" "$MOCK_REPO/install.sh"
@@ -343,7 +344,9 @@ homebrew_cask_link_parent_is_immutable_to_caller() {
 }
 main "$@"
 EOF
-	touch "$MOCK_REPO/flake.nix" "$MOCK_REPO/docker/hermes-agent/compose.yml"
+	touch "$MOCK_REPO/flake.nix" \
+		"$MOCK_REPO/docker/hermes-agent/compose.yml" \
+		"$MOCK_REPO/docker/hindsight/compose.yml"
 
 	cat >"$MOCK_REPO/scripts/sh/hermes-agent.sh" <<'EOF'
 printf 'selected-installer=%s\n' "${DOTFILES_TEST_SELECTED_INSTALLER:-${BASH_SOURCE[1]}}" >>"$COMMAND_LOG"
@@ -418,11 +421,13 @@ case "${1:-}" in
     fi
     ;;
   /usr/bin/env)
-    if [[ $# -eq 13 && ${2:-} == "NIX_CONFIG=extra-experimental-features = nix-command flakes" &&
+    if [[ $# -eq 16 && ${2:-} == "NIX_CONFIG=extra-experimental-features = nix-command flakes" &&
       ${3:-} == "DOTFILES_USER=$fixture_user" && ${4:-} == "DOTFILES_HOME=$HOME" &&
-      ${5:-} == "DOTFILES_ROOT=$DOTFILES_ROOT" && ${6:-} == "${PATH%%:*}/nix" &&
-      ${7:-} == run && ${8:-} == .#darwin-rebuild && ${9:-} == -- &&
-      ${10:-} == switch && ${11:-} == --flake && ${12:-} == .#macos && ${13:-} == --impure ]]; then
+      ${5:-} == "DOTFILES_ROOT=$DOTFILES_ROOT" && ${6:-} == DOTFILES_WITH_OLLAMA=* &&
+      ${7:-} == DOTFILES_WITH_DOCKER=* && ${8:-} == DOTFILES_WITH_HERMES=* &&
+      ${9:-} == "${PATH%%:*}/nix" && ${10:-} == run && ${11:-} == .#darwin-rebuild &&
+      ${12:-} == -- && ${13:-} == switch && ${14:-} == --flake &&
+      ${15:-} == .#macos && ${16:-} == --impure ]]; then
       exec "$@"
     fi
     ;;
@@ -460,6 +465,7 @@ EOF
 
 run_mocked_installer() {
 	local platform="$1"
+	shift
 	local test_root fixture_root marker hardware prebuilt systemd_dir os_release user_profile_root
 	local homebrew_bin_dir homebrew_cli_plugins_dir
 	test_root="$(cd "$BATS_TEST_TMPDIR" && pwd -P)"
@@ -530,7 +536,7 @@ EOF
 		DOTFILES_NIXOS_MARKER="$marker" \
 		DOTFILES_NIXOS_HARDWARE_CONFIG="$hardware" \
 		DOTFILES_NIXOS_PREBUILT_SYSTEM="$MOCK_NIXOS_PREBUILT_SYSTEM" \
-		"$MOCK_REPO/install.sh"
+		"$MOCK_REPO/install.sh" "$@"
 }
 
 @test "Unix installers use the Taskfile as the canonical Hermes handoff" {
@@ -547,7 +553,11 @@ EOF
 	local platform task_line apply_line task_line_number expected_sudo_count target
 	for platform in macos linux nixos; do
 		: >"$COMMAND_LOG"
-		run_mocked_installer "$platform"
+		if [[ $platform == macos ]]; then
+			run_mocked_installer "$platform" --with-hermes
+		else
+			run_mocked_installer "$platform"
+		fi
 
 		if [[ $status -ne 0 ]]; then
 			printf '%s installer failed:\n%s\n' "$platform" "$output" >&3
@@ -563,7 +573,7 @@ EOF
 		if [[ $platform == macos ]]; then
 			grep -Fxq 'docker info' "$COMMAND_LOG"
 			grep -Fxq 'docker compose version' "$COMMAND_LOG"
-			grep -Fqx "sudo </usr/bin/env> <NIX_CONFIG=extra-experimental-features = nix-command flakes> <DOTFILES_USER=test-user> <DOTFILES_HOME=$TEST_HOME> <DOTFILES_ROOT=$MOCK_REPO> <$MOCK_BIN/nix> <run> <.#darwin-rebuild> <--> <switch> <--flake> <.#macos> <--impure>" "$COMMAND_LOG"
+			grep -Fqx "sudo </usr/bin/env> <NIX_CONFIG=extra-experimental-features = nix-command flakes> <DOTFILES_USER=test-user> <DOTFILES_HOME=$TEST_HOME> <DOTFILES_ROOT=$MOCK_REPO> <DOTFILES_WITH_OLLAMA=1> <DOTFILES_WITH_DOCKER=1> <DOTFILES_WITH_HERMES=1> <$MOCK_BIN/nix> <run> <.#darwin-rebuild> <--> <switch> <--flake> <.#macos> <--impure>" "$COMMAND_LOG"
 			grep -Fqx 'sudo </usr/sbin/chown> <test-user:admin> </usr/local/bin>' "$COMMAND_LOG"
 			grep -Fqx 'sudo </bin/chmod> <0775> </usr/local/bin>' "$COMMAND_LOG"
 			grep -Fqx 'sudo </usr/sbin/chown> <test-user:admin> </usr/local/cli-plugins>' "$COMMAND_LOG"

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -135,11 +135,13 @@ case "${1:-}" in
 		fi
 		;;
 	/usr/bin/env)
-		if [[ $# -eq 13 && ${2:-} == "NIX_CONFIG=extra-experimental-features = nix-command flakes" &&
+		if [[ $# -eq 16 && ${2:-} == "NIX_CONFIG=extra-experimental-features = nix-command flakes" &&
 			${3:-} == "DOTFILES_USER=$fixture_user" && ${4:-} == "DOTFILES_HOME=$HOME" &&
-			${5:-} == "DOTFILES_ROOT=$DOTFILES_ROOT" && ${6:-} == "$STUB_BIN/nix" &&
-			${7:-} == run && ${8:-} == ".#darwin-rebuild" && ${9:-} == -- &&
-			${10:-} == switch && ${11:-} == --flake && ${12:-} == ".#macos" && ${13:-} == --impure ]]; then
+			${5:-} == "DOTFILES_ROOT=$DOTFILES_ROOT" && ${6:-} == DOTFILES_WITH_OLLAMA=* &&
+			${7:-} == DOTFILES_WITH_DOCKER=* && ${8:-} == DOTFILES_WITH_HERMES=* &&
+			${9:-} == "$STUB_BIN/nix" && ${10:-} == run && ${11:-} == ".#darwin-rebuild" &&
+			${12:-} == -- && ${13:-} == switch && ${14:-} == --flake &&
+			${15:-} == ".#macos" && ${16:-} == --impure ]]; then
 			exec "$@"
 		fi
 		;;
@@ -171,7 +173,7 @@ printf " <%s>" "$@" >&2
 printf "\n" >&2
 exit 97
 '
-	write_stub verify-environment 'printf "verify-environment %s\n" "$*" >>"$COMMAND_LOG"'
+	write_stub verify-environment 'printf "verify-environment compose=%s args=%s\n" "${DOTFILES_COMPOSE_FILE:-}" "$*" >>"$COMMAND_LOG"'
 	write_stub jq 'exec "$REAL_JQ" "$@"'
 	write_stub task '
 printf "task %s\n" "$*" >>"$COMMAND_LOG"
@@ -422,19 +424,51 @@ run_macos_installer() {
 	assert_no_homebrew_cask_link_mutations
 }
 
-@test "installed prerequisites run nix-darwin chezmoi and Compose in order" {
+@test "default profile applies core configuration without optional runtimes" {
 	write_installed_stubs
 
 	run_macos_installer
 
 	[ "$status" -eq 0 ]
-	grep -Fqx "sudo </usr/bin/env> <NIX_CONFIG=extra-experimental-features = nix-command flakes> <DOTFILES_USER=test-user> <DOTFILES_HOME=$TEST_HOME> <DOTFILES_ROOT=$REPO_ROOT> <$STUB_BIN/nix> <run> <.#darwin-rebuild> <--> <switch> <--flake> <.#macos> <--impure>" "$COMMAND_LOG"
+	grep -Fq '<DOTFILES_WITH_OLLAMA=0> <DOTFILES_WITH_DOCKER=0> <DOTFILES_WITH_HERMES=0>' "$COMMAND_LOG"
 	assert_log_order \
 		"nix flake update --flake $REPO_ROOT" \
 		"nix run .#darwin-rebuild -- switch --flake .#macos --impure" \
-		"docker info" \
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
+		"verify-environment compose= args="
+	! grep -q '^docker ' "$COMMAND_LOG"
+	! grep -q '^task .*\(hindsight:up\|hermes:bootstrap\)' "$COMMAND_LOG"
+}
+
+@test "WithDocker includes Ollama and starts only independent Hindsight after chezmoi" {
+	write_installed_stubs
+
+	run_macos_installer --with-docker
+
+	[ "$status" -eq 0 ]
+	grep -Fq '<DOTFILES_WITH_OLLAMA=1> <DOTFILES_WITH_DOCKER=1> <DOTFILES_WITH_HERMES=0>' "$COMMAND_LOG"
+	assert_log_order \
+		"chezmoi apply --force" \
+		"docker info" \
+		"task --dir $REPO_ROOT hindsight:up" \
+		"verify-environment compose=$REPO_ROOT/docker/hindsight/compose.yml args=--runtime"
+	! grep -q 'task .*hermes:bootstrap' "$COMMAND_LOG"
+}
+
+@test "WithHermes runs nix-darwin chezmoi and Compose in order" {
+	write_installed_stubs
+
+	run_macos_installer --with-hermes
+
+	[ "$status" -eq 0 ]
+	grep -Fq '<DOTFILES_WITH_OLLAMA=1> <DOTFILES_WITH_DOCKER=1> <DOTFILES_WITH_HERMES=1>' "$COMMAND_LOG"
+	assert_log_order \
+		"nix flake update --flake $REPO_ROOT" \
+		"nix run .#darwin-rebuild -- switch --flake .#macos --impure" \
+		"chezmoi init --source $REPO_ROOT/chezmoi" \
+		"chezmoi apply --force" \
+		"docker info" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml config --quiet" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml build --pull hermes hermes-bootstrap chromium xapi-mcp" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml stop hermes" \
@@ -442,13 +476,23 @@ run_macos_installer() {
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml run --rm --no-deps -T hermes-bootstrap apply" \
 		"docker compose -f $REPO_ROOT/docker/hermes-agent/compose.yml up -d --force-recreate" \
 		"docker image prune --force" \
-		"verify-environment --runtime"
+		"verify-environment compose=$REPO_ROOT/docker/hermes-agent/compose.yml args=--runtime"
 	[ "$(grep -c '^op item get ' "$COMMAND_LOG")" -eq 12 ]
 	[ "$(grep -c '^op signin --account my.1password.com$' "$COMMAND_LOG")" -eq 2 ]
 	[ -s "$PAYLOAD_CAPTURE" ]
 	! grep -q 'brew install --cask' "$COMMAND_LOG"
 	! grep -q 'desktop.docker.com/mac' "$COMMAND_LOG"
 	! grep -q 'docker-install' "$COMMAND_LOG"
+}
+
+@test "unknown install profile stops before mutation" {
+	write_installed_stubs
+
+	run_macos_installer --with-unknown
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Unknown argument: --with-unknown"* ]]
+	[ ! -s "$COMMAND_LOG" ]
 }
 
 @test "migrates an unmanaged WezTerm install before nix-darwin activation" {
@@ -683,7 +727,7 @@ docker_desktop_md5_link_state /sbin/md5 "$1"
 	run_macos_installer
 
 	[ "$status" -eq 0 ]
-	grep -Fqx "sudo </usr/bin/env> <NIX_CONFIG=extra-experimental-features = nix-command flakes> <DOTFILES_USER=test-user> <DOTFILES_HOME=$TEST_HOME> <DOTFILES_ROOT=$REPO_ROOT> <$STUB_BIN/nix> <run> <.#darwin-rebuild> <--> <switch> <--flake> <.#macos> <--impure>" "$COMMAND_LOG"
+	grep -Fq '<DOTFILES_WITH_OLLAMA=0> <DOTFILES_WITH_DOCKER=0> <DOTFILES_WITH_HERMES=0>' "$COMMAND_LOG"
 	! grep -Fq "$DOTFILES_HOMEBREW_CASK_BIN_DIR" "$COMMAND_LOG"
 	! grep -Fq "$DOTFILES_HOMEBREW_CASK_CLI_PLUGIN_DIR" "$COMMAND_LOG"
 	[ "$(grep -Fxc 'sudo </usr/sbin/chown> <test-user:admin> </usr/local/bin>' "$COMMAND_LOG")" -eq 1 ]
@@ -704,7 +748,7 @@ docker_desktop_md5_link_state /sbin/md5 "$1"
 		"sudo </bin/chmod> <0775> </usr/local/bin>" \
 		"sudo </usr/sbin/chown> <test-user:admin> </usr/local/cli-plugins>" \
 		"sudo </bin/chmod> <0775> </usr/local/cli-plugins>" \
-		"docker info"
+		"chezmoi apply --force"
 }
 
 @test "Linux harness stubs macOS-only parent inspection" {
@@ -850,7 +894,7 @@ docker_desktop_md5_link_state /sbin/md5 "$1"
 	write_installed_stubs
 	export HERMES_BOOTSTRAP_STATUS=45
 
-	run_macos_installer
+	run_macos_installer --with-hermes
 
 	[ "$status" -eq 45 ]
 	grep -q 'hermes-bootstrap apply' "$COMMAND_LOG"
@@ -894,7 +938,7 @@ esac
 EOF
 	chmod +x "$FAKE_DOCKER_APP/Contents/Resources/bin/docker"
 
-	run_macos_installer
+	run_macos_installer --with-docker
 
 	[ "$status" -eq 0 ]
 	assert_log_order \
@@ -938,7 +982,7 @@ if [ "${1:-}" = "run" ]; then exit 42; fi
 	write_fresh_install_stubs
 	rmdir "$FAKE_HOMEBREW_BIN_DIR" "$FAKE_HOMEBREW_CLI_PLUGINS_DIR"
 
-	run_macos_installer
+	run_macos_installer --with-hermes
 
 	[ "$status" -eq 0 ]
 	grep -Fqx "sudo </bin/mkdir> <--> <$FAKE_HOMEBREW_BIN_DIR>" "$COMMAND_LOG"
@@ -946,8 +990,8 @@ if [ "${1:-}" = "run" ]; then exit 42; fi
 	assert_log_order \
 		"nix-installer --daemon" \
 		"nix run .#darwin-rebuild -- switch --flake .#macos --impure" \
-		"docker-install --accept-license --user=test-user" \
-		"chezmoi init --source $REPO_ROOT/chezmoi"
+		"chezmoi init --source $REPO_ROOT/chezmoi" \
+		"docker-install --accept-license --user=test-user"
 	[ "$(grep -c 'nix-installer --daemon' "$COMMAND_LOG")" -eq 1 ]
 	! grep -q 'raw.githubusercontent.com/Homebrew/install' "$COMMAND_LOG"
 	! grep -q 'brew install --cask' "$COMMAND_LOG"
@@ -1010,7 +1054,7 @@ exit 0
 EOF
 	chmod +x "$FAKE_DOCKER_APP/Contents/Resources/bin/docker"
 
-	run_macos_installer
+	run_macos_installer --with-docker
 
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"Timed out waiting for Docker Desktop engine after 2 attempts."* ]]

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -10,6 +10,7 @@ setup() {
 	COMMAND_LOG="$BATS_TEST_TMPDIR/commands.log"
 	PAYLOAD_CAPTURE="$BATS_TEST_TMPDIR/payload.ndjson"
 	FAKE_DOCKER_APP="$BATS_TEST_TMPDIR/Docker.app"
+	FAKE_OLLAMA_APP="$BATS_TEST_TMPDIR/Ollama.app"
 	FAKE_NIX_PROFILE="$BATS_TEST_TMPDIR/nix-daemon.sh"
 	FAKE_BASHRC="$BATS_TEST_TMPDIR/etc/bashrc"
 	FAKE_ZSHRC="$BATS_TEST_TMPDIR/etc/zshrc"
@@ -35,6 +36,7 @@ setup() {
 	export COMMAND_LOG STUB_BIN PAYLOAD_CAPTURE REAL_JQ INSTALLER REPO_ROOT
 	export DOTFILES_SKIP_HERDR_INSTALL=1
 	export FAKE_BASHRC FAKE_ZSHRC FAKE_DOCKER_APP
+	export FAKE_OLLAMA_APP
 	export FAKE_HOMEBREW_BIN_DIR FAKE_HOMEBREW_CLI_PLUGINS_DIR
 	export TEST_HOMEBREW_CASK_PARENT_DIR TEST_HOMEBREW_CASK_BIN_DIR
 	export TEST_HOMEBREW_CASK_CLI_PLUGIN_DIR TEST_HOMEBREW_LINK_TARGET
@@ -44,6 +46,8 @@ setup() {
 	export HERMES_XAPI_OAUTH_ITEM_JSON='{"id":"xapi-oauth-item","fields":[{"label":"X_API_REFRESH_TOKEN","value":"xapi-refresh-token-marker"}]}'
 	export HERMES_BOOTSTRAP_STATUS=0
 	export DOTFILES_DOCKER_APP_PATH="$FAKE_DOCKER_APP"
+	export DOTFILES_OLLAMA_APP_PATH="$FAKE_OLLAMA_APP"
+	export DOTFILES_OPEN_COMMAND="$STUB_BIN/open"
 	export DOTFILES_DOCKER_SETUP_MARKER="$TEST_HOME/.config/dotfiles/docker-desktop-installed"
 	export DOTFILES_NIX_PROFILE_SCRIPT="$FAKE_NIX_PROFILE"
 	export DOTFILES_BASHRC_PATH="$FAKE_BASHRC"
@@ -52,6 +56,7 @@ setup() {
 	export DOTFILES_HOMEBREW_BIN_DIR="$FAKE_HOMEBREW_BIN_DIR"
 	export DOTFILES_HOMEBREW_CLI_PLUGINS_DIR="$FAKE_HOMEBREW_CLI_PLUGINS_DIR"
 	export DOTFILES_DOCKER_WAIT_ATTEMPTS=2
+	export DOTFILES_OLLAMA_WAIT_ATTEMPTS=2
 	export DOTFILES_WAIT_SLEEP_SECONDS=0
 	export DOTFILES_VERIFY_ENVIRONMENT="$STUB_BIN/verify-environment"
 	export DOTFILES_HERMES_OLLAMA_EXECUTABLE="$STUB_BIN/ollama"
@@ -83,11 +88,17 @@ exit 2
 	write_stub curl '
 printf "curl %s\n" "$*" >>"$COMMAND_LOG"
 case "$*" in
+	*"/api/version"*)
+		if [[ ${OLLAMA_API_REQUIRES_OPEN:-0} == 1 ]] && ! grep -q "^open .*Ollama" "$COMMAND_LOG"; then
+			exit 1
+		fi
+		;;
   *"/api/tags"*) printf "%s\n" "{\"models\":[{\"name\":\"qwen3.6:35b\"},{\"name\":\"qwen3-embedding:0.6b\"}]}" ;;
   *"127.0.0.1:8888/health"*) printf "%s\n" "{\"status\":\"healthy\",\"database\":\"connected\"}" ;;
 esac
 exit 0
 '
+	write_stub open 'printf "open %s\n" "$*" >>"$COMMAND_LOG"'
 	write_stub ollama 'printf "ollama %s\n" "$*" >>"$COMMAND_LOG"'
 	write_stub pgrep '
 printf "pgrep %s\n" "$*" >>"$COMMAND_LOG"
@@ -237,7 +248,7 @@ EOF
 
 write_installed_stubs() {
 	write_docker_app
-	mkdir -p "$FAKE_HOMEBREW_BIN_DIR" "$FAKE_HOMEBREW_CLI_PLUGINS_DIR"
+	mkdir -p "$FAKE_HOMEBREW_BIN_DIR" "$FAKE_HOMEBREW_CLI_PLUGINS_DIR" "$FAKE_OLLAMA_APP"
 	mkdir -p "$(dirname "$DOTFILES_DOCKER_SETUP_MARKER")"
 	touch "$DOTFILES_DOCKER_SETUP_MARKER"
 
@@ -271,7 +282,7 @@ cat >"$STUB_BIN/nix" <<'"'"'NIX'"'"'
 set -euo pipefail
 printf "nix %s\n" "$*" >>"$COMMAND_LOG"
 if [ "${1:-}" = "run" ]; then
-	mkdir -p "$DOTFILES_DOCKER_APP_PATH/Contents/MacOS" "$DOTFILES_DOCKER_APP_PATH/Contents/Resources/bin"
+	mkdir -p "$DOTFILES_DOCKER_APP_PATH/Contents/MacOS" "$DOTFILES_DOCKER_APP_PATH/Contents/Resources/bin" "$DOTFILES_OLLAMA_APP_PATH"
 		cat >"$DOTFILES_DOCKER_APP_PATH/Contents/MacOS/install" <<'"'"'DOCKER_INSTALL'"'"'
 #!/usr/bin/env bash
 printf "docker-install %s\n" "$*" >>"$COMMAND_LOG"
@@ -441,8 +452,27 @@ run_macos_installer() {
 	! grep -q '^task .*\(hindsight:up\|hermes:bootstrap\)' "$COMMAND_LOG"
 }
 
+@test "WithOllama starts its API after chezmoi without starting Docker" {
+	write_installed_stubs
+	export OLLAMA_API_REQUIRES_OPEN=1
+
+	run_macos_installer --with-ollama
+
+	[ "$status" -eq 0 ]
+	grep -Fq '<DOTFILES_WITH_OLLAMA=1> <DOTFILES_WITH_DOCKER=0> <DOTFILES_WITH_HERMES=0>' "$COMMAND_LOG"
+	assert_log_order \
+		"chezmoi apply --force" \
+		"open -gj -a $FAKE_OLLAMA_APP" \
+		"verify-environment compose= args="
+	[ "$(grep -Fc 'curl --fail --silent --show-error --max-time 2 http://127.0.0.1:11434/api/version' "$COMMAND_LOG")" -eq 2 ]
+	[ "$(grep -nF "open -gj -a $FAKE_OLLAMA_APP" "$COMMAND_LOG" | cut -d: -f1)" -lt \
+		"$(grep -nF 'curl --fail --silent --show-error --max-time 2 http://127.0.0.1:11434/api/version' "$COMMAND_LOG" | tail -1 | cut -d: -f1)" ]
+	! grep -q '^docker ' "$COMMAND_LOG"
+}
+
 @test "WithDocker includes Ollama and starts only independent Hindsight after chezmoi" {
 	write_installed_stubs
+	export OLLAMA_API_REQUIRES_OPEN=1
 
 	run_macos_installer --with-docker
 
@@ -450,10 +480,27 @@ run_macos_installer() {
 	grep -Fq '<DOTFILES_WITH_OLLAMA=1> <DOTFILES_WITH_DOCKER=1> <DOTFILES_WITH_HERMES=0>' "$COMMAND_LOG"
 	assert_log_order \
 		"chezmoi apply --force" \
+		"open -gj -a $FAKE_OLLAMA_APP" \
 		"docker info" \
 		"task --dir $REPO_ROOT hindsight:up" \
 		"verify-environment compose=$REPO_ROOT/docker/hindsight/compose.yml args=--runtime"
 	! grep -q 'task .*hermes:bootstrap' "$COMMAND_LOG"
+}
+
+@test "Ollama readiness timeout stops before Docker startup" {
+	write_installed_stubs
+	write_stub curl '
+printf "curl %s\n" "$*" >>"$COMMAND_LOG"
+exit 1
+'
+
+	run_macos_installer --with-docker
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Timed out waiting for Ollama API after 2 attempts."* ]]
+	grep -Fq "open -gj -a $FAKE_OLLAMA_APP" "$COMMAND_LOG"
+	! grep -q '^docker info$' "$COMMAND_LOG"
+	! grep -q 'task .*hindsight:up' "$COMMAND_LOG"
 }
 
 @test "WithHermes runs nix-darwin chezmoi and Compose in order" {

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -448,6 +448,8 @@ run_macos_installer() {
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
 		"verify-environment compose= args="
+	! grep -q "^open .*${FAKE_OLLAMA_APP}" "$COMMAND_LOG"
+	! grep -q '/api/version' "$COMMAND_LOG"
 	! grep -q '^docker ' "$COMMAND_LOG"
 	! grep -q '^task .*\(hindsight:up\|hermes:bootstrap\)' "$COMMAND_LOG"
 }

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -20,8 +20,59 @@ setup() {
 
 @test "Darwin uses nix-homebrew catalog casks and Home Manager" {
 	grep -q 'nix-homebrew = {' "$REPO_ROOT/nix/hosts/darwin/default.nix"
-	grep -q 'casks = sets.darwinCasks' "$REPO_ROOT/nix/hosts/darwin/default.nix"
+	grep -q 'casks = sets.darwinCasksForInstallFeatures' "$REPO_ROOT/nix/hosts/darwin/default.nix"
 	grep -q 'home-manager.darwinModules.home-manager' "$REPO_ROOT/nix/flakes/darwin.nix"
+}
+
+@test "Darwin default profile excludes optional casks" {
+	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
+
+	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex \
+		nix eval --impure --json --expr "
+			let config = (builtins.getFlake (toString $REPO_ROOT)).darwinConfigurations.macos.config;
+			in config.homebrew.casks
+		"
+
+	[ "$status" -eq 0 ]
+	run jq -e 'all(.[]; [.name] | inside(["ollama-app", "docker-desktop", "google-chrome", "discord"]) | not)' <<<"$output"
+	[ "$status" -eq 0 ]
+}
+
+@test "Darwin Docker profile includes Ollama and Docker but not Hermes desktop casks" {
+	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
+
+	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex DOTFILES_WITH_DOCKER=1 \
+		nix eval --impure --json --expr "
+			let config = (builtins.getFlake (toString $REPO_ROOT)).darwinConfigurations.macos.config;
+			in config.homebrew.casks
+		"
+
+	[ "$status" -eq 0 ]
+	run jq -e '
+		any(.[]; .name == "ollama-app") and
+		any(.[]; .name == "docker-desktop") and
+		all(.[]; .name != "google-chrome" and .name != "discord")
+	' <<<"$output"
+	[ "$status" -eq 0 ]
+}
+
+@test "Darwin Hermes profile includes its complete optional cask set" {
+	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
+
+	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex DOTFILES_WITH_HERMES=1 \
+		nix eval --impure --json --expr "
+			let config = (builtins.getFlake (toString $REPO_ROOT)).darwinConfigurations.macos.config;
+			in config.homebrew.casks
+		"
+
+	[ "$status" -eq 0 ]
+	run jq -e '
+		any(.[]; .name == "ollama-app") and
+		any(.[]; .name == "docker-desktop") and
+		any(.[]; .name == "google-chrome") and
+		any(.[]; .name == "discord")
+	' <<<"$output"
+	[ "$status" -eq 0 ]
 }
 
 @test "Darwin enables automatic Homebrew cask upgrades" {
@@ -121,10 +172,10 @@ setup() {
 	[ "$output" = "86400" ]
 }
 
-@test "Darwin uses Homebrew's renamed Ollama cask" {
+@test "Darwin Ollama profile uses Homebrew's renamed Ollama cask" {
 	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
 
-	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex \
+	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex DOTFILES_WITH_OLLAMA=1 \
 		nix eval --impure --json --expr "
 			let
 				config = (builtins.getFlake (toString $REPO_ROOT)).darwinConfigurations.macos.config;

--- a/tests/bash/verify_environment.bats
+++ b/tests/bash/verify_environment.bats
@@ -81,6 +81,15 @@ EOF
 	! grep -q '^docker run ' "$COMMAND_LOG"
 }
 
+@test "Darwin core verification does not require Docker" {
+	rm "$STUB_BIN/docker"
+
+	run "$VERIFIER"
+
+	[ "$status" -eq 0 ]
+	! grep -q '^docker ' "$COMMAND_LOG"
+}
+
 @test "missing running Compose service fails runtime verification" {
 	export COMPOSE_RUNNING_MISMATCH=1
 


### PR DESCRIPTION
## Summary

- keep the default macOS install focused on core tools and gate Ollama, Docker, Hindsight, Hermes, Chrome, and Discord behind explicit profiles
- start and verify Ollama only after chezmoi, then start Docker and the selected optional runtimes in dependency order
- filter nix-darwin Homebrew casks by the selected profile and verify only the selected runtime layer
- document the profile behavior and add regression coverage for default and opt-in installs

Closes #515

## Validation

- `bats tests/bash` — 302 tests, 0 failures
- `nix fmt -- --fail-on-change`
- `shellcheck scripts/sh/install-macos.sh`
- `SKIP=hermes-bootstrap-tests pre-commit run --all-files`
- read-only code review: Ready to merge; previous Ollama/Hindsight ordering finding resolved

The local Docker-backed pre-commit hook was skipped because Docker Desktop is intentionally stopped; hosted Actions provide the Docker-backed validation.
