### PR TITLE
test(nix): add Home Manager import-boundary tests

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,7 +51,9 @@
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1785627969,
@@ -69,7 +71,7 @@
     },
     "flake-parts_2": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
         "lastModified": 1772408722,
@@ -171,6 +173,27 @@
         "type": "github"
       }
     },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-unit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1737420293,
+        "narHash": "sha256-F1G5ifvqTpJq7fdkT34e/Jy9VCyzd5XfJ9TO8fHhJWE=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "f4158fa080ef4503c8f4c820967d946c2af31ec9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
     "nix-homebrew": {
       "inputs": {
         "brew-src": "brew-src"
@@ -186,6 +209,28 @@
       "original": {
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
+        "type": "github"
+      }
+    },
+    "nix-unit": {
+      "inputs": {
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1784925540,
+        "narHash": "sha256-11IOL5tyJbB3vMQzzhIULuPtoHJpkLFz4BaKApm6t0Q=",
+        "owner": "nix-community",
+        "repo": "nix-unit",
+        "rev": "b3d16367c54621fd073aa8c1dd510042f771f624",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-unit",
         "type": "github"
       }
     },
@@ -246,21 +291,6 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1785031560,
-        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib_2": {
-      "locked": {
         "lastModified": 1772328832,
         "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
         "owner": "nix-community",
@@ -308,12 +338,13 @@
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
+        "nix-unit": "nix-unit",
         "nixos-vscode-server": "nixos-vscode-server",
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs",
         "system-manager": "system-manager",
         "systems": "systems_2",
-        "treefmt-nix": "treefmt-nix",
+        "treefmt-nix": "treefmt-nix_2",
         "workmux": "workmux"
       }
     },
@@ -370,6 +401,27 @@
       }
     },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-unit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784369104,
