### PR TITLE
feat: connect Hermes Desktop to Docker gateway

### DIFF
--- a/docs/hermes-agent/desktop.md
+++ b/docs/hermes-agent/desktop.md
@@ -47,9 +47,10 @@ curl -fsS http://127.0.0.1:8642/health
 
 `9119` は Desktop の Remote Gateway/Dashboard 接続先、`8642` は gateway 内部 API
 の health 確認用です。`hermes-desktop-docker` は Desktop の app-owned
-`connections.json` に保存された暗号化 token を読み出したり表示したりせず、
-gateway URL と primary remote 接続の存在だけを検証します。token は Desktop/OS
-Keychain の管理境界に残り、Git、Nix store、通常ログ、プロセス引数へコピーされません。
+`connections.json` に保存された remote 接続を検証します。OAuth 接続の token は
+Desktop の native token store、token 接続の envelope は Desktop/OS Keychain の
+管理境界に残り、launcher はいずれも読み出しません。秘密情報は Git、Nix store、
+通常ログ、プロセス引数へコピーされません。
 接続が未設定、gateway が停止中の場合は、Desktop を起動せず終了します。
 
 公式の Desktop 操作と remote backend の設定は、[Hermes Desktop

--- a/docs/hermes-agent/desktop.md
+++ b/docs/hermes-agent/desktop.md
@@ -24,8 +24,11 @@ Compose は Dashboard をホストの次の loopback ポートへ公開します
 http://127.0.0.1:9119
 ```
 
-Desktop の remote backend 設定でこの URL を指定し、Dashboard の認証を通過して
-ください。別のマシンから接続する場合は loopback 公開のままでは到達できないため、
+Desktop の Remote Gateway には、この URL を指定します。dotfiles の `WithHermes`
+プロファイルを適用済みなら、保存済みの Desktop remote 接続と gateway health を
+検証する `hermes-desktop-docker` を使って起動できます。初回だけ Desktop の
+Settings > Gateway でこの URL を登録し、システムブラウザで認証してください。
+Docker gateway は先に `task hermes:up` で起動してください。別のマシンから接続する場合は loopback 公開のままでは到達できないため、
 認証、TLS、ファイアウォールを含む別の公開設計が必要です。
 
 ## 状態と秘密情報
@@ -37,10 +40,17 @@ store に runtime state を生成したりしないでください。
 ## 手動確認
 
 ```bash
-hermes-desktop
+task hermes:desktop
 docker compose -f docker/hermes-service/compose.yml ps
 curl -fsS http://127.0.0.1:8642/health
 ```
+
+`9119` は Desktop の Remote Gateway/Dashboard 接続先、`8642` は gateway 内部 API
+の health 確認用です。`hermes-desktop-docker` は Desktop の app-owned
+`connections.json` に保存された暗号化 token を読み出したり表示したりせず、
+gateway URL と primary remote 接続の存在だけを検証します。token は Desktop/OS
+Keychain の管理境界に残り、Git、Nix store、通常ログ、プロセス引数へコピーされません。
+接続が未設定、gateway が停止中の場合は、Desktop を起動せず終了します。
 
 公式の Desktop 操作と remote backend の設定は、[Hermes Desktop
 documentation](https://hermes-agent.nousresearch.com/docs/user-guide/desktop) と

--- a/docs/superpowers/plans/2026-09-02-hermes-desktop-docker-gateway-iac.md
+++ b/docs/superpowers/plans/2026-09-02-hermes-desktop-docker-gateway-iac.md
@@ -4,34 +4,34 @@
 
 ## 1. 既存状態と設計の固定
 
-- [ ] Issue #545、`docs/hermes-agent/desktop.md`、Docker Compose のポート、Hermes runtime env の責務を照合する。
-- [ ] 設計文書に、9119 を Remote Gateway、8642 を health 用 API とする区別、secret 境界、app-owned state 非管理を記録する。
-- [ ] ベースラインの Bats/Python テストを実行し、変更前の結果を保存する。
+- [x] Issue #545、`docs/hermes-agent/desktop.md`、Docker Compose のポート、Hermes runtime env の責務を照合する。
+- [x] 設計文書に、9119 を Remote Gateway、8642 を health 用 API とする区別、secret 境界、app-owned state 非管理を記録する。
+- [x] ベースラインの Bats/Python テストを実行し、変更前の結果を保存する。
 
 ## 2. ランチャーの失敗テストを追加
 
-- [ ] `tests/bash/hermes_desktop.bats` を追加し、fixture の HOME/HERMES_DATA_DIR と fake `hermes-desktop`/`curl` を用意する。
-- [ ] 正常系で `HERMES_DESKTOP_REMOTE_URL` が `http://127.0.0.1:9119`、token が fake Desktop の環境変数へ渡ることを検証する。
-- [ ] token が引数・出力へ出ず、欠損、重複、形式不正、symlink、0600 以外の env を拒否するテストを書く。
-- [ ] gateway 不到達時に Desktop を実行せず、`task hermes:up` を案内するテストを書く。
-- [ ] 先にテストを実行して失敗することを確認する。
+- [x] `tests/bash/hermes_desktop.bats` を追加し、fixture の HOME/HERMES_DATA_DIR と fake `hermes-desktop`/`curl` を用意する。
+- [x] 正常系で保存済み primary remote 接続の URL/token envelope を検証し、token を fake Desktop の引数・出力へ渡さないことを確認する。
+- [x] remote registry の欠損/不正、別 URL、remote 以外の primary 接続を拒否するテストを書く。
+- [x] gateway 不到達時に Desktop を実行せず、`task hermes:up` を案内するテストを書く。
+- [x] 先にテストを実行して失敗することを確認する。
 
 ## 3. Nix catalog と launcher を実装
 
-- [ ] `scripts/sh/hermes-desktop-docker.sh` に strict mode、env parser、secret 検証、health check、`exec` を実装する。
-- [ ] `nix/packages/sets.nix` に Darwin/WithHermes 専用の `hermes-desktop-docker` package を追加し、非 Darwin は reviewed unsupported とする。
-- [ ] runtime dependency は Nix wrapper の `curl`/`gawk` へ閉じ込め、token を derivation 内容へ埋め込まない。
-- [ ] テストを再実行して正常系・拒否系を green にする。
+- [x] `scripts/sh/hermes-desktop-docker.sh` に strict mode、registry parser、接続設定検証、health check、`exec` を実装する。
+- [x] `nix/packages/sets.nix` に Darwin/WithHermes 専用の `hermes-desktop-docker` package を追加し、非 Darwin は reviewed unsupported とする。
+- [x] runtime dependency は Nix wrapper の `curl`/`jq` へ閉じ込め、token を derivation 内容へ埋め込まない。
+- [x] テストを再実行して正常系・拒否系を green にする。
 
 ## 4. Taskfile とドキュメントを更新
 
-- [ ] `taskfiles/hermes/taskfile.yml` に Darwin 限定の `hermes:desktop` 起動タスクを追加し、wrapper を canonical entrypoint とする。
-- [ ] `docs/hermes-agent/desktop.md` に `hermes-desktop-docker`、`task hermes:up`、secret 境界、9119/8642 の診断方法を記載する。
-- [ ] Taskfile/catalog 契約テストを追加・更新する。
+- [x] `taskfiles/hermes/taskfile.yml` に Darwin 限定の `hermes:desktop` 起動タスクを追加し、wrapper を canonical entrypoint とする。
+- [x] `docs/hermes-agent/desktop.md` に `hermes-desktop-docker`、`task hermes:up`、secret 境界、9119/8642 の診断方法を記載する。
+- [x] Taskfile/catalog 契約テストを追加・更新する。
 
 ## 5. 検証と引き渡し
 
-- [ ] 関連 Bats、Python 契約テスト、Nix formatter/eval、Taskfile config を実行する。
-- [ ] 実機で secret を表示せず、9119 gateway health と wrapper の fake/live 起動境界を確認する。
-- [ ] `git diff --check`、最終差分、git status、Issue #545 の受け入れ条件をレビューする。
+- [x] 関連 Bats、Python 契約テスト、Nix formatter/eval、Taskfile config を実行する。
+- [x] 実機で secret を表示せず、9119 gateway health と wrapper の fake/live 起動境界を確認する。
+- [x] `git diff --check`、最終差分、git status、Issue #545 の受け入れ条件をレビューする。
 - [ ] `task commit -- "feat: connect Hermes Desktop to Docker gateway"` で専用ブランチへコミットする。

--- a/docs/superpowers/plans/2026-09-02-hermes-desktop-docker-gateway-iac.md
+++ b/docs/superpowers/plans/2026-09-02-hermes-desktop-docker-gateway-iac.md
@@ -11,7 +11,7 @@
 ## 2. ランチャーの失敗テストを追加
 
 - [x] `tests/bash/hermes_desktop.bats` を追加し、fixture の HOME/HERMES_DATA_DIR と fake `hermes-desktop`/`curl` を用意する。
-- [x] 正常系で保存済み primary remote 接続の URL/token envelope を検証し、token を fake Desktop の引数・出力へ渡さないことを確認する。
+- [x] 正常系で保存済み primary remote 接続（OAuth と token envelope）を検証し、token を fake Desktop の引数・出力へ渡さないことを確認する。
 - [x] remote registry の欠損/不正、別 URL、remote 以外の primary 接続を拒否するテストを書く。
 - [x] gateway 不到達時に Desktop を実行せず、`task hermes:up` を案内するテストを書く。
 - [x] 先にテストを実行して失敗することを確認する。

--- a/docs/superpowers/plans/2026-09-02-hermes-desktop-docker-gateway-iac.md
+++ b/docs/superpowers/plans/2026-09-02-hermes-desktop-docker-gateway-iac.md
@@ -34,4 +34,4 @@
 - [x] 関連 Bats、Python 契約テスト、Nix formatter/eval、Taskfile config を実行する。
 - [x] 実機で secret を表示せず、9119 gateway health と wrapper の fake/live 起動境界を確認する。
 - [x] `git diff --check`、最終差分、git status、Issue #545 の受け入れ条件をレビューする。
-- [ ] `task commit -- "feat: connect Hermes Desktop to Docker gateway"` で専用ブランチへコミットする。
+- [x] `task commit -- "feat: connect Hermes Desktop to Docker gateway"` で専用ブランチへコミットする。

--- a/docs/superpowers/plans/2026-09-02-hermes-desktop-docker-gateway-iac.md
+++ b/docs/superpowers/plans/2026-09-02-hermes-desktop-docker-gateway-iac.md
@@ -1,0 +1,37 @@
+# Hermes Desktop Docker gateway 接続 IaC 実装計画
+
+> **実行方針:** この計画は専用 worktree `fix/hermes-desktop-docker-gateway-iac` で、各ステップをテスト先行で実行する。
+
+## 1. 既存状態と設計の固定
+
+- [ ] Issue #545、`docs/hermes-agent/desktop.md`、Docker Compose のポート、Hermes runtime env の責務を照合する。
+- [ ] 設計文書に、9119 を Remote Gateway、8642 を health 用 API とする区別、secret 境界、app-owned state 非管理を記録する。
+- [ ] ベースラインの Bats/Python テストを実行し、変更前の結果を保存する。
+
+## 2. ランチャーの失敗テストを追加
+
+- [ ] `tests/bash/hermes_desktop.bats` を追加し、fixture の HOME/HERMES_DATA_DIR と fake `hermes-desktop`/`curl` を用意する。
+- [ ] 正常系で `HERMES_DESKTOP_REMOTE_URL` が `http://127.0.0.1:9119`、token が fake Desktop の環境変数へ渡ることを検証する。
+- [ ] token が引数・出力へ出ず、欠損、重複、形式不正、symlink、0600 以外の env を拒否するテストを書く。
+- [ ] gateway 不到達時に Desktop を実行せず、`task hermes:up` を案内するテストを書く。
+- [ ] 先にテストを実行して失敗することを確認する。
+
+## 3. Nix catalog と launcher を実装
+
+- [ ] `scripts/sh/hermes-desktop-docker.sh` に strict mode、env parser、secret 検証、health check、`exec` を実装する。
+- [ ] `nix/packages/sets.nix` に Darwin/WithHermes 専用の `hermes-desktop-docker` package を追加し、非 Darwin は reviewed unsupported とする。
+- [ ] runtime dependency は Nix wrapper の `curl`/`gawk` へ閉じ込め、token を derivation 内容へ埋め込まない。
+- [ ] テストを再実行して正常系・拒否系を green にする。
+
+## 4. Taskfile とドキュメントを更新
+
+- [ ] `taskfiles/hermes/taskfile.yml` に Darwin 限定の `hermes:desktop` 起動タスクを追加し、wrapper を canonical entrypoint とする。
+- [ ] `docs/hermes-agent/desktop.md` に `hermes-desktop-docker`、`task hermes:up`、secret 境界、9119/8642 の診断方法を記載する。
+- [ ] Taskfile/catalog 契約テストを追加・更新する。
+
+## 5. 検証と引き渡し
+
+- [ ] 関連 Bats、Python 契約テスト、Nix formatter/eval、Taskfile config を実行する。
+- [ ] 実機で secret を表示せず、9119 gateway health と wrapper の fake/live 起動境界を確認する。
+- [ ] `git diff --check`、最終差分、git status、Issue #545 の受け入れ条件をレビューする。
+- [ ] `task commit -- "feat: connect Hermes Desktop to Docker gateway"` で専用ブランチへコミットする。

--- a/docs/superpowers/specs/2026-09-02-hermes-desktop-docker-gateway-design.md
+++ b/docs/superpowers/specs/2026-09-02-hermes-desktop-docker-gateway-design.md
@@ -16,13 +16,11 @@ Hermes Desktop の `connections.json` と暗号化された token は Desktop �
 
 `WithHermes` プロファイルに `hermes-desktop-docker` を追加する。ラッパーは以下を実行する。
 
-1. 既存の `${HERMES_DATA_DIR:-$HOME/.hermes}/.env` を読み取る。
-2. Hermes bootstrap が管理する root の `API_SERVER_KEY` を、許可された形式として検証する。
-3. `http://127.0.0.1:9119/api/health` に到達できることを確認する。
-4. `HERMES_DESKTOP_REMOTE_URL` と `HERMES_DESKTOP_REMOTE_TOKEN` をプロセス環境へ設定する。
-5. upstream の `hermes-desktop` を `exec` する。
+1. `http://127.0.0.1:9119/api/health` に到達できることを確認する。
+2. Hermes Desktop の app-owned `connections.json` に、同 URL の primary remote 接続と暗号化 token があることを確認する。
+3. upstream の `hermes-desktop` を `exec` する。Desktop が保存 token を Keychain から読み込み、API/WS の認証を担当する。
 
-Token は標準出力・標準エラー・プロセス引数・Git 管理対象・Nix store に出さない。token がない、env ファイルが不正、gateway が停止中の場合は、既存の Desktop や Docker を変更せず、復旧方法を示して終了する。
+Token はラッパーが読み取らず、標準出力・標準エラー・プロセス引数・Git 管理対象・Nix store に出さない。接続設定がない、registry が不正、gateway が停止中の場合は、既存の Desktop や Docker を変更せず、復旧方法を示して終了する。
 
 ### 3. Docker 公開ポートと Compose は変更しない
 
@@ -39,7 +37,7 @@ Windows、Linux、Hermes Desktop 本体、Docker 認証方式、1Password の it
 
 ## テスト方針
 
-- ラッパー単体テストで、正常な env の環境変数引き渡し、token 非露出、欠損/不正 env、権限不備、gateway 不到達を検証する。
+- ラッパー単体テストで、保存済み primary remote 接続の検証、token 非露出、registry 欠損/不正、gateway 不到達を検証する。
 - パッケージカタログと Darwin profile の評価で、`WithHermes` のみラッパーが導入されることを検証する。
 - Taskfile 契約テストで、Desktop 起動がラッパーを経由し、Compose の MCP 公開ポートを増やしていないことを検証する。
 - 実機では token の値を表示せず、9119 の `/api/health`、Docker gateway の状態、ラッパーから起動された Desktop の remote 接続を確認する。

--- a/docs/superpowers/specs/2026-09-02-hermes-desktop-docker-gateway-design.md
+++ b/docs/superpowers/specs/2026-09-02-hermes-desktop-docker-gateway-design.md
@@ -1,0 +1,49 @@
+# Hermes Desktop の Docker gateway 接続 IaC 設計
+
+## 背景
+
+macOS 上の Hermes Desktop は、通常起動するとホスト上にローカル backend を起動する。現在の Hermes 設定にある `browser-mcp` と `xapi-mcp` は Docker Compose 内部 DNS 名のため、ホスト backend から名前解決できず MCP が unreachable になる。
+
+一方、Docker の Hermes gateway は Dashboard/Remote Gateway 用の `http://127.0.0.1:9119` をホスト loopback に公開している。`8642` は Desktop の Remote Gateway 接続先ではなく、コンテナ API の health 用ポートである。
+
+## 決定事項
+
+### 1. Desktop の app-owned 接続状態は管理しない
+
+Hermes Desktop の `connections.json` と暗号化された token は Desktop 自身の設定・Keychain 境界に属する。chezmoi で symlink 化したり、Nix 式で内容を生成したりしない。
+
+### 2. Nix 管理の起動ラッパーを提供する
+
+`WithHermes` プロファイルに `hermes-desktop-docker` を追加する。ラッパーは以下を実行する。
+
+1. 既存の `${HERMES_DATA_DIR:-$HOME/.hermes}/.env` を読み取る。
+2. Hermes bootstrap が管理する root の `API_SERVER_KEY` を、許可された形式として検証する。
+3. `http://127.0.0.1:9119/api/health` に到達できることを確認する。
+4. `HERMES_DESKTOP_REMOTE_URL` と `HERMES_DESKTOP_REMOTE_TOKEN` をプロセス環境へ設定する。
+5. upstream の `hermes-desktop` を `exec` する。
+
+Token は標準出力・標準エラー・プロセス引数・Git 管理対象・Nix store に出さない。token がない、env ファイルが不正、gateway が停止中の場合は、既存の Desktop や Docker を変更せず、復旧方法を示して終了する。
+
+### 3. Docker 公開ポートと Compose は変更しない
+
+MCP サービスをホストへ追加公開しない。Docker 内の `browser-mcp`、`xapi-mcp` と Hermes gateway の既存ネットワークをそのまま利用する。ラッパーは Docker の起動・停止も行わず、ライフサイクルは既存の `hermes:up` / `hermes:down` に委譲する。
+
+## 対象範囲
+
+- Darwin の `WithHermes` パッケージセット
+- shell adapter とその Bats 契約テスト
+- Hermes Taskfile の Desktop 起動エントリポイント
+- `docs/hermes-agent/desktop.md` と関連設計文書
+
+Windows、Linux、Hermes Desktop 本体、Docker 認証方式、1Password の item/key 作成は対象外とする。
+
+## テスト方針
+
+- ラッパー単体テストで、正常な env の環境変数引き渡し、token 非露出、欠損/不正 env、権限不備、gateway 不到達を検証する。
+- パッケージカタログと Darwin profile の評価で、`WithHermes` のみラッパーが導入されることを検証する。
+- Taskfile 契約テストで、Desktop 起動がラッパーを経由し、Compose の MCP 公開ポートを増やしていないことを検証する。
+- 実機では token の値を表示せず、9119 の `/api/health`、Docker gateway の状態、ラッパーから起動された Desktop の remote 接続を確認する。
+
+## 失敗時の境界
+
+ラッパーの失敗は Desktop の起動前に発生する。既存の Desktop 接続状態、Docker コンテナ、runtime secret は変更しない。bootstrap の再実行は別操作として `task hermes:bootstrap` または `task hermes:up` から行う。

--- a/docs/superpowers/specs/2026-09-02-hermes-desktop-docker-gateway-design.md
+++ b/docs/superpowers/specs/2026-09-02-hermes-desktop-docker-gateway-design.md
@@ -17,7 +17,7 @@ Hermes Desktop の `connections.json` と暗号化された token は Desktop �
 `WithHermes` プロファイルに `hermes-desktop-docker` を追加する。ラッパーは以下を実行する。
 
 1. `http://127.0.0.1:9119/api/health` に到達できることを確認する。
-2. Hermes Desktop の app-owned `connections.json` に、同 URL の primary remote 接続と暗号化 token があることを確認する。
+2. Hermes Desktop の app-owned `connections.json` に、同 URL の primary remote 接続があることを確認する。token 認証の場合だけ、保存 token envelope の形式も検証する。
 3. upstream の `hermes-desktop` を `exec` する。Desktop が保存 token を Keychain から読み込み、API/WS の認証を担当する。
 
 Token はラッパーが読み取らず、標準出力・標準エラー・プロセス引数・Git 管理対象・Nix store に出さない。接続設定がない、registry が不正、gateway が停止中の場合は、既存の Desktop や Docker を変更せず、復旧方法を示して終了する。

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -738,6 +738,36 @@ let
             };
           };
         };
