### PR TITLE
feat: manage Hermes Desktop with Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,20 @@ editor 同期が完了してから起動します。
 ```bash
 ./install.sh --with-ollama # Ollama のみ
 ./install.sh --with-docker # Ollama + Docker + 独立 Hindsight
-./install.sh --with-hermes # 上記 + Hermes + Chrome + Discord + browser-mcp
+./install.sh --with-hermes # 上記 + native Hermes Desktop + Docker Agent/Dashboard + Chrome + Discord + browser-mcp
 ```
 
 Nix installer と nix-darwin がシステムを収束させ、nix-homebrew が選択した
 Homebrew formula/cask を管理します。Home Manager と chezmoi も同じコマンド内で
 適用します。macOS では WSL や NixOS を導入しません。
+
+`--with-hermes` の macOS 構成では、Hermes Desktop は公式 Hermes flake の Nix
+パッケージとしてホストに導入されます。Agent/gateway と Web Dashboard は既存の
+Docker Compose 側で起動し、Desktop から `http://127.0.0.1:9119` に接続します。
+Dashboard の認証情報、セッション、モデル、その他の runtime state は Nix store
+に保存しません。Desktop を Agent コンテナへインストールする構成ではありません。
+
+詳細は [Hermes Desktop の運用](./docs/hermes-agent/desktop.md) を参照してください。
 
 Tart CLI もこの macOS activation で導入されますが、約25GBの VM image は通常の `./install.sh` では取得しません。大容量ダウンロードを開始するタイミングを分離するため、初回だけ次を実行します。
 

