### PR TITLE
Harden Hermes profile synchronization

### DIFF
--- a/docker/hermes-agent/bootstrap-manifest.yaml
+++ b/docker/hermes-agent/bootstrap-manifest.yaml
@@ -71,37 +71,50 @@ root_distribution:
   name: default
   source: https://github.com/rurusasu/hermes-home.git
   ref: main
+  commit: 6821e5dfa23a098ef4a5332780ca8c5cb832e2d4
   target: /opt/data
   manifest: root-distribution.yaml
 profiles:
   - name: rick
     source: https://github.com/rurusasu/hermes-profile-rick.git
     ref: main
+    commit: c32fcd55a884b5fe3ae17f51f02b75f15ffcce12
+    max_deleted_paths: 10
     target: /opt/data/profiles/rick
     manifest: distribution.yaml
   - name: hoffman
     source: https://github.com/rurusasu/hermes-profile-hoffman.git
     ref: main
+    commit: 57386d922b5bc75ec385fc01eccc3b2958df9f58
+    max_deleted_paths: 10
     target: /opt/data/profiles/hoffman
     manifest: distribution.yaml
   - name: risarisa
     source: https://github.com/rurusasu/hermes-profile-risarisa.git
     ref: main
+    commit: c5f459f04e5c680af37e3eaefc51316c83b89e3a
+    max_deleted_paths: 10
     target: /opt/data/profiles/risarisa
     manifest: distribution.yaml
   - name: nancy
     source: https://github.com/rurusasu/hermes-profile-nancy.git
     ref: main
+    commit: 7df0a12cd312b79503b8c33e3e1b3327b7d256d4
+    max_deleted_paths: 10
     target: /opt/data/profiles/nancy
     manifest: distribution.yaml
   - name: kuroda
     source: https://github.com/rurusasu/hermes-profile-kuroda.git
     ref: main
+    commit: d3f97b3d77574497046596063c06c74b9409a197
+    max_deleted_paths: 10
     target: /opt/data/profiles/kuroda
     manifest: distribution.yaml
   - name: shiraishi
     source: https://github.com/rurusasu/hermes-profile-shiraishi.git
     ref: main
+    commit: 9be096ac23741e3cb1816e1e6f1bdced09d3cb44
+    max_deleted_paths: 10
     target: /opt/data/profiles/shiraishi
     manifest: distribution.yaml
 shared_repositories:

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/app.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/app.py
@@ -6,8 +6,9 @@ import json
 import os
 import re
 import stat
+import tempfile
 from collections.abc import Mapping
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path, PurePosixPath
 from typing import Callable, TextIO
@@ -188,44 +189,14 @@ def _apply_sensitive(
             allow_missing=True,
         )
         missing_names = frozenset(source.name for source in prepared.missing)
-        sync_prepared = replace(prepared, missing=())
-        profile_report = profile_sync.synchronize_prepared_profiles(
-            sync_prepared, auth, dry_run=False
-        )
-        if profile_report.exit_code != 0:
-            failed = ",".join(
-                item.name
-                for item in profile_report.profiles
-                if item.status == "failed"
-            )
-            raise RepositoryError(
-                f"named profile repository sync failed: {failed}"
-            )
-
-        commit_by_name = {
-            item.name: item.commit
-            for item in profile_report.profiles
-            if item.commit is not None
-        }
-        status_by_name = {
-            item.name: item.status for item in profile_report.profiles
-        }
         profile_sync_summary: dict[str, str] = {}
         profile_sources: list[DistributionSource] = []
         for source in manifest.profiles:
             if source.name in missing_names:
-                exact = source
                 profile_sync_summary[source.name] = "installed"
+                profile_sources.append(source)
             else:
-                commit = commit_by_name.get(source.name)
-                status = status_by_name.get(source.name)
-                if commit is None or status is None:
-                    raise RepositoryError(
-                        f"named profile repository sync failed: {source.name}"
-                    )
-                exact = replace(source, ref=commit)
-                profile_sync_summary[source.name] = status
-            profile_sources.append(exact)
+                profile_sync_summary[source.name] = "preserved"
 
         root_stage = stage_distribution(
             manifest.root_distribution,
@@ -501,7 +472,7 @@ def _private_scratch(data_root: Path) -> PrivateDirectory:
     _require_safe_directory(data_root)
     try:
         return create_private_directory(
-            data_root,
+            Path(tempfile.gettempdir()),
             prefix=".hermes-bootstrap-",
         )
     except (OSError, ValueError):

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/git.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/git.py
@@ -104,6 +104,11 @@ def _stage_distribution_boundary(
         if commit is None or _OBJECT_ID.fullmatch(commit) is None:
             return _StageFailure("the declared Git ref does not resolve to a commit")
         commit = commit.lower()
+        if (
+            source.source_commit is not None
+            and commit != source.source_commit.lower()
+        ):
+            return _StageFailure("the staged Git source does not match its pinned commit")
         if _run_git(("checkout", "--detach", commit), stage, environment) is None:
             return _StageFailure("could not check out the declared Git commit")
         head = _run_git(("rev-parse", "HEAD"), stage, environment)

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/manifest.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/manifest.py
@@ -27,6 +27,7 @@ _GITHUB_SOURCE_PATTERN = re.compile(
     r"https://github\.com/[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?"
     r"/[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?\.git\Z"
 )
+_OBJECT_ID_PATTERN = re.compile(r"[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?\Z")
 _T = TypeVar("_T")
 
 
@@ -188,14 +189,33 @@ def _onepassword_items(value: object) -> tuple[OnePasswordItem, ...]:
 
 def _distribution(value: object, context: str, data_root: Path) -> DistributionSource:
     source = _mapping(value, context)
-    _keys(source, {"name", "source", "ref", "target", "manifest"}, context)
+    _keys(
+        source,
+        {"name", "source", "ref", "target", "manifest"},
+        context,
+        optional={"commit", "max_deleted_paths"},
+    )
     name = _name(source["name"], f"{context}.name")
+    source_commit = (
+        _commit(source["commit"], f"{context}.commit")
+        if "commit" in source
+        else None
+    )
+    max_deleted_paths = (
+        _integer(source["max_deleted_paths"], f"{context}.max_deleted_paths")
+        if "max_deleted_paths" in source
+        else 10
+    )
+    if max_deleted_paths < 0:
+        _invalid(f"{context}.max_deleted_paths must not be negative")
     return DistributionSource(
         name=name,
         source=_github_source(source["source"], f"{context}.source"),
         ref=_ref(source["ref"], f"{context}.ref"),
         target=_managed_path(source["target"], f"{context}.target", data_root),
         manifest_name=_manifest_name(source["manifest"], f"{context}.manifest"),
+        source_commit=source_commit,
+        max_deleted_paths=max_deleted_paths,
     )
 
 
@@ -205,7 +225,7 @@ def _repository(value: object, context: str, data_root: Path) -> SharedRepositor
         repository,
         {"name", "source", "ref", "target", "mode"},
         context,
-        optional={"sync_owner", "legacy_target"},
+        optional={"sync_owner", "legacy_target", "commit"},
     )
     name = _name(repository["name"], f"{context}.name")
     mode = _text(repository["mode"], f"{context}.mode")
@@ -217,6 +237,8 @@ def _repository(value: object, context: str, data_root: Path) -> SharedRepositor
         sync_owner = _name(repository["sync_owner"], f"{context}.sync_owner")
     if mode == "read-write" and sync_owner is None:
         _invalid(f"{context}.sync_owner is required for read-write repositories")
+    if mode == "read-write" and "commit" in repository:
+        _invalid(f"{context}.commit is only valid for read-only repositories")
 
     legacy_target = None
     if "legacy_target" in repository and repository["legacy_target"] is not None:
@@ -232,6 +254,11 @@ def _repository(value: object, context: str, data_root: Path) -> SharedRepositor
         mode=mode,
         sync_owner=sync_owner,
         legacy_target=legacy_target,
+        source_commit=(
+            _commit(repository["commit"], f"{context}.commit")
+            if "commit" in repository
+            else None
+        ),
     )
 
 
@@ -355,6 +382,13 @@ def _ref(value: object, context: str) -> str:
     if invalid:
         _invalid(f"{context} is not a valid Git ref")
     return ref
+
+
+def _commit(value: object, context: str) -> str:
+    commit = _text(value, context)
+    if _OBJECT_ID_PATTERN.fullmatch(commit) is None:
+        _invalid(f"{context} must be a full Git object ID")
+    return commit.lower()
 
 
 def _manifest_name(value: object, context: str) -> str:

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/models.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/models.py
@@ -30,6 +30,8 @@ class DistributionSource:
     ref: str
     target: Path
     manifest_name: str
+    source_commit: str | None = None
+    max_deleted_paths: int = 10
 
 
 @dataclass(frozen=True)
@@ -41,6 +43,7 @@ class SharedRepository:
     mode: Literal["read-only", "read-write"]
     sync_owner: str | None
     legacy_target: Path | None
+    source_commit: str | None = None
 
 
 @dataclass(frozen=True)

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_snapshot.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_snapshot.py
@@ -50,6 +50,13 @@ _PRIVATE_KEY_HEADERS = (
     b"-----BEGIN OPENSSH PRIVATE KEY-----",
 )
 _PRIVATE_KEY_CARRY_BYTES = max(len(header) for header in _PRIVATE_KEY_HEADERS) - 1
+_STRUCTURED_SECRET_PATTERNS = (
+    re.compile(rb"(?<![A-Za-z0-9])(?:AKIA|ASIA)[A-Z0-9]{16}(?![A-Za-z0-9])"),
+    re.compile(rb"(?<![A-Za-z0-9])eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}(?![A-Za-z0-9])"),
+    re.compile(rb"(?<![A-Za-z0-9])(?:sk-|hf_|xai-)[A-Za-z0-9_-]{20,}(?![A-Za-z0-9])"),
+    re.compile(rb"(?<![A-Za-z0-9])1//[A-Za-z0-9._-]{20,}(?![A-Za-z0-9])"),
+)
+_STRUCTURED_SECRET_CARRY_BYTES = 4096
 _ASCII_ALNUM = frozenset(
     b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 )
@@ -66,7 +73,11 @@ _RESERVED_COMPONENTS = frozenset(
     }
 )
 _CREDENTIAL_STEMS = frozenset(
-    {"auth", "credential", "credentials", "secret", "secrets", "token", "tokens"}
+    {
+        "api-key", "apikey", "auth", "certificate", "client-secret", "credential",
+        "credentials", "password", "passwd", "private-key", "refresh-token",
+        "secret", "secrets", "token", "tokens",
+    }
 )
 _ENV_TEMPLATE = PurePosixPath(".env.template")
 _INSTALLED_ENV_EXAMPLE = PurePosixPath(".env.EXAMPLE")
@@ -288,6 +299,7 @@ class _SensitiveStreamScanner:
         self._github = _IncrementalTokenDetector(_GITHUB_TOKEN_RULES)
         self._slack = _IncrementalTokenDetector(_SLACK_TOKEN_RULES)
         self._private_tail = b""
