### PR TITLE
feat: make Hermes Docker storage initialization failure-safe

### DIFF
--- a/.github/e2e/run-bootstrap-acceptance.sh
+++ b/.github/e2e/run-bootstrap-acceptance.sh
@@ -12,6 +12,12 @@ HINDSIGHT_DIR="$REPO_ROOT/docker/local-ai-services"
   exit 1
 }
 
+# The acceptance Compose file deliberately replaces the production service
+# image with lightweight fixtures. Build the production image separately so
+# Hermes storage seeding still exercises the same helper used in real runs.
+docker build -t local/hermes-agent-gh:latest \
+  -f "$REPO_ROOT/docker/hermes-agent/Dockerfile" "$REPO_ROOT/docker"
+
 install -m 0644 "$FIXTURE_ROOT/bootstrap-compose.yml" "$CANONICAL_DIR/compose.yml"
 install -m 0644 "$FIXTURE_ROOT/hindsight-compose.yml" "$HINDSIGHT_DIR/compose.yml"
 install -m 0755 "$FIXTURE_ROOT/hermes-bootstrap-fixture.sh" \

--- a/.github/e2e/run-bootstrap-acceptance.sh
+++ b/.github/e2e/run-bootstrap-acceptance.sh
@@ -15,8 +15,13 @@ HINDSIGHT_DIR="$REPO_ROOT/docker/local-ai-services"
 # The acceptance Compose file deliberately replaces the production service
 # image with lightweight fixtures. Build the production image separately so
 # Hermes storage seeding still exercises the same helper used in real runs.
-docker build -t local/hermes-agent-gh:latest \
-  -f "$REPO_ROOT/docker/hermes-agent/Dockerfile" "$REPO_ROOT/docker"
+# Offline NixOS tests preload a small equivalent image instead.
+if [[ -n ${DOTFILES_ACCEPTANCE_PRELOADED_STORAGE_SEED_IMAGE:-} ]]; then
+  docker image inspect "$DOTFILES_ACCEPTANCE_PRELOADED_STORAGE_SEED_IMAGE" >/dev/null
+else
+  docker build -t local/hermes-agent-gh:latest \
+    -f "$REPO_ROOT/docker/hermes-agent/Dockerfile" "$REPO_ROOT/docker"
+fi
 
 install -m 0644 "$FIXTURE_ROOT/bootstrap-compose.yml" "$CANONICAL_DIR/compose.yml"
 install -m 0644 "$FIXTURE_ROOT/hindsight-compose.yml" "$HINDSIGHT_DIR/compose.yml"

--- a/docker/hermes-agent/Dockerfile
+++ b/docker/hermes-agent/Dockerfile
@@ -16,8 +16,10 @@ COPY hermes-agent/bootstrap-manifest.yaml /usr/local/share/hermes-bootstrap/boot
 COPY hermes-agent/hermes-bootstrap /usr/local/bin/hermes-bootstrap
 COPY hermes-agent/hindsight_acceptance.py /usr/local/bin/hermes-hindsight-acceptance
 COPY hermes-agent/gateway_convergence.py /usr/local/bin/hermes-gateway-converge
+COPY hermes-agent/hermes_storage_seed.py /usr/local/bin/hermes-storage-seed
 RUN chmod 0755 /usr/local/bin/hermes-hindsight-acceptance
 RUN chmod 0755 /usr/local/bin/hermes-gateway-converge
+RUN chmod 0755 /usr/local/bin/hermes-storage-seed
 
 RUN python3 - <<'PY'
 import re
@@ -160,11 +162,16 @@ COPY hindsight/hindsight.env /workspace/docker/hindsight/hindsight.env
 COPY hermes-agent/bootstrap-manifest.yaml /workspace/docker/hermes-agent/bootstrap-manifest.yaml
 COPY hermes-agent/hindsight_acceptance.py /workspace/docker/hermes-agent/hindsight_acceptance.py
 COPY hermes-agent/gateway_convergence.py /workspace/docker/hermes-agent/gateway_convergence.py
+COPY hermes-agent/hermes_storage_seed.py /workspace/docker/hermes-agent/hermes_storage_seed.py
+COPY hermes-agent/tests /workspace/docker/hermes-agent/tests
 COPY hermes-agent/bootstrap/tests /workspace/docker/hermes-agent/bootstrap/tests
 
 RUN PYTHONPATH=/usr/local/lib/hermes-bootstrap /opt/hermes/.venv/bin/python -m unittest discover \
   -s /workspace/docker/hermes-agent/bootstrap/tests \
   -p 'test_[!t]*.py'
+
+RUN PYTHONPATH=/workspace/docker/hermes-agent /opt/hermes/.venv/bin/python -m unittest \
+  /workspace/docker/hermes-agent/tests/test_hermes_storage_seed.py
 
 RUN PYTHONPATH=/usr/local/lib/hermes-bootstrap /opt/hermes/.venv/bin/python -m unittest discover \
   -s /workspace/docker/hermes-agent/bootstrap/tests \