--- a/docs/hermes-agent/desktop.md
+++ b/docs/hermes-agent/desktop.md
@@ -1,0 +1,48 @@
+# Hermes Desktop
+
+## 構成
+
+macOS の `./install.sh --with-hermes` は、次の2つを別々に管理します。
+
+- ホスト: 公式 `NousResearch/hermes-agent` flake の `desktop` 出力を Nix/Home
+  Manager で導入し、`hermes-desktop` コマンドを提供する。
+- Docker: `docker/hermes-service/compose.yml` の Hermes Agent、gateway、Web
+  Dashboard、Browser/MCP サービスを起動する。
+
+Desktop の GUI を Agent コンテナに入れる必要はありません。コンテナは GUI を
+提供するイメージではなく、Agent の実行環境と Dashboard/API を提供します。
+
+公式ドキュメントでも Desktop App、CLI/TUI、Web Dashboard は同じ Agent に接続
+する別のフロントエンドとして説明されています。Desktop は `hermes-desktop`
+で起動し、Web Dashboard は `hermes dashboard` が提供します。
+
+## 接続先
+
+Compose は Dashboard をホストの次の loopback ポートへ公開します。
+
+```text
+http://127.0.0.1:9119
+```
+
+Desktop の remote backend 設定でこの URL を指定し、Dashboard の認証を通過して
+ください。別のマシンから接続する場合は loopback 公開のままでは到達できないため、
+認証、TLS、ファイアウォールを含む別の公開設計が必要です。
+
+## 状態と秘密情報
+
+API key、OAuth token、profile、session、memory、モデル、Docker のデータは
+`~/.hermes` などの runtime path に保存します。Nix 式へ秘密値を記述したり、Nix
+store に runtime state を生成したりしないでください。
+
+## 手動確認
+
+```bash
+hermes-desktop
+docker compose -f docker/hermes-service/compose.yml ps
+curl -fsS http://127.0.0.1:8642/health
+```
+
+公式の Desktop 操作と remote backend の設定は、[Hermes Desktop
+documentation](https://hermes-agent.nousresearch.com/docs/user-guide/desktop) と
+[Web Dashboard の remote 接続ガイド](https://hermes-agent.nousresearch.com/docs/user-guide/features/web-dashboard)
+を参照してください。

--- a/docs/superpowers/plans/2026-09-01-hermes-desktop-nix.md
+++ b/docs/superpowers/plans/2026-09-01-hermes-desktop-nix.md
@@ -1,0 +1,77 @@
+# Hermes Desktop Nix Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add the official Hermes Desktop Nix output to the `WithHermes` macOS
+profile while keeping the Agent and Web Dashboard in the existing Compose stack.
+
+**Architecture:** The root flake pins `NousResearch/hermes-agent` and passes its
+`packages.<system>.desktop` output into the package catalog. `hermes-desktop` is
+a Darwin command package enabled by `WithHermes`; the existing `hermes` container
+continues to own the gateway and dashboard at `127.0.0.1:9119`.
+
+**Tech Stack:** Nix flakes, nix-darwin, Home Manager, Docker Compose, Bash/Bats,
+Python unittest, go-task, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-hermes-desktop-nix-design.md`
+
+## Global Constraints
+
+- Work only in `/Users/ktome1995/Program/dotfiles/.worktrees/hermes-desktop-nix`.
+- Preserve all unrelated changes in the primary checkout.
+- Keep Hermes credentials, sessions, models, and runtime state outside `/nix/store`.
+- Do not add Electron or a GUI runtime to `docker/hermes-agent`.
+- Keep `--with-hermes` as the single opt-in switch for Docker Hermes and Desktop.
+- Record the existing `bootstrap-nixos-vm` baseline evaluation failure; do not fix
+  unrelated NixOS test code in this change.
+
+## Task 1: Pin the upstream Hermes flake and add the catalog contract
+
+**Files:** `flake.nix`, `flake.lock`, `nix/packages/sets.nix`,
+`nix/packages/darwin-provider-candidates.nix`,
+`tests/bash/package_catalog.bats`, `tests/python/test_update_darwin_packages.py`
+
+- [ ] Add a failing contract test for the `hermes-desktop` candidate, its
+      `WithHermes` feature, and Darwin-only provider metadata.
+- [ ] Run the focused test and confirm it fails because the catalog entry/input
+      does not exist.
+- [ ] Add the official `hermes-agent` flake input, following the repository's
+      nixpkgs where compatible, and update `flake.lock` with Nix.
+- [ ] Add an optional `hermesDesktopPackage` argument to `sets.nix`; resolve
+      `hermes-desktop` from the supplied upstream package on Darwin only.
+- [ ] Add provider metadata and ensure the package is a Darwin Nix/Home Manager
+      package enabled only by `WithHermes`.
+- [ ] Run the focused catalog tests and `nix eval` checks for default/WithHermes
+      resolution.
+- [ ] Commit the flake/catalog foundation.
+
+## Task 2: Wire the package through nix-darwin and document the split
+
+**Files:** `nix/hosts/darwin/default.nix`, `nix/flakes/packages.nix`,
+`README.md`, `scripts/sh/install-macos.sh`, `docs/hermes-agent/desktop.md`,
+`tests/bash/install_macos.bats`, `tests/python/test_ci_workflow_routing.py`
+
+- [ ] Add a failing assertion that the Darwin host passes the upstream Desktop
+      output and that `--with-hermes` describes the native GUI plus Compose backend.
+- [ ] Pass the package from flake inputs into nix-darwin's catalog and keep
+      standalone package outputs consistent.
+- [ ] Update installer help and user documentation with the host/container split,
+      Dashboard URL, authentication requirement, and runtime-state boundary.
+- [ ] Add the Hermes Desktop documentation path to the existing CI routing.
+- [ ] Run focused Bash/Python contract tests and Nix evaluation.
+- [ ] Commit the host wiring and documentation.
+
+## Task 3: Verify, review, and deliver through GitHub
+
+**Files:** only files changed by Tasks 1-2 unless CI exposes a necessary contract.
+
+- [ ] Run `nix fmt`, focused Bats/Python tests, `docker compose ... config --quiet`,
+      and relevant package-provider checks.
+- [ ] Run `nix flake check --no-build --impure --all-systems`, record only the
+      pre-existing bootstrap VM assertion failure if it remains.
+- [ ] Review the final diff, commit, and push the feature branch.
+- [ ] Create a PR closing issue #538, inspect the repository ruleset and review
+      threads, and wait for all required Actions checks.
+- [ ] Address Critical/Important review or CI failures, rerun verification, and
+      repeat until the PR is mergeable.
+- [ ] Merge with the repository-allowed method and verify the merged PR and issue.

--- a/docs/superpowers/specs/2026-09-01-hermes-desktop-nix-design.md
+++ b/docs/superpowers/specs/2026-09-01-hermes-desktop-nix-design.md
@@ -1,0 +1,34 @@
+# Hermes Desktop Nix 管理設計
+
+## 目的
+
+`--with-hermes` を選んだ macOS 環境で、Hermes Desktop をホスト側の Nix
+管理下に置き、Hermes Agent の実行環境と Web Dashboard は既存の Docker
+Compose に残す。Desktop は GUI クライアントとしてコンテナの Dashboard に
+接続できる構成にする。
+
+## 決定事項
+
+- Hermes Desktop は公式 `NousResearch/hermes-agent` flake の
+  `packages.<system>.desktop` を root flake input に追加して固定する。
+- `nix/packages/sets.nix` をパッケージカタログの SSOT とし、カタログ ID
+  `hermes-desktop` に `installFeature = "WithHermes"` を設定する。
+- `--with-hermes` が有効な macOS では、Home Manager のユーザーパッケージ
+  として Desktop を反映する。通常プロファイルでは評価・インストールしない。
+- Desktop を `hermes-agent` コンテナへ入れない。コンテナは gateway、API、
+  Web Dashboard、既存の MCP/Browser サービスを担当する。
+- Desktop のリモート接続先は `http://127.0.0.1:9119` とし、資格情報や
+  Hermes のランタイム状態は Nix 式・Nix store に置かない。
+- `x86_64-darwin` は現在の公式 Desktop 出力が対象外のため、既存の flake
+  system matrix どおり Apple Silicon を対象とする。
+
+## 受け入れ条件
+
+1. `nix flake check --no-build --impure --all-systems` の既存 bootstrap VM
+   評価エラーを除き、今回の変更由来の評価エラーがない。
+2. `hermes-desktop` が `WithHermes` でのみ Darwin system package に解決され、
+   通常プロファイルには現れない。
+3. 公式 flake input の lock 情報と Desktop 出力を Nix が評価できる。
+4. 既存の macOS installer の `--with-hermes` 契約、Compose 契約、パッケージ
+   カタログ検証、ドキュメントが更新される。
+5. Hosted Actions が成功し、PR のレビューコメントが解決済みである。

--- a/flake.lock
+++ b/flake.lock
@@ -132,7 +132,53 @@
         "type": "github"
       }
     },