+        self._structured_tail = b""
 
     def feed(self, content: bytes) -> None:
         self._github.feed(content)
@@ -296,6 +308,13 @@ class _SensitiveStreamScanner:
         if any(header in private_window for header in _PRIVATE_KEY_HEADERS):
             raise ValueError("secret candidate")
         self._private_tail = private_window[-_PRIVATE_KEY_CARRY_BYTES:]
+        structured_window = self._structured_tail + content
+        if any(
+            pattern.search(structured_window)
+            for pattern in _STRUCTURED_SECRET_PATTERNS
+        ) or b"-----BEGIN CERTIFICATE-----" in structured_window:
+            raise ValueError("secret candidate")
+        self._structured_tail = structured_window[-_STRUCTURED_SECRET_CARRY_BYTES:]
 
     def finish(self) -> None:
         self._github.finish()

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_snapshot.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_snapshot.py
@@ -52,9 +52,6 @@ _PRIVATE_KEY_HEADERS = (
 _PRIVATE_KEY_CARRY_BYTES = max(len(header) for header in _PRIVATE_KEY_HEADERS) - 1
 _STRUCTURED_SECRET_PATTERNS = (
     re.compile(rb"(?<![A-Za-z0-9])(?:AKIA|ASIA)[A-Z0-9]{16}(?![A-Za-z0-9])"),
-    re.compile(rb"(?<![A-Za-z0-9])eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}(?![A-Za-z0-9])"),
-    re.compile(rb"(?<![A-Za-z0-9])(?:sk-|hf_|xai-)[A-Za-z0-9_-]{20,}(?![A-Za-z0-9])"),
-    re.compile(rb"(?<![A-Za-z0-9])1//[A-Za-z0-9._-]{20,}(?![A-Za-z0-9])"),
 )
 _STRUCTURED_SECRET_CARRY_BYTES = 4096
 _ASCII_ALNUM = frozenset(
@@ -166,6 +163,10 @@ _SLACK_TOKEN_RULES = tuple(
     _TokenRule(prefix, _SLACK_BODY, 1, _SLACK_CONTINUATION)
     for prefix in (b"xoxb-", b"xoxp-", b"xoxa-", b"xoxr-", b"xoxs-", b"xapp-")
 )
+_STRUCTURED_TOKEN_RULES = tuple(
+    _TokenRule(prefix, _ASCII_ALNUM | frozenset(b"_-"), 20, _ASCII_ALNUM)
+    for prefix in (b"sk-", b"hf_", b"xai-")
+) + (_TokenRule(b"1//", _ASCII_ALNUM | frozenset(b"._-"), 20, _ASCII_ALNUM),)
 
 
 @dataclass
@@ -202,8 +203,14 @@ class _RetainedFdBudget:
 
 
 class _IncrementalTokenDetector:
-    def __init__(self, rules: tuple[_TokenRule, ...]) -> None:
+    def __init__(
+        self,
+        rules: tuple[_TokenRule, ...],
+        *,
+        leading_forbidden: frozenset[int] = _ASCII_WORD,
+    ) -> None:
         self._rules = rules
+        self._leading_forbidden = leading_forbidden
         self._start = bytes((rules[0].prefix[0],))
         self._candidates: tuple[_TokenRule, ...] = ()
         self._prefix_index = 0
@@ -228,7 +235,7 @@ class _IncrementalTokenDetector:
             byte = content[candidate]
             self._previous = byte
             index = candidate + 1
-            if previous is None or previous not in _ASCII_WORD:
+            if previous is None or previous not in self._leading_forbidden:
                 self._candidates = self._rules
                 self._prefix_index = 1
 
@@ -255,7 +262,7 @@ class _IncrementalTokenDetector:
             self._prefix_index = 0
             if (
                 byte == self._start[0]
-                and (previous is None or previous not in _ASCII_WORD)
+                and (previous is None or previous not in self._leading_forbidden)
             ):
                 self._candidates = self._rules
                 self._prefix_index = 1
@@ -294,16 +301,111 @@ class _IncrementalTokenDetector:
         return end
 
 
+class _IncrementalJwtDetector:
+    """Detect JWT-shaped credentials without a fixed-size candidate buffer."""
+
+    _BODY = _ASCII_ALNUM | frozenset(b"_-")
+    _MIN_SEGMENT_BYTES = 10
+    _MIN_FIRST_SEGMENT_BYTES = 13
+
+    def __init__(self) -> None:
+        self._recent = b""
+        self._before_recent: int | None = None
+        self._segments: list[int] | None = None
+
+    def feed(self, content: bytes) -> None:
+        for byte in content:
+            if self._segments is None:
+                self._consume_idle(byte)
+            else:
+                self._consume_candidate(byte)
+
+    def finish(self) -> None:
+        if self._valid_candidate:
+            raise ValueError("secret candidate")
+
+    @property
+    def _valid_candidate(self) -> bool:
+        return bool(
+            self._segments is not None
+            and len(self._segments) == 3
+            and self._segments[0] >= self._MIN_FIRST_SEGMENT_BYTES
+            and all(length >= self._MIN_SEGMENT_BYTES for length in self._segments[1:])
+        )
+
+    def _consume_idle(self, byte: int) -> None:
+        window = self._recent + bytes((byte,))
+        if window == b"eyJ" and (
+            self._before_recent is None
+            or self._before_recent not in _ASCII_ALNUM
+        ):
+            self._segments = [3]
+            self._recent = b""
+            self._before_recent = None
+            return
+        if len(self._recent) == 2:
+            self._before_recent = self._recent[0]
+            self._recent = self._recent[1:] + bytes((byte,))
+        elif self._recent:
+            self._recent += bytes((byte,))
+        else:
+            self._recent = bytes((byte,))
+
+    def _consume_candidate(self, byte: int) -> None:
+        assert self._segments is not None
+        if byte in self._BODY:
+            self._segments[-1] += 1
+            return
+        if byte == ord("."):
+            if (
+                len(self._segments) >= 3
+                and self._valid_candidate
+            ):
+                raise ValueError("secret candidate")
+            if (
+                len(self._segments) >= 3
+                or self._segments[-1]
+                < (
+                    self._MIN_FIRST_SEGMENT_BYTES
+                    if len(self._segments) == 1
+                    else self._MIN_SEGMENT_BYTES
+                )
+            ):
+                self._reset()
+            else:
+                self._segments.append(0)
+            return
+        if self._valid_candidate:
+            raise ValueError("secret candidate")
+        self._reset()
+
+    def _reset(self) -> None:
+        self._segments = None
+        self._recent = b""
+        self._before_recent = None
+
+
 class _SensitiveStreamScanner:
     def __init__(self) -> None:
         self._github = _IncrementalTokenDetector(_GITHUB_TOKEN_RULES)
         self._slack = _IncrementalTokenDetector(_SLACK_TOKEN_RULES)
+        self._structured_tokens = tuple(
+            _IncrementalTokenDetector(
+                (rule,),
+                leading_forbidden=_ASCII_ALNUM,
+            )
+            for rule in _STRUCTURED_TOKEN_RULES
+        )
+        self._jwt = _IncrementalJwtDetector()
         self._private_tail = b""
         self._structured_tail = b""
 
     def feed(self, content: bytes) -> None:
         self._github.feed(content)
         self._slack.feed(content)
+        for detector in self._structured_tokens:
+            detector.feed(content)
+        self._jwt.feed(content)
         private_window = self._private_tail + content
         if any(header in private_window for header in _PRIVATE_KEY_HEADERS):
             raise ValueError("secret candidate")
@@ -319,6 +421,9 @@ class _SensitiveStreamScanner:
     def finish(self) -> None:
         self._github.finish()
         self._slack.finish()
+        for detector in self._structured_tokens:
+            detector.finish()
+        self._jwt.finish()
 
 
 def _open_descriptor_count() -> int:

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_sync.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_sync.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import re
 import stat
+import tempfile
 import unicodedata
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -117,6 +118,10 @@ class _PushRaceExhausted(Exception):
     pass
 
 
+class _DeletionLimitExceeded(Exception):
+    pass
+
+
 def failed_profile_report(
     profiles: tuple[DistributionSource, ...],
     *,
@@ -185,7 +190,7 @@ def synchronize_profiles(
     try:
         _validate_manifest_profiles(manifest)
         scratch = create_private_directory(
-            manifest.data_root,
+            Path(tempfile.gettempdir()),
             prefix=".hermes-profile-snapshots-",
         )
         prepared = prepare_profile_snapshots(
@@ -281,11 +286,11 @@ def _synchronize_one_boundary(
         with _RepositoryLock(lock_path, data_root) as repository_lock:
             repository_lock.require_held()
             repository = create_private_directory(
-                data_root,
+                Path(tempfile.gettempdir()),
                 prefix=".hermes-profile-sync-",
             )
             repository_path = repository.path
-            askpass = _create_askpass(data_root)
+            askpass = _create_askpass(Path(tempfile.gettempdir()))
             environment = _git_environment(auth, askpass)
             attempt = _exact_tree_attempt(
                 snapshot,
@@ -338,6 +343,8 @@ def _synchronize_one_boundary(
                     category = "dry_run"
                     message = "profile snapshot changes detected"
                 else:
+                    if len(diff.deleted) > declaration.max_deleted_paths:
+                        raise _DeletionLimitExceeded
                     commit, final_parent = _commit_and_push(
                         snapshot,
                         attempt,
@@ -375,6 +382,13 @@ def _synchronize_one_boundary(
             snapshot,
             "push_race_exhausted",
             "profile publication changed repeatedly",
+        )
+    except _DeletionLimitExceeded as error:
+        error = _scrub_exception_graph(error)
+        outcome = _failed(
+            snapshot,
+            "deletion_limit_exceeded",
+            "profile publication exceeded the configured deletion limit",
         )
     except Exception as error:
         error = _scrub_exception_graph(error)

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_sync.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_sync.py
@@ -561,6 +561,11 @@ def _commit_and_push(
             )
             if rebuilt_tree != attempt.tree:
                 raise ValueError("profile snapshot tree changed during retry")
+        if (
+            _staged_deleted_path_count(parent, repository, environment)
+            > declaration.max_deleted_paths
+        ):
+            raise _DeletionLimitExceeded
         commit = _create_commit(
             snapshot, attempt.tree, parent, repository, environment
         )
@@ -584,6 +589,32 @@ def _commit_and_push(
             raise _PushRaceExhausted
         parent = remote_commit
     raise _PushRaceExhausted
+
+
+def _staged_deleted_path_count(
+    base_commit: str,
+    repository: Path,
+    environment: dict[str, str],
+) -> int:
+    raw = _git_bytes(
+        (
+            "diff",
+            "--cached",
+            "--name-status",
+            "-z",
+            "--no-renames",
+            base_commit,
+        ),
+        repository,
+        environment,
+        max_output_bytes=_INDEX_OUTPUT_MAX_BYTES,
+    )
+    records = _nul_records(raw)
+    if len(records) % 2:
+        raise ValueError("invalid staged profile diff")
+    return sum(
+        records[index] == b"D" for index in range(0, len(records), 2)
+    )
 
 
 def _rebuild_snapshot_tree(

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/repositories.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/repositories.py
@@ -517,6 +517,7 @@ def _initialize_checkout(repo: SharedRepository, checkout: Path, environment: di
     _require_git_success(("remote", "add", "origin", "--", repo.source), checkout, environment)
     _verify_checkout_identity(repo, checkout, environment)
     remote_commit = _fetch_declared_commit(repo, checkout, environment)
+    _validate_pinned_commit(repo, remote_commit)
     _validate_commit_tree(checkout, _local_git_environment(environment), remote_commit)
     _require_safe_checkout_location(repo, checkout)
     _require_git_success(("checkout", "--detach", remote_commit), checkout, environment)
@@ -557,6 +558,7 @@ def _synchronize_checkout(repo: SharedRepository, checkout: Path, environment: d
         ) != b"":
             raise ValueError("read-only checkout is dirty")
         remote_commit = _fetch_declared_commit(repo, checkout, environment)
+        _validate_pinned_commit(repo, remote_commit)
         _validate_commit_tree(checkout, local_environment, remote_commit)
         head = _head_commit(checkout, local_environment)
         if not _is_ancestor(head, remote_commit, checkout, local_environment):
@@ -688,6 +690,11 @@ def _fetch_head_commit(checkout: Path, environment: dict[str, str]) -> str:
     if commit is None or _OBJECT_ID.fullmatch(commit.lower()) is None:
         raise ValueError("declared ref is not a commit")
     return commit.lower()
+
+
+def _validate_pinned_commit(repo: SharedRepository, commit: str) -> None:
+    if repo.source_commit is not None and commit != repo.source_commit:
+        raise ValueError("declared repository commit does not match its pinned commit")
 
 
 def _head_commit(checkout: Path, environment: dict[str, str]) -> str:

--- a/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
+++ b/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
@@ -408,11 +408,21 @@ class BootstrapFlowTests(unittest.TestCase):
 
     def _local_manifest(self) -> BootstrapManifest:
         parsed = load_manifest(PRODUCTION_MANIFEST)
-        root = replace(parsed.root_distribution, target=self.data_root)
+        root = replace(
+            parsed.root_distribution,
+            target=self.data_root,
+            source_commit=run_git("--git-dir", str(self.source_remotes["root"]), "rev-parse", "main"),
+        )
         profiles = tuple(
             replace(
                 source,
                 target=self.data_root / "profiles" / source.name,
+                source_commit=run_git(
+                    "--git-dir",
+                    str(self.source_remotes[source.name]),
+                    "rev-parse",
+                    "main",
+                ),
             )
             for source in parsed.profiles
         )
@@ -530,7 +540,26 @@ class BootstrapFlowTests(unittest.TestCase):
         run_git("add", "-A", cwd=seed)
         run_git("commit", "-m", message, cwd=seed)
         run_git("push", "origin", "main", cwd=seed)
-        return run_git("rev-parse", "HEAD", cwd=seed)
+        commit = run_git("rev-parse", "HEAD", cwd=seed)
+        if name == "root":
+            self.manifest = replace(
+                self.manifest,
+                root_distribution=replace(
+                    self.manifest.root_distribution,
+                    source_commit=commit,
+                ),
+            )
+        else:
+            self.manifest = replace(
+                self.manifest,
+                profiles=tuple(
+                    replace(profile, source_commit=commit)
+                    if profile.name == name
+                    else profile
+                    for profile in self.manifest.profiles
+                ),
+            )
+        return commit
 
     def _payload(self, token: str = FIXTURE_TOKEN) -> io.StringIO:
         records: list[dict[str, object]] = [{"type": "header", "schema_version": SCHEMA_VERSION}]
@@ -951,9 +980,9 @@ class BootstrapFlowTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(
             command_stdout.getvalue(),
-            '{"profile_sync":{"hoffman":"unchanged","kuroda":"unchanged",'
-            '"nancy":"unchanged","rick":"unchanged","risarisa":"unchanged",'
-            '"shiraishi":"unchanged"},'
+            '{"profile_sync":{"hoffman":"preserved","kuroda":"preserved",'
+            '"nancy":"preserved","rick":"preserved","risarisa":"preserved",'
+            '"shiraishi":"preserved"},'
             '"profiles":["rick","hoffman","risarisa","nancy","kuroda","shiraishi"],'
             '"repositories":["lifelog"],"status":"applied"}\n',
         )
@@ -962,9 +991,10 @@ class BootstrapFlowTests(unittest.TestCase):
         # The pinned hermes_cli emits deprecation warnings here; the leak scan
         # above still treats ambient stderr as protected output.
 
+        # Existing profiles are local-authoritative during apply, so their
+        # remotes must not be accessed until the explicit sync-profiles route.
         declared_sources = (
             self.manifest.root_distribution,
-            *self.manifest.profiles,
             *self.manifest.shared_repositories,
         )
         visible_arguments = {
@@ -977,26 +1007,7 @@ class BootstrapFlowTests(unittest.TestCase):
         for remote in self.source_remotes.values():
             self.assertNotIn(str(remote), visible_arguments)
 
-        self.assertEqual(
-            [
-                name
-                for name, _source, _ref, _staged_commit, _head
-                in self.profile_stage_refs
-            ],
-            list(PROFILE_NAMES),
-        )
-        for (
-            name,
-            source,
-            ref,
-            staged_commit,
-            remote_head,
-        ) in self.profile_stage_refs:
-            with self.subTest(staged_profile=name):
-                self.assertEqual(source, production_profiles[name].source)
-                self.assertEqual(ref, remote_head)
-                self.assertEqual(staged_commit, ref)
-                self.assertRegex(ref, r"\A[0-9a-f]{40}(?:[0-9a-f]{24})?\Z")
+        self.assertEqual(self.profile_stage_refs, [])
 
         for name, expected in PROFILE_IDENTITIES.items():
             with self.subTest(profile=name):
@@ -1161,7 +1172,7 @@ class BootstrapFlowTests(unittest.TestCase):
             runtime_before,
         )
         self.assertEqual((target / "sessions" / "runtime.txt").read_text(encoding="utf-8"), "rick session\n")
-        self.assertNotEqual(
+        self.assertEqual(
             run_git(
                 "--git-dir",
                 str(self.source_remotes["rick"]),
@@ -1480,16 +1491,10 @@ class BootstrapFlowTests(unittest.TestCase):
         self.assertEqual(self._snapshot_managed_tree(), before)
         self.assertFalse(future_source.target.exists())
 
-    def test_runtime_failpoints_rollback_each_mutation_phase_without_reversing_remote_pushes(self) -> None:
+    def test_runtime_failpoints_rollback_each_mutation_phase_without_changing_remote_profiles(self) -> None:
         self._initial_apply()
         phases = (
             "root-apply",
-            "profile-apply:rick",
-            "profile-apply:hoffman",
-            "profile-apply:risarisa",
-            "profile-apply:nancy",
-            "profile-apply:kuroda",
-            "profile-apply:shiraishi",
             "shared-apply:lifelog",
             "env-merge:default",
             "env-merge:rick",
@@ -1817,7 +1822,7 @@ class BootstrapFlowTests(unittest.TestCase):
                     self.assertNotEqual(transaction_remote, remote_before)
                     self.assertEqual(remote_after, transaction_remote)
                     for profile in PROFILE_NAMES:
-                        self.assertNotEqual(
+                        self.assertEqual(
                             run_git(
                                 "--git-dir",
                                 str(self.source_remotes[profile]),

--- a/docker/hermes-agent/bootstrap/tests/integration/test_profile_sync_flow.py
+++ b/docker/hermes-agent/bootstrap/tests/integration/test_profile_sync_flow.py
@@ -12,6 +12,7 @@ import subprocess
 import unittest
 from builtins import BaseExceptionGroup, ExceptionGroup
 from contextlib import redirect_stderr, redirect_stdout
+from dataclasses import replace
 from pathlib import Path, PurePosixPath
 from types import FrameType, TracebackType
 from unittest import mock
@@ -100,7 +101,16 @@ class ProfileSyncFlowTests(unittest.TestCase):
                     "tests/test_distribution.py": b"def test_stale(): pass\n",
                 }
             )
-            self._commit_seed(source.name, remote_files, "seed stale profile remote")
+            commit = self._commit_seed(source.name, remote_files, "seed stale profile remote")
+            self.flow.manifest = replace(
+                self.flow.manifest,
+                profiles=tuple(
+                    replace(profile, source_commit=commit)
+                    if profile.name == source.name
+                    else profile
+                    for profile in self.flow.manifest.profiles
+                ),
+            )
             local_files = self._profile_files(
                 source, version="0.2.0", marker="local"
             )
@@ -958,7 +968,7 @@ class ProfileSyncFlowTests(unittest.TestCase):
         self.assertEqual(profile_summary[missing.name], "installed")
         self.assertTrue(
             all(
-                profile_summary[source.name] == "unchanged"
+                profile_summary[source.name] == "preserved"
                 for source in existing
             )
         )
@@ -978,7 +988,7 @@ class ProfileSyncFlowTests(unittest.TestCase):
         assert installed is not None
         self.assertEqual(installed.name, missing.name)
         self.assertEqual(installed.source, missing.source)
-        self.assertEqual(installed.version, missing_before.version)
+        self.assertEqual(installed.version, "0.1.0")
         self.assertFalse((missing.target / ".git").exists())
         owned_files = self._expected_owned_files(missing.target)
         self.assertTrue(owned_files)
@@ -990,6 +1000,7 @@ class ProfileSyncFlowTests(unittest.TestCase):
                 )
             )
 
+    @unittest.skip("existing profile publication is explicit sync-profiles")
     def test_apply_stages_each_existing_profile_at_its_reported_commit(
         self,
     ) -> None:
@@ -1068,6 +1079,7 @@ class ProfileSyncFlowTests(unittest.TestCase):
         for remote in self.flow.source_remotes.values():
             self.assertNotIn(str(remote), visible_arguments)
 
+    @unittest.skip("existing profile publication is explicit sync-profiles")
     def test_existing_profile_chrome_validation_fails_after_publication_before_local_mutation(
         self,
     ) -> None:
@@ -1120,6 +1132,7 @@ class ProfileSyncFlowTests(unittest.TestCase):
         )
         self.flow._assert_no_temporary_resources()
 
+    @unittest.skip("existing profile publication is explicit sync-profiles")
     def test_late_existing_profile_drift_after_publication_preserves_local_bytes_and_skips_transaction(
         self,
     ) -> None:
@@ -1246,6 +1259,7 @@ class ProfileSyncFlowTests(unittest.TestCase):
         )
         self.flow._assert_no_temporary_resources()
 
+    @unittest.skip("existing profile publication is explicit sync-profiles")
     def test_existing_profile_deleted_after_revalidation_rejects_install_and_preserves_replacement(
         self,
     ) -> None:
@@ -1498,6 +1512,7 @@ class ProfileSyncFlowTests(unittest.TestCase):
         )
         self.assertEqual(self.flow._snapshot_tree(journals), journals_before)
 
+    @unittest.skip("profile publication is explicit sync-profiles")
     def test_apply_sync_failure_preserves_runtime_and_transaction_journals(
         self,
     ) -> None:

--- a/docker/hermes-agent/bootstrap/tests/test_app.py
+++ b/docker/hermes-agent/bootstrap/tests/test_app.py
@@ -602,32 +602,12 @@ class AppTests(unittest.TestCase):
             mock.Mock(declaration=profile) for profile in configured.profiles
         )
         prepared = PreparedProfiles(snapshots, ())
-        commits = {
-            profile.name: str(index) * 40
-            for index, profile in enumerate(configured.profiles, start=1)
-        }
         statuses = {
-            "rick": "changed",
-            "hoffman": "unchanged",
-            "risarisa": "changed",
-            "nancy": "unchanged",
+            "rick": "preserved",
+            "hoffman": "preserved",
+            "risarisa": "preserved",
+            "nancy": "preserved",
         }
-        profile_report = ProfileSyncReport(
-            dry_run=False,
-            profiles=tuple(
-                ProfileSyncResult(
-                    name=profile.name,
-                    status=statuses[profile.name],  # type: ignore[arg-type]
-                    commit=commits[profile.name],
-                    snapshot=f"snapshot-{profile.name}",
-                    diff=ProfileDiff(),
-                    category=statuses[profile.name],
-                    message="safe",
-                )
-                for profile in configured.profiles
-            ),
-            exit_code=0,
-        )
         remote = RemoteSyncResult("lifelog", "a" * 40, False, self.root / ".remote")
         staged_sources: list[DistributionSource] = []
 
@@ -649,18 +629,6 @@ class AppTests(unittest.TestCase):
             self.assertTrue(allow_missing)
             return prepared
 
-        def sync_profiles(
-            sync_prepared: PreparedProfiles, _auth: GitAuth, *, dry_run: bool
-        ) -> ProfileSyncReport:
-            self.assertEqual(sync_prepared.missing, ())
-            self.assertEqual(sync_prepared.snapshots, snapshots)
-            self.assertFalse(dry_run)
-            events.extend(
-                f"profile-sync:{snapshot.declaration.name}"
-                for snapshot in sync_prepared.snapshots
-            )
-            return profile_report
-
         def stage(source: DistributionSource, _scratch: Path, _auth: GitAuth):
             staged_sources.append(source)
             if source.name == "default":
@@ -681,16 +649,8 @@ class AppTests(unittest.TestCase):
                     "recover",
                     "payload",
                     "profile-preflight",
-                    "profile-sync:rick",
-                    "profile-sync:hoffman",
-                    "profile-sync:risarisa",
-                    "profile-sync:nancy",
                     "stage:default",
-                    f"stage:rick:{commits['rick']}",
-                    f"stage:hoffman:{commits['hoffman']}",
-                    f"stage:risarisa:{commits['risarisa']}",
-                    f"stage:nancy:{commits['nancy']}",
-                    "source-contract:default,rick,hoffman,risarisa,nancy",
+                    "source-contract:default",
                     "sync:lifelog",
                     "revalidate",
                 ],
@@ -745,11 +705,7 @@ class AppTests(unittest.TestCase):
             mock.patch.object(app, "read_secret_payload", side_effect=read_payload),
             mock.patch.object(app, "GitHubClient", return_value=client),
             mock.patch.object(app, "prepare_profile_snapshots", side_effect=prepare),
-            mock.patch.object(
-                app.profile_sync,
-                "synchronize_prepared_profiles",
-                side_effect=sync_profiles,
-            ),
+            mock.patch.object(app.profile_sync, "synchronize_prepared_profiles") as publication_sync,
             mock.patch.object(app, "stage_distribution", side_effect=stage),
             mock.patch.object(app, "synchronize_remote", side_effect=sync),
             mock.patch.object(app.Transaction, "begin", side_effect=begin),
@@ -782,23 +738,11 @@ class AppTests(unittest.TestCase):
                 "recover",
                 "payload",
                 "profile-preflight",
-                "profile-sync:rick",
-                "profile-sync:hoffman",
-                "profile-sync:risarisa",
-                "profile-sync:nancy",
                 "stage:default",
-                f"stage:rick:{commits['rick']}",
-                f"stage:hoffman:{commits['hoffman']}",
-                f"stage:risarisa:{commits['risarisa']}",
-                f"stage:nancy:{commits['nancy']}",
-                "source-contract:default,rick,hoffman,risarisa,nancy",
+                "source-contract:default",
                 "sync:lifelog",
                 "revalidate",
                 "root",
-                "profile:rick",
-                "profile:hoffman",
-                "profile:risarisa",
-                "profile:nancy",
                 "shared:lifelog",
                 "calendar-config:data,rick,hoffman,risarisa,nancy:True",
                 "gmail-config:data,rick,hoffman,risarisa,nancy:True",
@@ -815,11 +759,9 @@ class AppTests(unittest.TestCase):
         )
         self.assertEqual(
             [source.name for source in staged_sources],
-            ["default", "rick", "hoffman", "risarisa", "nancy"],
+            ["default"],
         )
-        for source, declaration in zip(staged_sources[1:], configured.profiles):
-            self.assertEqual(source.source, declaration.source)
-            self.assertEqual(source.ref, commits[source.name])
+        publication_sync.assert_not_called()
         self.assertEqual(client.authenticated_login.call_count, 6)
         self.assertEqual(client.assert_repository_access.call_count, 6)
 
@@ -831,22 +773,6 @@ class AppTests(unittest.TestCase):
         configured = manifest(self.root, ("rick", "nancy"))
         existing = mock.Mock(declaration=configured.profiles[0])
         prepared = PreparedProfiles((existing,), (configured.profiles[1],))
-        exact_commit = "1" * 40
-        report = ProfileSyncReport(
-            dry_run=False,
-            profiles=(
-                ProfileSyncResult(
-                    "rick",
-                    "unchanged",
-                    exact_commit,
-                    "snapshot-rick",
-                    ProfileDiff(),
-                    "unchanged",
-                    "safe",
-                ),
-            ),
-            exit_code=0,
-        )
         tx = FakeTransaction([])
         staged_sources: list[DistributionSource] = []
         applied_profiles: list[tuple[str, dict[str, object]]] = []
@@ -870,11 +796,7 @@ class AppTests(unittest.TestCase):
             mock.patch.object(
                 app, "prepare_profile_snapshots", return_value=prepared
             ),
-            mock.patch.object(
-                app.profile_sync,
-                "synchronize_prepared_profiles",
-                return_value=report,
-            ) as sync,
+            mock.patch.object(app.profile_sync, "synchronize_prepared_profiles") as publication_sync,
             mock.patch.object(app, "stage_distribution", side_effect=stage),
             mock.patch.object(
                 app,
@@ -909,28 +831,23 @@ class AppTests(unittest.TestCase):
         ):
             result = app.apply(Path("manifest.yaml"), io.StringIO("payload"))
 
-        sync_prepared = sync.call_args.args[0]
-        self.assertEqual(sync_prepared.snapshots, (existing,))
-        self.assertEqual(sync_prepared.missing, ())
+        publication_sync.assert_not_called()
         self.assertEqual(
             [(source.name, source.ref) for source in staged_sources],
             [
                 ("default", "main"),
-                ("rick", exact_commit),
                 ("nancy", "main"),
             ],
         )
         self.assertEqual(
             [name for name, _kwargs in applied_profiles],
-            ["rick", "nancy"],
+            ["nancy"],
         )
-        self.assertNotIn("managed_environment", applied_profiles[0][1])
-        self.assertIs(applied_profiles[0][1]["expected_missing"], False)
         self.assertEqual(
-            applied_profiles[1][1]["managed_environment"],
+            applied_profiles[0][1]["managed_environment"],
             {"GH_TOKEN": "token"},
         )
-        self.assertIs(applied_profiles[1][1]["expected_missing"], True)
+        self.assertIs(applied_profiles[0][1]["expected_missing"], True)
         self.assertEqual(
             [call.args[0] for call in merge_env.call_args_list],
             [
@@ -940,9 +857,11 @@ class AppTests(unittest.TestCase):
         )
         self.assertEqual(
             result["profile_sync"],
-            {"rick": "unchanged", "nancy": "installed"},
+            {"rick": "preserved", "nancy": "installed"},
         )
+        publication_sync.assert_not_called()
 
+    @unittest.skip("existing profile publication was removed from apply")
     def test_apply_rejects_existing_and_new_profile_drift_at_every_late_checkpoint(
         self,
     ) -> None:
@@ -1212,6 +1131,7 @@ class AppTests(unittest.TestCase):
         self.assertEqual((target / "distribution.yaml").read_bytes(), invalid)
         self.assertFalse(any(self.root.glob(".hermes-bootstrap-*")))
 
+    @unittest.skip("profile publication is an explicit sync-profiles operation")
     def test_profile_sync_failure_precedes_mutation_and_preserves_partial_report(
         self,
     ) -> None:
@@ -1412,7 +1332,7 @@ class AppTests(unittest.TestCase):
         ):
             result = app.apply(Path("manifest.yaml"), io.StringIO("payload"))
 
-        self.assertEqual(result["profile_sync"], {"rick": "unchanged"})
+        self.assertEqual(result["profile_sync"], {"rick": "preserved"})
         self.assertEqual(
             {
                 path.name: (path.read_bytes(), stat.S_IMODE(path.stat().st_mode))
@@ -2011,6 +1931,7 @@ class AppTests(unittest.TestCase):
         self.assertTrue((scratch_path / "retained-fifo").exists())
         self.assertNotIn(sensitive_marker, repr(caught.exception))
 
+    @unittest.skip("existing profile publication was removed from apply")
     def test_every_local_failpoint_restores_exact_state_and_retains_remote_result(self) -> None:
         from hermes_bootstrap import app
 

--- a/docker/hermes-agent/bootstrap/tests/test_git.py
+++ b/docker/hermes-agent/bootstrap/tests/test_git.py
@@ -55,8 +55,21 @@ class GitStagingTests(unittest.TestCase):
         git("branch", "-M", "main", cwd=self.checkout)
         git("push", "-u", "origin", "main", cwd=self.checkout)
 
-    def source(self, *, ref: str = "main", manifest: str = "distribution.yaml") -> DistributionSource:
-        return DistributionSource("rick", str(self.remote), ref, Path("/opt/data/profiles/rick"), manifest)
+    def source(
+        self,
+        *,
+        ref: str = "main",
+        manifest: str = "distribution.yaml",
+        source_commit: str | None = None,
+    ) -> DistributionSource:
+        return DistributionSource(
+            "rick",
+            str(self.remote),
+            ref,
+            Path("/opt/data/profiles/rick"),
+            manifest,
+            source_commit,
+        )
 
     def assert_hidden(self, error: BaseException, *markers: str) -> None:
         pending: list[object] = [error]
@@ -222,6 +235,20 @@ class GitStagingTests(unittest.TestCase):
                     stage_distribution(source, self.workdir, auth())
                 self.assertEqual(list(self.workdir.glob("stage-*")), [])
                 self.assertEqual(list(self.workdir.glob("askpass-*")), [])
+
+    def test_pinned_source_commit_must_match_fetched_ref(self) -> None:
+        expected = git("rev-parse", "HEAD", cwd=self.checkout)
+        wrong = "0" * 40
+
+        with self.assertRaises(RepositoryError):
+            stage_distribution(
+                self.source(source_commit=wrong), self.workdir, auth()
+            )
+
+        staged = stage_distribution(
+            self.source(source_commit=expected.upper()), self.workdir, auth()
+        )
+        self.assertEqual(staged.commit, expected)
 
     def test_observed_remote_identity_mismatch_is_rejected_after_successful_clone(self) -> None:
         real_run = git_module._run_git

--- a/docker/hermes-agent/bootstrap/tests/test_manifest.py
+++ b/docker/hermes-agent/bootstrap/tests/test_manifest.py
@@ -104,6 +104,10 @@ class ManifestTests(unittest.TestCase):
         self.assertEqual(manifest.root_distribution.name, "default")
         self.assertEqual(manifest.root_distribution.target, Path("/opt/data"))
         self.assertEqual(
+            manifest.root_distribution.source_commit,
+            "6821e5dfa23a098ef4a5332780ca8c5cb832e2d4",
+        )
+        self.assertEqual(
             tuple(profile.name for profile in manifest.profiles),
             ("rick", "hoffman", "risarisa", "nancy", "kuroda", "shiraishi"),
         )
@@ -138,6 +142,33 @@ class ManifestTests(unittest.TestCase):
         self.assertEqual(manifest.shared_repositories[0].legacy_target, Path("/opt/data/core/lifelog"))
         with self.assertRaises(FrozenInstanceError):
             manifest.schema_version = 2
+
+    def test_distribution_commit_and_deletion_limit_are_validated(self) -> None:
+        data = manifest_data()
+        data["root_distribution"]["commit"] = "A" * 40
+        data["profiles"][0]["commit"] = "b" * 40
+        data["profiles"][0]["max_deleted_paths"] = 3
+
+        manifest = self.load_data(data)
+
+        self.assertEqual(manifest.root_distribution.source_commit, "a" * 40)
+        self.assertEqual(manifest.profiles[0].source_commit, "b" * 40)
+        self.assertEqual(manifest.profiles[0].max_deleted_paths, 3)
+
+    def test_invalid_source_commit_and_deletion_limit_are_rejected(self) -> None:
+        for commit in ("short", "g" * 40, "a" * 39):
+            with self.subTest(commit=commit):
+                data = manifest_data()
+                data["root_distribution"]["commit"] = commit
+                self.assert_validation_error(data)
+
+        data = manifest_data()
+        data["profiles"][0]["max_deleted_paths"] = -1
+        self.assert_validation_error(data)
+
+        data = manifest_data()
+        data["shared_repositories"][0]["commit"] = "c" * 40
+        self.assert_validation_error(data)
 
     def test_target_outside_data_root_is_rejected(self) -> None:
         data = manifest_data()

--- a/docker/hermes-agent/bootstrap/tests/test_profile_snapshot.py
+++ b/docker/hermes-agent/bootstrap/tests/test_profile_snapshot.py
@@ -431,6 +431,13 @@ class ProfileSnapshotTests(unittest.TestCase):
 
     def test_rejects_credential_stems_in_every_path_component(self) -> None:
         unsafe_paths = (
+            "api-key.json/payload.txt",
+            "apikey.txt/payload.txt",
+            "client-secret.json/payload.txt",
+            "password.txt/payload.txt",
+            "private-key.pem/payload.txt",
+            "refresh-token.json/payload.txt",
+            "certificate.pem/payload.txt",
             "token.json/payload.txt",
             "credentials.pem/nested/data.txt",
             "secret.txt/archive/payload.txt",
@@ -638,6 +645,22 @@ class ProfileSnapshotTests(unittest.TestCase):
 
         self.assertEqual(caught.exception.category, "invalid_local_profile")
         self.assertEqual(list(self.scratch.iterdir()), [])
+
+    def test_rejects_common_structured_credentials(self) -> None:
+        candidates = (
+            b"AKIAIOSFODNN7EXAMPLE",
+            b"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature-value-long",
+            b"sk-abcdefghijklmnopqrstuvwxyz",
+            b"hf_abcdefghijklmnopqrstuvwxyz",
+            b"xai-abcdefghijklmnopqrstuvwxyz",
+            b"1//abcdefghijklmnopqrstuvwxyz",
+            b"-----BEGIN CERTIFICATE-----",
+        )
+        for index, candidate in enumerate(candidates):
+            with self.subTest(candidate=candidate[:8]):
+                scanner = profile_snapshot._SensitiveStreamScanner()
+                with self.assertRaises(ValueError):
+                    scanner.feed(b"safe=" + candidate)
 
     def test_rejects_every_supported_private_key_header_at_every_split(self) -> None:
         headers = (

--- a/docker/hermes-agent/bootstrap/tests/test_profile_snapshot.py
+++ b/docker/hermes-agent/bootstrap/tests/test_profile_snapshot.py
@@ -661,6 +661,17 @@ class ProfileSnapshotTests(unittest.TestCase):
                 scanner = profile_snapshot._SensitiveStreamScanner()
                 with self.assertRaises(ValueError):
                     scanner.feed(b"safe=" + candidate)
+                    scanner.finish()
+
+    def test_rejects_a_jwt_with_an_arbitrarily_long_segment(self) -> None:
+        candidate = (
+            b"eyJ" + b"A" * 100000 + b"." + b"B" * 20 + b"." + b"C" * 20
+        )
+        scanner = profile_snapshot._SensitiveStreamScanner()
+        with self.assertRaises(ValueError):
+            for start in range(0, len(candidate), 64 * 1024):
+                scanner.feed(candidate[start : start + 64 * 1024])
+            scanner.finish()
 
     def test_rejects_every_supported_private_key_header_at_every_split(self) -> None:
         headers = (

--- a/docker/hermes-agent/bootstrap/tests/test_profile_sync.py
+++ b/docker/hermes-agent/bootstrap/tests/test_profile_sync.py
@@ -689,6 +689,41 @@ class ProfileSyncTests(unittest.TestCase):
             [".gitignore", "SOUL.md", "distribution.yaml"],
         )
 
+    def test_real_publication_rejects_bulk_deletion_above_manifest_limit(self) -> None:
+        remote = self.root / "profile-a.git"
+        base = self.profile("profile-a", remote)
+        declaration = DistributionSource(
+            base.name,
+            base.source,
+            base.ref,
+            base.target,
+            base.manifest_name,
+            base.source_commit,
+            1,
+        )
+        snapshot = self.snapshot(declaration, {"SOUL.md": b"safe local profile\n"})
+        self.seed_remote_files(
+            remote,
+            declaration.name,
+            {"old-a.md": b"old\n", "old-b.md": b"old\n"},
+        )
+
+        dry_run = synchronize_prepared_profiles(
+            PreparedProfiles((snapshot,), ()), self.auth, dry_run=True
+        )
+        self.assertEqual(dry_run.exit_code, 0)
+        self.assertEqual(len(dry_run.profiles[0].diff.deleted), 2)
+
+        report = synchronize_prepared_profiles(
+            PreparedProfiles((snapshot,), ()), self.auth, dry_run=False
+        )
+        self.assertEqual(report.exit_code, 4)
+        self.assertEqual(report.profiles[0].category, "deletion_limit_exceeded")
+        self.assertEqual(
+            self.git(remote, "ls-tree", "-r", "--name-only", "main").splitlines(),
+            ["old-a.md", "old-b.md"],
+        )
+
     def test_unsafe_raw_paths_use_non_reversible_digest_identifiers(self) -> None:
         remote = self.root / "profile-a.git"
         declaration = self.profile("profile-a", remote)

--- a/docker/hermes-agent/bootstrap/tests/test_profile_sync.py
+++ b/docker/hermes-agent/bootstrap/tests/test_profile_sync.py
@@ -1078,6 +1078,56 @@ class ProfileSyncTests(unittest.TestCase):
         self.assertGreaterEqual(len(fetched_refs), 3)
         self.assertEqual(set(fetched_refs), {"refs/heads/main"})
 
+    def test_push_race_rechecks_the_deletion_limit_against_new_head(self) -> None:
+        remote = self.root / "profile-a.git"
+        base = self.profile("profile-a", remote)
+        declaration = DistributionSource(
+            base.name,
+            base.source,
+            base.ref,
+            base.target,
+            base.manifest_name,
+            base.source_commit,
+            1,
+        )
+        snapshot = self.snapshot(declaration, {"SOUL.md": b"local\n"})
+        self.seed_remote_files(remote, declaration.name, {"README.md": b"old\n"})
+        original_run = profile_sync._run_git_bytes
+        push_calls = 0
+
+        def race_after_push(arguments, cwd, environment, *, max_output_bytes):
+            nonlocal push_calls
+            output = original_run(
+                arguments, cwd, environment, max_output_bytes=max_output_bytes
+            )
+            if arguments and arguments[0] == "push" and output is not None:
+                push_calls += 1
+                if push_calls == 1:
+                    self.advance_remote(remote)
+                    self.advance_remote(remote)
+            return output
+
+        with mock.patch.object(
+            profile_sync, "_run_git_bytes", side_effect=race_after_push
+        ):
+            report = synchronize_prepared_profiles(
+                PreparedProfiles((snapshot,), ()), self.auth, dry_run=False
+            )
+
+        self.assertEqual(push_calls, 1)
+        self.assertEqual(report.exit_code, 4)
+        self.assertEqual(report.profiles[0].category, "deletion_limit_exceeded")
+        self.assertEqual(
+            self.git(remote, "ls-tree", "-r", "--name-only", "main").splitlines(),
+            [
+                ".gitignore",
+                "SOUL.md",
+                "distribution.yaml",
+                "race-1.txt",
+                "race-2.txt",
+            ],
+        )
+
     def test_different_tree_after_successful_retry_exhausts_the_race(self) -> None:
         remote = self.root / "profile-a.git"
         declaration = self.profile("profile-a", remote)

--- a/docker/hermes-agent/bootstrap/tests/test_profile_sync_provenance_verifier.py
+++ b/docker/hermes-agent/bootstrap/tests/test_profile_sync_provenance_verifier.py
@@ -563,7 +563,10 @@ class ProfileSyncProvenanceVerifierTests(unittest.TestCase):
             stderr=subprocess.PIPE,
             text=True,
             check=False,
-            timeout=10,
+            # The container build runs this subprocess while the full suite
+            # is under load; retain a bound without making valid negative
+            # cases flaky on shared CI runners.
+            timeout=30,
         )
 
     def _replace_provenance(self, **replacements: object) -> None:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,14 +86,17 @@ runtime mount is `/opt/data`, not a Git checkout. The root and named profile
 homes are applied from source repositories, while live secrets, memories,
 sessions, logs, and browser state remain local runtime data.
 
-| Owner                 | Source                                                                                  | Responsibility                                                                              |
-| --------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Dotfiles              | [rurusasu/dotfiles](https://github.com/rurusasu/dotfiles)                               | Compose wiring, manifest, host adapters, operator Taskfile and documentation                |
-| Root distribution     | [rurusasu/hermes-home](https://github.com/rurusasu/hermes-home)                         | `root-distribution.yaml` and root declarative config, policy, cron, scripts, and MCP blocks |
-| Rick distribution     | [rurusasu/hermes-profile-rick](https://github.com/rurusasu/hermes-profile-rick)         | Official `distribution.yaml` and Rick declarative content                                   |
-| Hoffman distribution  | [rurusasu/hermes-profile-hoffman](https://github.com/rurusasu/hermes-profile-hoffman)   | Official `distribution.yaml` and Hoffman declarative content                                |
-| Risarisa distribution | [rurusasu/hermes-profile-risarisa](https://github.com/rurusasu/hermes-profile-risarisa) | Official `distribution.yaml` and Risarisa declarative content                               |
-| Shared data           | [rurusasu/lifelog](https://github.com/rurusasu/lifelog)                                 | The one locked read-write checkout at `/opt/data/shared/lifelog`                            |
+| Owner                  | Source                                                                                    | Responsibility                                                                              |
+| ---------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Dotfiles               | [rurusasu/dotfiles](https://github.com/rurusasu/dotfiles)                                 | Compose wiring, manifest, host adapters, operator Taskfile and documentation                |
+| Root distribution      | [rurusasu/hermes-home](https://github.com/rurusasu/hermes-home)                           | `root-distribution.yaml` and root declarative config, policy, cron, scripts, and MCP blocks |
+| Rick distribution      | [rurusasu/hermes-profile-rick](https://github.com/rurusasu/hermes-profile-rick)           | Official `distribution.yaml` and Rick declarative content                                   |
+| Hoffman distribution   | [rurusasu/hermes-profile-hoffman](https://github.com/rurusasu/hermes-profile-hoffman)     | Official `distribution.yaml` and Hoffman declarative content                                |
+| Risarisa distribution  | [rurusasu/hermes-profile-risarisa](https://github.com/rurusasu/hermes-profile-risarisa)   | Official `distribution.yaml` and Risarisa declarative content                               |
+| Nancy distribution     | [rurusasu/hermes-profile-nancy](https://github.com/rurusasu/hermes-profile-nancy)         | Official `distribution.yaml` and Nancy declarative content                                  |
+| Kuroda distribution    | [rurusasu/hermes-profile-kuroda](https://github.com/rurusasu/hermes-profile-kuroda)       | Official `distribution.yaml` and Kuroda declarative content                                 |
+| Shiraishi distribution | [rurusasu/hermes-profile-shiraishi](https://github.com/rurusasu/hermes-profile-shiraishi) | Official `distribution.yaml` and Shiraishi declarative content                              |
+| Shared data            | [rurusasu/lifelog](https://github.com/rurusasu/lifelog)                                   | The one locked read-write checkout at `/opt/data/shared/lifelog`                            |
 
 `/opt/data/core/lifelog` is migration-only and is absent after bootstrap;
 profile homes are never Git repositories. The default profile owns

--- a/docs/hermes-agent/bootstrap-design.md
+++ b/docs/hermes-agent/bootstrap-design.md
@@ -53,7 +53,9 @@ host ~/.hermes/                    container /opt/data/ (HERMES_HOME)
 │   ├── rick/                      official Hermes target; local-authoritative when present
 │   ├── hoffman/
 │   ├── risarisa/
-│   └── nancy/
+│   ├── nancy/
+│   ├── kuroda/
+│   └── shiraishi/
 ├── shared/
 │   └── lifelog/                   writable independent Git repository
 ├── memories/                      root runtime state
@@ -161,13 +163,13 @@ commit/rebase/push workflow. All profiles continue to use
    validated.
 3. Read the secret payload without logging it, then validate required fields,
    GitHub credentials, remote identities, and access.
-4. Snapshot every existing named profile, complete aggregate preflight, and
-   synchronize each exact local snapshot to its configured remote before any
-   staging or local transaction.
+4. Snapshot every existing named profile and validate the local-authoritative
+   boundary. Existing profiles are preserved; only truly missing profiles are
+   staged from their configured, optionally pinned first-install source.
 5. Stage the remote-authoritative root distribution.
-6. In manifest order, stage each named profile: use the exact commit reported by
-   publication for an existing profile, or the configured branch only for a
-   truly missing first install.
+6. In manifest order, stage each missing named profile from its configured
+   branch and verify its pinned commit when one is declared. Existing profiles
+   are not staged or replaced by `apply`.
 7. Validate the staged root and every named profile against the required Chrome
    MCP source contract, then install the canonical X API entry.
 8. Synchronize each shared repository remote, including lifelog under its
@@ -177,7 +179,9 @@ commit/rebase/push workflow. All profiles continue to use
    working trees, install the Google Calendar MCP entry and shared credentials,
    and merge private `.env` files with mode `0600`.
 10. Validate the installed layout, commit the transaction, report the
-    `profile_sync` summary, then recreate and health-check the gateway.
+    `profile_sync` summary (`installed` or `preserved`), then recreate and
+    health-check the gateway. Run `sync-profiles` separately to publish local
+    profile snapshots.
 
 Before step 9, apply creates a second full local snapshot and compares it to
 the published snapshot by target set, canonical manifests, generated
@@ -193,40 +197,32 @@ user-owned paths. The pinned runtime restricts direct profile installation to
 the manifest's top-level `distribution_owned` roots, so repository workflows,
 tests, and validator tooling are not copied into the profile.
 
-If aggregate profile preflight or publication fails, bootstrap stops before
-root/profile staging, shared synchronization, or the local transaction.
-Snapshot-preflight rejection happens before `profile_report` exists; public
-`apply` stderr is `profile snapshot rejected (<category>)`, with no profile
-name or report. Standalone `sync-profiles --dry-run` repeats aggregate
-preflight and identifies the invalid profile and category in its JSON. A
-nonzero post-preflight publication report instead produces
-`named profile repository sync failed: <failed names>`; the Python exception
-retains that report internally, but the CLI does not serialize its categories.
-In both cases `apply` stdout is empty. By default stderr is one safe message.
-With `HERMES_BOOTSTRAP_DEBUG=1`, the CLI may append a sanitized traceback from
-its public boundary; it does not retain tokens or the raw internal exception
-graph.
+If local profile snapshot preflight fails, bootstrap stops before root/profile
+staging, shared synchronization, or the local transaction. Existing profiles
+are not published by `apply`; profile publication is the explicit
+`sync-profiles` operation. Snapshot rejection reports
+`profile snapshot rejected (<category>)` without a profile name in `apply`.
+Standalone `sync-profiles --dry-run` identifies the invalid profile and
+category in its JSON. In both cases `apply` stdout is empty. By default stderr
+is one safe message. With `HERMES_BOOTSTRAP_DEBUG=1`, the CLI may append a
+sanitized traceback from its public boundary; it does not retain tokens or the
+raw internal exception graph.
 
-Because a post-preflight `named profile repository sync failed: <failed names>`
-message hides its category, every such apply failure triggers guarded
-inventories of both profile scratch and outer apply scratch before retry or
-closure. Reliably empty inventories follow ordinary push recovery; any
-candidate or indeterminate check activates the full quiescent quarantine path.
-Later successful dry-run/real commands do not replace the required inventories
-because they do not revisit old artifacts.
+Because profile publication spans independent repositories, a partial
+`sync-profiles` result is eventual consistency rather than an atomic
+transaction. Completed pushes remain valid; repair the failed profile and retry
+it after checking the cleanup inventory. Profile snapshot, revalidation, Git
+staging, and askpass artifacts are private `/tmp` children rather than files in
+the `/opt/data` bind mount. Later successful dry-run/real commands do not
+replace required cleanup checks because they do not revisit old artifacts.
 
-Snapshot-preflight rejection is not this hidden-category trigger. Its category
-is public and publication has not started. If final outer apply scratch cleanup
-also fails, the CLI reports `could not clean bootstrap staging resources`
-instead of the snapshot rejection. That outer message can also replace a
-post-preflight publication or later primary failure and can retain a hidden
-profile report internally, so it is an indeterminate trigger. Inventory both
-`.hermes-profile-snapshots-*`, `.hermes-profile-sync-*`, and `askpass-*` profile
-artifacts and `.hermes-bootstrap-*` outer artifacts. A candidate or
-indeterminate determination uses the same full-window, mount-aware, atomic
-quarantine procedure. An exact `profile snapshot rejected (cleanup_failed)`
-message means the final outer scratch cleanup did not replace it and does not
-by itself trigger the direct-child publication inventory.
+Snapshot-preflight rejection is not a publication cleanup trigger because
+publication has not started. If final cleanup fails, the CLI reports
+`could not clean bootstrap staging resources` and the operator must inspect
+`/tmp/.hermes-profile-snapshots-*`, `/tmp/.hermes-profile-sync-*`,
+`/tmp/askpass-*`, `/tmp/.hermes-bootstrap-*`, and private
+`/opt/data/shared/.hermes-repository-*` stages using the same full-window,
+mount-aware, atomic quarantine procedure.
 
 Dry-run is limited to preflight and diff inspection. It never pushes, so a
 changed entry has category `dry_run` and cannot reproduce push-only categories
@@ -325,8 +321,8 @@ this model, so cleanup makes no unsupported claim to defeat that actor.
 
 ## Verification
 
-`task hermes:bootstrap:test` covers manifest-generic four-profile sequencing,
-including Nancy; existing-local snapshots; missing-only first install; invalid
+`task hermes:bootstrap:test` covers manifest-generic six-profile sequencing,
+including Nancy, Kuroda, and Shiraishi; existing-local snapshots; missing-only first install; invalid
 existing profiles; exact remote deletion; local immutability; aggregate
 preflight; sequential continuation; retry and same-tree descendant acceptance;
 compact JSON; exit codes; and redaction.

--- a/docs/hermes-agent/bootstrap.md
+++ b/docs/hermes-agent/bootstrap.md
@@ -67,7 +67,7 @@ host adapter
   -> docker compose run --rm --no-deps -T hermes-bootstrap apply
   -> load manifest and recover any crash journal
   -> validate payload, credentials, and source access
-  -> publish existing profiles, stage sources, and sync shared remotes
+  -> validate existing local profiles, stage missing sources, and sync shared remotes
   -> reconcile Hermes onepassword references in root and profile config.yaml files
   -> transactional install under /opt/data
   -> docker compose up -d --force-recreate only after success
@@ -154,10 +154,11 @@ sources fail closed. The command validates the canonical repository, acquires
 commit/rebase/push workflow. Its success JSON reports `status`, `name`,
 `commit`, and `pushed`.
 
-The successful bootstrap JSON contains `status: "applied"`, the four profile
+The successful bootstrap JSON contains `status: "applied"`, the six profile
 names, `repositories: ["lifelog"]`, and `profile_sync`. `profile_sync` maps
-each named profile to `changed`, `unchanged`, or `installed`; `installed` is
-only the truly missing first-install case.
+each named profile to `preserved` or `installed`; `installed` is only the
+truly missing first-install case. Existing profile publication is explicit:
+run `sync-profiles` separately.
 
 ## Sync Existing Named Profiles
 
@@ -214,18 +215,17 @@ Task 5 fixtures cover declared assets for Rick, Hoffman, and Nancy and no
 ## First Install And Bootstrap Ordering
 
 Bootstrap validates credentials and repository access, snapshots all existing
-profiles, and completes their exact local-to-remote publication before staging.
-It then stages the remote-authoritative root distribution; stages every profile
-in manifest order using the exact returned commit for an existing profile or
-the configured branch for a truly missing profile; runs
-`validate_chrome_mcp_sources` over the staged root and profiles; synchronizes
-shared repositories, including lifelog; and only then calls
-`Transaction.begin`. Inside the transaction it applies root, named profiles in
-manifest order, shared working trees, and managed environment files. Existing
-named-profile publication has already completed before the staged Chrome gate.
-If that validation fails, its reported remote commits remain valid and are not
-rolled back; bootstrap fails before shared-repository synchronization or local
-transaction mutation.
+profiles, and stages only truly missing profiles. Existing named profiles remain
+local-authoritative and are not published or replaced by `apply`; publication is
+owned by the explicit `sync-profiles` command. Bootstrap then stages the
+remote-authoritative root distribution, stages each missing profile in manifest
+order using its configured branch and optional pinned commit, runs
+`validate_chrome_mcp_sources` over the staged root and profiles, synchronizes
+shared repositories including lifelog, and only then calls `Transaction.begin`.
+Inside the transaction it applies root, missing profiles in manifest order,
+shared working trees, and managed environment files. If a staged validation
+fails, no profile publication has occurred and bootstrap fails before
+shared-repository synchronization or local transaction mutation.
 
 `apply` holds the canonical nonblocking `EngineLock` at
 `/opt/data/locks/bootstrap-engine.lock` from before crash-journal recovery
@@ -250,8 +250,12 @@ for the first official Hermes install. An existing malformed or incomplete
 profile is not absent: bootstrap fails before its transaction and never falls
 back to a remote overwrite.
 
-If synchronization fails, bootstrap does not begin its local transaction or
-restart Hermes. There are two public diagnostics:
+If explicit synchronization fails, the report contains per-profile failures;
+completed pushes remain valid because independent profile repositories are not
+cross-repository atomic. Repair the failed local boundary and retry it. A
+normal `apply` does not publish existing profiles and therefore does not fail
+because a profile push failed. There are two public diagnostics for the
+explicit synchronization command:
 
 - Snapshot preflight can fail before a `profile_report` is created. `apply`
   writes `profile snapshot rejected (<category>)` to stderr, without a profile
@@ -261,11 +265,13 @@ restart Hermes. There are two public diagnostics:
   `named profile repository sync failed: <failed names>` to stderr. The Python
   exception can retain the report internally.
 
-Every `named profile repository sync failed: <failed names>` message requires
-the guarded profile, outer-bootstrap, and private shared-repository stage
-artifact inventories in the cleanup runbook before any retry or closure. The
-CLI-hidden category could be `cleanup_failed`; neither an expected push
-diagnosis nor a later successful sync excludes that possibility.
+Every cleanup failure requires the guarded profile and private
+shared-repository stage artifact inventories in the cleanup runbook before any
+retry or closure. Profile snapshot, revalidation, Git staging, and askpass
+artifacts are under the container's private `/tmp` (for example,
+`/tmp/.hermes-profile-sync-*`), not the `/opt/data` bind mount. The CLI-hidden
+category could be `cleanup_failed`; neither an expected push diagnosis nor a
+later successful sync excludes that possibility.
 
 Snapshot-preflight rejection is a different trigger. Publication has not begun,
 and `profile snapshot rejected (<category>)` exposes its category. If the inner
@@ -279,27 +285,26 @@ trigger.
 
 `could not clean bootstrap staging resources` is itself an indeterminate
 cleanup trigger. Final outer cleanup can replace a snapshot-preflight,
-publication, staging, transaction, validation, or other primary failure. If a
-profile report had already been created, it can remain attached internally, but
-the CLI exposes neither that report nor the replaced primary failure. Before
-retry or closure, inventory both the profile scratch prefixes and the outer
-`.hermes-bootstrap-*` prefix below, plus private
+staging, transaction, validation, or other primary failure. Before retry or
+closure, inventory `/tmp/.hermes-profile-snapshots-*`,
+`/tmp/.hermes-profile-sync-*`, `/tmp/askpass-*`, and private
 `/opt/data/shared/.hermes-repository-*` stages. A candidate or indeterminate
 determination activates the same full-window quiescent quarantine procedure; a
 later successful command does not waive any inventory.
 
-Once synchronization has created `profile_report`, later staging, transaction,
-installed-layout validation, cleanup, or rollback failures can also retain that
-report on the internal Python exception. The CLI never serializes this
-attribute. By default every failed `apply` has empty stdout and exactly one safe
-error message on stderr. With `HERMES_BOOTSTRAP_DEBUG=1`, a sanitized traceback
-from the public CLI boundary may follow that message; it contains neither
-tokens nor the raw internal exception graph.
+The `apply` command does not create a profile publication report because it
+does not publish existing profiles. By default every failed `apply` has empty
+stdout and exactly one safe error message on stderr. With
+`HERMES_BOOTSTRAP_DEBUG=1`, a sanitized traceback from the public CLI boundary
+may follow that message; it contains neither tokens nor the raw internal
+exception graph.
 
 Use dry-run only for aggregate preflight and diff inspection. It never pushes,
 so a changed entry reports category `dry_run`; it cannot reproduce
 `push_rejected`, `push_race_exhausted`, or another push-only failure. To obtain
 a push-only category, run standalone real `sync-profiles` and inspect its JSON.
+The real synchronizer also enforces each profile's `max_deleted_paths` limit;
+an over-limit result uses category `deletion_limit_exceeded` and does not push.
 The real aggregate processes every manifest profile and may push changes for
 profiles other than the original failure. Successful pushes remain valid and
 cannot be rolled back; a subsequent run reports them as `unchanged` when the
@@ -399,11 +404,9 @@ bypasses `EngineLock` is outside this model; cleanup does not claim an atomic
 identity-check-and-delete guarantee against that actor.
 
 The full procedure is mandatory for an explicit standalone `cleanup_failed`
-report. A post-preflight apply publication message has a hidden category, and
-`could not clean bootstrap staging resources` can replace an earlier hidden
-profile report or another primary failure. Both messages must complete the
-unified quiescent inventory and decision steps below even when the suspected
-cause is an ordinary push failure.
+report or `could not clean bootstrap staging resources`. These messages must
+complete the unified quiescent inventory and decision steps below even when
+the suspected cause is an ordinary push failure.
 
 1. Establish one named maintenance owner. Stop and disable every launch path
    for the entire recovery window: the Hermes gateway and scheduler, any
@@ -413,28 +416,25 @@ cause is an ordinary push failure.
    transaction or repository lock has an owner. Lock files may persist while
    unlocked. Do not re-enable any launcher until the final step; only the
    maintenance owner may run the controlled verification commands below.
-2. From a maintenance environment that sees the same `/opt/data` mount
-   namespace, inventory only direct children whose complete names match
-   `.hermes-profile-snapshots-*`, `.hermes-profile-sync-*`, `askpass-*`, or
-   `.hermes-bootstrap-*` under canonical `/opt/data`. Separately inventory only
-   direct children of canonical `/opt/data/shared` whose complete names match
-   `.hermes-repository-*`; `repositories.py` creates these private first-clone
-   stages in the shared repository target's parent. Always inventory the
-   profile-scratch, outer-bootstrap, and private shared-repository stage groups,
-   even when the public error names only one phase. Separately inventory any
-   prior `.hermes-profile-cleanup-quarantine-*` directory. An existing
-   quarantine is unresolved recovery evidence: do not reuse or remove it; stop
-   and escalate.
-3. Inspect every candidate individually with no symlink following. Both
-   `.hermes-profile-*` forms and `.hermes-bootstrap-*` must be real directories
-   directly under canonical `/opt/data`, owned by the maintenance service
-   UID/GID, with mode `0700` and the exact expected prefix. A
+2. From a maintenance environment that sees the same `/opt/data` and `/tmp`
+   mount namespaces, inventory only direct children whose complete names match
+   `.hermes-profile-snapshots-*`, `.hermes-profile-sync-*`,
+   `.hermes-bootstrap-*`, or `askpass-*` under canonical `/tmp`. Separately
+   inventory only direct children of canonical `/opt/data/shared` whose
+   complete names match `.hermes-repository-*`; `repositories.py` creates
+   these private first-clone stages in the shared repository target's parent.
+   Always inventory both groups, even when the public error names only one
+   phase. Separately inventory any prior quarantine in each relevant parent.
+   An existing quarantine is unresolved recovery evidence: do not reuse or
+   remove it; stop and escalate.
+3. Inspect every candidate individually with no symlink following. All
+   `.hermes-profile-*`, `.hermes-bootstrap-*`, and `askpass-*` candidates must
+   be directly beneath `/tmp`, owned by the maintenance service UID/GID, and
+   use the expected type, mode, link count, and prefix. A
    `.hermes-repository-*` candidate must meet the same directory, owner, and
-   mode checks directly under canonical `/opt/data/shared`. An `askpass-*`
-   candidate must be a real regular file directly under `/opt/data`, with the
-   same owner, mode `0700`, link count `1`, and exact prefix. Any unexpected
-   path, descendant mount, type, owner, mode, link count, prefix, or location is
-   an escalation, not a deletion candidate.
+   mode checks directly under canonical `/opt/data/shared`. Any unexpected
+   path, descendant mount, type, owner, mode, link count, prefix, or location
+   is an escalation, not a deletion candidate.
 4. Capture an authoritative mount inventory for that maintenance namespace,
    such as Linux `/proc/self/mountinfo` or reliable mountpoint tooling. Compare
    its canonical mount targets against each canonical candidate subtree.
@@ -457,12 +457,14 @@ cause is an ordinary push failure.
    aggregate exit `0` never substitutes for this pre-retry inventory because
    old artifacts are not revisited.
 6. Create a unique `.hermes-profile-cleanup-quarantine-<incident-id>` directory
-   directly under `/opt/data`. Verify that it is owner-created, non-symlink,
-   mode `0700`, contains no mountpoint, and has the same filesystem device as
-   every candidate. Revalidate each candidate immediately before moving it,
-   then atomically rename each exact candidate into quarantine without using
-   globs. Any rename failure, including `EXDEV` or `EBUSY`, aborts the operation;
-   leave the quarantine untouched and escalate.
+   in `/tmp` for `/tmp` candidates and a separate quarantine in the candidate's
+   `/opt/data/shared` parent for shared-repository candidates. Verify each is
+   owner-created, non-symlink, mode `0700`, contains no mountpoint, and has the
+   same filesystem device as the candidates it receives. Revalidate each
+   candidate immediately before moving it, then atomically rename each exact
+   candidate into its same-parent quarantine without using globs. Any rename
+   failure, including `EXDEV` or `EBUSY`, aborts the operation; leave the
+   quarantine untouched and escalate.
 7. After every candidate is isolated, refresh the mount inventory and recheck
    the quarantine and every descendant. Confirm the quarantined entries match
    the reviewed candidate set and remain mount-free. Only then remove the
@@ -470,7 +472,7 @@ cause is an ordinary push failure.
    crossings. Do not use blind `rm -rf`, wildcard `rm`, a broad `.hermes-*`
    pattern, or `find -delete`.
 8. While all ordinary launch paths remain disabled, require zero direct
-   profile-scratch and outer-bootstrap names under `/opt/data`, zero private
+   profile-scratch and outer-bootstrap names under `/tmp`, zero private
    `.hermes-repository-*` stage names under `/opt/data/shared`, zero quarantine
    names, and no related mount issue. The maintenance owner then runs
    standalone dry-run and real `sync-profiles`, consumes both JSON reports
@@ -497,12 +499,12 @@ two local applies from mutating managed paths concurrently. Recovery may restore
 or remove previously journaled managed paths; it is intentionally not covered
 by validation-before-new-write claims.
 
-After recovery completes, credential validation, profile publication,
-root/profile staging, staged `validate_chrome_mcp_sources`, and shared remote
-synchronization finish before `Transaction.begin` because remote pushes cannot
-be rolled back. Existing named-profile publication is already complete when
-the staged Chrome gate runs and remains valid if that gate fails. Inside the
-new transaction, bootstrap snapshots root-owned paths, named profile targets,
+After recovery completes, credential validation, root/profile staging, staged
+`validate_chrome_mcp_sources`, and shared remote synchronization finish before
+`Transaction.begin`. `apply` does not publish existing named profiles: those
+local-authoritative snapshots are published only by the explicit
+`sync-profiles` command. Inside the new transaction, bootstrap snapshots
+root-owned paths, named profile targets,
 shared working-tree publication, deprecated-path cleanup, and managed `.env`
 files before replacement. Environment files use atomic rename and mode `0600`,
 preserve unmanaged keys, and replace only managed keys.
@@ -645,7 +647,7 @@ operations docs:
 task hermes:bootstrap:test
 ```
 
-The suite covers four-profile bootstrap sequencing, first-install seeding,
+The suite covers six-profile bootstrap sequencing, first-install seeding,
 invalid-existing failure without fallback, aggregate preflight, exact remote
 tree deletion, local immutability, retry behavior, compact JSON, exit status,
 and redaction.

--- a/docs/hermes-agent/profile-local-authoritative-sync-design.md
+++ b/docs/hermes-agent/profile-local-authoritative-sync-design.md
@@ -17,11 +17,11 @@ The three managed content classes deliberately use different authority models:
 | Root/default   | `rurusasu/hermes-home`                                     | remote distribution to local runtime                                            |
 | Shared lifelog | `/opt/data/shared/lifelog`                                 | normal locked read-write Git repository                                         |
 
-`docker/hermes-agent/bootstrap-manifest.yaml` currently declares four named
+`docker/hermes-agent/bootstrap-manifest.yaml` currently declares six named
 profiles: `rick`, `hoffman`, `risarisa`, `nancy`, `kuroda`, and `shiraishi`.
-The manifest is the
-configuration source for their name, remote, branch, and target; operations and
-tests must not assume a fixed three-profile set.
+The manifest is the configuration source for their name, remote, branch,
+optional pinned first-install commit, deletion safety limit, and target;
+operations and tests must not assume a fixed profile set.
 
 For an existing valid named profile, the local `distribution.yaml` and its
 `distribution_owned` allowlist are authoritative. Remote changes never flow
@@ -241,23 +241,26 @@ mixing versions in a commit and keeps local profile bytes and modes immutable.
 After preflight, profiles run sequentially under per-profile repository locks.
 A post-preflight Git failure for one profile is recorded but does not stop
 later profiles from being attempted. Earlier successful pushes remain valid
-and are not rolled back. A normal push race gets one retry: the synchronizer
-fetches the new remote head, rebuilds the same expected tree, and retries. It
-accepts a remote descendant when that descendant has the same expected tree;
-a second race failure is reported as `push_race_exhausted`.
+and are not rolled back: publication across the independent profile
+repositories is intentionally not a cross-repository atomic transaction.
+Operators must treat a partial report as eventual consistency and retry only
+the failed profile after its local boundary is repaired. A normal push race
+gets one retry: the synchronizer fetches the new remote head, rebuilds the
+same expected tree, and retries. It accepts a remote descendant when that
+descendant has the same expected tree; a second race failure is reported as
+`push_race_exhausted`.
 
 After any crash-journal recovery, bootstrap validates credentials and
-repositories, then runs the same snapshot-and-publication phase before staging
-or starting a new local transaction. It then stages root, stages profiles in
-manifest order using either the reported exact commit or the configured branch
-for a truly missing target, runs `validate_chrome_mcp_sources` over the staged
-root and profiles, synchronizes shared repositories, and only then begins the
-transaction. Existing named-profile publication has already completed before
-this staged Chrome gate. Its reported remote commits remain valid and are not
-rolled back if Chrome validation fails; apply stops before shared-repository
-synchronization or `Transaction.begin`. The successful `apply` result includes
-a `profile_sync` summary whose entries are `changed`, `unchanged`, or
-`installed`.
+repositories, stages the remote-authoritative root, and stages only a truly
+missing named profile in manifest order. Existing named profiles are preserved
+as local-authoritative runtime state; `apply` does not publish or replace them.
+The explicit `sync-profiles` command owns publication. A configured `commit`
+pins each first-install source to a full Git object ID; it is not a moving-branch
+pin for an existing local profile. Explicit profile publication reads the
+current configured branch and returns the resulting commit for that run.
+Bootstrap then validates the staged root and missing profiles, synchronizes shared
+repositories, and begins the local transaction. The successful `apply` result
+maps each profile to `installed` or `preserved`.
 
 Immediately before `Transaction.begin`, `apply` repeats the full profile
 snapshot and compares the existing/missing target set, canonical manifest and
@@ -287,29 +290,28 @@ exception graph. The publication message has failed names but no categories.
 Root staging stays remote-authoritative and shared lifelog continues its
 ordinary locked read-write Git synchronization.
 
-Every post-preflight apply publication message is therefore a cleanup inventory
-trigger before retry or closure: its hidden category could be
-`cleanup_failed`. Inventory profile scratch and outer apply scratch directly
-under `/opt/data`, plus private shared-repository stages matching
-`/opt/data/shared/.hermes-repository-*`. If all guarded inventories are reliably
-empty, continue ordinary push-failure recovery. A candidate or indeterminate
-check activates the full quiescent, mount-aware, atomic-quarantine procedure.
-Later successful dry-run/real results do not waive the earlier inventories.
+Every profile publication failure is therefore a cleanup inventory trigger
+before retry or closure: its category could be `cleanup_failed`. Profile
+snapshot, revalidation, Git staging, and askpass artifacts are created beneath
+the container's private `/tmp` rather than the `/opt/data` bind mount. Inventory
+`/tmp/.hermes-profile-snapshots-*`, `/tmp/.hermes-profile-sync-*`, and
+`/tmp/askpass-*`, plus private shared-repository stages under
+`/opt/data/shared/.hermes-repository-*`. If all guarded inventories are
+reliably empty, continue ordinary push-failure recovery. A candidate or
+indeterminate check activates the full quiescent, mount-aware,
+atomic-quarantine procedure. Later successful dry-run/real results do not waive
+the earlier inventories.
 
 Snapshot-preflight rejection remains separate because its category is public
-and publication has not started. If final outer apply scratch cleanup fails,
-`could not clean bootstrap staging resources` replaces the snapshot rejection;
-that outer error can also replace a post-preflight publication or later primary
-failure and can retain an internal profile report that the CLI does not expose.
-It is therefore an indeterminate trigger requiring both the direct-child
-profile inventory for `.hermes-profile-snapshots-*`,
-`.hermes-profile-sync-*`, and `askpass-*` and the outer inventory for
-`.hermes-bootstrap-*` under `/opt/data`, plus the direct-child private
-shared-repository stage inventory for `.hermes-repository-*` under
-`/opt/data/shared`. A candidate or indeterminate determination activates the
-same full recovery procedure. An exact
-`profile snapshot rejected (cleanup_failed)` message means final outer scratch
-cleanup did not replace it and does not alone trigger these inventories.
+and publication has not started. If final cleanup fails, the CLI reports
+`could not clean bootstrap staging resources`; inspect
+`/tmp/.hermes-profile-snapshots-*`, `/tmp/.hermes-profile-sync-*`,
+`/tmp/askpass-*`, `/tmp/.hermes-bootstrap-*`, and private
+`.hermes-repository-*` stages under `/opt/data/shared`. A candidate or
+indeterminate determination activates the same full recovery procedure. An
+exact `profile snapshot rejected (cleanup_failed)` message means final outer
+scratch cleanup did not replace it and does not alone trigger these
+inventories.
 
 ## Repair Handoff
 


### PR DESCRIPTION
## Summary
- keep existing local profiles authoritative during `apply`; publish them only via explicit `sync-profiles`
- pin first-install sources, enforce deletion limits, and keep scratch/askpass artifacts private
- harden profile secret filtering and document six-profile, non-atomic publication semantics
- add regression coverage for all behavior and update architecture/runbook docs

## Issues
Closes #530
Closes #531
Closes #532
Closes #533
Closes #534
Closes #535
Closes #536

## Verification
- `task hermes:bootstrap:test`
- `pre-commit run --all-files`
- Docker bootstrap image: 583 + 53 + 1 tests passed