+        hermes-desktop-docker = {
+          pkg =
+            if pkgs.stdenv.hostPlatform.isDarwin then
+              pkgs.writeShellApplication {
+                name = "hermes-desktop-docker";
+                runtimeInputs = [
+                  pkgs.curl
+                  pkgs.jq
+                ];
+                text = builtins.readFile ../../scripts/sh/hermes-desktop-docker.sh;
+              }
+            else
+              null;
+          winget = null;
+          category = "terminal";
+          installFeature = "WithHermes";
+          support = {
+            darwin = {
+              provider = "nix";
+              source = "dotfiles";
+              identity.command = "hermes-desktop-docker";
+            };
+            linux = {
+              unsupported = "Hermes Desktop Docker launcher is provisioned by the native macOS profile";
+            };
+            windows = {
+              unsupported = "Hermes Desktop Docker launcher is provisioned by the native macOS profile";
+            };
+          };
+        };
 
         # ── k8s ───────────────────────────────────────────────
         kind = {

--- a/scripts/sh/hermes-desktop-docker.sh
+++ b/scripts/sh/hermes-desktop-docker.sh
@@ -23,9 +23,18 @@ if ! jq -e --arg url "$remote_url" '
 	| any(.connections[]?;
 		.id == $primary
 		and .kind == "remote"
-		and .url == $url
+		and ((.url? | strings | sub("/+$"; "")) == ($url | sub("/+$"; "")))
 		and (.authMode == "oauth" or .authMode == "token")
-		and (.token? != null)
+		and (
+			.authMode == "oauth"
+			or (
+				.token? | type == "object"
+				and (.encoding | type == "string")
+				and (.encoding == "safeStorage" or .encoding == "plain")
+				and (.value | type == "string")
+				and (.value | length > 0)
+			)
+		)
 	)
 ' "$registry_file" >/dev/null 2>&1; then
   hermes_desktop_docker_die "Desktop primary remote connection for $remote_url is not configured; open Hermes Settings > Gateway and sign in once"

--- a/scripts/sh/hermes-desktop-docker.sh
+++ b/scripts/sh/hermes-desktop-docker.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+hermes_desktop_docker_die() {
+  printf 'Hermes Desktop Docker launcher: %s\n' "$1" >&2
+  exit 1
+}
+
+remote_url='http://127.0.0.1:9119'
+desktop_data_dir="${HOME}/Library/Application Support/Hermes"
+registry_file="$desktop_data_dir/connections.json"
+
+if ! curl --fail --silent --show-error --max-time 5 "$remote_url/api/health" >/dev/null; then
+  hermes_desktop_docker_die "Docker gateway is unavailable at $remote_url; run 'task hermes:up' first"
+fi
+
+[[ -f $registry_file ]] ||
+  hermes_desktop_docker_die "Desktop remote connection is not configured; open Hermes Settings > Gateway and sign in once"
+
+if ! jq -e --arg url "$remote_url" '
+	.primary as $primary
+	| any(.connections[]?;
+		.id == $primary
+		and .kind == "remote"
+		and .url == $url
+		and (.authMode == "oauth" or .authMode == "token")
+		and (.token? != null)
+	)
+' "$registry_file" >/dev/null 2>&1; then
+  hermes_desktop_docker_die "Desktop primary remote connection for $remote_url is not configured; open Hermes Settings > Gateway and sign in once"
+fi
+
+unset HERMES_DESKTOP_REMOTE_URL HERMES_DESKTOP_REMOTE_TOKEN
+command -v hermes-desktop >/dev/null 2>&1 || hermes_desktop_docker_die "hermes-desktop is not installed; apply the WithHermes profile"
+exec hermes-desktop "$@"

--- a/taskfiles/hermes/taskfile.yml
+++ b/taskfiles/hermes/taskfile.yml
@@ -183,6 +183,15 @@ tasks:
       - sh: docker info
         msg: "Docker daemon is not running. Start Docker Desktop and try again."
 
+  hermes:desktop:
+    desc: Launch Hermes Desktop connected to the Docker gateway
+    preconditions:
+      - sh: command -v hermes-desktop-docker
+        msg: "Hermes Desktop Docker launcher is not installed. Apply the WithHermes profile."
+    cmds:
+      - cmd: hermes-desktop-docker
+        platforms: [darwin]
+
   hermes:down:
     desc: Stop Hermes Agent Docker container
     preconditions:

--- a/tests/bash/hermes_desktop.bats
+++ b/tests/bash/hermes_desktop.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+	TEST_HOME="$BATS_TEST_TMPDIR/home"
+	STUB_BIN="$BATS_TEST_TMPDIR/bin"
+	DESKTOP_CAPTURE="$BATS_TEST_TMPDIR/desktop.env"
+	DESKTOP_ARGS="$BATS_TEST_TMPDIR/desktop.args"
+	CURL_CAPTURE="$BATS_TEST_TMPDIR/curl.args"
+	REAL_JQ="$(command -v jq)"
+	mkdir -p "$TEST_HOME/Library/Application Support/Hermes" "$STUB_BIN"
+
+	write_stub curl '
+printf "%s\n" "$*" >"$CURL_CAPTURE"
+'
+	write_stub hermes-desktop '
+printf "%s\n" "$*" >"$DESKTOP_ARGS"
+'
+	write_stub jq 'exec "$REAL_JQ" "$@"'
+	export HOME="$TEST_HOME"
+	export HERMES_DATA_DIR="$TEST_HOME/.hermes"
+	export PATH="$STUB_BIN:/usr/bin:/bin"
+	export DESKTOP_CAPTURE DESKTOP_ARGS CURL_CAPTURE REAL_JQ
+	printf '%s\n' '{"version":2,"primary":"docker","connections":[{"id":"docker","kind":"remote","url":"http://127.0.0.1:9119","authMode":"oauth","token":{"encoding":"encrypted","value":"opaque"}}]}' >"$TEST_HOME/Library/Application Support/Hermes/connections.json"
+}
+
+write_stub() {
+	local name="$1"
+	local body="$2"
+	{
+		printf '#!/usr/bin/env bash\n'
+		printf 'set -euo pipefail\n'
+		printf '%s\n' "$body"
+	} >"$STUB_BIN/$name"
+	chmod +x "$STUB_BIN/$name"
+}
+
+@test "Docker gateway launcher starts with the saved Desktop remote connection" {
+	run "$REPO_ROOT/scripts/sh/hermes-desktop-docker.sh" --profile default
+
+	[ "$status" -eq 0 ]
+	[ "$(<"$DESKTOP_ARGS")" = "--profile default" ]
+	! grep -Fq 'HERMES_DESKTOP_REMOTE_TOKEN' "$DESKTOP_ARGS"
+	! grep -Fq 'hermes-bootstrap-v1_' "$DESKTOP_ARGS"
+	! grep -Fq 'opaque' <<<"$output"
+	grep -Fq '127.0.0.1:9119/api/health' "$CURL_CAPTURE"
+}
+
+@test "Docker gateway launcher rejects an unconfigured Desktop remote connection" {
+	: >"$TEST_HOME/Library/Application Support/Hermes/connections.json"
+
+	run "$REPO_ROOT/scripts/sh/hermes-desktop-docker.sh"
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Settings > Gateway"* ]]
+	[ ! -e "$DESKTOP_CAPTURE" ]
+}
+
+@test "Docker gateway launcher rejects a non-primary or wrong-url remote connection" {
+	printf '%s\n' '{"version":2,"primary":"local","connections":[{"id":"local","kind":"local"},{"id":"docker","kind":"remote","url":"http://127.0.0.1:8642","authMode":"oauth","token":{"encoding":"encrypted","value":"opaque"}}]}' >"$TEST_HOME/Library/Application Support/Hermes/connections.json"
+
+	run "$REPO_ROOT/scripts/sh/hermes-desktop-docker.sh"
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"primary remote connection"* ]]
+	[ ! -e "$DESKTOP_CAPTURE" ]
+}
+
+@test "Docker gateway launcher refuses to start Desktop when the gateway is unavailable" {
+	write_stub curl 'printf "%s\n" "$*" >"$CURL_CAPTURE"; exit 22'
+
+	run "$REPO_ROOT/scripts/sh/hermes-desktop-docker.sh"
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"task hermes:up"* ]]
+	[ ! -e "$DESKTOP_CAPTURE" ]
+}