+    "hermes-agent": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "home-manager": "home-manager",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "npm-lockfile-fix": "npm-lockfile-fix",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      },
+      "locked": {
+        "lastModified": 1788189266,
+        "narHash": "sha256-KRDA43R7XkCDnJFliAcIuTj4/dek8GL/zZlfmJPSgiI=",
+        "type": "tarball",
+        "url": "https://codeload.github.com/NousResearch/hermes-agent/tar.gz/a071fc80da30ffc4311ae1a6fb4f86f6947cf655"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://codeload.github.com/NousResearch/hermes-agent/tar.gz/a071fc80da30ffc4311ae1a6fb4f86f6947cf655"
+      }
+    },
     "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786487128,
+        "narHash": "sha256-ad60hrRVhH/bo3Jl1YLzO+QcS3mUNZr9LNJdzhMO2P4=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "f404edbfa4117810c96b97048299242fc50e5362",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
@@ -304,6 +350,27 @@
         "type": "github"
       }
     },
+    "npm-lockfile-fix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775903712,
+        "narHash": "sha256-2GV79U6iVH4gKAPWYrxUReB0S41ty/Y3dBLquU8AlaA=",
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
+        "rev": "c6093acb0c0548e0f9b8b3d82918823721930fe8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
+        "type": "github"
+      }
+    },
     "pre-commit-hooks-nix": {
       "inputs": {
         "flake-compat": [
@@ -332,10 +399,61 @@
         "type": "github"
       }
     },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "hermes-agent",
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "hermes-agent",
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785115949,
+        "narHash": "sha256-8AM37BfyGaL2v/SZyg4PupRxJ01Y4htvM+WrTjWrPpo=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "62c0d86027edb1c4f39a5facc09876348144f7c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784591072,
+        "narHash": "sha256-zP/WaDxrRu8GANZM61+V2LT/7ycEEdoyLWn7M6WzU7M=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "e3b599ca2e7fcf93d4edf65d7f19bbf6491724f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "home-manager": "home-manager",
+        "hermes-agent": "hermes-agent",
+        "home-manager": "home-manager_2",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
         "nix-unit": "nix-unit",
@@ -467,6 +585,31 @@
         "owner": "jfroche",
         "ref": "system-manager",
         "repo": "userborn",
+        "type": "github"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "hermes-agent",
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785277507,
+        "narHash": "sha256-9Tq3UDX2hD/aveW/HvkBlAmEwJTOlY5HQXJM+L5BGmE=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "5a836d395cbf5fc22670eb98dd4aa4fc4d406977",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,11 @@
       url = "github:raine/workmux";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    hermes-agent = {
+      url = "https://codeload.github.com/NousResearch/hermes-agent/tar.gz/a071fc80da30ffc4311ae1a6fb4f86f6947cf655";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-parts.follows = "flake-parts";
+    };
   };
 
   outputs =

