### PR TITLE
feat(hermes): enable LCM context engine for all profiles

### DIFF
--- a/docker/hermes-agent/Dockerfile
+++ b/docker/hermes-agent/Dockerfile
@@ -6,6 +6,8 @@ ARG ARTICLE_COLLECTOR_VERSION=v0.6.17
 ARG GOOGLE_CALENDAR_MCP_VERSION=2.6.2
 ARG GOOGLE_GMAIL_MCP_VERSION=1.2.3
 ARG HINDSIGHT_CLIENT_VERSION=0.6.1
+ARG HERMES_LCM_VERSION=v0.20.0
+ARG HERMES_LCM_COMMIT=49e99a272d2d461e5c90732e7ef2bc20e96f0826
 
 COPY hermes-agent/xapi-mcp.sh /usr/local/bin/hermes-xapi-mcp
 COPY hermes-agent/gh-wrapper.sh /usr/local/bin/gh
@@ -97,7 +99,7 @@ replace_once(
 PY
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl gh gnupg \
+  && apt-get install -y --no-install-recommends ca-certificates curl git gh gnupg \
   && arch="$(dpkg --print-architecture)" \
   && case "$arch" in \
     amd64|arm64) ;; \
@@ -135,6 +137,17 @@ RUN apt-get update \
   && chmod 0755 /usr/local/bin/hermes-xapi-mcp \
   && chmod 0755 /usr/local/bin/hermes-bootstrap \
   && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --quiet --depth 1 --branch "${HERMES_LCM_VERSION}" \
+    https://github.com/stephenschoettler/hermes-lcm \
+    /opt/hermes/plugins/hermes-lcm \
+  && test "$(git -C /opt/hermes/plugins/hermes-lcm rev-parse HEAD)" = "${HERMES_LCM_COMMIT}" \
+  && /opt/hermes/.venv/bin/python -m py_compile /opt/hermes/plugins/hermes-lcm/__init__.py \
+  && rm -rf /opt/hermes/plugins/hermes-lcm/.git
+
+RUN /opt/hermes/.venv/bin/python -c \
+      'import os; os.environ["HERMES_HOME"] = "/tmp/hermes-lcm-build-check"; from pathlib import Path; home = Path(os.environ["HERMES_HOME"]); home.mkdir(parents=True, exist_ok=True); (home / "config.yaml").write_text("plugins:\n  enabled:\n    - hermes-lcm\ncontext:\n  engine: lcm\n", encoding="utf-8"); from hermes_cli.plugins import discover_plugins, get_plugin_context_engine; discover_plugins(force=True); engine = get_plugin_context_engine(); assert engine is not None and engine.name == "lcm"' \
+  && rm -rf /tmp/hermes-lcm-build-check
 
 FROM hermes-bootstrap-runtime AS hermes-bootstrap-test
 

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/app.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/app.py
@@ -15,6 +15,11 @@ from typing import Callable, TextIO
 from dotenv.parser import parse_stream
 
 from . import profile_sync