--- a/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
+++ b/docker/hermes-agent/bootstrap/tests/test_compose_contract.py
@@ -19,9 +19,9 @@ HINDSIGHT_SHELL_SCRIPT = REPOSITORY_ROOT / "scripts/sh/hindsight.sh"
 HINDSIGHT_POWERSHELL_SCRIPT = REPOSITORY_ROOT / "scripts/powershell/hindsight.ps1"
 DOCKERFILE = REPOSITORY_ROOT / "docker/hermes-agent/Dockerfile"
 RESOLVED_CONFIG_ENV = "HERMES_BOOTSTRAP_COMPOSE_CONFIG_JSON"
-DATA_BIND = {
-    "type": "bind",
-    "source": "${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}",
+DATA_VOLUME = {
+    "type": "volume",
+    "source": "hermes-data",
     "target": "/opt/data",
 }
 XURL_BIND = {
@@ -101,7 +101,7 @@ class ComposeContractTests(unittest.TestCase):
             {"context": "..", "dockerfile": "hermes-agent/Dockerfile"},
         )
         self.assertEqual(self.bootstrap["image"], self.hermes["image"])
-        self.assertEqual(self.bootstrap["volumes"], [DATA_BIND])
+        self.assertEqual(self.bootstrap["volumes"], [DATA_VOLUME])
         self.assertEqual(self.bootstrap["environment"], {"HERMES_HOME": "/opt/data"})
         self.assertEqual(self.bootstrap["profiles"], ["bootstrap"])
         self.assertEqual(self.bootstrap["entrypoint"], "/usr/local/bin/hermes-bootstrap")
@@ -115,6 +115,21 @@ class ComposeContractTests(unittest.TestCase):
 
     def test_gateway_uses_the_canonical_hermes_home(self) -> None:
         self.assertEqual(self.hermes["environment"]["HERMES_HOME"], "/opt/data")
+
+    def test_gateway_runtime_home_uses_a_docker_managed_named_volume(self) -> None:
+        self.assertEqual(self.hermes["volumes"][0], DATA_VOLUME)
+        self.assertEqual(self.bootstrap["volumes"][0], DATA_VOLUME)
+        self.assertEqual(
+            self.compose["volumes"]["hermes-data"],
+            {"name": "${HERMES_DATA_VOLUME:-hermes-data}"},
+        )
+        self.assertFalse(
+            any(
+                mount.get("target") == "/opt/data" and mount.get("type") == "bind"
+                for service in self.services.values()
+                for mount in service.get("volumes", [])
+            )
+        )
 
     def test_gateway_reconnects_on_the_first_failed_discord_liveness_sample(self) -> None:
         self.assertEqual(
@@ -361,6 +376,11 @@ class ComposeContractTests(unittest.TestCase):
         )
         self.assertIn("chmod 0755 /usr/local/bin/hermes-bootstrap", dockerfile)
         self.assertIn("FROM hermes-bootstrap-runtime AS hermes-bootstrap-test", dockerfile)
+        self.assertIn(
+            "COPY hermes-agent/hermes_storage_seed.py /usr/local/bin/hermes-storage-seed",
+            dockerfile,
+        )
+        self.assertIn("chmod 0755 /usr/local/bin/hermes-storage-seed", dockerfile)
         self.assertIn("COPY hermes-agent/bootstrap/tests /workspace/docker/hermes-agent/bootstrap/tests", dockerfile)
         self.assertIn("python -m unittest discover", dockerfile)
         self.assertTrue(dockerfile.rstrip().endswith("FROM hermes-bootstrap-runtime\n\nWORKDIR /"))

--- a/docker/hermes-agent/hermes_storage_seed.py
+++ b/docker/hermes-agent/hermes_storage_seed.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Seed a fresh Hermes Docker volume from a stopped host data directory."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sqlite3
+import stat
+from pathlib import Path
+
+
+TRANSIENT_SQLITE_SUFFIXES = ("-wal", "-shm", "-journal")
+EXCLUDED_ROOT_ENTRIES = {".browser", ".op.env", ".xurl"}
+
+
+def _is_sqlite_database(path: Path) -> bool:
+    try:
+        with path.open("rb") as handle:
+            return handle.read(16) == b"SQLite format 3\x00"
+    except OSError:
+        return False
+
+
+def _copy_sqlite_database(source: Path, destination: Path) -> None:
+    source_uri = f"file:{source.as_posix()}?mode=ro"
+    source_connection = sqlite3.connect(source_uri, uri=True)
+    destination_connection = sqlite3.connect(destination)
+    try:
+        source_connection.backup(destination_connection)
+    finally:
+        destination_connection.close()
+        source_connection.close()
+
+
+def _copy_file(source: Path, destination: Path) -> None:
+    source_mode = stat.S_IMODE(source.stat().st_mode)
+    shutil.copy2(source, destination)
+    destination.chmod(source_mode)
+
+
+def _validate_paths(source: Path, destination: Path) -> None:
+    if not source.is_dir() or source.is_symlink():
+        raise ValueError(f"source must be a real directory: {source}")
+    if not destination.is_dir() or destination.is_symlink():
+        raise ValueError(f"destination must be a real directory: {destination}")
+    if any(destination.iterdir()):
+        raise ValueError(f"destination must be empty: {destination}")
+
+
+def seed(source: Path, destination: Path) -> None:
+    """Copy a stopped Hermes home into an empty destination directory."""
+
+    _validate_paths(source, destination)
+    for source_root, directory_names, file_names in os.walk(source, followlinks=False):
+        source_directory = Path(source_root)
+        relative_directory = source_directory.relative_to(source)
+        is_root = relative_directory == Path(".")
+        destination_directory = destination / relative_directory
+        destination_directory.mkdir(parents=True, exist_ok=True)
+
+        retained_directories: list[str] = []
+        for directory_name in directory_names:
+            relative_path = relative_directory / directory_name
+            if is_root and directory_name in EXCLUDED_ROOT_ENTRIES:
+                continue
+            source_path = source / relative_path
+            if source_path.is_symlink():
+                raise ValueError(f"symlinks are not supported in Hermes data: {source_path}")
+            retained_directories.append(directory_name)
+            (destination / relative_path).mkdir(exist_ok=True)
+        directory_names[:] = retained_directories
+
+        for file_name in file_names:
+            if file_name.endswith(TRANSIENT_SQLITE_SUFFIXES):
+                continue
+            if is_root and file_name in EXCLUDED_ROOT_ENTRIES:
+                continue
+            relative_path = relative_directory / file_name
+            source_path = source / relative_path
+            if source_path.is_symlink():
+                raise ValueError(f"symlinks are not supported in Hermes data: {source_path}")
+            destination_path = destination / relative_path
+            if source_path.suffix == ".db" and _is_sqlite_database(source_path):
+                _copy_sqlite_database(source_path, destination_path)
+                destination_path.chmod(stat.S_IMODE(source_path.stat().st_mode))
+            else:
+                _copy_file(source_path, destination_path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--destination", type=Path, required=True)
+    arguments = parser.parse_args()
+    try:
+        seed(arguments.source, arguments.destination)
+    except (OSError, sqlite3.Error, ValueError) as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker/hermes-agent/tests/test_hermes_storage_seed.py
+++ b/docker/hermes-agent/tests/test_hermes_storage_seed.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from hermes_storage_seed import seed
+
+
+class HermesStorageSeedTests(unittest.TestCase):
+    def test_copies_regular_files_and_sqlite_databases_without_sidecars(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            (source / "config.yaml").write_text("gateway: docker\n", encoding="utf-8")
+            (source / ".op.env").write_text("OP_SERVICE_ACCOUNT_TOKEN=secret\n", encoding="utf-8")
+            (source / ".xurl").mkdir()
+            (source / ".xurl" / "auth.json").write_text("cache", encoding="utf-8")
+            (source / ".browser").mkdir()
+            (source / ".browser" / "profile").write_text("browser", encoding="utf-8")
+            database = source / "state.db"
+            connection = sqlite3.connect(database)
+            connection.execute("create table messages (body text)")
+            connection.execute("insert into messages values ('kept')")
+            connection.commit()
+            connection.close()
+            (source / "state.db-wal").write_text("do not copy", encoding="utf-8")
+            (source / "state.db-shm").write_text("do not copy", encoding="utf-8")
+
+            seed(source, destination)
+
+            self.assertEqual((destination / "config.yaml").read_text(encoding="utf-8"), "gateway: docker\n")
+            self.assertFalse((destination / ".op.env").exists())
+            self.assertFalse((destination / ".xurl").exists())
+            self.assertFalse((destination / ".browser").exists())
+            self.assertFalse((destination / "state.db-wal").exists())
+            self.assertFalse((destination / "state.db-shm").exists())
+            copied = sqlite3.connect(destination / "state.db")
+            self.assertEqual(copied.execute("select body from messages").fetchone()[0], "kept")
+            copied.close()
+
+    def test_requires_an_empty_destination(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            (destination / "existing").write_text("keep", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "destination must be empty"):
+                seed(source, destination)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker/hermes-service/compose.yml
+++ b/docker/hermes-service/compose.yml
@@ -23,8 +23,8 @@ services:
       - "127.0.0.1:${HERMES_DASHBOARD_PORT:-9119}:9119"
       - "127.0.0.1:3500-3505:3500-3505"
     volumes:
-      - type: bind
-        source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}
+      - type: volume
+        source: hermes-data
         target: /opt/data
       - type: bind
         source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.xurl
@@ -58,8 +58,8 @@ services:
       - path: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}/.op.env
         required: false
     volumes:
-      - type: bind
-        source: ${HERMES_DATA_DIR:-${USERPROFILE:-${HOME}}/.hermes}
+      - type: volume
+        source: hermes-data
         target: /opt/data
     environment:
       HERMES_HOME: /opt/data
@@ -169,3 +169,7 @@ networks:
   local-ai-services:
     name: local-ai-services
     external: true
+
+volumes:
+  hermes-data:
+    name: ${HERMES_DATA_VOLUME:-hermes-data}

--- a/nix/tests/bootstrap-nixos.nix
+++ b/nix/tests/bootstrap-nixos.nix
@@ -33,6 +33,24 @@ let
       "80"
     ];
   };
