### PR TITLE
fix(codex): use managed permission profile

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -5,12 +5,7 @@ model_reasoning_summary = "auto"
 model_verbosity = "low"
 project_doc_fallback_filenames = [ "copilot-instructions.md" ]
 approval_policy = "never"
-sandbox_mode = "danger-full-access"
-
-[sandbox_workspace_write]
-exclude_slash_tmp = false
-exclude_tmpdir_env_var = false
-network_access = true
+default_permissions = ":danger-full-access"
 web_search = "live"
 mcp_oauth_credentials_store = "auto"
 hide_agent_reasoning = false

--- a/chezmoi/dot_codex/config.toml.tmpl
+++ b/chezmoi/dot_codex/config.toml.tmpl
@@ -30,7 +30,7 @@ model_verbosity = "low"
 project_doc_fallback_filenames = [ "copilot-instructions.md" ]
 
 ################################################################################
-# 承認とサンドボックス設定 (自律実行の中核)
+# 承認と権限プロファイル設定 (自律実行の中核)
 ################################################################################
 
 # 自律実行のため承認プロンプトを出さない。
@@ -39,8 +39,10 @@ project_doc_fallback_filenames = [ "copilot-instructions.md" ]
 #   2. hooks/ (保護ブランチへの直接コミットを deny)
 approval_policy = "never"
 
-# Git 操作まで自律実行できるよう、ファイルシステム sandbox は無効化する。
-sandbox_mode = "danger-full-access"
+# Git 操作まで自律実行できるよう、管理可能なフルアクセス権限を選ぶ。
+# sandbox_mode を併記すると permission profile が無効になり、Codex Security の
+# read-only worker に親タスクの権限境界を安全に継承できない。
+default_permissions = ":danger-full-access"
 
 ################################################################################
 # ウェブ検索
@@ -48,17 +50,6 @@ sandbox_mode = "danger-full-access"
 
 # 自律実行では最新情報 (ライブラリの API 変更等) の取得が品質に直結する
 web_search = "live"
-
-################################################################################
-# workspace-write 時だけ適用するサンドボックスの追加設定
-################################################################################
-
-[sandbox_workspace_write]
-# ビルド・テストツール (pytest, npm 等) が一時ディレクトリを使えるようにする
-exclude_slash_tmp = false
-exclude_tmpdir_env_var = false
-# パッケージ取得や API 呼び出しを伴うタスクをサンドボックス内で完結させる
-network_access = true
 
 ################################################################################
 # シェル環境ポリシー

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -533,6 +533,21 @@ Describe 'chezmoi テンプレート バリデーション' {
             $content | Should -Match 'env "ProgramData"' -Because "Docker Desktop backend は ProgramData が無いと起動に失敗する"
         }
 
+        It 'Codex 設定では managed permission profile を使用すること' {
+            $configPaths = @(
+                (Join-Path $script:chezmoiRoot "dot_codex/config.toml.tmpl")
+                (Join-Path $script:repoRoot ".codex/config.toml")
+            )
+
+            foreach ($configPath in $configPaths) {
+                $content = Get-Content -Path $configPath -Raw
+
+                $content | Should -Match '(?m)^default_permissions\s*=\s*":danger-full-access"\s*$' -Because "Deep Security Scan worker は親タスクの managed permission profile を継承する: $configPath"
+                $content | Should -Not -Match '(?m)^sandbox_mode\s*=' -Because "旧 sandbox 設定があると permission profile が無効になる: $configPath"
+                $content | Should -Not -Match '(?m)^\[sandbox_workspace_write\]\s*$' -Because "新旧の権限設定を混在させない: $configPath"
+            }
+        }
+
         It 'should enable Codex apps for plugin-bundled connectors' {
             $templatePath = Join-Path $script:chezmoiRoot "dot_codex/config.toml.tmpl"
             $content = Get-Content -Path $templatePath -Raw

--- a/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
+++ b/scripts/powershell/tests/chezmoi/ChezmoiTemplate.Tests.ps1
@@ -533,7 +533,7 @@ Describe 'chezmoi テンプレート バリデーション' {
             $content | Should -Match 'env "ProgramData"' -Because "Docker Desktop backend は ProgramData が無いと起動に失敗する"
         }
 
-        It 'Codex 設定では managed permission profile を使用すること' {
+        It 'should use managed permission profiles in Codex configs' {
             $configPaths = @(
                 (Join-Path $script:chezmoiRoot "dot_codex/config.toml.tmpl")
                 (Join-Path $script:repoRoot ".codex/config.toml")


### PR DESCRIPTION
## Summary\n\n- migrate both global and project Codex configs from legacy sandbox keys to default_permissions = ":danger-full-access"\n- keep Codex Security workers on a managed permission profile\n- add a regression test covering both configuration layers\n\n## Validation\n\n- pre-commit run on all three changed files\n- Pester: 52 passed, 0 failed, 0 skipped\n- git diff --check\n- independent review: no remaining Critical or Important findings