### PR TITLE
feat: orchestrate local AI service dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ Hindsight、Hermes、Chrome、Discord、Chromium/browser-mcp は導入しませ�
 
 ```powershell
 .\install.cmd -WithOllama # Ollama のみ
-.\install.cmd -WithDocker # Ollama + Docker + 独立 Hindsight
-.\install.cmd -WithHermes # 上記 + Hermes + Chrome + Discord + browser-mcp
+.\install.cmd -WithDocker # Docker のみ
+.\install.cmd -WithMLflow # Ollama + Docker + MLflow
+.\install.cmd -WithHindsight # Ollama + Docker + MLflow + Hindsight
+.\install.cmd -WithHermes # Ollama + Docker + MLflow + Hindsight + Hermes + Chrome + Discord + browser-mcp
 ```
 
 ### macOS (Apple Silicon)

--- a/docs/hermes-agent/hindsight-memory.md
+++ b/docs/hermes-agent/hindsight-memory.md
@@ -44,8 +44,10 @@ native Ollama のモデル存在・readiness を確認するためだけのも�
 
 ## Installation
 
-Windows では `-WithDocker` または `-WithHermes` を指定すると、Ollama、Docker、
-独立 Hindsight が順に有効になります。Hindsight 単体の通常の操作入口は次です。
+Windows のインストーラーはサービス単位のスイッチを受け付けます。`-WithDocker` は
+Docker のみ、`-WithMLflow` は Ollama と Docker に加えて MLflow、`-WithHindsight` は
+さらに Hindsight、`-WithHermes` はさらに Hermes とそのブラウザー依存を有効にします。
+引数なしでは optional service を変更しません。Hindsight 単体の通常の操作入口は次です。
 
 ```text
 task hindsight:up

--- a/scripts/powershell/handlers/Handler.HermesAgent.ps1
+++ b/scripts/powershell/handlers/Handler.HermesAgent.ps1
@@ -71,7 +71,7 @@ class HermesAgentHandler : SetupHandlerBase {
                 return $this.CreateFailureResult("Hermes Compose validation failed: $($validation.Message)")
             }
 
-            $build = $this.InvokeCompose($composeFile, @('build', 'hermes', 'hermes-bootstrap', 'chromium', 'xapi-mcp'))
+            $build = $this.InvokeCompose($composeFile, @('build', '--pull', 'hermes', 'hermes-bootstrap', 'chromium', 'xapi-mcp'))
             if (-not $build.Success) {
                 return $this.CreateFailureResult("Hermes image build failed: $($build.Message)")
             }
@@ -114,7 +114,7 @@ class HermesAgentHandler : SetupHandlerBase {
             try {
                 $handler = $this
                 $start = Invoke-HermesXApiCredentialScope -DataDir $dataDir -Action {
-                    $handler.InvokeCompose($composeFile, @('up', '-d', '--force-recreate', 'hermes', 'chromium', 'browser-mcp', 'xapi-mcp'))
+                    $handler.InvokeCompose($composeFile, @('up', '-d', '--force-recreate', '--remove-orphans', 'hermes', 'chromium', 'browser-mcp', 'xapi-mcp'))
                 }
             }
             catch {

--- a/scripts/powershell/handlers/Handler.HermesAgent.ps1
+++ b/scripts/powershell/handlers/Handler.HermesAgent.ps1
@@ -71,7 +71,7 @@ class HermesAgentHandler : SetupHandlerBase {
                 return $this.CreateFailureResult("Hermes Compose validation failed: $($validation.Message)")
             }
 
-            $build = $this.InvokeCompose($composeFile, @('build', '--pull', 'hermes', 'hermes-bootstrap', 'chromium', 'xapi-mcp'))
+            $build = $this.InvokeCompose($composeFile, @('build', '--pull', 'hermes', 'hermes-bootstrap', 'chromium', 'browser-mcp', 'xapi-mcp'))
             if (-not $build.Success) {
                 return $this.CreateFailureResult("Hermes image build failed: $($build.Message)")
             }

--- a/scripts/powershell/handlers/Handler.HermesAgent.ps1
+++ b/scripts/powershell/handlers/Handler.HermesAgent.ps1
@@ -19,6 +19,7 @@ class HermesAgentHandler : SetupHandlerBase {
         $this.Order = 56
         $this.RequiresAdmin = $false
         $this.Phase = 2
+        $this.DependsOn = @('Hindsight')
     }
 
     [bool] CanApply([SetupContext]$ctx) {

--- a/scripts/powershell/handlers/Handler.Hindsight.ps1
+++ b/scripts/powershell/handlers/Handler.Hindsight.ps1
@@ -15,6 +15,7 @@ class HindsightHandler : SetupHandlerBase {
         $this.Order = 55
         $this.RequiresAdmin = $false
         $this.Phase = 2
+        $this.DependsOn = @('MLflow')
     }
 
     [bool] CanApply([SetupContext]$ctx) {

--- a/scripts/powershell/handlers/Handler.MLflow.ps1
+++ b/scripts/powershell/handlers/Handler.MLflow.ps1
@@ -22,6 +22,7 @@ class MLflowHandler : SetupHandlerBase {
         $this.Order = 54
         $this.RequiresAdmin = $false
         $this.Phase = 2
+        $this.DependsOn = @('Docker')
     }
 
     [bool] CanApply([SetupContext]$ctx) {

--- a/scripts/powershell/handlers/Handler.MLflow.ps1
+++ b/scripts/powershell/handlers/Handler.MLflow.ps1
@@ -1,0 +1,122 @@
+<#
+.SYNOPSIS
+    Shared MLflow Gateway Docker service handler.
+
+.DESCRIPTION
+    Creates the shared local-ai-services network and reconciles the MLflow
+    container to the compose definition. The explicit WithMLflow option is
+    resolved before this handler runs, so Hindsight and Hermes can depend on
+    the same network and gateway.
+#>
+
+$libPath = Split-Path -Parent $PSScriptRoot
+. (Join-Path $libPath 'lib\Invoke-ExternalCommand.ps1')
+
+class MLflowHandler : SetupHandlerBase {
+    [int]$DockerCheckTimeoutSeconds = 15
+    [int]$DockerComposeTimeoutSeconds = 180
+
+    MLflowHandler() {
+        $this.Name = 'MLflow'
+        $this.Description = 'Shared MLflow Gateway Docker service'
+        $this.Order = 54
+        $this.RequiresAdmin = $false
+        $this.Phase = 2
+    }
+
+    [bool] CanApply([SetupContext]$ctx) {
+        if (-not $this.IsTruthy($ctx.GetOption('WithMLflow', $false))) {
+            $this.Log('MLflow setup is disabled by option.', 'Gray')
+            return $false
+        }
+        if (-not (Get-Command -Name 'docker' -ErrorAction SilentlyContinue)) {
+            $this.Log('docker command was not found.', 'Gray')
+            return $false
+        }
+        if (-not (Test-DockerDaemon -TimeoutSeconds $this.DockerCheckTimeoutSeconds)) {
+            $this.Log('Docker daemon is not ready; skipping MLflow.', 'Gray')
+            return $false
+        }
+        return Test-Path -LiteralPath $this.GetComposeFilePath($ctx) -PathType Leaf
+    }
+
+    [SetupResult] Apply([SetupContext]$ctx) {
+        $composeFile = $this.GetComposeFilePath($ctx)
+        try {
+            $network = $this.EnsureSharedNetwork()
+            if (-not $network.Success) {
+                return $this.CreateFailureResult("MLflow network setup failed: $($network.Message)")
+            }
+
+            $validation = $this.InvokeCompose($composeFile, @('config', '--quiet'))
+            if (-not $validation.Success) {
+                return $this.CreateFailureResult("MLflow Compose validation failed: $($validation.Message)")
+            }
+
+            $pull = $this.InvokeCompose($composeFile, @('pull', 'mlflow'))
+            if (-not $pull.Success) {
+                return $this.CreateFailureResult("MLflow image update failed: $($pull.Message)")
+            }
+
+            $start = $this.InvokeCompose($composeFile, @('up', '-d', '--force-recreate', '--remove-orphans', '--wait', 'mlflow'))
+            if (-not $start.Success) {
+                return $this.CreateFailureResult("MLflow startup failed: $($start.Message)")
+            }
+
+            $configure = $this.InvokeCompose($composeFile, @(
+                    'exec', '-T', 'mlflow', 'python', '/opt/mlflow/configure.py',
+                    '--base-url', 'http://127.0.0.1:5000',
+                    '--manifest', '/opt/mlflow/endpoints.yml'
+                ))
+            if (-not $configure.Success) {
+                return $this.CreateFailureResult("MLflow endpoint configuration failed: $($configure.Message)")
+            }
+
+            return $this.CreateSuccessResult('MLflow Gateway started at http://127.0.0.1:5000')
+        }
+        catch {
+            return $this.CreateFailureResult('MLflow setup failed.', $_.Exception)
+        }
+    }
+
+    hidden [pscustomobject] EnsureSharedNetwork() {
+        $null = @(Invoke-Docker -Arguments @('network', 'inspect', 'local-ai-services') -TimeoutSeconds $this.DockerComposeTimeoutSeconds)
+        if ($LASTEXITCODE -eq 0) {
+            return [PSCustomObject]@{ Success = $true; Message = '' }
+        }
+
+        $null = @(Invoke-Docker -Arguments @('network', 'create', 'local-ai-services') -TimeoutSeconds $this.DockerComposeTimeoutSeconds)
+        if ($LASTEXITCODE -eq 0) {
+            return [PSCustomObject]@{ Success = $true; Message = '' }
+        }
+        return [PSCustomObject]@{ Success = $false; Message = "exit code $LASTEXITCODE" }
+    }
+
+    hidden [pscustomobject] InvokeCompose([string]$composeFile, [string[]]$command) {
+        $arguments = @('compose', '-f', $composeFile) + $command
+        $output = @(Invoke-Docker -Arguments $arguments -TimeoutSeconds $this.DockerComposeTimeoutSeconds)
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -eq 0) {
+            return [PSCustomObject]@{ Success = $true; Message = '' }
+        }
+
+        $message = (($output -join "`n").Trim())
+        if ([string]::IsNullOrWhiteSpace($message)) {
+            $message = "exit code $exitCode"
+        }
+        elseif ($message.Length -gt 4096) {
+            $message = "$($message.Substring(0, 4096))..."
+        }
+        return [PSCustomObject]@{ Success = $false; Message = $message }
+    }
+
+    hidden [string] GetComposeFilePath([SetupContext]$ctx) {
+        return Join-Path $ctx.DotfilesPath 'docker\mlflow\compose.yml'
+    }
+
+    hidden [bool] IsTruthy([object]$value) {
+        if ($null -eq $value) { return $false }
+        if ($value -is [bool]) { return [bool]$value }
+        return ([string]$value).Trim() -match '^(1|true|yes|on)$'
+    }
+}