--- a/nix/flakes/home.nix
+++ b/nix/flakes/home.nix
@@ -5,6 +5,13 @@
 #   home-manager switch --flake .#aarch64-linux
 { inputs, ... }:
 let
+  withHermes = builtins.getEnv "DOTFILES_WITH_HERMES" == "1";
+  withDocker = withHermes || builtins.getEnv "DOTFILES_WITH_DOCKER" == "1";
+  withOllama = withDocker || builtins.getEnv "DOTFILES_WITH_OLLAMA" == "1";
+  installFeatures =
+    inputs.nixpkgs.lib.optionals withOllama [ "WithOllama" ]
+    ++ inputs.nixpkgs.lib.optionals withDocker [ "WithDocker" ]
+    ++ inputs.nixpkgs.lib.optionals withHermes [ "WithHermes" ];
   Workmux = import ./lib/workmux.nix { inherit inputs; };
   workmuxOverlay = Workmux.mkOverlay (system: inputs.workmux.packages.${system}.default);
   mkHome = system: {
@@ -14,7 +21,7 @@ let
       overlays = [ workmuxOverlay ];
     };
     extraSpecialArgs = {
-      inherit inputs;
+      inherit inputs installFeatures;
       hermesDesktopPackage = inputs.nixpkgs.lib.attrByPath [
         "hermes-agent"
         "packages"

--- a/nix/flakes/home.nix
+++ b/nix/flakes/home.nix
@@ -15,6 +15,12 @@ let
     };
     extraSpecialArgs = {
       inherit inputs;
+      hermesDesktopPackage = inputs.nixpkgs.lib.attrByPath [
+        "hermes-agent"
+        "packages"
+        system
+        "desktop"
+      ] null inputs;
       isWSL = false;
     };
   };

