### PR TITLE
fix(hermes): bootstrap Hindsight memory before startup

### DIFF
--- a/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
@@ -113,6 +113,9 @@ class ComposeContractTests(unittest.TestCase):
     def test_gateway_uses_the_canonical_shared_lifelog_path(self) -> None:
         self.assertEqual(self.hermes["environment"]["LIFELOG_ROOT"], "/opt/data/shared/lifelog")
 
+    def test_gateway_uses_the_canonical_hermes_home(self) -> None:
+        self.assertEqual(self.hermes["environment"]["HERMES_HOME"], "/opt/data")
+
     def test_gateway_reconnects_on_the_first_failed_discord_liveness_sample(self) -> None:
         self.assertEqual(
             self.hermes["environment"]["HERMES_DISCORD_LIVENESS_FAILURE_THRESHOLD"],

--- a/docker/hermes-service/compose.yml
+++ b/docker/hermes-service/compose.yml
@@ -31,6 +31,7 @@ services:
         target: /root/.xurl
     environment:
       API_SERVER_HOST: "0.0.0.0"
+      HERMES_HOME: /opt/data
       HERMES_DASHBOARD: "1"
       HERMES_DASHBOARD_HOST: "0.0.0.0"
       # Rebuild a Discord Gateway on the first failed WebSocket liveness

--- a/docs/hermes-agent/hindsight-memory.md
+++ b/docs/hermes-agent/hindsight-memory.md
@@ -91,6 +91,18 @@ Hindsight の chat 推論は `local-ai-services` 上の MLflow Gateway
 task hindsight:up
 ```
 
+Hermes gateway を memory 接続済みの状態で起動・再作成する場合は、次の
+transactional task を使います。
+
+```text
+task hermes:up
+```
+
+この task は独立した `hindsight:up` を準備した後、全 managed profile の
+Hindsight 設定を atomic bootstrap で reconcile し、その成功後に Hermes stack を
+起動します。`docker compose -f docker/hermes-service/compose.yml up` だけでは
+profile 設定の bootstrap は実行されません。
+
 起動の成否はポートの listen だけで判断せず、`/health` の `status` が
 `healthy` かつ `database` が `connected` であることを確認します。
 

--- a/docs/hermes-agent/xapi-mcp.md
+++ b/docs/hermes-agent/xapi-mcp.md
@@ -82,14 +82,17 @@ xurl is not overwritten by an older 1Password value. To intentionally
 re-materialize the cache, set `DOTFILES_HERMES_XAPI_FORCE_CACHE_SYNC=1` for
 that run.
 
-Start or recreate the stack manually when using the atomic tasks:
+Start or recreate the stack through the atomic bootstrap task:
 
 ```bash
 task hermes:up
 task hermes:xapi:logs
 ```
 
-The normal bootstrap path also builds and starts `xapi-mcp`:
+`task hermes:up` first runs the transactional Hermes bootstrap, which
+reconciles Hindsight memory configuration for every managed profile, then
+builds and starts `xapi-mcp` and the Hermes stack. The explicit bootstrap
+task remains available for the same operation:
 
 ```bash
 task hermes:bootstrap

--- a/scripts/powershell/handlers/Handler.HermesAgent.ps1
+++ b/scripts/powershell/handlers/Handler.HermesAgent.ps1
@@ -169,7 +169,7 @@ class HermesAgentHandler : SetupHandlerBase {
     }
 
     hidden [string] GetComposeFilePath([SetupContext]$ctx) {
-        return Join-Path $ctx.DotfilesPath 'docker\hermes-agent\compose.yml'
+        return Join-Path $ctx.DotfilesPath 'docker\hermes-service\compose.yml'
     }
 
     hidden [string] GetDataDir() {

--- a/scripts/powershell/handlers/Handler.Hindsight.ps1
+++ b/scripts/powershell/handlers/Handler.Hindsight.ps1
@@ -55,7 +55,7 @@ class HindsightHandler : SetupHandlerBase {
     }
 
     hidden [string] GetComposeFilePath([SetupContext]$ctx) {
-        return Join-Path $ctx.DotfilesPath 'docker\hindsight\compose.yml'
+        return Join-Path $ctx.DotfilesPath 'docker\local-ai-services\compose.yml'
     }
 
     hidden [bool] IsTruthy([object]$value) {

--- a/scripts/powershell/hermes-bootstrap.ps1
+++ b/scripts/powershell/hermes-bootstrap.ps1
@@ -43,11 +43,20 @@ function Get-HermesBootstrapEntrypointPath {
     )
 
     $repositoryRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
-    $resolvedComposeFile = if ([string]::IsNullOrWhiteSpace($ComposeFile)) {
+    $composeOverride = if (-not [string]::IsNullOrWhiteSpace($ComposeFile)) {
+        $ComposeFile
+    }
+    elseif (-not [string]::IsNullOrWhiteSpace($env:HERMES_COMPOSE_FILE)) {
+        $env:HERMES_COMPOSE_FILE
+    }
+    else {
+        ''
+    }
+    $resolvedComposeFile = if ([string]::IsNullOrWhiteSpace($composeOverride)) {
         Join-Path $repositoryRoot 'docker/hermes-service/compose.yml'
     }
     else {
-        [System.IO.Path]::GetFullPath($ComposeFile)
+        [System.IO.Path]::GetFullPath($composeOverride)
     }
 
     $profileRoot = if (-not [string]::IsNullOrWhiteSpace($DataDir)) {
@@ -165,6 +174,41 @@ function Wait-HermesBootstrapApi {
     return $false
 }
 
+function Get-HermesBootstrapRuntimeState {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ComposeFile
+    )
+
+    try {
+        $global:LASTEXITCODE = 0
+        $output = @(Invoke-Docker `
+                -Arguments @('compose', '-f', $ComposeFile, 'ps', '--all', '--services', 'hermes') `
+                2>$null)
+        if ($global:LASTEXITCODE -ne 0) {
+            return [PSCustomObject]@{
+                Success = $false
+                Exists  = $false
+                Message = 'Hermes runtime inspection failed.'
+            }
+        }
+
+        return [PSCustomObject]@{
+            Success = $true
+            Exists  = @($output | Where-Object { ([string]$_).Trim() -eq 'hermes' }).Count -eq 1
+            Message = ''
+        }
+    }
+    catch {
+        return [PSCustomObject]@{
+            Success = $false
+            Exists  = $false
+            Message = 'Hermes runtime inspection failed.'
+        }
+    }
+}
+
 function Invoke-HermesBootstrapDockerPhase {
     [CmdletBinding()]
     param(
@@ -187,6 +231,59 @@ function Invoke-HermesBootstrapDockerPhase {
     }
 }
 
+function Invoke-HermesBootstrapRuntimeRecovery {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ComposeFile
+    )
+
+    $start = Invoke-HermesBootstrapDockerPhase `
+        -Arguments @('compose', '-f', $ComposeFile, 'start', 'hermes', 'chromium', 'browser-mcp', 'xapi-mcp') `
+        -FailureMessage 'Hermes runtime recovery start failed.'
+    if ($start.ExitCode -ne 0) {
+        return $start
+    }
+
+    if (-not (Wait-HermesBootstrapApi)) {
+        $attempts = Get-HermesBootstrapEnvironmentInteger `
+            -Name 'HERMES_API_READY_ATTEMPTS' `
+            -DefaultValue 30
+        return New-HermesBootstrapEntrypointResult `
+            -ExitCode 1 `
+            -Message "Hermes runtime recovery readiness failed: Hermes API did not become ready after $attempts attempts."
+    }
+
+    return New-HermesBootstrapEntrypointResult -ExitCode 0 -Message ''
+}
+
+function New-HermesBootstrapFailureResult {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ComposeFile,
+        [Parameter(Mandatory)]
+        [bool]$RuntimeExisted,
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$FailureMessage,
+        [int]$ExitCode = 1
+    )
+
+    if (-not $RuntimeExisted) {
+        return New-HermesBootstrapEntrypointResult -ExitCode $ExitCode -Message $FailureMessage
+    }
+
+    $recovery = Invoke-HermesBootstrapRuntimeRecovery -ComposeFile $ComposeFile
+    if ($recovery.ExitCode -ne 0) {
+        return New-HermesBootstrapEntrypointResult `
+            -ExitCode $ExitCode `
+            -Message "$FailureMessage $($recovery.Message)"
+    }
+
+    return New-HermesBootstrapEntrypointResult -ExitCode $ExitCode -Message $FailureMessage
+}
+
 function Invoke-HermesBootstrapEntrypoint {
     [CmdletBinding()]
     param(
@@ -194,6 +291,9 @@ function Invoke-HermesBootstrapEntrypoint {
         [string]$DataDir = '',
         [string]$BrowserDataDir = ''
     )
+
+    $runtimeExisted = $false
+    $runtimeStopped = $false
 
     try {
         $paths = Get-HermesBootstrapEntrypointPath `
@@ -267,17 +367,27 @@ function Invoke-HermesBootstrapEntrypoint {
                 -FailureMessage 'Hermes image build failed.'
             if ($build.ExitCode -ne 0) { return $build }
 
+            $runtime = Get-HermesBootstrapRuntimeState -ComposeFile $paths.ComposeFile
+            if (-not $runtime.Success) {
+                return New-HermesBootstrapEntrypointResult -ExitCode 1 -Message $runtime.Message
+            }
+            $runtimeExisted = $runtime.Exists
+
             $stop = Invoke-HermesBootstrapDockerPhase `
                 -Arguments @('compose', '-f', $paths.ComposeFile, 'stop', 'hermes') `
                 -FailureMessage 'Hermes gateway stop failed.'
             if ($stop.ExitCode -ne 0) { return $stop }
+            $runtimeStopped = $true
 
             try {
                 $global:LASTEXITCODE = 0
                 $bootstrap = Invoke-HermesBootstrap -ComposeFile $paths.ComposeFile -DataDir $paths.DataDir
             }
             catch {
-                return New-HermesBootstrapEntrypointResult -ExitCode 1 -Message 'Hermes bootstrap failed.'
+                return New-HermesBootstrapFailureResult `
+                    -ComposeFile $paths.ComposeFile `
+                    -RuntimeExisted $runtimeExisted `
+                    -FailureMessage 'Hermes bootstrap failed.'
             }
             if (-not $bootstrap.Success) {
                 $message = if ([string]::IsNullOrWhiteSpace([string]$bootstrap.Message)) {
@@ -286,9 +396,12 @@ function Invoke-HermesBootstrapEntrypoint {
                 else {
                     [string]$bootstrap.Message
                 }
-                return New-HermesBootstrapEntrypointResult `
-                    -ExitCode (Get-HermesBootstrapEntrypointExitCode) `
-                    -Message $message
+                $failure = New-HermesBootstrapFailureResult `
+                    -ComposeFile $paths.ComposeFile `
+                    -RuntimeExisted $runtimeExisted `
+                    -FailureMessage $message
+                $failure.ExitCode = Get-HermesBootstrapEntrypointExitCode
+                return $failure
             }
 
             try {
@@ -302,11 +415,18 @@ function Invoke-HermesBootstrapEntrypoint {
                 if ($_.Exception.Message -ne 'Hermes X API credential retrieval failed.') {
                     throw
                 }
-                return New-HermesBootstrapEntrypointResult `
-                    -ExitCode 1 `
-                    -Message 'Hermes X API credential retrieval failed.'
+                return New-HermesBootstrapFailureResult `
+                    -ComposeFile $paths.ComposeFile `
+                    -RuntimeExisted $runtimeExisted `
+                    -FailureMessage 'Hermes X API credential retrieval failed.'
             }
-            if ($startup.ExitCode -ne 0) { return $startup }
+            if ($startup.ExitCode -ne 0) {
+                return New-HermesBootstrapFailureResult `
+                    -ComposeFile $paths.ComposeFile `
+                    -RuntimeExisted $runtimeExisted `
+                    -FailureMessage $startup.Message `
+                    -ExitCode $startup.ExitCode
+            }
 
             if (-not (Wait-HermesBootstrapApi)) {
                 try {
@@ -320,18 +440,20 @@ function Invoke-HermesBootstrapEntrypoint {
                 $attempts = Get-HermesBootstrapEnvironmentInteger `
                     -Name 'HERMES_API_READY_ATTEMPTS' `
                     -DefaultValue 30
-                return New-HermesBootstrapEntrypointResult `
-                    -ExitCode 1 `
-                    -Message "Hermes API did not become ready after $attempts attempts."
+                return New-HermesBootstrapFailureResult `
+                    -ComposeFile $paths.ComposeFile `
+                    -RuntimeExisted $runtimeExisted `
+                    -FailureMessage "Hermes API did not become ready after $attempts attempts."
             }
 
             try {
                 Invoke-HermesGatewayConvergence -ComposeFile $paths.ComposeFile
             }
             catch [System.InvalidOperationException] {
-                return New-HermesBootstrapEntrypointResult `
-                    -ExitCode 1 `
-                    -Message $_.Exception.Message
+                return New-HermesBootstrapFailureResult `
+                    -ComposeFile $paths.ComposeFile `
+                    -RuntimeExisted $runtimeExisted `
+                    -FailureMessage $_.Exception.Message
             }
 
             return New-HermesBootstrapEntrypointResult -ExitCode 0 -Message 'Hermes bootstrap completed.'
@@ -356,6 +478,14 @@ function Invoke-HermesBootstrapEntrypoint {
         }
     }
     catch {
+        if ($runtimeStopped -and $runtimeExisted) {
+            $recovery = Invoke-HermesBootstrapRuntimeRecovery -ComposeFile $paths.ComposeFile
+            if ($recovery.ExitCode -ne 0) {
+                return New-HermesBootstrapEntrypointResult `
+                    -ExitCode 1 `
+                    -Message "Hermes bootstrap entrypoint failed. $($recovery.Message)"
+            }
+        }
         return New-HermesBootstrapEntrypointResult -ExitCode 1 -Message 'Hermes bootstrap entrypoint failed.'
     }
 }

--- a/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
+++ b/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
@@ -136,12 +136,13 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             -BrowserDataDir $script:browserDir
 
         $result.ExitCode | Should -Be 0
-        $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'xapi-credentials', 'up')
+        $script:eventLog | Should -Be @('config', 'build', 'ps', 'stop', 'bootstrap', 'xapi-credentials', 'up')
         $script:dockerCalls | Should -Be @(
             'info',
             'compose version',
             "compose -f $script:composeFile config --quiet",
             "compose -f $script:composeFile build hermes hermes-bootstrap chromium xapi-mcp",
+            "compose -f $script:composeFile ps --all --services hermes",
             "compose -f $script:composeFile stop hermes",
             "compose -f $script:composeFile up -d --force-recreate"
         )
@@ -150,6 +151,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             'compose version',
             'config',
             'build',
+            'ps',
             'stop',
             'bootstrap',
             'up'
@@ -179,6 +181,35 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
         Should -Invoke Start-Sleep -Times 0 -Exactly
     }
 
+    It 'should recover an existing Hermes runtime after bootstrap failure' {
+        Mock Invoke-Docker {
+            $script:dockerCalls.Add(($Arguments -join ' '))
+            if ($Arguments -contains '--services') {
+                $global:LASTEXITCODE = 0
+                return 'hermes'
+            }
+            $global:LASTEXITCODE = 0
+            return @()
+        }
+        Mock Invoke-HermesBootstrap {
+            [PSCustomObject]@{
+                Success = $false
+                Changed = $false
+                Message = 'Hermes bootstrap failed.'
+            }
+        }
+
+        $result = Invoke-HermesBootstrapEntrypoint `
+            -ComposeFile $script:composeFile `
+            -DataDir $script:dataDir `
+            -BrowserDataDir $script:browserDir
+
+        $result.ExitCode | Should -Be 1
+        $result.Message | Should -Be 'Hermes bootstrap failed.'
+        $script:dockerCalls | Should -Contain "compose -f $script:composeFile start hermes chromium browser-mcp xapi-mcp"
+        Should -Invoke Invoke-WebRequest -Times 1 -Exactly
+    }
+
     It 'should retry readiness until the API returns a successful status' {
         $env:HERMES_API_PORT = '9864'
         $env:HERMES_API_READY_ATTEMPTS = '3'
@@ -205,7 +236,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             $TimeoutSec -eq 1
         }
         Should -Invoke Start-Sleep -Times 2 -Exactly -ParameterFilter { $Seconds -eq 0 }
-        ($script:dockerCalls -join "`n") | Should -Not -Match 'ps --all'
+        $script:dockerCalls | Should -Not -Contain "compose -f $script:composeFile ps --all"
     }
 
     It 'should converge gateways after API readiness and before reporting success' {
@@ -225,7 +256,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
 
         $result.ExitCode | Should -Be 0
         $script:eventLog | Should -Be @(
-            'config', 'build', 'stop', 'bootstrap', 'xapi-credentials', 'up',
+            'config', 'build', 'ps', 'stop', 'bootstrap', 'xapi-credentials', 'up',
             'health', 'gateway-convergence', 'success'
         )
         Should -Invoke Invoke-HermesGatewayConvergence -Times 1 -Exactly -ParameterFilter {
@@ -271,11 +302,36 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
         $script:dockerCalls[-1] | Should -Be "compose -f $script:composeFile ps --all"
     }
 
+    It 'should recover an existing Hermes runtime after readiness failure' {
+        $env:HERMES_API_READY_ATTEMPTS = '1'
+        Mock Invoke-Docker {
+            $script:dockerCalls.Add(($Arguments -join ' '))
+            if ($Arguments -contains '--services') {
+                $global:LASTEXITCODE = 0
+                return 'hermes'
+            }
+            $global:LASTEXITCODE = 0
+            return @()
+        }
+        Mock Invoke-WebRequest { throw 'still starting' }
+
+        $result = Invoke-HermesBootstrapEntrypoint `
+            -ComposeFile $script:composeFile `
+            -DataDir $script:dataDir `
+            -BrowserDataDir $script:browserDir
+
+        $result.ExitCode | Should -Be 1
+        $result.Message | Should -Match 'Hermes API did not become ready after 1 attempts.'
+        $script:dockerCalls | Should -Contain "compose -f $script:composeFile start hermes chromium browser-mcp xapi-mcp"
+        Should -Invoke Invoke-WebRequest -Times 2 -Exactly
+    }
+
     It 'should make the Windows task use the focused pwsh entrypoint without installer skip gates' {
         $taskfile = Get-Content -LiteralPath $script:taskfilePath -Raw
         $source = Get-Content -LiteralPath $script:entrypointPath -Raw
 
         $taskfile | Should -Match "pwsh -NoProfile -File scripts/powershell/hermes-bootstrap\.ps1"
+        $taskfile | Should -Match 'hermes-bootstrap\.ps1 -ComposeFile "\{\{\.HERMES_COMPOSE_FILE\}\}"'
         $taskfile | Should -Not -Match "cmd\.exe /d /c install\.cmd"
         $source | Should -Not -Match 'SkipHermesAgent|NixRebuildApplied|Test-WslAvailable|install\.cmd'
     }
@@ -438,7 +494,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
         $result.ExitCode | Should -Be 23
         $result.Message | Should -Be 'Hermes bootstrap failed (exit code 23). [REDACTED]'
         $result.Message | Should -Not -Match ([regex]::Escape($secret))
-        $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap')
+        $script:eventLog | Should -Be @('config', 'build', 'ps', 'stop', 'bootstrap')
         ($script:dockerCalls -join "`n") | Should -Not -Match 'force-recreate'
     }
 
@@ -458,7 +514,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
         $result.ExitCode | Should -Not -Be 0
         $result.Message | Should -Be 'Hermes bootstrap failed.'
         $result.Message | Should -Not -Match 'secret-bearing'
-        $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap')
+        $script:eventLog | Should -Be @('config', 'build', 'ps', 'stop', 'bootstrap')
         ($script:dockerCalls -join "`n") | Should -Not -Match 'force-recreate'
         (Test-Path -LiteralPath Env:\HERMES_DATA_DIR) | Should -BeFalse
         (Test-Path -LiteralPath Env:\HERMES_BROWSER_DATA_DIR) | Should -BeTrue
@@ -484,7 +540,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             -BrowserDataDir $script:browserDir
 
         $result.ExitCode | Should -Be 29
-        $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'xapi-credentials', 'up')
+        $script:eventLog | Should -Be @('config', 'build', 'ps', 'stop', 'bootstrap', 'xapi-credentials', 'up')
         $script:dockerCalls[-1] | Should -Be "compose -f $script:composeFile up -d --force-recreate"
     }
 
@@ -501,7 +557,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
 
         $result.ExitCode | Should -Be 1
         $result.Message | Should -Be 'Hermes X API credential retrieval failed.'
-        $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'xapi-credentials')
+        $script:eventLog | Should -Be @('config', 'build', 'ps', 'stop', 'bootstrap', 'xapi-credentials')
         ($script:dockerCalls -join "`n") | Should -Not -Match 'force-recreate'
     }
 }

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'HermesAgentHandler' {
         $script:handler = [HermesAgentHandler]::new()
         $script:ctx = [SetupContext]::new($TestDrive)
         $script:ctx.Options['WithHermes'] = $true
-        $script:composeDir = Join-Path $TestDrive 'docker/hermes-agent'
+        $script:composeDir = Join-Path $TestDrive 'docker/hermes-service'
         $script:composeFile = Join-Path $script:composeDir 'compose.yml'
         $script:userProfile = Join-Path $TestDrive 'user'
         $script:oldUserProfile = $env:USERPROFILE
@@ -100,6 +100,10 @@ Describe 'HermesAgentHandler' {
     }
 
     Context 'constructor and prerequisites' {
+        It 'resolves the current Hermes service Compose path' {
+            $handler.CanApply($ctx) | Should -BeTrue
+        }
+
         It 'is disabled by default without WithHermes' {
             $ctx.Options.Remove('WithHermes')
 

--- a/scripts/powershell/tests/handlers/Handler.Hindsight.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.Hindsight.Tests.ps1
@@ -10,7 +10,7 @@ BeforeAll {
 Describe 'HindsightHandler' {
     BeforeEach {
         $root = Join-Path $TestDrive 'dotfiles'
-        $composeDir = Join-Path $root 'docker/hindsight'
+        $composeDir = Join-Path $root 'docker/local-ai-services'
         $scriptDir = Join-Path $root 'scripts/powershell'
         New-Item -ItemType Directory -Path $composeDir, $scriptDir -Force | Out-Null
         Set-Content -LiteralPath (Join-Path $composeDir 'compose.yml') -Value 'services: {}'
@@ -23,6 +23,11 @@ Describe 'HindsightHandler' {
 
     It 'is disabled by default' {
         $script:handler.CanApply($script:ctx) | Should -BeFalse
+    }
+
+    It 'resolves the current local-ai-services Compose path' {
+        $script:ctx.Options['WithHindsight'] = $true
+        $script:handler.CanApply($script:ctx) | Should -BeTrue
     }
 
     It 'is enabled only by the resolved Hindsight option' {

--- a/taskfiles/hermes/taskfile.yml
+++ b/taskfiles/hermes/taskfile.yml
@@ -29,7 +29,7 @@ tasks:
     cmds:
       - cmd: bash -lc 'set -euo pipefail; source scripts/sh/install-common.sh; source scripts/sh/hermes-agent.sh; dotfiles_hermes_start_stack docker "{{.HERMES_COMPOSE_FILE}}"'
         platforms: [linux, darwin]
-      - cmd: pwsh -NoProfile -File scripts/powershell/hermes-bootstrap.ps1
+      - cmd: pwsh -NoProfile -File scripts/powershell/hermes-bootstrap.ps1 -ComposeFile "{{.HERMES_COMPOSE_FILE}}"
         platforms: [windows]
 
   hermes:bootstrap:test:

--- a/taskfiles/hermes/taskfile.yml
+++ b/taskfiles/hermes/taskfile.yml
@@ -176,17 +176,12 @@ tasks:
         platforms: [windows]
 
   hermes:up:
-    desc: Start Hermes Agent gateway and dashboard in Docker
+    desc: Bootstrap Hermes memory configuration and start the gateway in Docker
     deps:
-      - task: hindsight:up
+      - task: hermes:bootstrap
     preconditions:
       - sh: docker info
         msg: "Docker daemon is not running. Start Docker Desktop and try again."
-    cmds:
-      - cmd: HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE}} bash scripts/sh/hermes-xapi.sh up
-        platforms: [linux, darwin]
-      - cmd: pwsh -NoProfile -File scripts/powershell/hermes-xapi.ps1 -Action up -ComposeFile "{{.HERMES_COMPOSE_FILE}}"
-        platforms: [windows]
 
   hermes:down:
     desc: Stop Hermes Agent Docker container
@@ -249,7 +244,7 @@ tasks:
   hermes:rick:up:
     desc: Start Rick Hermes profile gateway in the Hermes container
     deps:
-      - task: hindsight:up
+      - task: hermes:up
     preconditions:
       - sh: docker info
         msg: "Docker daemon is not running. Start Docker Desktop and try again."
@@ -285,7 +280,7 @@ tasks:
   hermes:hoffman:up:
     desc: Start Hoffman Hermes profile gateway in the Hermes container
     deps:
-      - task: hindsight:up
+      - task: hermes:up
     preconditions:
       - sh: docker info
         msg: "Docker daemon is not running. Start Docker Desktop and try again."
@@ -321,7 +316,7 @@ tasks:
   hermes:risarisa:up:
     desc: Start RisaRisa Hermes profile gateway in the Hermes container
     deps:
-      - task: hindsight:up
+      - task: hermes:up
     preconditions:
       - sh: docker info
         msg: "Docker daemon is not running. Start Docker Desktop and try again."
@@ -357,7 +352,7 @@ tasks:
   hermes:nancy:up:
     desc: Start Nancy Hermes profile gateway in the Hermes container
     deps:
-      - task: hindsight:up
+      - task: hermes:up
     preconditions:
       - sh: docker info
         msg: "Docker daemon is not running. Start Docker Desktop and try again."

--- a/tests/bash/taskfile_test_routing.bats
+++ b/tests/bash/taskfile_test_routing.bats
@@ -102,6 +102,16 @@ EOF
 	[ "$sync_line" -lt "$restart_line" ]
 }
 
+@test "Hermes up applies the transactional bootstrap before starting the gateway" {
+	command -v task >/dev/null || skip "go-task is unavailable"
+
+	run task --dir "$REPO_ROOT" --dry --force hermes:up
+
+	[ "$status" -eq 0 ]
+	bootstrap_line="$(grep -n 'task: \[hermes:bootstrap\]' <<<"$output" | cut -d: -f1)"
+	[ -n "$bootstrap_line" ]
+}
+
 @test "nrs orders rebuild, profile activation, and Hermes bootstrap" {
 	command -v task >/dev/null || skip "go-task is unavailable"
 
@@ -124,12 +134,12 @@ EOF
 	grep -Fq 'nrb = "~/.dotfiles/scripts/sh/nixos-rebuild-with-user.sh boot' "$REPO_ROOT/nix/home/wsl.nix"
 }
 
-@test "Hermes restart reuses the xapi-aware up task" {
+@test "Hermes restart reuses the transactional bootstrap up task" {
 	command -v task >/dev/null || skip "go-task is unavailable"
 
 	run task --dir "$REPO_ROOT" --dry --force hermes:restart
 
 	[ "$status" -eq 0 ]
-	[[ "$output" == *"task: [hermes:up]"* ]]
-	[[ "$output" == *"scripts/sh/hermes-xapi.sh up"* ]]
+	[[ "$output" == *"task: [hermes:bootstrap]"* ]]
+	[[ "$output" != *"scripts/sh/hermes-xapi.sh up"* ]]
 }

--- a/tests/python/test_taskfile_contract.py
+++ b/tests/python/test_taskfile_contract.py
@@ -54,11 +54,9 @@ class TaskfileContractTests(unittest.TestCase):
             "scripts/powershell/hermes-xapi.ps1 -Action restart",
             self._command_text("hermes:xapi:restart"),
         )
-        self.assertIn(
-            "scripts/sh/hermes-xapi.sh up",
-            self._command_text("hermes:up"),
-        )
-        self.assertIn(
+        self.assertIn("task: hermes:bootstrap", self._task_block("hermes:up"))
+        self.assertNotIn("scripts/sh/hermes-xapi.sh up", self._command_text("hermes:up"))
+        self.assertNotIn(
             "scripts/powershell/hermes-xapi.ps1 -Action up",
             self._command_text("hermes:up"),
         )
@@ -85,17 +83,16 @@ class TaskfileContractTests(unittest.TestCase):
         )
 
     def test_public_hermes_entrypoints_start_the_independent_memory_service(self) -> None:
+        self.assertIn("task: hindsight:up", self._task_block("hermes:setup"))
+        self.assertIn("task: hindsight:up", self._task_block("hermes:bootstrap"))
         for task_name in (
-            "hermes:setup",
-            "hermes:bootstrap",
-            "hermes:up",
             "hermes:rick:up",
             "hermes:hoffman:up",
             "hermes:risarisa:up",
             "hermes:nancy:up",
         ):
             with self.subTest(task_name=task_name):
-                self.assertIn("task: hindsight:up", self._task_block(task_name))
+                self.assertIn("task: hermes:up", self._task_block(task_name))
 
     def test_xapi_lifecycle_reads_oauth_credentials_from_1password(self) -> None:
         wrapper = XAPI_WRAPPER.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Keep Hindsight as an independent service in `docker/local-ai-services/compose.yml`
- Make Hermes gateway use the canonical persistent `HERMES_HOME=/opt/data`
- Make `task hermes:up` depend on the atomic `hermes:bootstrap` path
- Route named Hermes profile startup through the same bootstrap path
- Update contract tests and operator documentation

## Constraints

- No Hindsight container or `depends_on` was added to `docker/hermes-service/compose.yml`
- No temporary `docker exec` or ad-hoc CLI configuration is required
- Fixes #537

## Validation

- Focused Bats: 27/27 passed
- Python taskfile contract: 9/9 passed
- Hermes compose contract in bootstrap test image: 19 tests, 1 skipped
- Bootstrap container suite: 633 tests, 4 skipped
- `nix fmt -- --fail-on-change`: passed
- `git diff --check`: passed
- Full Bash suite has 5 unrelated NixOS installer fixture failures because the real Docker CLI precedes the test stub after PATH mutation; reproduced on an unchanged worktree.