+        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,10 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
     systems.url = "github:nix-systems/default";
     nixos-wsl = {
       url = "github:nix-community/NixOS-WSL";
@@ -13,6 +16,10 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     nix-homebrew.url = "github:zhaofengli/nix-homebrew";
+    nix-unit = {
+      url = "github:nix-community/nix-unit";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     system-manager = {
       url = "github:numtide/system-manager";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/flakes/default.nix
+++ b/nix/flakes/default.nix
@@ -1,6 +1,7 @@
 { inputs, ... }:
 {
   imports = [
+    inputs.nix-unit.modules.flake.default
     inputs.treefmt-nix.flakeModule
     ./apps.nix
     ./darwin.nix
@@ -9,6 +10,7 @@
     ./packages.nix
     ./system-manager.nix
     ./systems.nix
+    ./tests.nix
     ./treefmt.nix
   ];
 }

--- a/nix/flakes/tests.nix
+++ b/nix/flakes/tests.nix
@@ -1,0 +1,23 @@
+{ inputs, ... }:
+{
+  perSystem = {
+    nix-unit.inputs = {
+      inherit (inputs)
+        flake-parts
+        home-manager
+        nix-darwin
+        nix-homebrew
+        nix-unit
+        nixos-vscode-server
+        nixos-wsl
+        nixpkgs
+        system-manager
+        systems
+        treefmt-nix
+        workmux
+        ;
+    };
+
+    nix-unit.tests = import ../tests/home/import-boundary.nix;
+  };
+}

--- a/nix/home/README.md
+++ b/nix/home/README.md
@@ -41,4 +41,4 @@ flake 評価へ同じ識別情報を渡します。
    import しないことを確認する。
 4. パッケージ追加なら先に `nix/packages/sets.nix` の所有範囲と各 OS への影響を確認する。
 5. dotfile または秘密の扱いなら `chezmoi/` と既存の secret 経路に置き、所有の重複を避ける。
-6. 対象 OS の評価・テストと `tests/bash/home_layout.bats` を実行する。
+6. 対象 OS の評価と `nix flake check --no-build` を実行する。

--- a/nix/tests/home/README.md
+++ b/nix/tests/home/README.md
@@ -1,0 +1,22 @@
+# Home Manager テスト
+
+## 対象
+
+`nix/tests/home/` は Home Manager の構造・import 境界・評価可能な設定を検査する。
+システムの activation、実機依存の動作、秘密情報は対象外とする。
+
+## ファイル規則
+
+- ファイル名は `<topic>.nix` の kebab-case とする。
+- 1ファイル1責務とし、import 境界・OS 入口・設定評価などの単位で分ける。
+- テストは `nix-unit` 形式の attrset とし、属性名は `test` で始める。
+- 各テストは `expr` と `expected` を持ち、評価結果を直接比較する。
+- テスト内のパスはテストファイルからの相対 Nix path を使う。
+
+## 実行規則
+
+- テストは純粋・決定的に保つ。ネットワーク、secret、環境依存の値、Home Manager activation を使わない。
+- 外部コマンドを起動せず、必要な検査は Nix 式で実装する。
+- 新しいテストは `nix/flakes/tests.nix` の `perSystem.nix-unit.tests` に登録する。
+- 標準実行は `nix flake check` とし、全対応 system の確認には `nix flake check --all-systems` を使う。
+- テスト変更時は対象テストと `nix flake check` を実行する。

--- a/nix/tests/home/import-boundary.nix
+++ b/nix/tests/home/import-boundary.nix
@@ -33,6 +33,12 @@ let
 
   contains = pattern: content: builtins.length (builtins.split pattern content) > 1;
 
+  containsImport =
+    target: content:
+    builtins.any (
+      line: builtins.match ".*(import|imports)[[:space:]=].*${target}\\.nix.*" line != null
+    ) (builtins.filter builtins.isString (builtins.split "\n" content));
+
   entryModules = [
     ../../home/darwin.nix
     ../../home/linux.nix
@@ -58,7 +64,7 @@ let
   );
 
   externalDirectImports = builtins.filter (
-    path: contains "common\\.nix" (builtins.readFile path)
+    path: containsImport "common" (builtins.readFile path)
   ) externalNixFiles;
 in
 {
@@ -83,7 +89,7 @@ in
   };
 
   testOSHomeEntrypointsImportCommon = {
-    expr = builtins.map (path: contains "common\\.nix" (builtins.readFile path)) entryModules;
+    expr = builtins.map (path: containsImport "common" (builtins.readFile path)) entryModules;
     expected = [
       true
       true
@@ -92,19 +98,11 @@ in
   };
 
   testSharedHomeModuleDoesNotImportOSModules = {
-    expr =
-      builtins.map
-        (
-          os:
-          contains "^[[:space:]]*(import|imports)[[:space:]=].*${os}\\.nix" (
-            builtins.readFile ../../home/common.nix
-          )
-        )
-        [
-          "darwin"
-          "linux"
-          "wsl"
-        ];
+    expr = builtins.map (os: containsImport os (builtins.readFile ../../home/common.nix)) [
+      "darwin"
+      "linux"
+      "wsl"
+    ];
     expected = [
       false
       false

--- a/nix/tests/home/import-boundary.nix
+++ b/nix/tests/home/import-boundary.nix
@@ -1,0 +1,119 @@
+let
+  nixRoot = ../..;
+  homeRoot = ../../home;
+  testsRoot = ./.;
+
+  filesUnder =
+    dir:
+    let
+      entries = builtins.readDir dir;
+    in
+    builtins.concatLists (
+      map (
+        name:
+        let
+          path = dir + "/${name}";
+        in
+        if entries.${name} == "directory" then
+          filesUnder path
+        else if builtins.match ".*\\.nix" name != null then
+          [ path ]
+        else
+          [ ]
+      ) (builtins.attrNames entries)
+    );
+
+  isUnder =
+    root: path:
+    let
+      rootText = toString root;
+      pathText = toString path;
+    in
+    builtins.substring 0 (builtins.stringLength rootText) pathText == rootText;
+
+  contains = pattern: content: builtins.length (builtins.split pattern content) > 1;
+
+  entryModules = [
+    ../../home/darwin.nix
+    ../../home/linux.nix
+    ../../home/wsl.nix
+  ];
+
+  homeLayout = {
+    required = [
+      ../../home/README.md
+      ../../home/common.nix
+      ../../home/darwin.nix
+      ../../home/linux.nix
+      ../../home/wsl.nix
+    ];
+    removed = [
+      ../../home/default.nix
+      ../../home/users
+    ];
+  };
+
+  externalNixFiles = builtins.filter (path: !(isUnder homeRoot path) && !(isUnder testsRoot path)) (
+    filesUnder nixRoot
+  );
+
+  externalDirectImports = builtins.filter (
+    path: contains "common\\.nix" (builtins.readFile path)
+  ) externalNixFiles;
+in
+{
+  testHomeManagerUsesCanonicalFlatOSModuleLayout = {
+    expr = {
+      required = builtins.map builtins.pathExists homeLayout.required;
+      removed = builtins.map builtins.pathExists homeLayout.removed;
+    };
+    expected = {
+      required = [
+        true
+        true
+        true
+        true
+        true
+      ];
+      removed = [
+        false
+        false
+      ];
+    };
+  };
+
+  testOSHomeEntrypointsImportCommon = {
+    expr = builtins.map (path: contains "common\\.nix" (builtins.readFile path)) entryModules;
+    expected = [
+      true
+      true
+      true
+    ];
+  };
+
+  testSharedHomeModuleDoesNotImportOSModules = {
+    expr =
+      builtins.map
+        (
+          os:
+          contains "^[[:space:]]*(import|imports)[[:space:]=].*${os}\\.nix" (
+            builtins.readFile ../../home/common.nix
+          )
+        )
+        [
+          "darwin"
+          "linux"
+          "wsl"
+        ];
+    expected = [
+      false
+      false
+      false
+    ];
+  };
+
+  testExternalCallersDoNotImportCommon = {
+    expr = externalDirectImports;
+    expected = [ ];
+  };
+}


### PR DESCRIPTION
## Summary
- add nix-unit checks for the canonical Home Manager layout and import direction
- register Home Manager tests through flake-parts checks
- document test file and execution rules

Closes #521

## Validation
- nix build .#checks.aarch64-darwin.nix-unit --no-link --print-build-logs
- nix flake check --no-build --all-systems --show-trace
- nix fmt -- --fail-on-change
- pre-commit run --all-files