--- a/nix/flakes/packages.nix
+++ b/nix/flakes/packages.nix
@@ -27,14 +27,32 @@
       sets = import ../packages/sets.nix {
         pkgs = pkgs.extend workmuxOverlay;
         inherit lib;
+        hermesDesktopPackage = lib.attrByPath [
+          "hermes-agent"
+          "packages"
+          pkgs.system
+          "desktop"
+        ] null inputs;
       };
       unfreeSets = import ../packages/sets.nix {
         pkgs = unfreePkgs;
         inherit lib;
+        hermesDesktopPackage = lib.attrByPath [
+          "hermes-agent"
+          "packages"
+          pkgs.system
+          "desktop"
+        ] null inputs;
       };
       packageSupportReport = import ../packages/support-report.nix {
         pkgs = unfreePkgs;
         inherit lib;
+        hermesDesktopPackage = lib.attrByPath [
+          "hermes-agent"
+          "packages"
+          pkgs.system
+          "desktop"
+        ] null inputs;
       };
     in
     {

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -10,7 +10,7 @@
   pkgs,
   lib,
   inputs ? null,
-  installFeatures ? null,
+  installFeatures ? [ ],
   hermesDesktopPackage ? null,
   isWSL,
   ...

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -11,12 +11,13 @@
   lib,
   inputs ? null,
   installFeatures ? null,
+  hermesDesktopPackage ? null,
   isWSL,
   ...
 }:
 let
   sets = import ../packages/sets.nix {
-    inherit pkgs lib;
+    inherit pkgs lib hermesDesktopPackage;
   };
   bootstrapUser = builtins.getEnv "DOTFILES_USER";
   bootstrapHome = builtins.getEnv "DOTFILES_HOME";

--- a/nix/hosts/darwin/default.nix
+++ b/nix/hosts/darwin/default.nix
@@ -7,8 +7,10 @@
 let
   user = builtins.getEnv "DOTFILES_USER";
   home = builtins.getEnv "DOTFILES_HOME";
+  hermesDesktopPackage = inputs.hermes-agent.packages.${pkgs.system}.desktop;
   sets = import ../../packages/sets.nix {
     inherit pkgs lib;
+    inherit hermesDesktopPackage;
   };
   discordPackage = sets.darwinDiscordPackage;
   withHermes = builtins.getEnv "DOTFILES_WITH_HERMES" == "1";
@@ -206,7 +208,7 @@ in
       imports = [ ../../home/darwin.nix ];
     };
     extraSpecialArgs = {
-      inherit inputs installFeatures;
+      inherit inputs installFeatures hermesDesktopPackage;
       isWSL = false;
     };
   };

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -35,6 +35,7 @@
   pkgs,
   lib,
   catalogOverride ? null,
+  hermesDesktopPackage ? null,
 }:
 let
   darwinProviderCandidates = import ./darwin-provider-candidates.nix;
@@ -713,6 +714,28 @@ let
           legacyDarwin = {
             provider = "homebrew-cask";
             name = "docker-desktop";
+          };
+        };
+        hermes-desktop = {
+          pkg = if pkgs.stdenv.hostPlatform.isDarwin then hermesDesktopPackage else null;
+          winget = null;
+          category = "terminal";
+          installFeature = "WithHermes";
+          support = {
+            darwin = {
+              provider = "nix";
+              source = "hermes-agent";
+              identity = {
+                command = "hermes-desktop";
+                versionArgs = [ "--version" ];
+              };
+            };
+            linux = {
+              unsupported = "Hermes Desktop is provisioned by the native macOS profile";
+            };
+            windows = {
+              unsupported = "Hermes Desktop is provisioned by the native macOS profile";
+            };
           };
         };
 

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -1138,7 +1138,10 @@ let
   resolveForInstallFeatures =
     enabledFeatures: resolveForInstallFeaturesWhere enabledFeatures (_: true);
 
-  resolve = resolveForInstallFeatures null;
+  # Default package outputs contain only packages without an opt-in feature.
+  # Feature profiles use allForInstallFeatures or the platform-specific
+  # resolvers below with an explicit feature list.
+  resolve = resolveForInstallFeatures [ ];
 
   darwinSystemPackagesForInstallFeatures =
     enabledFeatures:
@@ -1390,12 +1393,14 @@ lib.mapAttrs (_: resolve) grouped
   ];
 
   # All packages (flat list)
-  all = resolve (lib.attrNames catalog);
+  all = resolveForInstallFeatures null (lib.attrNames catalog);
   allForInstallFeatures =
     enabledFeatures: resolveForInstallFeatures enabledFeatures (lib.attrNames catalog);
   allWithout =
     excludedNames:
-    resolve (builtins.filter (name: !(builtins.elem name excludedNames)) (lib.attrNames catalog));
+    resolveForInstallFeatures null (
+      builtins.filter (name: !(builtins.elem name excludedNames)) (lib.attrNames catalog)
+    );
   allWithoutForInstallFeatures =
     enabledFeatures: excludedNames:
     resolveForInstallFeatures enabledFeatures (

--- a/nix/packages/support-report.nix
+++ b/nix/packages/support-report.nix
@@ -1,9 +1,10 @@
 {
   pkgs,
   lib,
+  hermesDesktopPackage ? null,
 }:
 let
-  sets = import ./sets.nix { inherit pkgs lib; };
+  sets = import ./sets.nix { inherit pkgs lib hermesDesktopPackage; };
   reportFile = pkgs.writeText "package-support.json" (builtins.toJSON sets.supportReport);
   darwinPackagesFile = pkgs.writeText "darwin-packages.json" (
     builtins.toJSON (builtins.attrNames sets.darwinPackages)

--- a/scripts/sh/install-macos.sh
+++ b/scripts/sh/install-macos.sh
@@ -51,7 +51,8 @@ Usage: ./install.sh [--with-ollama | --with-docker | --with-hermes]
 
   --with-ollama  Install and update Ollama.
   --with-docker  Include Ollama, Docker Desktop, and independent Hindsight.
-  --with-hermes  Include the Docker profile, Hermes, Chrome, and Discord.
+  --with-hermes  Include native Hermes Desktop, the Docker Agent/Dashboard,
+                  Chrome, and Discord (Dashboard: http://127.0.0.1:9119).
 EOF
 }
 

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -563,6 +563,14 @@ exit 1
 	! grep -q 'docker-install' "$COMMAND_LOG"
 }
 
+@test "WithHermes help documents the native Desktop and container dashboard" {
+	run "$INSTALLER" --help
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Hermes Desktop"* ]]
+	[[ "$output" == *"127.0.0.1:9119"* ]]
+}
+
 @test "unknown install profile stops before mutation" {
 	write_installed_stubs
 

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -89,6 +89,21 @@ nix_fixture_darwin_package_split() {
 	grep -q 'linuxSystemModules' "$SETS"
 }
 
+@test "Hermes Desktop uses the official Nix output only with the Hermes profile" {
+	run awk '
+		/^[[:space:]]*hermes-desktop = \{/ { in_entry=1 }
+		in_entry { print }
+		in_entry && /^        };/ { exit }
+	' "$SETS"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'hermesDesktopPackage'* ]]
+	[[ "$output" == *'installFeature = "WithHermes";'* ]]
+	[[ "$output" == *'provider = "nix"'* ]]
+	[[ "$output" == *'source = "hermes-agent";'* ]]
+	[[ "$output" == *'command = "hermes-desktop";'* ]]
+	[[ "$output" != *'appName = '* ]]
+}
+
 @test "catalog rejects incomplete metadata and invalid active Nix packages" {
 	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
 	command -v jq >/dev/null 2>&1 || skip "jq is not available in this test environment"

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -102,6 +102,7 @@ nix_fixture_darwin_package_split() {
 	[[ "$output" == *'source = "hermes-agent";'* ]]
 	[[ "$output" == *'command = "hermes-desktop";'* ]]
 	[[ "$output" != *'appName = '* ]]
+	grep -q 'inherit inputs installFeatures;' "$REPO_ROOT/nix/flakes/home.nix"
 }
 
 @test "Hermes Desktop is absent from default package outputs" {
@@ -146,22 +147,6 @@ nix_fixture_darwin_package_split() {
 	[ "$status" -eq 0 ]
 	run jq -e '.default == false and .withHermes == true' <<<"$output"
 	[ "$status" -eq 0 ]
-}
-
-@test "standalone Darwin Home Manager gates Hermes Desktop behind WithHermes" {
-	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
-
-	run --separate-stderr env DOTFILES_USER=test-user DOTFILES_HOME=/tmp \
-		nix eval --impure --json ".#homeConfigurations.aarch64-darwin.config.home.packages" \
-		--apply 'packages: builtins.any (package: (package.pname or "") == "hermes-desktop") packages'
-	[ "$status" -eq 0 ]
-	[ "$output" = "false" ]
-
-	run --separate-stderr env DOTFILES_USER=test-user DOTFILES_HOME=/tmp DOTFILES_WITH_HERMES=1 \
-		nix eval --impure --json ".#homeConfigurations.aarch64-darwin.config.home.packages" \
-		--apply 'packages: builtins.any (package: (package.pname or "") == "hermes-desktop") packages'
-	[ "$status" -eq 0 ]
-	[ "$output" = "true" ]
 }
 
 @test "catalog rejects incomplete metadata and invalid active Nix packages" {

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -104,6 +104,66 @@ nix_fixture_darwin_package_split() {
 	[[ "$output" != *'appName = '* ]]
 }
 
+@test "Hermes Desktop is absent from default package outputs" {
+	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
+	command -v jq >/dev/null 2>&1 || skip "jq is not available in this test environment"
+
+	run --separate-stderr nix eval --impure --json --expr "
+		let
+			flake = builtins.getFlake (toString $REPO_ROOT);
+			pkgs = import flake.inputs.nixpkgs { system = \"aarch64-darwin\"; config.allowUnfree = true; };
+			sets = import $SETS {
+				inherit pkgs;
+				lib = pkgs.lib;
+				catalogOverride = {
+					hermes-desktop = {
+						pkg = pkgs.hello;
+						category = \"terminal\";
+						installFeature = \"WithHermes\";
+						support.darwin = {
+							provider = \"nix\";
+							source = \"hermes-agent\";
+							identity.command = \"hermes-desktop\";
+						};
+					};
+					base = {
+						pkg = pkgs.cowsay;
+						category = \"terminal\";
+						support.darwin = {
+							provider = \"nix\";
+							source = \"nixpkgs\";
+							identity = \"cowsay\";
+						};
+					};
+				};
+			};
+			contains = package: packages: builtins.elem package packages;
+		in {
+			default = contains pkgs.hello sets.terminal;
+			withHermes = contains pkgs.hello (sets.allForInstallFeatures [ \"WithHermes\" ]);
+		}
+	"
+	[ "$status" -eq 0 ]
+	run jq -e '.default == false and .withHermes == true' <<<"$output"
+	[ "$status" -eq 0 ]
+}
+
+@test "standalone Darwin Home Manager gates Hermes Desktop behind WithHermes" {
+	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
+
+	run --separate-stderr env DOTFILES_USER=test-user DOTFILES_HOME=/tmp \
+		nix eval --impure --json ".#homeConfigurations.aarch64-darwin.config.home.packages" \
+		--apply 'packages: builtins.any (package: (package.pname or "") == "hermes-desktop") packages'
+	[ "$status" -eq 0 ]
+	[ "$output" = "false" ]
+
+	run --separate-stderr env DOTFILES_USER=test-user DOTFILES_HOME=/tmp DOTFILES_WITH_HERMES=1 \
+		nix eval --impure --json ".#homeConfigurations.aarch64-darwin.config.home.packages" \
+		--apply 'packages: builtins.any (package: (package.pname or "") == "hermes-desktop") packages'
+	[ "$status" -eq 0 ]
+	[ "$output" = "true" ]
+}
+
 @test "catalog rejects incomplete metadata and invalid active Nix packages" {
 	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
 	command -v jq >/dev/null 2>&1 || skip "jq is not available in this test environment"


### PR DESCRIPTION
## Summary
- add the official Hermes Agent flake desktop output to the Darwin/Home Manager catalog
- couple native Hermes Desktop provisioning to `--with-hermes`
- document the host Desktop and Docker Agent/Web Dashboard split

## Validation
- Bats package/install contracts: 80 passed
- Python workflow/provider contracts: 24 passed
- Compose config: passed
- Nix provider report and Darwin Desktop evaluation: passed
- full flake check has the pre-existing `bootstrap-nixos-vm` user/group assertion

Closes #538