### PR TITLE
Harden Hermes profile snapshot publication

### DIFF
--- a/ci/path-routing.json
+++ b/ci/path-routing.json
@@ -52,6 +52,14 @@
       ]
     },
     {
+      "patterns": [
+        "scripts/python/update_darwin_packages.py",
+        "tests/python/test_update_darwin_packages.py",
+        ".github/workflows/update-darwin-packages.yml"
+      ],
+      "outputs": ["darwin", "contract", "nix", "package_catalog"]
+    },
+    {
       "patterns": ["windows/winget/packages.json", "windows/npm/packages.json"],
       "outputs": ["windows", "contract", "package_catalog"]
     },

--- a/ci/path-routing.json
+++ b/ci/path-routing.json
@@ -52,14 +52,6 @@
       ]
     },
     {
-      "patterns": [
-        "scripts/python/update_darwin_packages.py",
-        "tests/python/test_update_darwin_packages.py",
-        ".github/workflows/update-darwin-packages.yml"
-      ],
-      "outputs": ["darwin", "contract", "nix", "package_catalog"]
-    },
-    {
       "patterns": ["windows/winget/packages.json", "windows/npm/packages.json"],
       "outputs": ["windows", "contract", "package_catalog"]
     },
@@ -97,7 +89,7 @@
       "outputs": ["darwin", "contract", "nix"]
     },
     {
-      "patterns": ["nix/home/README.md"],
+      "patterns": ["nix/README.md", "nix/home/README.md"],
       "outputs": ["linux", "darwin", "wsl", "contract", "nix"]
     },
     {

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_sync.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_sync.py
@@ -189,6 +189,10 @@ def synchronize_profiles(
     report: ProfileSyncReport
     try:
         _validate_manifest_profiles(manifest)
+        # Keep the read-only publication snapshot off the bind-mounted Hermes
+        # home. Docker Desktop can remap ownership on that mount while a
+        # profile gateway is active, which makes the descriptor-backed
+        # snapshot fail its ownership attestation.
         scratch = create_private_directory(
             Path(tempfile.gettempdir()),
             prefix=".hermes-profile-snapshots-",

--- a/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_sync.py
+++ b/docker/hermes-agent/bootstrap/hermes_bootstrap/profile_sync.py
@@ -194,7 +194,7 @@ def synchronize_profiles(
         # profile gateway is active, which makes the descriptor-backed
         # snapshot fail its ownership attestation.
         scratch = create_private_directory(
-            Path(tempfile.gettempdir()),
+            _profile_snapshot_scratch_parent(manifest.data_root),
             prefix=".hermes-profile-snapshots-",
         )
         prepared = prepare_profile_snapshots(
@@ -245,6 +245,21 @@ def _validate_manifest_profiles(manifest: BootstrapManifest) -> None:
         )
     ):
         raise ValueError("invalid profile manifest")
+
+
+def _profile_snapshot_scratch_parent(data_root: Path) -> Path:
+    """Return a real temporary parent that is outside the Hermes data root."""
+
+    try:
+        scratch_parent = Path(tempfile.gettempdir()).resolve(strict=True)
+        resolved_data_root = data_root.resolve(strict=True)
+    except OSError as error:
+        raise ValueError("invalid profile snapshot scratch parent") from error
+    if scratch_parent == resolved_data_root or scratch_parent.is_relative_to(
+        resolved_data_root
+    ):
+        raise ValueError("profile snapshot scratch parent is inside Hermes data root")
+    return scratch_parent
 
 
 def _profile_preflight_failure(

--- a/docker/hermes-agent/bootstrap/tests/test_profile_sync.py
+++ b/docker/hermes-agent/bootstrap/tests/test_profile_sync.py
@@ -1768,7 +1768,7 @@ class ProfileSyncTests(unittest.TestCase):
             self.assertIs(_manifest, manifest)
             self.assertFalse(allow_missing)
             self.assertEqual(stat.S_IMODE(scratch.stat().st_mode), 0o700)
-            self.assertEqual(scratch.parent, Path(tempfile.gettempdir()))
+            self.assertEqual(scratch.parent, Path(tempfile.gettempdir()).resolve())
             observed_scratch.append(scratch)
             return PreparedProfiles((snapshot_a, snapshot_b), ())
 
@@ -1785,7 +1785,10 @@ class ProfileSyncTests(unittest.TestCase):
         self.assertTrue(observed_scratch)
         self.assertTrue(observed_private_parents)
         self.assertTrue(
-            all(parent == Path(tempfile.gettempdir()) for parent in observed_private_parents)
+            all(
+                parent == Path(tempfile.gettempdir()).resolve()
+                for parent in observed_private_parents
+            )
         )
         self.assertFalse(observed_scratch[0].exists())
 

--- a/docker/hermes-agent/bootstrap/tests/test_profile_sync.py
+++ b/docker/hermes-agent/bootstrap/tests/test_profile_sync.py
@@ -1809,6 +1809,27 @@ class ProfileSyncTests(unittest.TestCase):
             cleanup = synchronize_profiles(manifest, self.auth, dry_run=False)
         self.assertTrue(all(item.category == "cleanup_failed" for item in cleanup.profiles))
 
+    def test_scratch_inside_data_root_is_rejected_before_creation(self) -> None:
+        profile = self.profile("profile-a", self.root / "profile-a.git")
+        manifest = self.manifest(profile)
+
+        with (
+            mock.patch.object(
+                profile_sync.tempfile,
+                "gettempdir",
+                return_value=str(self.data_root),
+            ),
+            mock.patch.object(profile_sync, "create_private_directory") as create_private,
+            mock.patch.object(profile_sync, "prepare_profile_snapshots") as prepare,
+        ):
+            report = synchronize_profiles(manifest, self.auth, dry_run=False)
+
+        self.assertEqual(report.exit_code, 4)
+        self.assertEqual(report.profiles[0].category, "aggregate_preflight_blocked")
+        create_private.assert_not_called()
+        prepare.assert_not_called()
+        self.assertEqual(list(self.data_root.glob(".hermes-profile-snapshots-*")), [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docker/hermes-agent/bootstrap/tests/test_profile_sync.py
+++ b/docker/hermes-agent/bootstrap/tests/test_profile_sync.py
@@ -1756,18 +1756,37 @@ class ProfileSyncTests(unittest.TestCase):
         self.seed_remote(remote_b, snapshot_b)
         manifest = self.manifest(profile_a, profile_b)
         observed_scratch: list[Path] = []
+        observed_private_parents: list[Path] = []
+
+        original_create_private_directory = profile_sync.create_private_directory
+
+        def create_private_directory(parent, *, prefix):
+            observed_private_parents.append(parent)
+            return original_create_private_directory(parent, prefix=prefix)
 
         def prepared(_manifest, scratch, *, allow_missing):
             self.assertIs(_manifest, manifest)
             self.assertFalse(allow_missing)
             self.assertEqual(stat.S_IMODE(scratch.stat().st_mode), 0o700)
+            self.assertEqual(scratch.parent, Path(tempfile.gettempdir()))
             observed_scratch.append(scratch)
             return PreparedProfiles((snapshot_a, snapshot_b), ())
 
-        with mock.patch.object(profile_sync, "prepare_profile_snapshots", side_effect=prepared):
+        with (
+            mock.patch.object(profile_sync, "prepare_profile_snapshots", side_effect=prepared),
+            mock.patch.object(
+                profile_sync,
+                "create_private_directory",
+                side_effect=create_private_directory,
+            ),
+        ):
             report = synchronize_profiles(manifest, self.auth, dry_run=False)
         self.assertEqual([item.status for item in report.profiles], ["unchanged", "unchanged"])
         self.assertTrue(observed_scratch)
+        self.assertTrue(observed_private_parents)
+        self.assertTrue(
+            all(parent == Path(tempfile.gettempdir()) for parent in observed_private_parents)
+        )
         self.assertFalse(observed_scratch[0].exists())
 
         with mock.patch.object(

--- a/flake.lock
+++ b/flake.lock
@@ -321,11 +321,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787498568,
-        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "lastModified": 1787900134,
+        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
         "type": "github"
       },
       "original": {
@@ -620,11 +620,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787774558,
-        "narHash": "sha256-qubWyOxzzODezZjNtQT71NmrFP7xoEGhMjbw/2QZnQk=",
+        "lastModified": 1788085765,
+        "narHash": "sha256-twHAd8m9tSoskIl7BUxYuY1p3+bqO38haKQUflsEbhg=",
         "owner": "raine",
         "repo": "workmux",
-        "rev": "0025eec2da459fe238dbf96d462ff2ecda610ed7",
+        "rev": "a72be9426136aa7af36c2bd7b3d92155b7be114e",
         "type": "github"
       },
       "original": {

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,25 @@
+# Nix レイアウト
+
+## 所有境界
+
+| パス                    | 所有範囲                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------ |
+| `nix/hosts/`            | system/host サービス、OS ユーザー、hardware、host 固有の NixOS/nix-darwin 設定 |
+| `nix/packages/sets.nix` | クロスプラットフォームのパッケージ集合（単一情報源）                           |
+| `nix/home/`             | Home Manager のユーザー環境、ユーザー systemd サービス、OS 固有設定            |
+| `chezmoi/`              | Nix で表現しない dotfile、テンプレート、アプリ設定                             |
+
+- host / hardware 設定を `nix/home/` に置かない。
+- Home Manager と chezmoi で同じファイルを所有しない。
+
+秘密情報はリポジトリや Nix モジュールに書かない。既存の 1Password / chezmoi テンプレートまたは
+実行時環境変数を使い、秘密の値を Nix store に入れない。
+
+## 設定の配置
+
+1. OS 固有の Home Manager 設定は対象 OS の `nix/home/darwin.nix`、`linux.nix`、`wsl.nix` に追加する。
+2. system、host サービス、ユーザー、hardware は `nix/hosts/` に追加する。
+3. Home Manager の OS ファイルは `imports = [ ./common.nix ];` を維持し、`common.nix` を OS 非依存に保つ。
+4. パッケージ追加前に `nix/packages/sets.nix` の所有範囲と各 OS への影響を確認する。
+5. dotfile と秘密情報は `chezmoi/` と既存の secret 経路を使い、所有を重複させない。
+6. 対象 OS の評価・テストと `tests/bash/home_layout.bats` を実行する。

--- a/nix/README.md
+++ b/nix/README.md
@@ -19,7 +19,7 @@
 
 1. OS 固有の Home Manager 設定は対象 OS の `nix/home/darwin.nix`、`linux.nix`、`wsl.nix` に追加する。
 2. system、host サービス、ユーザー、hardware は `nix/hosts/` に追加する。
-3. Home Manager の OS ファイルは `imports = [ ./common.nix ];` を維持し、`common.nix` を OS 非依存に保つ。
+3. Home Manager の OS ファイルは `imports = [ ./common.nix ];` を維持する。`common.nix` から OS 固有ファイルを import せず、共通設定内の platform-scoped な分岐は最小限に保つ。
 4. パッケージ追加前に `nix/packages/sets.nix` の所有範囲と各 OS への影響を確認する。
 5. dotfile と秘密情報は `chezmoi/` と既存の secret 経路を使い、所有を重複させない。
 6. 対象 OS の評価・テストと `tests/bash/home_layout.bats` を実行する。

--- a/nix/home/README.md
+++ b/nix/home/README.md
@@ -1,44 +1,32 @@
 # Home Manager レイアウト
 
-`nix/home/` はユーザー単位の Home Manager 設定を管理します。OS 固有の入口は
-`darwin.nix`、`linux.nix`、`wsl.nix`、共通設定は `common.nix` です。
+`nix/home/` はユーザー単位の Home Manager 設定です。
 
-## import の方向
+| 入口         | 内容           |
+| ------------ | -------------- |
+| `darwin.nix` | macOS 固有設定 |
+| `linux.nix`  | Linux 固有設定 |
+| `wsl.nix`    | WSL 固有設定   |
+| `common.nix` | 共通設定       |
 
-依存方向は `caller -> <os>.nix -> common.nix` です。flake または NixOS/nix-darwin の
-caller は対象 OS のファイルだけを読み込み、各 OS ファイルが `./common.nix` を import します。
-`common.nix` から OS 固有ファイルを import してはいけません。
+## import 方向
 
-このため `default.nix` と `users.nix` は置きません。どちらも入口を曖昧にし、ユーザー別の
-中継層を作って OS 固有の依存方向を逆転させるためです。ユーザー名とホームディレクトリは
-`DOTFILES_USER` と `DOTFILES_HOME` から取り、NixOS の wiring では `DOTFILES_USER` 未指定時に
-`nixos` を fallback とします。WSL では postinstall が同じユーザーを NixOS host と Home
-Manager の両方へ渡すため、host 側の `wsl.defaultUser` と Home Manager の対象も一致します。
-日常の `nrs`、`nrt`、`nrb` も `scripts/sh/nixos-rebuild-with-user.sh` を経由し、`sudo` 後の
-flake 評価へ同じ識別情報を渡します。
+```text
+caller -> <os>.nix -> common.nix
+```
 
-## 所有境界
+- caller は対象 OS のファイルだけを import する。
+- 各 OS ファイルは `./common.nix` を import する。
+- `common.nix` から OS 固有ファイルを import しない。
+- `default.nix` と `users.nix` は作らない。入口と OS 依存方向を曖昧にするため。
 
-- `nix/hosts/`: system/host サービス、OS ユーザー、hardware 設定、host 固有の NixOS/nix-darwin
-  設定を所有します。host/hardware 設定を `nix/home/` に置いてはいけません。
-- `nix/packages/sets.nix`: クロスプラットフォームのパッケージ集合の単一情報源。Home Manager の
-  `common.nix` はこの集合を消費します。
-- `nix/home/`: Home Manager が所有するユーザー環境、ユーザー systemd サービス、OS 固有の
-  Home Manager 設定。
-- `chezmoi/`: Nix で表現しない dotfile、テンプレート、アプリケーション設定。Home Manager と
-  chezmoi の両方で同じファイルを所有しないでください。
+ユーザー名とホームディレクトリは `DOTFILES_USER` / `DOTFILES_HOME` から取得する。
+NixOS は `DOTFILES_USER` 未指定時に `nixos` を使う。WSL postinstall は同じユーザーを
+NixOS host と Home Manager に渡し、`wsl.defaultUser` と Home Manager の対象を一致させる。
+`nrs` / `nrt` / `nrb` は `scripts/sh/nixos-rebuild-with-user.sh` 経由で実行し、同じ識別情報を
+flake 評価へ渡す。
 
-秘密情報はリポジトリやこのモジュールに直接書きません。既存の 1Password/chezmoi テンプレートや
-実行時の環境変数を使い、秘密の値を Nix store に入れないでください。
+## Home Manager 固有のチェック
 
-## OS 固有設定を追加するチェックリスト
-
-1. 対象 OS の `darwin.nix`、`linux.nix`、または `wsl.nix` に追加し、`common.nix` に OS 条件を
-   増やさずに済むか確認する。
-2. system/host サービス、ユーザー、hardware、host 固有設定なら `nix/hosts/` に追加し、
-   `nix/home/` には置かない。
-3. OS ファイルが `imports = [ ./common.nix ];` を維持し、`common.nix` が OS 固有ファイルを
-   import しないことを確認する。
-4. パッケージ追加なら先に `nix/packages/sets.nix` の所有範囲と各 OS への影響を確認する。
-5. dotfile または秘密の扱いなら `chezmoi/` と既存の secret 経路に置き、所有の重複を避ける。
-6. 対象 OS の評価と `nix flake check --no-build` を実行する。
+- OS 固有設定は対象 OS の Home Manager ファイルに追加し、`common.nix` に OS 条件を増やさない。
+- 対象 OS の評価・テストと `tests/bash/home_layout.bats` を実行する。

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -101,6 +101,7 @@ in
       shellAliases = {
         find = "fd";
         grep = "rg";
+        lg = "lazygit";
         l = "eza -lhaT --level=2 --icons=auto --hyperlink -F --group-directories-first --color=auto";
         la = "eza -lhaT --level=2 --icons=auto --hyperlink -F --group-directories-first --color=auto";
         ll = "eza -lhaT --level=2 --icons=auto --hyperlink -F --group-directories-first --color=auto";


### PR DESCRIPTION
## Summary
- keep profile publication snapshots in a private temporary directory
- add regression coverage for the snapshot parent boundary
- document the Nix/Home Manager layout and update routing/flake metadata

## Verification
- task commit (pre-commit, format, template lint, Hermes bootstrap container tests)
- nix flake check --no-build
- task hermes:bootstrap:config
- task test:bash (macOS NixOS fixture tests are environment-dependent; 5 failures occur when the fixture resolves the host Docker CLI)

Generated from the pending local changes preserved during the Hermes follow-up.