+  storageSeedImage = pkgs.dockerTools.buildImage {
+    name = "local/hermes-agent-gh";
+    tag = "latest";
+    copyToRoot = pkgs.buildEnv {
+      name = "hermes-storage-seed-root";
+      paths = [
+        pkgs.coreutils
+        pkgs.python3
+      ];
+      pathsToLink = [ "/bin" ];
+    };
+    extraCommands = ''
+      mkdir -p usr/bin usr/local/bin
+      ln -s /bin/env usr/bin/env
+      cp ${dotfilesSource}/docker/hermes-agent/hermes_storage_seed.py usr/local/bin/hermes-storage-seed
+      chmod 0755 usr/local/bin/hermes-storage-seed
+    '';
+  };
 in
 pkgs.testers.runNixOSTest {
   name = "bootstrap-nixos-vm";
@@ -93,12 +111,13 @@ pkgs.testers.runNixOSTest {
     machine.wait_for_unit("docker.service")
     machine.succeed("docker load < ${helloWorldImage}")
     machine.succeed("docker load < ${acceptanceImage}")
+    machine.succeed("docker load < ${storageSeedImage}")
     machine.succeed("cp -r ${dotfilesSource} /home/nixos/dotfiles")
     machine.succeed("chmod -R u+w /home/nixos/dotfiles && chown -R nixos:users /home/nixos/dotfiles")
 
     # The VM intentionally has no external DNS. Herdr's official installer is
     # covered by the platform adapter tests; keep this bootstrap fixture offline.
-    install = "su - nixos -c 'env DOTFILES_SKIP_FLAKE_UPDATE=1 DOTFILES_SKIP_HERDR_INSTALL=1 DOTFILES_NIXOS_PREBUILT_SYSTEM=${nodes.machine.system.build.toplevel} DOTFILES_NIXOS_HARDWARE_CONFIG=/etc/nixos/hardware-configuration.nix DOTFILES_CHECKOUT_TARGET=/home/nixos/dotfiles /home/nixos/dotfiles/.github/e2e/run-bootstrap-acceptance.sh'"
+    install = "su - nixos -c 'env DOTFILES_ACCEPTANCE_PRELOADED_STORAGE_SEED_IMAGE=local/hermes-agent-gh:latest DOTFILES_SKIP_FLAKE_UPDATE=1 DOTFILES_SKIP_HERDR_INSTALL=1 DOTFILES_NIXOS_PREBUILT_SYSTEM=${nodes.machine.system.build.toplevel} DOTFILES_NIXOS_HARDWARE_CONFIG=/etc/nixos/hardware-configuration.nix DOTFILES_CHECKOUT_TARGET=/home/nixos/dotfiles /home/nixos/dotfiles/.github/e2e/run-bootstrap-acceptance.sh'"
     machine.succeed(install)
     machine.succeed(install)
     machine.succeed("su - nixos -c 'export PATH=/run/current-system/sw/bin:/etc/profiles/per-user/nixos/bin:$HOME/.nix-profile/bin:$PATH; cd /home/nixos/dotfiles; DOTFILES_VERIFY_SYSTEM_LAYER=nixos ./scripts/sh/verify-environment.sh --runtime'")

--- a/scripts/powershell/handlers/Handler.HermesAgent.ps1
+++ b/scripts/powershell/handlers/Handler.HermesAgent.ps1
@@ -8,6 +8,7 @@ $libPath = Split-Path -Parent $PSScriptRoot
 . (Join-Path $libPath 'lib\HermesBootstrap.ps1')
 . (Join-Path $libPath 'lib\HermesXApi.ps1')
 . (Join-Path $libPath 'lib\HermesGateway.ps1')
+. (Join-Path $libPath 'lib\HermesStorage.ps1')
 
 class HermesAgentHandler : SetupHandlerBase {
     [int]$DockerCheckTimeoutSeconds = 15
@@ -86,6 +87,16 @@ class HermesAgentHandler : SetupHandlerBase {
             $stop = $this.InvokeCompose($composeFile, @('stop', 'hermes'))
             if (-not $stop.Success) {
                 return $this.CreateFailureResult("Hermes Agent stop failed: $($stop.Message)")
+            }
+
+            try {
+                $storage = Initialize-HermesStorageVolume -DataDir $dataDir
+            }
+            catch {
+                return $this.CreateFailureResult('Hermes data volume configuration failed.')
+            }
+            if (-not $storage.Success) {
+                return $this.CreateFailureResult($storage.Message)
             }
 
             try {

--- a/scripts/powershell/hermes-bootstrap.ps1
+++ b/scripts/powershell/hermes-bootstrap.ps1
@@ -17,6 +17,7 @@ $ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot 'lib/HermesBootstrap.ps1')
 . (Join-Path $PSScriptRoot 'lib/HermesXApi.ps1')
 . (Join-Path $PSScriptRoot 'lib/HermesGateway.ps1')
+. (Join-Path $PSScriptRoot 'lib/HermesStorage.ps1')
 
 function New-HermesBootstrapEntrypointResult {
     [CmdletBinding()]
@@ -378,6 +379,22 @@ function Invoke-HermesBootstrapEntrypoint {
                 -FailureMessage 'Hermes gateway stop failed.'
             if ($stop.ExitCode -ne 0) { return $stop }
             $runtimeStopped = $true
+
+            try {
+                $storage = Initialize-HermesStorageVolume -DataDir $paths.DataDir
+            }
+            catch {
+                return New-HermesBootstrapFailureResult `
+                    -ComposeFile $paths.ComposeFile `
+                    -RuntimeExisted $runtimeExisted `
+                    -FailureMessage 'Hermes data volume configuration failed.'
+            }
+            if (-not $storage.Success) {
+                return New-HermesBootstrapFailureResult `
+                    -ComposeFile $paths.ComposeFile `
+                    -RuntimeExisted $runtimeExisted `
+                    -FailureMessage $storage.Message
+            }
 
             try {
                 $global:LASTEXITCODE = 0

--- a/scripts/powershell/lib/HermesStorage.ps1
+++ b/scripts/powershell/lib/HermesStorage.ps1
@@ -42,10 +42,10 @@ function Initialize-HermesStorageVolume {
 
     $seedArguments = @(
         'run', '--rm',
+        '--entrypoint', '/usr/local/bin/hermes-storage-seed',
         '--mount', "type=bind,source=$DataDir,target=/source,readonly",
         '--mount', "type=volume,source=$volumeName,target=/target",
         'local/hermes-agent-gh:latest',
-        '/usr/local/bin/hermes-storage-seed',
         '--source', '/source',
         '--destination', '/target'
     )

--- a/scripts/powershell/lib/HermesStorage.ps1
+++ b/scripts/powershell/lib/HermesStorage.ps1
@@ -1,0 +1,59 @@
+<##
+.SYNOPSIS
+    Initializes the Docker-managed Hermes runtime data volume.
+#>
+
+function Get-HermesStorageVolumeName {
+    [CmdletBinding()]
+    param()
+
+    $name = if ([string]::IsNullOrWhiteSpace($env:HERMES_DATA_VOLUME)) {
+        'hermes-data'
+    }
+    else {
+        $env:HERMES_DATA_VOLUME.Trim()
+    }
+    if ($name -notmatch '^[A-Za-z0-9][A-Za-z0-9_.-]*$') {
+        throw [System.ArgumentException]::new('HERMES_DATA_VOLUME contains an invalid Docker volume name.')
+    }
+    return $name
+}
+
+function Initialize-HermesStorageVolume {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$DataDir
+    )
+
+    $volumeName = Get-HermesStorageVolumeName
+    $null = @(Invoke-Docker -Arguments @('volume', 'inspect', $volumeName) 2>$null)
+    if ($LASTEXITCODE -eq 0) {
+        return [PSCustomObject]@{ Success = $true; Existing = $true; Message = '' }
+    }
+    if ($LASTEXITCODE -ne 1) {
+        return [PSCustomObject]@{ Success = $false; Existing = $false; Message = 'Hermes data volume inspection failed.' }
+    }
+
+    $null = @(Invoke-Docker -Arguments @('volume', 'create', $volumeName) 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        return [PSCustomObject]@{ Success = $false; Existing = $false; Message = 'Hermes data volume creation failed.' }
+    }
+
+    $seedArguments = @(
+        'run', '--rm',
+        '--mount', "type=bind,source=$DataDir,target=/source,readonly",
+        '--mount', "type=volume,source=$volumeName,target=/target",
+        'local/hermes-agent-gh:latest',
+        '/usr/local/bin/hermes-storage-seed',
+        '--source', '/source',
+        '--destination', '/target'
+    )
+    $null = @(Invoke-Docker -Arguments $seedArguments 2>$null)
+    if ($LASTEXITCODE -eq 0) {
+        return [PSCustomObject]@{ Success = $true; Existing = $false; Message = '' }
+    }
+
+    $null = @(Invoke-Docker -Arguments @('volume', 'rm', $volumeName) 2>$null)
+    return [PSCustomObject]@{ Success = $false; Existing = $false; Message = 'Hermes data volume initialization failed.' }
+}

--- a/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
+++ b/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
@@ -144,6 +144,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             "compose -f $script:composeFile build hermes hermes-bootstrap chromium xapi-mcp",
             "compose -f $script:composeFile ps --all --services hermes",
             "compose -f $script:composeFile stop hermes",
+            'volume inspect hermes-data',
             "compose -f $script:composeFile up -d --force-recreate"
         )
         $script:environmentObservations.Phase | Should -Be @(
@@ -153,6 +154,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             'build',
             'ps',
             'stop',
+            'volume inspect hermes-data',
             'bootstrap',
             'up'
         )

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -57,7 +57,9 @@ Describe 'HermesAgentHandler' {
                 $global:LASTEXITCODE = 0
                 return
             }
-            $script:eventLog.Add([string]$Arguments[3])
+            if ($Arguments.Count -gt 3 -and $Arguments[0] -eq 'compose' -and $Arguments[1] -eq '-f') {
+                $script:eventLog.Add([string]$Arguments[3])
+            }
             $global:LASTEXITCODE = 0
         }
         Mock Invoke-HermesBootstrap {
@@ -177,6 +179,7 @@ Describe 'HermesAgentHandler' {
                 "compose -f $script:composeFile build --pull hermes hermes-bootstrap chromium browser-mcp xapi-mcp",
                 "compose -f $script:composeFile ps --all --services hermes",
                 "compose -f $script:composeFile stop hermes",
+                "volume inspect hermes-data",
                 "compose -f $script:composeFile up -d --force-recreate --remove-orphans hermes chromium browser-mcp xapi-mcp"
             )
             $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'xapi-credentials', 'up', 'health')
@@ -473,8 +476,9 @@ Describe 'HermesAgentHandler' {
 
         It 'returns failure after a compose startup exception with no later phase' {
             Mock Invoke-Docker {
-                $phase = [string]$Arguments[3]
-                $script:eventLog.Add($phase)
+                if ($Arguments.Count -gt 3 -and $Arguments[0] -eq 'compose' -and $Arguments[1] -eq '-f') {
+                    $script:eventLog.Add([string]$Arguments[3])
+                }
                 if ($Arguments -contains '--force-recreate') { throw 'startup exception' }
                 $global:LASTEXITCODE = 0
             }

--- a/scripts/powershell/tests/lib/HermesStorage.Tests.ps1
+++ b/scripts/powershell/tests/lib/HermesStorage.Tests.ps1
@@ -1,0 +1,80 @@
+#Requires -Module Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../lib/Invoke-ExternalCommand.ps1
+    . $PSScriptRoot/../../lib/HermesStorage.ps1
+}
+
+Describe 'Hermes Docker storage initialization' {
+    BeforeEach {
+        $script:dockerCalls = [System.Collections.Generic.List[string]]::new()
+        $script:volumeExists = $true
+        $script:seedExitCode = 0
+        $script:oldVolume = $env:HERMES_DATA_VOLUME
+        Remove-Item Env:\HERMES_DATA_VOLUME -ErrorAction SilentlyContinue
+
+        Mock Invoke-Docker {
+            $script:dockerCalls.Add(($Arguments -join ' '))
+            if ($Arguments[0] -eq 'volume' -and $Arguments[1] -eq 'inspect') {
+                    $global:LASTEXITCODE = if ($script:volumeExists) { 0 } else { 1 }
+            }
+            elseif ($Arguments[0] -eq 'volume' -and $Arguments[1] -eq 'create') {
+                $global:LASTEXITCODE = 0
+            }
+            elseif ($Arguments[0] -eq 'run') {
+                $global:LASTEXITCODE = $script:seedExitCode
+            }
+            elseif ($Arguments[0] -eq 'volume' -and $Arguments[1] -eq 'rm') {
+                $global:LASTEXITCODE = 0
+            }
+        }
+    }
+
+    AfterEach {
+        if ($null -eq $script:oldVolume) {
+            Remove-Item Env:\HERMES_DATA_VOLUME -ErrorAction SilentlyContinue
+        }
+        else {
+            Set-Item Env:\HERMES_DATA_VOLUME $script:oldVolume
+        }
+    }
+
+    It 'leaves an existing volume untouched' {
+        $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
+
+        $result.Success | Should -BeTrue
+        $result.Existing | Should -BeTrue
+        $script:dockerCalls | Should -Be @('volume inspect hermes-data')
+    }
+
+    It 'seeds a missing volume and does not remove it after success' {
+        $script:volumeExists = $false
+
+        $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
+
+        $result.Success | Should -BeTrue
+        $result.Existing | Should -BeFalse
+        $script:dockerCalls[0] | Should -Be 'volume inspect hermes-data'
+        $script:dockerCalls[1] | Should -Be 'volume create hermes-data'
+        $script:dockerCalls[2] | Should -Match 'run --rm --mount .*local/hermes-agent-gh:latest'
+        $script:dockerCalls | Should -Not -Contain 'volume rm hermes-data'
+    }
+
+    It 'removes only the newly created volume after a seed failure' {
+        $script:volumeExists = $false
+        $script:seedExitCode = 42
+
+        $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
+
+        $result.Success | Should -BeFalse
+        $script:dockerCalls[-1] | Should -Be 'volume rm hermes-data'
+    }
+
+    It 'rejects an unsafe volume name before Docker work' {
+        $env:HERMES_DATA_VOLUME = 'hermes/data'
+
+        { Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes' } |
+            Should -Throw '*invalid Docker volume name*'
+        $script:dockerCalls | Should -BeNullOrEmpty
+    }
+}

--- a/scripts/powershell/tests/lib/HermesStorage.Tests.ps1
+++ b/scripts/powershell/tests/lib/HermesStorage.Tests.ps1
@@ -56,7 +56,7 @@ Describe 'Hermes Docker storage initialization' {
         $result.Existing | Should -BeFalse
         $script:dockerCalls[0] | Should -Be 'volume inspect hermes-data'
         $script:dockerCalls[1] | Should -Be 'volume create hermes-data'
-        $script:dockerCalls[2] | Should -Match 'run --rm --mount .*local/hermes-agent-gh:latest'
+        $script:dockerCalls[2] | Should -Match 'run --rm --entrypoint /usr/local/bin/hermes-storage-seed --mount .*local/hermes-agent-gh:latest'
         $script:dockerCalls | Should -Not -Contain 'volume rm hermes-data'
     }
 

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -47,10 +47,11 @@ dotfiles_hermes_initialize_storage_volume() {
 
   "$docker_runner" volume create "$volume_name" >/dev/null || return $?
   if "$docker_runner" run --rm \
+    --entrypoint /usr/local/bin/hermes-storage-seed \
     --mount "type=bind,src=$data_dir,dst=/source,readonly" \
     --mount "type=volume,src=$volume_name,dst=/target" \
     local/hermes-agent-gh:latest \
-    /usr/local/bin/hermes-storage-seed --source /source --destination /target; then
+    --source /source --destination /target; then
     printf 'Hermes Docker data volume initialized: %s\n' "$volume_name" >&2
     return 0
   else

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -21,6 +21,47 @@ dotfiles_hermes_browser_data_dir() {
   fi
 }
 
+dotfiles_hermes_storage_volume_name() {
+  local volume_name="${HERMES_DATA_VOLUME:-hermes-data}"
+
+  [[ $volume_name =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ ]] || return 1
+  printf '%s\n' "$volume_name"
+}
+
+dotfiles_hermes_initialize_storage_volume() {
+  local docker_runner="$1"
+  local volume_name data_dir
+  local volume_status create_status
+
+  volume_name="$(dotfiles_hermes_storage_volume_name)" ||
+    dotfiles_die "HERMES_DATA_VOLUME contains an invalid Docker volume name."
+  data_dir="$(dotfiles_hermes_data_dir)"
+
+  if "$docker_runner" volume inspect "$volume_name" >/dev/null 2>&1; then
+    printf 'Hermes Docker data volume already exists; leaving it untouched: %s\n' "$volume_name" >&2
+    return 0
+  else
+    volume_status=$?
+    ((volume_status == 1)) || return "$volume_status"
+  fi
+
+  "$docker_runner" volume create "$volume_name" >/dev/null || return $?
+  if "$docker_runner" run --rm \
+    --mount "type=bind,src=$data_dir,dst=/source,readonly" \
+    --mount "type=volume,src=$volume_name,dst=/target" \
+    local/hermes-agent-gh:latest \
+    /usr/local/bin/hermes-storage-seed --source /source --destination /target; then
+    printf 'Hermes Docker data volume initialized: %s\n' "$volume_name" >&2
+    return 0
+  else
+    create_status=$?
+    # The volume was created by this invocation and is still empty or partial.
+    # Do not touch an existing volume; only remove this new initialization.
+    "$docker_runner" volume rm "$volume_name" >/dev/null 2>&1 || true
+    return "$create_status"
+  fi
+}
+
 dotfiles_hermes_prepare_runtime_home() {
   local data_dir browser_data_dir mode op_env_path
   data_dir="$(dotfiles_hermes_data_dir)"
@@ -588,6 +629,13 @@ dotfiles_hermes_start_stack() {
     esac
   fi
   if "$docker_runner" compose -f "$compose_file" stop hermes; then
+    :
+  else
+    status=$?
+    dotfiles_hermes_show_compose_diagnostics "$docker_runner" "$compose_file"
+    return "$status"
+  fi
+  if dotfiles_hermes_initialize_storage_volume "$docker_runner"; then
     :
   else
     status=$?

--- a/taskfiles/hermes/taskfile.yml
+++ b/taskfiles/hermes/taskfile.yml
@@ -17,7 +17,7 @@ tasks:
       - docker compose -f {{.HERMES_COMPOSE_FILE}} run --rm hermes setup
 
   hermes:bootstrap:
-    desc: Bootstrap the Hermes runtime through the supported host adapter
+    desc: Initialize the Docker data volume and bootstrap Hermes through the supported host adapter
     interactive: true
     deps:
       - task: hindsight:up
@@ -30,6 +30,17 @@ tasks:
       - cmd: bash -lc 'set -euo pipefail; source scripts/sh/install-common.sh; source scripts/sh/hermes-agent.sh; dotfiles_hermes_start_stack docker "{{.HERMES_COMPOSE_FILE}}"'
         platforms: [linux, darwin]
       - cmd: pwsh -NoProfile -File scripts/powershell/hermes-bootstrap.ps1 -ComposeFile "{{.HERMES_COMPOSE_FILE}}"
+        platforms: [windows]
+
+  hermes:storage:inspect:
+    desc: Inspect the Docker-managed Hermes runtime data volume
+    preconditions:
+      - sh: docker info
+        msg: "Docker daemon is not running. Start Docker Desktop and try again."
+    cmds:
+      - cmd: bash -lc 'docker volume inspect "${HERMES_DATA_VOLUME:-hermes-data}"'
+        platforms: [linux, darwin]
+      - cmd: pwsh -NoProfile -Command '$name = if ([string]::IsNullOrWhiteSpace($env:HERMES_DATA_VOLUME)) { "hermes-data" } else { $env:HERMES_DATA_VOLUME }; docker volume inspect $name'
         platforms: [windows]
 
   hermes:bootstrap:test:

--- a/tests/bash/bootstrap_acceptance.bats
+++ b/tests/bash/bootstrap_acceptance.bats
@@ -89,6 +89,10 @@ EOF
 	grep -Fq -- '-f "$REPO_ROOT/docker/hermes-agent/Dockerfile" "$REPO_ROOT/docker"' "$RUNNER"
 }
 
+@test "acceptance runner can use a preloaded offline storage seed image" {
+	grep -Fq 'DOTFILES_ACCEPTANCE_PRELOADED_STORAGE_SEED_IMAGE' "$RUNNER"
+}
+
 @test "acceptance secret fixtures are deterministic and reject unapproved lookups" {
 	bootstrap="$FIXTURE_ROOT/hermes-bootstrap-fixture.sh"
 	op="$FIXTURE_ROOT/bin/op"

--- a/tests/bash/bootstrap_acceptance.bats
+++ b/tests/bash/bootstrap_acceptance.bats
@@ -40,6 +40,11 @@ setup() {
 exit 99
 EOF
 	chmod +x "$test_root/activated/bin/op"
+	cat >"$test_root/activated/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+	chmod +x "$test_root/activated/bin/docker"
 	cat >"$test_root/install.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -72,10 +77,16 @@ EOF
 	run env \
 		DOTFILES_ACCEPTANCE_REPO_ROOT="$test_root" \
 		DOTFILES_ACCEPTANCE_FIXTURE_ROOT="$FIXTURE_ROOT" \
+		PATH="$test_root/activated/bin:$PATH" \
 		"$RUNNER"
 
 	[ "$status" -eq 0 ]
 	[[ "$output" == "$FIXTURE_ROOT/bin/op" ]]
+}
+
+@test "acceptance runner builds the Hermes image used by storage seeding" {
+	grep -Fq 'docker build -t local/hermes-agent-gh:latest' "$RUNNER"
+	grep -Fq -- '-f "$REPO_ROOT/docker/hermes-agent/Dockerfile" "$REPO_ROOT/docker"' "$RUNNER"
 }
 
 @test "acceptance secret fixtures are deterministic and reject unapproved lookups" {

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -229,6 +229,7 @@ printf "sleep <%s>\n" "$*" >>"$COMMAND_LOG"
 
 	[ "$status" -eq 0 ]
 	assert_log_order '<stop> <hermes>' '<volume> <inspect> <hermes-data>' '<volume> <create> <hermes-data>' '<run> <--rm>' '<secret-plan>'
+	grep -Fq '<run> <--rm> <--entrypoint> </usr/local/bin/hermes-storage-seed>' "$COMMAND_LOG"
 }
 
 @test "removes only a newly created volume when storage seeding fails" {

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -44,6 +44,7 @@ EOF
 	export OP_READ_COMPLETION_FILE=""
 	export BOOTSTRAP_EXIT_EARLY=0
 	export HERMES_RUNTIME_EXISTS=1
+	export HERMES_VOLUME_EXISTS=1
 	export API_READY_AFTER=1
 	export OLLAMA_READY_AFTER=1
 	export HINDSIGHT_API_DATABASE=connected
@@ -107,6 +108,25 @@ printf " <%s>" "$@" >>"$COMMAND_LOG"
 printf "\n" >>"$COMMAND_LOG"
 if [ "${1:-}" = "image" ] && [ "${2:-}" = "prune" ]; then
 	exit "$IMAGE_PRUNE_STATUS"
+fi
+if [ "${1:-}" = "volume" ]; then
+  case "${2:-}" in
+    inspect)
+      [[ ${HERMES_VOLUME_EXISTS:-1} == 1 ]] && printf '[{}]\n' || exit 1
+      ;;
+    create)
+      printf 'hermes-data\n'
+      ;;
+    rm)
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+if [ "${1:-}" = "run" ]; then
+  exit "${HERMES_STORAGE_SEED_STATUS:-0}"
 fi
 if [ "${1:-}" != "compose" ]; then
 	exit 1
@@ -200,6 +220,26 @@ shift
 	write_stub sleep '
 printf "sleep <%s>\n" "$*" >>"$COMMAND_LOG"
 '
+}
+
+@test "initializes a missing Hermes Docker data volume before bootstrap" {
+	export HERMES_VOLUME_EXISTS=0
+
+	run_start_stack
+
+	[ "$status" -eq 0 ]
+	assert_log_order '<stop> <hermes>' '<volume> <inspect> <hermes-data>' '<volume> <create> <hermes-data>' '<run> <--rm>' '<secret-plan>'
+}
+
+@test "removes only a newly created volume when storage seeding fails" {
+	export HERMES_VOLUME_EXISTS=0
+	export HERMES_STORAGE_SEED_STATUS=42
+
+	run_start_stack
+
+	[ "$status" -eq 42 ]
+	grep -Fq '<volume> <rm> <hermes-data>' "$COMMAND_LOG"
+	! grep -q '<secret-plan>' "$COMMAND_LOG"
 }
 
 write_stub() {


### PR DESCRIPTION
## Summary\n\n- move Hermes runtime state from host bind mounts to a Docker-managed named volume\n- seed a missing volume with SQLite backup API while excluding WAL/SHM/JOURNAL sidecars\n- integrate idempotent, failure-safe initialization into Unix and Windows bootstrap paths\n- add Compose, Python, Bash, PowerShell, and container contract coverage\n\nCloses #548\n\n## Verification\n\n- An error has occurred: FatalError: git failed. Is it installed, and are you in a Git repository directory?
Check the log at /Users/ktome1995/.cache/pre-commit/pre-commit.log\n- Docker bootstrap-test stage: 595 existing tests plus storage helper tests passed\n- Bash Hermes tests: 44 passed\n- PowerShell Hermes tests: 50 passed\n-  passed