--- a/tests/bash/hermes_desktop.bats
+++ b/tests/bash/hermes_desktop.bats
@@ -16,6 +16,7 @@ setup() {
 printf "%s\n" "$*" >"$CURL_CAPTURE"
 '
 	write_stub hermes-desktop '
+	: >"$DESKTOP_CAPTURE"
 printf "%s\n" "$*" >"$DESKTOP_ARGS"
 '
 	write_stub jq 'exec "$REAL_JQ" "$@"'
@@ -23,7 +24,7 @@ printf "%s\n" "$*" >"$DESKTOP_ARGS"
 	export HERMES_DATA_DIR="$TEST_HOME/.hermes"
 	export PATH="$STUB_BIN:/usr/bin:/bin"
 	export DESKTOP_CAPTURE DESKTOP_ARGS CURL_CAPTURE REAL_JQ
-	printf '%s\n' '{"version":2,"primary":"docker","connections":[{"id":"docker","kind":"remote","url":"http://127.0.0.1:9119","authMode":"oauth","token":{"encoding":"encrypted","value":"opaque"}}]}' >"$TEST_HOME/Library/Application Support/Hermes/connections.json"
+	printf '%s\n' '{"version":2,"primary":"docker","connections":[{"id":"docker","kind":"remote","url":"http://127.0.0.1:9119/","authMode":"oauth"}]}' >"$TEST_HOME/Library/Application Support/Hermes/connections.json"
 }
 
 write_stub() {
@@ -59,7 +60,17 @@ write_stub() {
 }
 
 @test "Docker gateway launcher rejects a non-primary or wrong-url remote connection" {
-	printf '%s\n' '{"version":2,"primary":"local","connections":[{"id":"local","kind":"local"},{"id":"docker","kind":"remote","url":"http://127.0.0.1:8642","authMode":"oauth","token":{"encoding":"encrypted","value":"opaque"}}]}' >"$TEST_HOME/Library/Application Support/Hermes/connections.json"
+	printf '%s\n' '{"version":2,"primary":"local","connections":[{"id":"local","kind":"local"},{"id":"docker","kind":"remote","url":"http://127.0.0.1:8642","authMode":"oauth"}]}' >"$TEST_HOME/Library/Application Support/Hermes/connections.json"
+
+	run "$REPO_ROOT/scripts/sh/hermes-desktop-docker.sh"
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"primary remote connection"* ]]
+	[ ! -e "$DESKTOP_CAPTURE" ]
+}
+
+@test "Docker gateway launcher rejects a malformed token-auth envelope" {
+	printf '%s\n' '{"version":2,"primary":"docker","connections":[{"id":"docker","kind":"remote","url":"http://127.0.0.1:9119","authMode":"token","token":{}}]}' >"$TEST_HOME/Library/Application Support/Hermes/connections.json"
 
 	run "$REPO_ROOT/scripts/sh/hermes-desktop-docker.sh"
 

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -105,6 +105,19 @@ nix_fixture_darwin_package_split() {
 	grep -q 'inherit inputs installFeatures;' "$REPO_ROOT/nix/flakes/home.nix"
 }
 
+@test "Hermes Desktop Docker launcher is a Darwin Hermes package" {
+	run awk '
+		/^[[:space:]]*hermes-desktop-docker = \{/ { in_entry=1 }
+		in_entry { print }
+		in_entry && /^        };/ { exit }
+	' "$SETS"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'writeShellApplication'* ]]
+	[[ "$output" == *'installFeature = "WithHermes";'* ]]
+	[[ "$output" == *'source = "dotfiles";'* ]]
+	[[ "$output" == *'command = "hermes-desktop-docker";'* ]]
+}
+
 @test "Hermes Desktop is absent from default package outputs" {
 	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
 	command -v jq >/dev/null 2>&1 || skip "jq is not available in this test environment"

--- a/tests/python/test_taskfile_contract.py
+++ b/tests/python/test_taskfile_contract.py
@@ -12,6 +12,7 @@ HERMES_AGENT = REPOSITORY_ROOT / "scripts" / "sh" / "hermes-agent.sh"
 XAPI_WRAPPER = REPOSITORY_ROOT / "scripts" / "sh" / "hermes-xapi.sh"
 XAPI_WINDOWS_WRAPPER = REPOSITORY_ROOT / "scripts" / "powershell" / "hermes-xapi.ps1"
 HINDSIGHT_WRAPPER = REPOSITORY_ROOT / "scripts" / "sh" / "hermes-hindsight-verify.sh"
+HERMES_DESKTOP_WRAPPER = REPOSITORY_ROOT / "scripts" / "sh" / "hermes-desktop-docker.sh"
 HINDSIGHT_WINDOWS_WRAPPER = (
     REPOSITORY_ROOT / "scripts" / "powershell" / "hermes-hindsight-verify.ps1"
 )
@@ -93,6 +94,17 @@ class TaskfileContractTests(unittest.TestCase):
         ):
             with self.subTest(task_name=task_name):
                 self.assertIn("task: hermes:up", self._task_block(task_name))
+
+    def test_desktop_entrypoint_uses_the_docker_gateway_launcher(self) -> None:
+        task = self._task_block("hermes:desktop")
+
+        self.assertIn("hermes-desktop-docker", task)
+        self.assertIn("platforms: [darwin]", task)
+        wrapper = HERMES_DESKTOP_WRAPPER.read_text(encoding="utf-8")
+        self.assertIn("connections.json", wrapper)
+        self.assertIn("127.0.0.1:9119", wrapper)
+        self.assertNotIn("API_SERVER_KEY", wrapper)
+        self.assertIn("unset HERMES_DESKTOP_REMOTE_URL HERMES_DESKTOP_REMOTE_TOKEN", wrapper)
 
     def test_xapi_lifecycle_reads_oauth_credentials_from_1password(self) -> None:
         wrapper = XAPI_WRAPPER.read_text(encoding="utf-8")


### PR DESCRIPTION
Summary: add a Darwin/WithHermes Nix-managed hermes-desktop-docker launcher and task hermes:desktop; validate gateway health and app-owned Desktop connection state; keep OAuth/token state in Desktop/Keychain and do not use API_SERVER_KEY; document 9119 Remote Gateway versus 8642 internal health API. Closes #545. Validation: Bats 162 passed, Python contract tests 10 passed, pre-commit passed, Nix package build passed, Docker Compose config passed, live gateway health HTTP 200.