+from .configfiles import reconcile_onepassword_configurations
+from .context_engine import (
+    install_context_engine_configurations,
+    validate_context_engine_installation,
+)
 from .distributions import (
     _normalize_owned_paths,
     _read_profile_manifest_at,
@@ -64,7 +69,6 @@ from .hindsight import (
     install_hindsight_configurations,
     validate_hindsight_installation,
 )
-from .configfiles import reconcile_onepassword_configurations
 from .github import GitAuth, GitHubClient
 from .manifest import load_manifest
 from .models import BootstrapManifest, DistributionSource, SharedRepository
@@ -288,6 +292,7 @@ def _apply_sensitive(
             tx,
         )
         install_hindsight_configurations(_environment_targets(manifest), tx)
+        install_context_engine_configurations(_environment_targets(manifest), tx)
         install_google_calendar_credentials(
             manifest.data_root,
             secrets.google_calendar,
@@ -634,6 +639,7 @@ def _validate_installed_layout(
             [target for _profile, target in _environment_targets(manifest)],
         )
         validate_hindsight_installation(_environment_targets(manifest))
+        validate_context_engine_installation(_environment_targets(manifest))
         for profile, target in _environment_targets(manifest):
             required = (
                 _MANAGED_ENV_KEYS

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/context_engine.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/context_engine.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import os
 import stat
+import uuid
 from collections.abc import Sequence
 from pathlib import Path
 
 import yaml
 
-from .distributions import _atomic_write
+from .distributions import _atomic_write as _atomic_write_path
 from .errors import ApplyError, ValidationError
 from .transaction import Transaction
 
@@ -29,7 +30,11 @@ def install_context_engine_configurations(
     try:
         for _profile, target in targets:
             _require_real_directory_chain(target)
-            _reconcile_config(target / "config.yaml", transaction)
+            with transaction.bind_reserved_directory(target) as reserved:
+                if reserved is None:
+                    _reconcile_config(target / "config.yaml", transaction)
+                else:
+                    _reconcile_reserved_configuration(reserved)
     except (
         ApplyError,
         OSError,
@@ -129,6 +134,177 @@ def _reconcile_config(path: Path, transaction: Transaction) -> None:
 
     transaction.snapshot(path)
     _atomic_write(path, content, 0o600)
+
+
+def _reconcile_reserved_configuration(directory: int) -> None:
+    metadata, original, config = _load_yaml_mapping_at(directory, "config.yaml")
+
+    context = config.get("context")
+    if context is None:
+        context = {}
+    if not isinstance(context, dict):
+        raise TypeError
+    merged_context = dict(context)
+    merged_context["engine"] = CONTEXT_ENGINE_NAME
+
+    plugins = config.get("plugins")
+    if plugins is None:
+        plugins = {}
+    if not isinstance(plugins, dict):
+        raise TypeError
+    merged_plugins = dict(plugins)
+
+    enabled_value = plugins.get("enabled", [])
+    if not isinstance(enabled_value, list) or any(
+        not isinstance(item, str) for item in enabled_value
+    ):
+        raise ValueError
+    enabled = list(enabled_value)
+    if CONTEXT_PLUGIN_NAME not in enabled:
+        enabled.append(CONTEXT_PLUGIN_NAME)
+    else:
+        enabled = [
+            item
+            for index, item in enumerate(enabled)
+            if item != CONTEXT_PLUGIN_NAME or CONTEXT_PLUGIN_NAME not in enabled[:index]
+        ]
+    merged_plugins["enabled"] = enabled
+
+    if "disabled" in plugins:
+        disabled_value = plugins["disabled"]
+        if not isinstance(disabled_value, list) or any(
+            not isinstance(item, str) for item in disabled_value
+        ):
+            raise ValueError
+        merged_plugins["disabled"] = [
+            item for item in disabled_value if item != CONTEXT_PLUGIN_NAME
+        ]
+
+    candidate = dict(config)
+    candidate["context"] = merged_context
+    candidate["plugins"] = merged_plugins
+    content = yaml.safe_dump(candidate, sort_keys=False).encode("utf-8")
+    if original == content and stat.S_IMODE(metadata.st_mode) == 0o600:
+        return
+    _atomic_write((directory, "config.yaml"), content, 0o600)
+
+
+def _atomic_write(
+    destination: Path | tuple[int, str],
+    content: bytes,
+    mode: int,
+) -> None:
+    if isinstance(destination, Path):
+        _atomic_write_path(destination, content, mode)
+        return
+    parent, name = destination
+    _atomic_write_at(parent, name, content, mode)
+
+
+def _atomic_write_at(
+    parent: int,
+    name: str,
+    content: bytes,
+    mode: int,
+) -> None:
+    _require_child_name(name)
+    temporary = f".{name}.hermes-bootstrap-{uuid.uuid4()}"
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | os.O_CLOEXEC
+            | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=parent,
+        )
+        remaining = memoryview(content)
+        while remaining:
+            written = os.write(descriptor, remaining)
+            if written <= 0:
+                raise OSError
+            remaining = remaining[written:]
+        os.fchmod(descriptor, mode)
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = None
+        os.replace(
+            temporary,
+            name,
+            src_dir_fd=parent,
+            dst_dir_fd=parent,
+        )
+        os.fsync(parent)
+        temporary = ""
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        if temporary:
+            try:
+                os.unlink(temporary, dir_fd=parent)
+            except FileNotFoundError:
+                pass
+
+
+def _load_yaml_mapping_at(
+    parent: int,
+    name: str,
+) -> tuple[os.stat_result, bytes, dict[object, object]]:
+    metadata, content = _read_regular_file_at(parent, name)
+    value = yaml.safe_load(content.decode("utf-8"))
+    if not isinstance(value, dict):
+        raise TypeError
+    return metadata, content, value
+
+
+def _read_regular_file_at(
+    parent: int,
+    name: str,
+) -> tuple[os.stat_result, bytes]:
+    _require_child_name(name)
+    before = os.stat(name, dir_fd=parent, follow_symlinks=False)
+    if (
+        stat.S_ISLNK(before.st_mode)
+        or not stat.S_ISREG(before.st_mode)
+        or before.st_nlink != 1
+    ):
+        raise ValueError
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            name,
+            os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=parent,
+        )
+        opened = os.fstat(descriptor)
+        after = os.stat(name, dir_fd=parent, follow_symlinks=False)
+        identities = {
+            (before.st_dev, before.st_ino),
+            (opened.st_dev, opened.st_ino),
+            (after.st_dev, after.st_ino),
+        }
+        if (
+            len(identities) != 1
+            or not stat.S_ISREG(opened.st_mode)
+            or opened.st_nlink != 1
+            or after.st_nlink != 1
+        ):
+            raise ValueError
+        chunks: list[bytes] = []
+        while chunk := os.read(descriptor, 65536):
+            chunks.append(chunk)
+        return opened, b"".join(chunks)
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _require_child_name(name: str) -> None:
+    if not name or name in {".", ".."} or "/" in name or "\\" in name:
+        raise ValueError
 
 
 def _load_yaml_mapping_with_content(

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/context_engine.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/context_engine.py
@@ -1,0 +1,171 @@
+"""Transactional Hermes context-engine configuration."""
+
+from __future__ import annotations
+
+import os
+import stat
+from collections.abc import Sequence
+from pathlib import Path
+
+import yaml
+
+from .distributions import _atomic_write
+from .errors import ApplyError, ValidationError
+from .transaction import Transaction
+
+CONTEXT_ENGINE_NAME = "lcm"
+CONTEXT_PLUGIN_NAME = "hermes-lcm"
+
+_APPLY_ERROR = "could not reconcile Hermes context engine configuration"
+_VALIDATION_ERROR = "installed Hermes context engine configuration is invalid"
+
+
+def install_context_engine_configurations(
+    targets: Sequence[tuple[str, Path]],
+    transaction: Transaction,
+) -> None:
+    """Enable the LCM engine and plugin in every managed Hermes config."""
+
+    try:
+        for _profile, target in targets:
+            _require_real_directory_chain(target)
+            _reconcile_config(target / "config.yaml", transaction)
+    except (
+        ApplyError,
+        OSError,
+        TypeError,
+        UnicodeError,
+        ValueError,
+        yaml.YAMLError,
+    ):
+        raise ApplyError(_APPLY_ERROR) from None
+
+
+def validate_context_engine_installation(
+    targets: Sequence[tuple[str, Path]],
+) -> None:
+    """Require LCM activation without inspecting memory-provider settings."""
+
+    try:
+        for _profile, target in targets:
+            _require_real_directory_chain(target)
+            metadata, config = _load_yaml_mapping(target / "config.yaml")
+            if stat.S_IMODE(metadata.st_mode) != 0o600:
+                raise ValueError
+
+            context = config.get("context")
+            if (
+                not isinstance(context, dict)
+                or context.get("engine") != CONTEXT_ENGINE_NAME
+            ):
+                raise ValueError
+
+            plugins = config.get("plugins")
+            if not isinstance(plugins, dict):
+                raise TypeError
+            enabled = plugins.get("enabled")
+            if not isinstance(enabled, list) or CONTEXT_PLUGIN_NAME not in enabled:
+                raise ValueError
+            disabled = plugins.get("disabled", [])
+            if not isinstance(disabled, list) or CONTEXT_PLUGIN_NAME in disabled:
+                raise ValueError
+    except (OSError, TypeError, UnicodeError, ValueError, yaml.YAMLError):
+        raise ValidationError(_VALIDATION_ERROR) from None
+
+
+def _reconcile_config(path: Path, transaction: Transaction) -> None:
+    metadata, original, config = _load_yaml_mapping_with_content(path)
+
+    context = config.get("context")
+    if context is None:
+        context = {}
+    if not isinstance(context, dict):
+        raise TypeError
+    merged_context = dict(context)
+    merged_context["engine"] = CONTEXT_ENGINE_NAME
+
+    plugins = config.get("plugins")
+    if plugins is None:
+        plugins = {}
+    if not isinstance(plugins, dict):
+        raise TypeError
+    merged_plugins = dict(plugins)
+
+    if "enabled" not in plugins:
+        enabled: list[object] = []
+    else:
+        enabled_value = plugins["enabled"]
+        if not isinstance(enabled_value, list) or any(
+            not isinstance(item, str) for item in enabled_value
+        ):
+            raise ValueError
+        enabled = list(enabled_value)
+    if CONTEXT_PLUGIN_NAME not in enabled:
+        enabled.append(CONTEXT_PLUGIN_NAME)
+    else:
+        enabled = [
+            item
+            for index, item in enumerate(enabled)
+            if item != CONTEXT_PLUGIN_NAME or CONTEXT_PLUGIN_NAME not in enabled[:index]
+        ]
+    merged_plugins["enabled"] = enabled
+
+    if "disabled" in plugins:
+        disabled_value = plugins["disabled"]
+        if not isinstance(disabled_value, list) or any(
+            not isinstance(item, str) for item in disabled_value
+        ):
+            raise ValueError
+        merged_plugins["disabled"] = [
+            item for item in disabled_value if item != CONTEXT_PLUGIN_NAME
+        ]
+
+    candidate = dict(config)
+    candidate["context"] = merged_context
+    candidate["plugins"] = merged_plugins
+    content = yaml.safe_dump(candidate, sort_keys=False).encode("utf-8")
+    if original == content and stat.S_IMODE(metadata.st_mode) == 0o600:
+        return
+
+    transaction.snapshot(path)
+    _atomic_write(path, content, 0o600)
+
+
+def _load_yaml_mapping_with_content(
+    path: Path,
+) -> tuple[os.stat_result, bytes, dict[object, object]]:
+    metadata = _require_regular_file(path)
+    content = path.read_bytes()
+    value = yaml.safe_load(content.decode("utf-8"))
+    if not isinstance(value, dict):
+        raise TypeError
+    return metadata, content, value
+
+
+def _load_yaml_mapping(path: Path) -> tuple[os.stat_result, dict[object, object]]:
+    metadata, _content, value = _load_yaml_mapping_with_content(path)
+    return metadata, value
+
+
+def _require_regular_file(path: Path) -> os.stat_result:
+    metadata = path.lstat()
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_nlink != 1
+    ):
+        raise ValueError
+    return metadata
+
+
+def _require_real_directory_chain(path: Path) -> None:
+    if not path.is_absolute():
+        raise ValueError
+    current = path
+    while True:
+        metadata = current.lstat()
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+            raise ValueError
+        if current.parent == current:
+            return
+        current = current.parent

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/distributions.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/distributions.py
@@ -836,6 +836,32 @@ def without_bootstrap_managed_config(
     """Compare distribution content without bootstrap-owned config additions."""
 
     result = _without_bootstrap_onepassword(config)
+    context = result.get("context")
+    if isinstance(context, dict):
+        retained_context = dict(context)
+        retained_context.pop("engine", None)
+        if retained_context:
+            result["context"] = retained_context
+        else:
+            result.pop("context", None)
+
+    plugins = result.get("plugins")
+    if isinstance(plugins, dict):
+        retained_plugins = dict(plugins)
+        for key in ("enabled", "disabled"):
+            values = retained_plugins.get(key)
+            if not isinstance(values, list):
+                continue
+            retained_values = [item for item in values if item != "hermes-lcm"]
+            if retained_values:
+                retained_plugins[key] = retained_values
+            else:
+                retained_plugins.pop(key, None)
+        if retained_plugins:
+            result["plugins"] = retained_plugins
+        else:
+            result.pop("plugins", None)
+
     mcp_servers = result.get("mcp_servers")
     if isinstance(mcp_servers, dict):
         gmail = mcp_servers.get("gmail")

--- a/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
+++ b/docker/hermes-agent/bootstrap/tests/integration/test_bootstrap_flow.py
@@ -146,6 +146,8 @@ def managed_source_config(
     assert isinstance(mcp_servers, dict)
     mcp_servers["gmail"] = GMAIL_CONFIGURATION
     config["memory"] = {"provider": "hindsight"}
+    config["context"] = {"engine": "lcm"}
+    config["plugins"] = {"enabled": ["hermes-lcm"]}
     managed = build_onepassword_config(manifest, profile)
     return (
         yaml.safe_dump(config, sort_keys=False)

--- a/docker/hermes-agent/bootstrap/tests/test_app.py
+++ b/docker/hermes-agent/bootstrap/tests/test_app.py
@@ -175,6 +175,13 @@ class AppTests(unittest.TestCase):
         )
         self.install_hindsight_configurations = hindsight_patcher.start()
         self.addCleanup(hindsight_patcher.stop)
+        context_engine_patcher = mock.patch.object(
+            app,
+            "install_context_engine_configurations",
+            create=True,
+        )
+        self.install_context_engine_configurations = context_engine_patcher.start()
+        self.addCleanup(context_engine_patcher.stop)
         revalidate_patcher = mock.patch.object(
             app,
             "revalidate_profile_snapshots",
@@ -242,6 +249,11 @@ class AppTests(unittest.TestCase):
         calendar_config = (
             "memory:\n"
             "  provider: hindsight\n"
+            "plugins:\n"
+            "  enabled:\n"
+            "    - hermes-lcm\n"
+            "context:\n"
+            "  engine: lcm\n"
             "mcp_servers:\n"
             "  calendar:\n"
             "    command: google-calendar-mcp\n"
@@ -738,6 +750,13 @@ class AppTests(unittest.TestCase):
                 + f":{transaction is tx}"
             )
         )
+        self.install_context_engine_configurations.side_effect = (
+            lambda targets, transaction: events.append(
+                "context-engine-config:"
+                + ",".join(profile for profile, _target in targets)
+                + f":{transaction is tx}"
+            )
+        )
 
         with (
             mock.patch.object(app, "load_manifest", return_value=configured),
@@ -803,6 +822,7 @@ class AppTests(unittest.TestCase):
                 "calendar-config:data,rick,hoffman,risarisa,nancy:True",
                 "gmail-config:data,rick,hoffman,risarisa,nancy:True",
                 "hindsight-config:default,rick,hoffman,risarisa,nancy:True",
+                "context-engine-config:default,rick,hoffman,risarisa,nancy:True",
                 "onepassword-config",
                 "env:data",
                 "env:rick",
@@ -2395,6 +2415,15 @@ class AppTests(unittest.TestCase):
             ) as validate_hindsight,
             mock.patch.object(
                 app,
+                "validate_context_engine_installation",
+                create=True,
+                side_effect=lambda targets: events.append(
+                    "context-engine:"
+                    + ",".join(profile for profile, _target in targets)
+                ),
+            ) as validate_context_engine,
+            mock.patch.object(
+                app,
                 "_validate_env_file",
                 side_effect=lambda path, _required: events.append(f"env:{path.parent.name}"),
             ),
@@ -2406,7 +2435,18 @@ class AppTests(unittest.TestCase):
         validate_hindsight.assert_called_once_with(
             app._environment_targets(self.manifest)
         )
-        self.assertEqual(events, ["hindsight:default,rick", "env:data", "env:rick"])
+        validate_context_engine.assert_called_once_with(
+            app._environment_targets(self.manifest)
+        )
+        self.assertEqual(
+            events,
+            [
+                "hindsight:default,rick",
+                "context-engine:default,rick",
+                "env:data",
+                "env:rick",
+            ],
+        )
 
     def test_installed_layout_validation_preserves_unmanaged_profile_entries(self) -> None:
         from hermes_bootstrap import app

--- a/docker/hermes-agent/bootstrap/tests/test_context_engine.py
+++ b/docker/hermes-agent/bootstrap/tests/test_context_engine.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import stat
+import sys
+import tempfile
+import unittest
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import yaml
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BOOTSTRAP_ROOT))
+
+from hermes_bootstrap.errors import ApplyError, ValidationError
+from hermes_bootstrap.transaction import Transaction
+
+
+class RecordingTransaction:
+    def __init__(self) -> None:
+        self.snapshots: list[Path] = []
+
+    def snapshot(self, path: Path) -> None:
+        self.snapshots.append(path)
+
+    @contextmanager
+    def bind_reserved_directory(self, path: Path) -> Iterator[int | None]:
+        del path
+        yield None
+
+
+class ContextEngineConfigurationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name).resolve() / "data"
+        self.root.mkdir(mode=0o700)
+
+    def write_target(self, profile: str, content: str | None = None) -> Path:
+        target = self.root if profile == "default" else self.root / "profiles" / profile
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "config.yaml").write_text(
+            content
+            or (
+                "model:\n  name: test\n"
+                "memory:\n  provider: hindsight\n  custom_policy: keep\n"
+                "plugins:\n"
+                "  enabled:\n    - existing-plugin\n    - hermes-lcm\n    - hermes-lcm\n"
+                "  disabled:\n    - hermes-lcm\n    - unrelated-plugin\n"
+                "unrelated:\n  nested: true\n"
+            ),
+            encoding="utf-8",
+        )
+        return target
+
+    def test_reconciles_root_and_all_managed_profiles_without_changing_memory(
+        self,
+    ) -> None:
+        from hermes_bootstrap.context_engine import (
+            CONTEXT_ENGINE_NAME,
+            CONTEXT_PLUGIN_NAME,
+            install_context_engine_configurations,
+        )
+
+        profiles = (
+            "default",
+            "rick",
+            "hoffman",
+            "risarisa",
+            "nancy",
+            "kuroda",
+            "shiraishi",
+        )
+        targets = tuple((profile, self.write_target(profile)) for profile in profiles)
+        transaction = RecordingTransaction()
+
+        install_context_engine_configurations(targets, transaction)
+
+        for profile, target in targets:
+            with self.subTest(profile=profile):
+                config = yaml.safe_load(
+                    (target / "config.yaml").read_text(encoding="utf-8")
+                )
+                self.assertEqual(config["context"], {"engine": CONTEXT_ENGINE_NAME})
+                self.assertEqual(
+                    config["memory"], {"provider": "hindsight", "custom_policy": "keep"}
+                )
+                self.assertEqual(
+                    config["plugins"]["enabled"],
+                    ["existing-plugin", CONTEXT_PLUGIN_NAME],
+                )
+                self.assertEqual(config["plugins"]["disabled"], ["unrelated-plugin"])
+                self.assertEqual(config["unrelated"], {"nested": True})
+                self.assertEqual(
+                    stat.S_IMODE((target / "config.yaml").stat().st_mode), 0o600
+                )
+
+        self.assertEqual(len(transaction.snapshots), len(targets))
+
+    def test_reconciliation_is_idempotent(self) -> None:
+        from hermes_bootstrap.context_engine import (
+            install_context_engine_configurations,
+        )
+
+        target = self.write_target("default")
+        first = RecordingTransaction()
+        install_context_engine_configurations((("default", target),), first)
+        expected = (target / "config.yaml").read_bytes()
+
+        second = RecordingTransaction()
+        install_context_engine_configurations((("default", target),), second)
+
+        self.assertEqual((target / "config.yaml").read_bytes(), expected)
+        self.assertEqual(second.snapshots, [])
+
+    def test_rejects_invalid_plugin_configuration_without_touching_config(self) -> None:
+        from hermes_bootstrap.context_engine import (
+            install_context_engine_configurations,
+        )
+
+        target = self.write_target("default", "plugins:\n  enabled: invalid\n")
+        original = (target / "config.yaml").read_bytes()
+        transaction = RecordingTransaction()
+
+        with self.assertRaisesRegex(
+            ApplyError, "could not reconcile Hermes context engine configuration"
+        ):
+            install_context_engine_configurations((("default", target),), transaction)
+
+        self.assertEqual((target / "config.yaml").read_bytes(), original)
+        self.assertEqual(transaction.snapshots, [])
+
+    def test_validation_requires_engine_activation_and_plugin_enablement(self) -> None:
+        from hermes_bootstrap.context_engine import (
+            install_context_engine_configurations,
+            validate_context_engine_installation,
+        )
+
+        target = self.write_target("default")
+        transaction = Transaction.begin(self.root)
+        install_context_engine_configurations((("default", target),), transaction)
+        transaction.commit()
+        validate_context_engine_installation((("default", target),))
+
+        config_path = target / "config.yaml"
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        config["context"]["engine"] = "compressor"
+        config_path.write_text(
+            yaml.safe_dump(config, sort_keys=False), encoding="utf-8"
+        )
+        config_path.chmod(0o600)
+
+        with self.assertRaisesRegex(
+            ValidationError, "installed Hermes context engine configuration is invalid"
+        ):
+            validate_context_engine_installation((("default", target),))
+
+    def test_distribution_comparison_ignores_only_bootstrap_owned_lcm_entries(self) -> None:
+        from hermes_bootstrap.distributions import without_bootstrap_managed_config
+
+        config = {
+            "context": {"engine": "lcm", "custom": "keep"},
+            "plugins": {
+                "enabled": ["hermes-lcm", "other-plugin"],
+                "disabled": ["hermes-lcm", "disabled-plugin"],
+                "custom": True,
+            },
+            "unrelated": "keep",
+        }
+
+        self.assertEqual(
+            without_bootstrap_managed_config(config),
+            {
+                "context": {"custom": "keep"},
+                "plugins": {
+                    "enabled": ["other-plugin"],
+                    "disabled": ["disabled-plugin"],
+                    "custom": True,
+                },
+                "unrelated": "keep",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker/hermes-agent/bootstrap/tests/test_context_engine.py
+++ b/docker/hermes-agent/bootstrap/tests/test_context_engine.py
@@ -7,6 +7,7 @@ import unittest
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from unittest import mock
 
 import yaml
 
@@ -114,6 +115,71 @@ class ContextEngineConfigurationTests(unittest.TestCase):
         self.assertEqual((target / "config.yaml").read_bytes(), expected)
         self.assertEqual(second.snapshots, [])
 
+    def test_reserved_profile_swap_cannot_redirect_the_atomic_write(self) -> None:
+        import hermes_bootstrap.context_engine as module
+
+        profiles = self.root / "profiles"
+        profiles.mkdir()
+        target = profiles / "nancy"
+        tx = Transaction.begin(self.root)
+        self.assertTrue(tx.reserve_directory(target))
+        config_path = target / "config.yaml"
+        config_path.write_bytes(
+            b"model:\n  name: reserved\nmemory:\n  provider: hindsight\n"
+        )
+        config_path.chmod(0o600)
+        replacement = profiles / ".external-nancy"
+        replacement.mkdir(mode=0o700)
+        external_config = (
+            b"model:\n"
+            b"  name: external\n"
+            b"memory:\n"
+            b"  provider: external\n"
+            b"  keep: untouched\n"
+        )
+        (replacement / "config.yaml").write_bytes(external_config)
+        (replacement / "config.yaml").chmod(0o600)
+        retired = profiles / ".retired-reservation"
+        original_atomic_write = module._atomic_write
+        swapped = False
+
+        def swap_profile_before_atomic_write(
+            path: Path | tuple[int, str],
+            content: bytes,
+            mode: int,
+        ) -> None:
+            nonlocal swapped
+            if not swapped and isinstance(path, tuple):
+                target.rename(retired)
+                replacement.rename(target)
+                swapped = True
+            original_atomic_write(path, content, mode)
+
+        try:
+            with (
+                mock.patch.object(
+                    module,
+                    "_atomic_write",
+                    side_effect=swap_profile_before_atomic_write,
+                ),
+                self.assertRaisesRegex(
+                    ApplyError,
+                    "could not reconcile Hermes context engine configuration",
+                ),
+            ):
+                module.install_context_engine_configurations(
+                    (("nancy", target),),
+                    tx,
+                )
+        finally:
+            tx.rollback()
+
+        external_target = target if swapped else replacement
+        self.assertEqual(
+            (external_target / "config.yaml").read_bytes(),
+            external_config,
+        )
+
     def test_rejects_invalid_plugin_configuration_without_touching_config(self) -> None:
         from hermes_bootstrap.context_engine import (
             install_context_engine_configurations,
@@ -156,7 +222,9 @@ class ContextEngineConfigurationTests(unittest.TestCase):
         ):
             validate_context_engine_installation((("default", target),))
 
-    def test_distribution_comparison_ignores_only_bootstrap_owned_lcm_entries(self) -> None:
+    def test_distribution_comparison_ignores_only_bootstrap_owned_lcm_entries(
+        self,
+    ) -> None:
         from hermes_bootstrap.distributions import without_bootstrap_managed_config
 
         config = {

--- a/docker/hermes-agent/bootstrap/tests/test_dockerfile_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/test_dockerfile_contract.py
@@ -1,14 +1,15 @@
-"""Dockerfile contracts for the Hermes Hindsight client."""
+"""Dockerfile contracts for the Hermes runtime integrations."""
 
 from __future__ import annotations
 
 import unittest
 from pathlib import Path
 
-
 REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
 DOCKERFILE = REPOSITORY_ROOT / "docker/hermes-agent/Dockerfile"
 HINDSIGHT_CLIENT_VERSION = "0.6.1"
+HERMES_LCM_VERSION = "v0.20.0"
+HERMES_LCM_COMMIT = "49e99a272d2d461e5c90732e7ef2bc20e96f0826"
 
 
 class DockerfileContractTests(unittest.TestCase):
@@ -28,11 +29,33 @@ class DockerfileContractTests(unittest.TestCase):
             f"ARG HINDSIGHT_CLIENT_VERSION={HINDSIGHT_CLIENT_VERSION}", dockerfile
         )
         self.assertIn(
-            'uv pip install --python /opt/hermes/.venv/bin/python \\\n'
+            "uv pip install --python /opt/hermes/.venv/bin/python \\\n"
             '      "hindsight-client==${HINDSIGHT_CLIENT_VERSION}" \\\n'
-            '  && /opt/hermes/.venv/bin/python -c \\\n'
+            "  && /opt/hermes/.venv/bin/python -c \\\n"
             '      "from importlib.metadata import version; assert '
             "version('hindsight-client') == '${HINDSIGHT_CLIENT_VERSION}'\"",
+            dockerfile,
+        )
+
+    def test_runtime_bakes_and_verifies_the_pinned_lcm_plugin(self) -> None:
+        dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+        self.assertIn(f"ARG HERMES_LCM_VERSION={HERMES_LCM_VERSION}", dockerfile)
+        self.assertIn(f"ARG HERMES_LCM_COMMIT={HERMES_LCM_COMMIT}", dockerfile)
+        self.assertIn(
+            "https://github.com/stephenschoettler/hermes-lcm",
+            dockerfile,
+        )
+        self.assertIn(
+            'git -C /opt/hermes/plugins/hermes-lcm rev-parse HEAD)" = "${HERMES_LCM_COMMIT}"',
+            dockerfile,
+        )
+        self.assertIn(
+            "/opt/hermes/plugins/hermes-lcm/__init__.py",
+            dockerfile,
+        )
+        self.assertIn(
+            'engine is not None and engine.name == "lcm"',
             dockerfile,
         )
 


### PR DESCRIPTION
## Summary
- pin and bake hermes-lcm v0.20.0 into the Hermes runtime image
- reconcile context.engine=lcm and plugins.enabled=hermes-lcm for root plus all managed profiles
- keep Hindsight memory provider settings unchanged
- add focused unit, integration, Docker build, and runtime discovery coverage

## Scope
This PR is limited to the context engine. Hindsight/memory-provider changes are intentionally excluded because they are tracked separately.

Closes #539