--- a/scripts/powershell/hindsight.ps1
+++ b/scripts/powershell/hindsight.ps1
@@ -244,6 +244,7 @@ function Invoke-HindsightMain {
         Move-HindsightLegacyData -DataDir $dataDir -ValidateOnly
         $null = Invoke-HindsightCommand -Command 'ollama' -Arguments @('pull', $llmModel)
         $null = Invoke-HindsightCommand -Command 'ollama' -Arguments @('pull', $embeddingModel)
+        $null = Invoke-HindsightCommand -Command 'docker' -Arguments @('compose', '-f', $RequestedComposeFile, 'pull', 'hindsight')
         New-Item -ItemType Directory -Path (Join-Path $dataDir 'pg0'), (Join-Path $dataDir 'cache') -Force | Out-Null
         $migrationStoppedRunningLegacy = [bool](Move-HindsightLegacyData -DataDir $dataDir)
 
@@ -253,7 +254,7 @@ function Invoke-HindsightMain {
             if ($legacyState.Running) {
                 $null = Invoke-HindsightCommand -Command 'docker' -Arguments @('stop', 'hermes-hindsight')
             }
-            $null = Invoke-HindsightCommand -Command 'docker' -Arguments @('compose', '-f', $RequestedComposeFile, 'up', '-d', 'hindsight')
+            $null = Invoke-HindsightCommand -Command 'docker' -Arguments @('compose', '-f', $RequestedComposeFile, 'up', '-d', '--force-recreate', '--remove-orphans', 'hindsight')
             Wait-HindsightApi
         }
         catch {

--- a/scripts/powershell/install.ps1
+++ b/scripts/powershell/install.ps1
@@ -30,6 +30,8 @@ param(
     [switch]$WingetVerifyCommandOnly,
     [switch]$WithOllama,
     [switch]$WithDocker,
+    [switch]$WithMLflow,
+    [switch]$WithHindsight,
     [switch]$WithHermes,
     [switch]$NoPause
 )
@@ -50,6 +52,8 @@ $Options = Resolve-DotfilesInstallOption `
     -Options $Options `
     -WithOllama:$WithOllama `
     -WithDocker:$WithDocker `
+    -WithMLflow:$WithMLflow `
+    -WithHindsight:$WithHindsight `
     -WithHermes:$WithHermes
 
 if (-not $PSBoundParameters.ContainsKey("InstallDir")) {

--- a/scripts/powershell/lib/InstallProfiles.ps1
+++ b/scripts/powershell/lib/InstallProfiles.ps1
@@ -17,6 +17,8 @@ function Resolve-DotfilesInstallOption {
         [hashtable]$Options = @{},
         [switch]$WithOllama,
         [switch]$WithDocker,
+        [switch]$WithMLflow,
+        [switch]$WithHindsight,
         [switch]$WithHermes
     )
 
@@ -25,13 +27,24 @@ function Resolve-DotfilesInstallOption {
         $resolved[$key] = $Options[$key]
     }
 
-    $hermesEnabled = $WithHermes -or (ConvertTo-DotfilesFeatureBoolean $resolved['WithHermes'])
-    $dockerEnabled = $hermesEnabled -or $WithDocker -or (ConvertTo-DotfilesFeatureBoolean $resolved['WithDocker'])
-    $ollamaEnabled = $dockerEnabled -or $WithOllama -or (ConvertTo-DotfilesFeatureBoolean $resolved['WithOllama'])
+    $hermesRequested = $WithHermes -or (ConvertTo-DotfilesFeatureBoolean $resolved['WithHermes'])
+    $hindsightRequested = $WithHindsight -or (ConvertTo-DotfilesFeatureBoolean $resolved['WithHindsight'])
+    $mlflowRequested = $WithMLflow -or (ConvertTo-DotfilesFeatureBoolean $resolved['WithMLflow'])
+    $dockerRequested = $WithDocker -or (ConvertTo-DotfilesFeatureBoolean $resolved['WithDocker'])
+    $ollamaRequested = $WithOllama -or (ConvertTo-DotfilesFeatureBoolean $resolved['WithOllama'])
+
+    # 依存関係は上位サービスから下位サービスへ閉包する。
+    # 個別フラグだけを指定した場合は、指定したサービス自身だけを有効にする。
+    $hermesEnabled = [bool]$hermesRequested
+    $hindsightEnabled = [bool]($hindsightRequested -or $hermesEnabled)
+    $mlflowEnabled = [bool]($mlflowRequested -or $hindsightEnabled)
+    $dockerEnabled = [bool]($dockerRequested -or $mlflowEnabled)
+    $ollamaEnabled = [bool]($ollamaRequested -or $mlflowEnabled)
 
     $resolved['WithOllama'] = [bool]$ollamaEnabled
     $resolved['WithDocker'] = [bool]$dockerEnabled
-    $resolved['WithHindsight'] = [bool]$dockerEnabled
+    $resolved['WithMLflow'] = [bool]$mlflowEnabled
+    $resolved['WithHindsight'] = [bool]$hindsightEnabled
     $resolved['WithHermes'] = [bool]$hermesEnabled
     $resolved['WithChrome'] = [bool]$hermesEnabled
     $resolved['WithDiscord'] = [bool]$hermesEnabled

--- a/scripts/powershell/lib/SetupHandler.ps1
+++ b/scripts/powershell/lib/SetupHandler.ps1
@@ -198,6 +198,9 @@ class SetupHandlerBase {
     # Phase 2: chezmoi, nix-rebuild, wsl-config, docker, vscode-server, nixos-wsl, vhd-manager
     [int]$Phase = 2
 
+    # 成功していなければ実行してはいけないハンドラー名
+    [string[]]$DependsOn = @()
+
     # オプショナルサービスの同意設定（設定されている場合、一括同意プロンプトの対象になる）
     # ConsentKey: consent.json に保存するキー名 (例: "docker_enabled")
     # ConsentLabel: 一括同意プロンプトに表示する説明文
@@ -669,6 +672,7 @@ function Invoke-SetupHandler {
     )
 
     $results = @()
+    $resultsByHandler = @{}
 
     if ($Handlers.Count -eq 0) {
         Write-Warning "No handlers to execute"
@@ -679,6 +683,18 @@ function Invoke-SetupHandler {
         # Skip if in skip list
         if ($handler.Name -in $SkipHandlers) {
             Write-Host "[$($handler.Name)] Skipped (user request)" -ForegroundColor Gray
+            continue
+        }
+
+        $dependencyBlocked = $false
+        foreach ($dependency in @($handler.DependsOn)) {
+            if (-not $resultsByHandler.ContainsKey($dependency) -or -not $resultsByHandler[$dependency].Success) {
+                Write-Warning "[$($handler.Name)] Skipped because dependency [$dependency] did not complete successfully."
+                $dependencyBlocked = $true
+                break
+            }
+        }
+        if ($dependencyBlocked) {
             continue
         }
 
@@ -709,6 +725,7 @@ function Invoke-SetupHandler {
         try {
             $result = $handler.Apply($Context)
             $results += $result
+            $resultsByHandler[$handler.Name] = $result
 
             if ($result.Success) {
                 # Summary で表示するため OK ログは省略
@@ -724,6 +741,7 @@ function Invoke-SetupHandler {
             $exception = $_.Exception
             $result = [SetupResult]::CreateFailure($handler.Name, "Unhandled exception", $exception)
             $results += $result
+            $resultsByHandler[$handler.Name] = $result
             Write-Host "[$($handler.Name)] FAIL Exception: $($exception.Message)" -ForegroundColor Red
         }
     }

--- a/scripts/powershell/tests/Hindsight.Tests.ps1
+++ b/scripts/powershell/tests/Hindsight.Tests.ps1
@@ -163,13 +163,15 @@ Describe 'Independent Hindsight startup cutover' {
 
         $validateIndex = $script:calls.IndexOf('migrate validate')
         $pullIndex = $script:calls.IndexOf('ollama pull qwen3-embedding:0.6b')
+        $imagePullIndex = $script:calls.IndexOf("docker compose -f $script:composeFile pull hindsight")
         $migrateIndex = $script:calls.IndexOf('migrate')
         $stopIndex = $script:calls.IndexOf('docker stop hermes-hindsight')
-        $upIndex = $script:calls.IndexOf("docker compose -f $script:composeFile up -d hindsight")
+        $upIndex = $script:calls.IndexOf("docker compose -f $script:composeFile up -d --force-recreate --remove-orphans hindsight")
         $waitIndex = $script:calls.IndexOf('wait')
         $retireIndex = $script:calls.IndexOf('docker rm hermes-hindsight')
         $validateIndex | Should -BeLessThan $pullIndex
-        $pullIndex | Should -BeLessThan $migrateIndex
+        $pullIndex | Should -BeLessThan $imagePullIndex
+        $imagePullIndex | Should -BeLessThan $migrateIndex
         $migrateIndex | Should -BeLessThan $stopIndex
         $stopIndex | Should -BeLessThan $upIndex
         $upIndex | Should -BeLessThan $waitIndex

--- a/scripts/powershell/tests/Install.Orchestrator.Tests.ps1
+++ b/scripts/powershell/tests/Install.Orchestrator.Tests.ps1
@@ -47,6 +47,15 @@ Describe 'install.ps1 (orchestrator)' {
         $content | Should -Match '\[switch\]\$NoPause'
     }
 
+    It 'should expose one explicit switch for each local AI service' {
+        $content = Get-Content -LiteralPath $script:target -Raw
+        $content | Should -Match '\[switch\]\$WithOllama'
+        $content | Should -Match '\[switch\]\$WithDocker'
+        $content | Should -Match '\[switch\]\$WithMLflow'
+        $content | Should -Match '\[switch\]\$WithHindsight'
+        $content | Should -Match '\[switch\]\$WithHermes'
+    }
+
     It 'should converge deferred Docker setup after admin work and before acceptance' {
         $content = Get-Content -LiteralPath $script:target -Raw
         $convergence = $content.IndexOf('Phase 2c: Post-Admin Docker Convergence')

--- a/scripts/powershell/tests/Install.Tests.ps1
+++ b/scripts/powershell/tests/Install.Tests.ps1
@@ -15,6 +15,34 @@ BeforeAll {
     # SetupHandler.ps1 に含まれています
     . $PSScriptRoot/../lib/SetupHandler.ps1
     . $PSScriptRoot/../lib/Invoke-ExternalCommand.ps1
+
+    function New-DependencyTestHandler {
+        param(
+            [string]$Name,
+            [int]$Order,
+            [string[]]$DependsOn,
+            [bool]$ShouldSucceed
+        )
+
+        $handler = [PSCustomObject]@{
+            Name = $Name
+            Order = $Order
+            DependsOn = $DependsOn
+            ShouldSucceed = $ShouldSucceed
+            _bufferLogs = $false
+            _logBuffer = [System.Collections.ArrayList]::new()
+        }
+        $handler | Add-Member ScriptMethod CanApply { return $true }
+        $handler | Add-Member ScriptMethod ClearLogBuffer { }
+        $handler | Add-Member ScriptMethod FlushLogBuffer { }
+        $handler | Add-Member ScriptMethod Apply {
+            if ($this.ShouldSucceed) {
+                return [SetupResult]::CreateSuccess($this.Name, 'OK')
+            }
+            return [SetupResult]::CreateFailure($this.Name, 'failed')
+        }
+        return $handler
+    }
 }
 
 Describe 'Get-SetupHandler' {
@@ -123,6 +151,7 @@ Describe 'Invoke-SetupHandler - 実際のハンドラーを使用' {
 
     BeforeEach {
         Mock Write-Host { }
+        Mock Write-Warning { }
         $script:ctx = [SetupContext]::new("D:\dotfiles")
     }
 
@@ -134,6 +163,19 @@ Describe 'Invoke-SetupHandler - 実際のハンドラーを使用' {
         $results | Should -HaveCount 0
         Should -Invoke Write-Host -ParameterFilter {
             $Object -match "Skipped"
+        }
+    }
+
+    It 'should not execute a handler when a dependency failed' {
+        $dependency = New-DependencyTestHandler 'MLflow' 10 @() $false
+        $dependent = New-DependencyTestHandler 'Hindsight' 20 @('MLflow') $true
+
+        $results = @(Invoke-SetupHandler -Handlers @($dependency, $dependent) -Context $ctx)
+
+        $results | Should -HaveCount 1
+        $results[0].HandlerName | Should -Be 'MLflow'
+        Should -Invoke Write-Warning -ParameterFilter {
+            $Message -match 'Hindsight.*MLflow'
         }
     }
 }

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -170,10 +170,10 @@ Describe 'HermesAgentHandler' {
             $browserDir | Should -Exist
             $script:dockerCalls | Should -Be @(
                 "compose -f $script:composeFile config --quiet",
-                "compose -f $script:composeFile build hermes hermes-bootstrap chromium xapi-mcp",
+                "compose -f $script:composeFile build --pull hermes hermes-bootstrap chromium xapi-mcp",
                 "compose -f $script:composeFile ps --all --services hermes",
                 "compose -f $script:composeFile stop hermes",
-                "compose -f $script:composeFile up -d --force-recreate hermes chromium browser-mcp xapi-mcp"
+                "compose -f $script:composeFile up -d --force-recreate --remove-orphans hermes chromium browser-mcp xapi-mcp"
             )
             $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'xapi-credentials', 'up', 'health')
             Should -Invoke Invoke-WebRequest -Times 1 -Exactly -ParameterFilter {
@@ -331,7 +331,7 @@ Describe 'HermesAgentHandler' {
 
             $result.Success | Should -BeFalse
             $result.Message | Should -Match 'startup failure'
-            $script:dockerCalls[-1] | Should -Be "compose -f $script:composeFile up -d --force-recreate hermes chromium browser-mcp xapi-mcp"
+            $script:dockerCalls[-1] | Should -Be "compose -f $script:composeFile up -d --force-recreate --remove-orphans hermes chromium browser-mcp xapi-mcp"
             $script:dockerCalls | Should -Contain "compose -f $script:composeFile stop hermes"
         }
 
@@ -346,7 +346,7 @@ Describe 'HermesAgentHandler' {
             $result.Success | Should -BeFalse
             $result.Message | Should -Be 'Hermes X API credential retrieval failed.'
             $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'xapi-credentials')
-            $script:dockerCalls | Should -Not -Contain "compose -f $script:composeFile up -d --force-recreate hermes chromium browser-mcp xapi-mcp"
+            $script:dockerCalls | Should -Not -Contain "compose -f $script:composeFile up -d --force-recreate --remove-orphans hermes chromium browser-mcp xapi-mcp"
         }
 
         It 'waits through transient API failures before reporting startup success' {

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -170,7 +170,7 @@ Describe 'HermesAgentHandler' {
             $browserDir | Should -Exist
             $script:dockerCalls | Should -Be @(
                 "compose -f $script:composeFile config --quiet",
-                "compose -f $script:composeFile build --pull hermes hermes-bootstrap chromium xapi-mcp",
+                "compose -f $script:composeFile build --pull hermes hermes-bootstrap chromium browser-mcp xapi-mcp",
                 "compose -f $script:composeFile ps --all --services hermes",
                 "compose -f $script:composeFile stop hermes",
                 "compose -f $script:composeFile up -d --force-recreate --remove-orphans hermes chromium browser-mcp xapi-mcp"

--- a/scripts/powershell/tests/handlers/Handler.Hindsight.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Hindsight.Tests.ps1
@@ -3,6 +3,7 @@
 BeforeAll {
     . $PSScriptRoot/../../lib/SetupHandler.ps1
     . $PSScriptRoot/../../lib/Invoke-ExternalCommand.ps1
+    . $PSScriptRoot/../../handlers/Handler.MLflow.ps1
     . $PSScriptRoot/../../handlers/Handler.Hindsight.ps1
 }
 
@@ -24,7 +25,7 @@ Describe 'HindsightHandler' {
         $script:handler.CanApply($script:ctx) | Should -BeFalse
     }
 
-    It 'is enabled by the Docker-derived Hindsight option' {
+    It 'is enabled only by the resolved Hindsight option' {
         $script:ctx.Options['WithHindsight'] = $true
         $script:handler.CanApply($script:ctx) | Should -BeTrue
     }
@@ -43,6 +44,7 @@ Describe 'HindsightHandler' {
 
     It 'runs before Hermes and outside its handler' {
         $script:handler.Order | Should -BeLessThan 56
+        $script:handler.Order | Should -BeGreaterThan ([MLflowHandler]::new().Order)
         $script:handler.Name | Should -Be 'Hindsight'
         $source = Get-Content -LiteralPath $PSScriptRoot/../../handlers/Handler.HermesAgent.ps1 -Raw
         $source | Should -Not -Match 'hindsight\.ps1|docker\\hindsight'

--- a/scripts/powershell/tests/handlers/Handler.MLflow.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.MLflow.Tests.ps1
@@ -1,0 +1,107 @@
+#Requires -Module Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../lib/SetupHandler.ps1
+    . $PSScriptRoot/../../lib/Invoke-ExternalCommand.ps1
+    . $PSScriptRoot/../../handlers/Handler.MLflow.ps1
+}
+
+Describe 'MLflowHandler' {
+    BeforeEach {
+        $script:root = Join-Path $TestDrive 'dotfiles'
+        $script:composeDir = Join-Path $script:root 'docker/mlflow'
+        $script:composeFile = Join-Path $script:composeDir 'compose.yml'
+        New-Item -ItemType Directory -Path $script:composeDir -Force | Out-Null
+        Set-Content -LiteralPath $script:composeFile -Value 'services: {}'
+        $script:ctx = [SetupContext]::new($script:root)
+        $script:handler = [MLflowHandler]::new()
+        $script:dockerCalls = [System.Collections.Generic.List[string]]::new()
+        Mock Get-Command { [PSCustomObject]@{ Name = $Name } }
+        Mock Test-DockerDaemon { $true }
+        Mock Invoke-Docker {
+            param([string[]]$Arguments)
+            $script:dockerCalls.Add(($Arguments -join ' '))
+            if ($Arguments -contains 'inspect') {
+                $global:LASTEXITCODE = 1
+                return
+            }
+            $global:LASTEXITCODE = 0
+        }
+    }
+
+    It 'sets Phase 2 metadata after Docker and before Hindsight' {
+        $handler.Name | Should -Be 'MLflow'
+        $handler.Description | Should -Be 'Shared MLflow Gateway Docker service'
+        $handler.Order | Should -Be 54
+        $handler.RequiresAdmin | Should -BeFalse
+        $handler.Phase | Should -Be 2
+    }
+
+    It 'is disabled unless WithMLflow is enabled' {
+        $handler.CanApply($ctx) | Should -BeFalse
+
+        $ctx.Options['WithMLflow'] = $true
+        $handler.CanApply($ctx) | Should -BeTrue
+    }
+
+    It 'skips when Docker is unavailable or not ready' {
+        $ctx.Options['WithMLflow'] = $true
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'docker' }
+        $handler.CanApply($ctx) | Should -BeFalse
+
+        Mock Get-Command { [PSCustomObject]@{ Name = 'docker' } } -ParameterFilter { $Name -eq 'docker' }
+        Mock Test-DockerDaemon { $false }
+        $handler.CanApply($ctx) | Should -BeFalse
+    }
+
+    It 'skips when the MLflow compose file is missing' {
+        $ctx.Options['WithMLflow'] = $true
+        Remove-Item -LiteralPath $composeFile -Force
+
+        $handler.CanApply($ctx) | Should -BeFalse
+    }
+
+    It 'uses the shared network and reconciles the pinned MLflow container' {
+        $ctx.Options['WithMLflow'] = $true
+
+        $result = $handler.Apply($ctx)
+
+        $result.Success | Should -BeTrue
+        $dockerCalls | Should -Be @(
+            'network inspect local-ai-services',
+            'network create local-ai-services',
+            "compose -f $composeFile config --quiet",
+            "compose -f $composeFile pull mlflow",
+            "compose -f $composeFile up -d --force-recreate --remove-orphans --wait mlflow",
+            "compose -f $composeFile exec -T mlflow python /opt/mlflow/configure.py --base-url http://127.0.0.1:5000 --manifest /opt/mlflow/endpoints.yml"
+        )
+    }
+
+    It 'does not recreate the shared network when it already exists' {
+        $ctx.Options['WithMLflow'] = $true
+        Mock Invoke-Docker {
+            param([string[]]$Arguments)
+            $script:dockerCalls.Add(($Arguments -join ' '))
+            $global:LASTEXITCODE = 0
+        }
+
+        $result = $handler.Apply($ctx)
+
+        $result.Success | Should -BeTrue
+        $dockerCalls | Should -Not -Contain 'network create local-ai-services'
+    }
+
+    It 'reports a network creation failure' {
+        $ctx.Options['WithMLflow'] = $true
+        Mock Invoke-Docker {
+            param([string[]]$Arguments)
+            $script:dockerCalls.Add(($Arguments -join ' '))
+            $global:LASTEXITCODE = if ($Arguments -contains 'create') { 17 } else { 1 }
+        }
+
+        $result = $handler.Apply($ctx)
+
+        $result.Success | Should -BeFalse
+        $result.Message | Should -Match 'network setup failed'
+    }
+}

--- a/scripts/powershell/tests/lib/InstallProfiles.Tests.ps1
+++ b/scripts/powershell/tests/lib/InstallProfiles.Tests.ps1
@@ -10,6 +10,7 @@ Describe 'Resolve-DotfilesInstallOption' {
 
         $result.WithOllama | Should -BeFalse
         $result.WithDocker | Should -BeFalse
+        $result.WithMLflow | Should -BeFalse
         $result.WithHindsight | Should -BeFalse
         $result.WithHermes | Should -BeFalse
         $result.WithChrome | Should -BeFalse
@@ -22,15 +23,37 @@ Describe 'Resolve-DotfilesInstallOption' {
 
         $result.WithOllama | Should -BeTrue
         $result.WithDocker | Should -BeFalse
+        $result.WithMLflow | Should -BeFalse
         $result.WithHindsight | Should -BeFalse
         $result.WithHermes | Should -BeFalse
     }
 
-    It 'expands WithDocker to Ollama and independent Hindsight' {
+    It 'enables only Docker for WithDocker' {
         $result = Resolve-DotfilesInstallOption -Options @{} -WithDocker
+
+        $result.WithOllama | Should -BeFalse
+        $result.WithDocker | Should -BeTrue
+        $result.WithMLflow | Should -BeFalse
+        $result.WithHindsight | Should -BeFalse
+        $result.WithHermes | Should -BeFalse
+    }
+
+    It 'expands WithMLflow to its Ollama and Docker dependencies' {
+        $result = Resolve-DotfilesInstallOption -Options @{} -WithMLflow
 
         $result.WithOllama | Should -BeTrue
         $result.WithDocker | Should -BeTrue
+        $result.WithMLflow | Should -BeTrue
+        $result.WithHindsight | Should -BeFalse
+        $result.WithHermes | Should -BeFalse
+    }
+
+    It 'expands WithHindsight to MLflow and its runtime dependencies' {
+        $result = Resolve-DotfilesInstallOption -Options @{} -WithHindsight
+
+        $result.WithOllama | Should -BeTrue
+        $result.WithDocker | Should -BeTrue
+        $result.WithMLflow | Should -BeTrue
         $result.WithHindsight | Should -BeTrue
         $result.WithHermes | Should -BeFalse
     }
@@ -40,6 +63,7 @@ Describe 'Resolve-DotfilesInstallOption' {
 
         $result.WithOllama | Should -BeTrue
         $result.WithDocker | Should -BeTrue
+        $result.WithMLflow | Should -BeTrue
         $result.WithHindsight | Should -BeTrue
         $result.WithHermes | Should -BeTrue
         $result.WithChrome | Should -BeTrue

--- a/scripts/sh/hindsight.sh
+++ b/scripts/sh/hindsight.sh
@@ -180,6 +180,7 @@ hindsight_prepare() {
 
   mkdir -p "$data_dir/pg0" "$data_dir/cache"
   docker compose -f "$compose_file" config --quiet
+  docker compose -f "$compose_file" pull hindsight
   hindsight_migrate_legacy_data "$data_dir"
 }
 
@@ -202,7 +203,7 @@ hindsight_up() {
   (
     trap hindsight_restore_legacy_after_replacement_failure EXIT
     set -e
-    docker compose -f "$compose_file" up -d hindsight
+    docker compose -f "$compose_file" up -d --force-recreate --remove-orphans hindsight
     hindsight_wait_for_api
   )
   replacement_status=$?

--- a/scripts/sh/hindsight.sh
+++ b/scripts/sh/hindsight.sh
@@ -180,8 +180,23 @@ hindsight_prepare() {
 
   mkdir -p "$data_dir/pg0" "$data_dir/cache"
   docker compose -f "$compose_file" config --quiet
-  docker compose -f "$compose_file" pull hindsight
+  hindsight_pull_image "$compose_file"
   hindsight_migrate_legacy_data "$data_dir"
+}
+
+hindsight_pull_image() {
+  local compose_file="$1" image
+  if docker compose -f "$compose_file" pull hindsight; then
+    return 0
+  fi
+
+  image="$(docker compose -f "$compose_file" config --images | sed -n '1p')"
+  if [[ -n $image ]] && docker image inspect "$image" >/dev/null 2>&1; then
+    printf 'Image pull failed; continuing with the cached Hindsight image.\n' >&2
+    return 0
+  fi
+
+  dotfiles_die "Could not pull the Hindsight image and no cached image is available."
 }
 
 hindsight_up() {

--- a/taskfiles/mlflow/taskfile.yml
+++ b/taskfiles/mlflow/taskfile.yml
@@ -18,7 +18,8 @@ tasks:
         platforms: [linux, darwin]
       - cmd: "pwsh -NoProfile -Command 'docker network inspect local-ai-services *> $null; if ($LASTEXITCODE -ne 0) { docker network create local-ai-services }'"
         platforms: [windows]
-      - docker compose -f {{.MLFLOW_COMPOSE_FILE}} up -d --wait mlflow
+      - docker compose -f {{.MLFLOW_COMPOSE_FILE}} pull mlflow
+      - docker compose -f {{.MLFLOW_COMPOSE_FILE}} up -d --force-recreate --remove-orphans --wait mlflow
       - task: mlflow:configure
 
   mlflow:configure:

--- a/tests/bash/hermes_hindsight_verify.bats
+++ b/tests/bash/hermes_hindsight_verify.bats
@@ -82,8 +82,9 @@ docker compose -f $HERMES_COMPOSE_FILE config --quiet
 ollama pull qwen3.6:35b
 ollama pull qwen3-embedding:0.6b
 docker compose -f $HINDSIGHT_COMPOSE_FILE config --quiet
+docker compose -f $HINDSIGHT_COMPOSE_FILE pull hindsight
 docker container inspect --format {{.State.Running}} hermes-hindsight
-docker compose -f $HINDSIGHT_COMPOSE_FILE up -d hindsight
+docker compose -f $HINDSIGHT_COMPOSE_FILE up -d --force-recreate --remove-orphans hindsight
 curl --fail --silent --show-error --max-time 2 http://127.0.0.1:8888/health
 docker compose -f $HERMES_COMPOSE_FILE exec -T hermes hermes-hindsight-acceptance probe --api-url http://hindsight:8888 --ollama-url http://host.docker.internal:11434 --strict-probes 20 --timeout 300 --evidence /opt/data/hindsight/acceptance.json
 docker compose -f $HERMES_COMPOSE_FILE exec -T hermes hermes-hindsight-acceptance seed --api-url http://hindsight:8888 --profiles default,rick,hoffman,risarisa,nancy,kuroda,shiraishi --timeout 300 --state /opt/data/hindsight/acceptance-state.json

--- a/tests/bash/hindsight_runtime.bats
+++ b/tests/bash/hindsight_runtime.bats
@@ -55,6 +55,16 @@ fi
 if [[ ${1:-} == compose && ${*: -5} == 'up -d --force-recreate --remove-orphans hindsight' && ${HINDSIGHT_COMPOSE_UP_FAIL:-0} == 1 ]]; then
 	exit 43
 fi
+if [[ ${1:-} == compose && ${4:-} == pull && ${5:-} == hindsight && ${HINDSIGHT_COMPOSE_PULL_FAIL:-0} == 1 ]]; then
+	exit 45
+fi
+if [[ ${1:-} == compose && ${4:-} == config && ${5:-} == --images ]]; then
+	printf 'nginx:1.29-alpine\n'
+	exit 0
+fi
+if [[ ${1:-} == image && ${2:-} == inspect && ${HINDSIGHT_LOCAL_IMAGE_EXISTS:-0} != 1 ]]; then
+	exit 1
+fi
 EOF
 cat >"$BIN/ollama" <<'EOF'
 #!/usr/bin/env bash
@@ -122,6 +132,17 @@ EOF
 	[ "$status" -ne 0 ]
 	run grep -Fxq 'docker rm hermes-hindsight' "$LOG"
 	[ "$status" -ne 0 ]
+}
+
+@test "image pull failure uses a cached image when the registry is unavailable" {
+	export HINDSIGHT_COMPOSE_PULL_FAIL=1 HINDSIGHT_LOCAL_IMAGE_EXISTS=1
+
+	run "$SCRIPT" up "$COMPOSE"
+
+	[ "$status" -eq 0 ]
+	grep -Fxq "docker compose -f $COMPOSE pull hindsight" "$LOG"
+	grep -Fxq 'docker image inspect nginx:1.29-alpine' "$LOG"
+	grep -Fxq "docker compose -f $COMPOSE up -d --force-recreate --remove-orphans hindsight" "$LOG"
 }
 
 @test "failed legacy migration restarts the container it stopped" {

--- a/tests/bash/hindsight_runtime.bats
+++ b/tests/bash/hindsight_runtime.bats
@@ -52,7 +52,7 @@ fi
 if [[ ${1:-} == stop && ${2:-} == hermes-hindsight ]]; then
 	printf '0\n' >"$LEGACY_CONTAINER_RUNNING_STATE"
 fi
-if [[ ${1:-} == compose && ${*: -3} == 'up -d hindsight' && ${HINDSIGHT_COMPOSE_UP_FAIL:-0} == 1 ]]; then
+if [[ ${1:-} == compose && ${*: -5} == 'up -d --force-recreate --remove-orphans hindsight' && ${HINDSIGHT_COMPOSE_UP_FAIL:-0} == 1 ]]; then
 	exit 43
 fi
 EOF
@@ -92,12 +92,14 @@ EOF
 	[ "$status" -ne 0 ]
 	pull_line="$(grep -nFx 'ollama pull qwen3-embedding:0.6b' "$LOG" | cut -d: -f1)"
 	config_line="$(grep -nFx "docker compose -f $COMPOSE config --quiet" "$LOG" | cut -d: -f1)"
+	image_pull_line="$(grep -nFx "docker compose -f $COMPOSE pull hindsight" "$LOG" | cut -d: -f1)"
 	stop_line="$(grep -nFx 'docker stop hermes-hindsight' "$LOG" | tail -n 1 | cut -d: -f1)"
-	start_line="$(grep -nFx "docker compose -f $COMPOSE up -d hindsight" "$LOG" | cut -d: -f1)"
+	start_line="$(grep -nFx "docker compose -f $COMPOSE up -d --force-recreate --remove-orphans hindsight" "$LOG" | cut -d: -f1)"
 	health_line="$(grep -nF 'curl --fail --silent --show-error' "$LOG" | cut -d: -f1)"
 	retire_line="$(grep -nFx 'docker rm hermes-hindsight' "$LOG" | cut -d: -f1)"
 	[ "$pull_line" -lt "$stop_line" ]
 	[ "$config_line" -lt "$stop_line" ]
+	[ "$image_pull_line" -lt "$stop_line" ]
 	[ "$stop_line" -lt "$start_line" ]
 	[ "$health_line" -lt "$retire_line" ]
 
@@ -206,7 +208,7 @@ EOF
 
 	[ "$status" -ne 0 ]
 	[ -f "$HOME/.local/share/hindsight/.legacy-migration-source" ]
-	grep -Fxq "docker compose -f $COMPOSE up -d hindsight" "$LOG"
+	grep -Fxq "docker compose -f $COMPOSE up -d --force-recreate --remove-orphans hindsight" "$LOG"
 
 	: >"$LOG"
 	export HINDSIGHT_LEGACY_RM_FAIL=0
@@ -217,7 +219,7 @@ EOF
 	[ "$status" -ne 0 ]
 	grep -Fxq 'docker rm hermes-hindsight' "$LOG"
 	retire_line="$(grep -nFx 'docker rm hermes-hindsight' "$LOG" | cut -d: -f1)"
-	start_line="$(grep -nFx "docker compose -f $COMPOSE up -d hindsight" "$LOG" | cut -d: -f1)"
+	start_line="$(grep -nFx "docker compose -f $COMPOSE up -d --force-recreate --remove-orphans hindsight" "$LOG" | cut -d: -f1)"
 	[ "$start_line" -lt "$retire_line" ]
 }
 
@@ -244,7 +246,7 @@ EOF
 	! grep -Fxq 'ollama pull ollama-chat-default' "$LOG"
 	! grep -Fxq 'ollama pull ollama-embedding-default' "$LOG"
 	grep -Fxq "docker compose -f $COMPOSE config --quiet" "$LOG"
-	grep -Fxq "docker compose -f $COMPOSE up -d hindsight" "$LOG"
+	grep -Fxq "docker compose -f $COMPOSE up -d --force-recreate --remove-orphans hindsight" "$LOG"
 	[ -d "$HOME/.local/share/hindsight/pg0" ]
 	[ -d "$HOME/.local/share/hindsight/cache" ]
 	! grep -Eq '^docker (stop|start|rm) hermes-hindsight$' "$LOG"

--- a/tests/bash/hindsight_service.bats
+++ b/tests/bash/hindsight_service.bats
@@ -43,7 +43,11 @@ setup() {
 
 @test "Windows installs Hindsight in its own handler before Hermes" {
 	hindsight_handler="$REPO_ROOT/scripts/powershell/handlers/Handler.Hindsight.ps1"
+	mlflow_handler="$REPO_ROOT/scripts/powershell/handlers/Handler.MLflow.ps1"
 	hermes_handler="$REPO_ROOT/scripts/powershell/handlers/Handler.HermesAgent.ps1"
+	grep -q "Name = 'MLflow'" "$mlflow_handler"
+	grep -q 'Order = 54' "$mlflow_handler"
+	grep -q "WithMLflow" "$mlflow_handler"
 	grep -q "Name = 'Hindsight'" "$hindsight_handler"
 	grep -q 'Order = 55' "$hindsight_handler"
 	grep -q "WithHindsight" "$hindsight_handler"

--- a/tests/bash/mlflow_task_contract.bats
+++ b/tests/bash/mlflow_task_contract.bats
@@ -47,7 +47,8 @@ run_task_command_through_shell() {
 
   [ -f "$taskfile" ]
   grep -Fq 'docker network inspect local-ai-services >/dev/null 2>&1 || docker network create local-ai-services' "$taskfile"
-  grep -Fq 'docker compose -f {{.MLFLOW_COMPOSE_FILE}} up -d --wait mlflow' "$taskfile"
+  grep -Fq 'docker compose -f {{.MLFLOW_COMPOSE_FILE}} pull mlflow' "$taskfile"
+  grep -Fq 'docker compose -f {{.MLFLOW_COMPOSE_FILE}} up -d --force-recreate --remove-orphans --wait mlflow' "$taskfile"
   down_block="$(awk '
     /^  mlflow:down:/ { in_down = 1; next }
     /^  [^[:space:]][^:]*:/ { in_down = 0 }

--- a/tests/python/test_mlflow_contract.py
+++ b/tests/python/test_mlflow_contract.py
@@ -204,7 +204,8 @@ class MlflowContractTests(unittest.TestCase):
                     "cmd": "pwsh -NoProfile -Command 'docker network inspect local-ai-services *> $null; if ($LASTEXITCODE -ne 0) { docker network create local-ai-services }'",
                     "platforms": ["windows"],
                 },
-                "docker compose -f {{.MLFLOW_COMPOSE_FILE}} up -d --wait mlflow",
+                "docker compose -f {{.MLFLOW_COMPOSE_FILE}} pull mlflow",
+                "docker compose -f {{.MLFLOW_COMPOSE_FILE}} up -d --force-recreate --remove-orphans --wait mlflow",
                 {"task": "mlflow:configure"},
             ],
         )


### PR DESCRIPTION
## Summary
- define dependency closure for Ollama, Docker, MLflow, Hindsight, and Hermes installer switches
- make MLflow join the shared local-ai-services network and update/recreate Docker services
- document the optional service levels and add PowerShell/Bash coverage

## Validation
- bats tests/bash (321/321)
- targeted PowerShell and Docker Compose contract tests

Closes #519