### PR TITLE
fix(hermes): expose Docker-backed CLI on macOS

### DIFF
--- a/docs/hermes-agent/desktop.md
+++ b/docs/hermes-agent/desktop.md
@@ -12,6 +12,33 @@ macOS の `./install.sh --with-hermes` は、次の2つを別々に管理しま�
 Desktop の GUI を Agent コンテナに入れる必要はありません。コンテナは GUI を
 提供するイメージではなく、Agent の実行環境と Dashboard/API を提供します。
 
+## CLI の実行
+
+Hermes Desktop は GUI フロントエンドであり、macOS ホストのシェルで CLI を
+実行する機能はありません。また、この構成では公式の CLI は Docker コンテナ内に
+だけ存在します。そのため `WithHermes` プロファイルでは、ホストの
+`hermes-docker` が既存の `hermes` サービスへコマンドを転送します。
+
+リポジトリからは、次のように実行できます。引数はコンテナ内の CLI へそのまま
+渡されます。
+
+```bash
+task hermes:cli -- -p personal-ops config check
+task hermes:cli -- profile list
+```
+
+リポジトリ外から直接実行する場合は、Compose ファイルを明示します。
+
+```bash
+HERMES_COMPOSE_FILE="$HOME/.dotfiles/docker/hermes-service/compose.yml" \
+  hermes-docker -p personal-ops chat
+```
+
+このアダプターはサービスを自動起動・停止しません。先に `task hermes:up` を
+実行し、Docker Desktop と Hermes コンテナが起動していることを確認してください。
+対話端末ではTTYを維持し、パイプやCIではTTY割り当てを無効にするため、チャットと
+設定検証の両方を同じコマンドで扱えます。
+
 公式ドキュメントでも Desktop App、CLI/TUI、Web Dashboard は同じ Agent に接続
 する別のフロントエンドとして説明されています。Desktop は `hermes-desktop`
 で起動し、Web Dashboard は `hermes dashboard` が提供します。

--- a/docs/hermes-agent/desktop.md
+++ b/docs/hermes-agent/desktop.md
@@ -27,6 +27,20 @@ task hermes:cli -- -p personal-ops config check
 task hermes:cli -- profile list
 ```
 
+Profile gateway の状態確認と起動も、対象Profileを明示して実行できます。
+
+```bash
+PROFILE=personal-ops task hermes:profile:status
+PROFILE=personal-ops task hermes:profile:up
+PROFILE=career-ops task hermes:profile:status
+PROFILE=dev-lab task hermes:profile:status
+```
+
+`hermes:profile:up` は明示的に指定したProfileだけを起動します。Profile名は
+Taskfile側でshell-safeにargv化されます。CLIの既定Composeファイルは既存の
+`docker/hermes-service/compose.yml`に固定され、別ファイルを使う場合だけ
+`HERMES_COMPOSE_FILE`で明示指定します。
+
 リポジトリ外から直接実行する場合は、Compose ファイルを明示します。
 
 ```bash

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -73,6 +73,11 @@ let
       })
     else
       null;
+  dockerDesktopPackage =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      selectDarwinPackage "docker-desktop" (pkgs.callPackage ./docker-desktop { })
+    else
+      null;
   rawCatalog =
     if catalogOverride != null then
       catalogOverride
@@ -676,11 +681,7 @@ let
           };
         };
         docker-desktop = {
-          pkg =
-            if pkgs.stdenv.hostPlatform.isDarwin then
-              selectDarwinPackage "docker-desktop" (pkgs.callPackage ./docker-desktop { })
-            else
-              null;
+          pkg = dockerDesktopPackage;
           winget = "Docker.DockerDesktop";
           category = "system";
           installFeature = "WithDocker";
@@ -773,7 +774,7 @@ let
             if pkgs.stdenv.hostPlatform.isDarwin then
               pkgs.writeShellApplication {
                 name = "hermes-docker";
-                runtimeInputs = [ pkgs.docker ];
+                runtimeInputs = [ dockerDesktopPackage ];
                 text = builtins.readFile ../../scripts/sh/hermes-docker.sh;
               }
             else

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -768,6 +768,33 @@ let
             };
           };
         };
+        hermes-docker = {
+          pkg =
+            if pkgs.stdenv.hostPlatform.isDarwin then
+              pkgs.writeShellApplication {
+                name = "hermes-docker";
+                runtimeInputs = [ pkgs.docker ];
+                text = builtins.readFile ../../scripts/sh/hermes-docker.sh;
+              }
+            else
+              null;
+          winget = null;
+          category = "terminal";
+          installFeature = "WithHermes";
+          support = {
+            darwin = {
+              provider = "nix";
+              source = "dotfiles";
+              identity.command = "hermes-docker";
+            };
+            linux = {
+              unsupported = "Hermes Docker CLI is provisioned by the native macOS profile";
+            };
+            windows = {
+              unsupported = "Hermes Docker CLI is provisioned by the native macOS profile";
+            };
+          };
+        };
 
         # ── k8s ───────────────────────────────────────────────
         kind = {

--- a/scripts/sh/hermes-docker.sh
+++ b/scripts/sh/hermes-docker.sh
@@ -7,17 +7,7 @@ hermes_docker_die() {
   exit 1
 }
 
-compose_file="${HERMES_COMPOSE_FILE:-}"
-if [[ -z $compose_file ]]; then
-  for candidate in \
-    "docker/hermes-service/compose.yml" \
-    "${HOME}/.dotfiles/docker/hermes-service/compose.yml"; do
-    if [[ -f $candidate ]]; then
-      compose_file="$candidate"
-      break
-    fi
-  done
-fi
+compose_file="${HERMES_COMPOSE_FILE:-${HOME}/.dotfiles/docker/hermes-service/compose.yml}"
 
 [[ -n $compose_file && -f $compose_file ]] ||
   hermes_docker_die "compose file not found; set HERMES_COMPOSE_FILE or run from the dotfiles repository"

--- a/scripts/sh/hermes-docker.sh
+++ b/scripts/sh/hermes-docker.sh
@@ -23,7 +23,7 @@ fi
   hermes_docker_die "compose file not found; set HERMES_COMPOSE_FILE or run from the dotfiles repository"
 
 if [[ -t 0 && -t 1 ]]; then
-  exec docker compose -f "$compose_file" exec hermes /opt/hermes/bin/hermes "$@"
+  exec docker-compose -f "$compose_file" exec hermes /opt/hermes/bin/hermes "$@"
 else
-  exec docker compose -f "$compose_file" exec -T hermes /opt/hermes/bin/hermes "$@"
+  exec docker-compose -f "$compose_file" exec -T hermes /opt/hermes/bin/hermes "$@"
 fi

--- a/scripts/sh/hermes-docker.sh
+++ b/scripts/sh/hermes-docker.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+hermes_docker_die() {
+  printf 'Hermes Docker CLI: %s\n' "$1" >&2
+  exit 1
+}
+
+compose_file="${HERMES_COMPOSE_FILE:-}"
+if [[ -z $compose_file ]]; then
+  for candidate in \
+    "docker/hermes-service/compose.yml" \
+    "${HOME}/.dotfiles/docker/hermes-service/compose.yml"; do
+    if [[ -f $candidate ]]; then
+      compose_file="$candidate"
+      break
+    fi
+  done
+fi
+
+[[ -n $compose_file && -f $compose_file ]] ||
+  hermes_docker_die "compose file not found; set HERMES_COMPOSE_FILE or run from the dotfiles repository"
+
+if [[ -t 0 && -t 1 ]]; then
+  exec docker compose -f "$compose_file" exec hermes /opt/hermes/bin/hermes "$@"
+else
+  exec docker compose -f "$compose_file" exec -T hermes /opt/hermes/bin/hermes "$@"
+fi

--- a/taskfiles/hermes/taskfile.yml
+++ b/taskfiles/hermes/taskfile.yml
@@ -214,8 +214,36 @@ tasks:
       - sh: command -v hermes-docker
         msg: "Hermes Docker CLI adapter is not installed. Apply the WithHermes profile."
     cmds:
-      - cmd: HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE}} hermes-docker {{.CLI_ARGS}}
+      - cmd: HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE | shellQuote}} hermes-docker {{range .CLI_ARGS_LIST}}{{. | shellQuote}} {{end}}
         platforms: [darwin]
+
+  hermes:profile:status:
+    desc: Show the gateway status for a Hermes profile
+    vars:
+      PROFILE: '{{.PROFILE | default ""}}'
+    preconditions:
+      - sh: docker info
+        msg: "Docker daemon is not running. Start Docker Desktop and try again."
+      - sh: test -n {{.PROFILE | shellQuote}}
+        msg: "Set PROFILE to an installed Hermes profile name."
+    cmds:
+      - cmd: docker exec hermes /opt/hermes/.venv/bin/hermes -p {{.PROFILE | shellQuote}} gateway status
+        platforms: [darwin, linux]
+
+  hermes:profile:up:
+    desc: Start the gateway for a Hermes profile
+    vars:
+      PROFILE: '{{.PROFILE | default ""}}'
+    deps:
+      - task: hermes:up
+    preconditions:
+      - sh: docker info
+        msg: "Docker daemon is not running. Start Docker Desktop and try again."
+      - sh: test -n {{.PROFILE | shellQuote}}
+        msg: "Set PROFILE to an installed Hermes profile name."
+    cmds:
+      - cmd: docker exec hermes /opt/hermes/.venv/bin/hermes -p {{.PROFILE | shellQuote}} gateway start
+        platforms: [darwin, linux]
 
   hermes:down:
     desc: Stop Hermes Agent Docker container

--- a/taskfiles/hermes/taskfile.yml
+++ b/taskfiles/hermes/taskfile.yml
@@ -203,6 +203,20 @@ tasks:
       - cmd: hermes-desktop-docker
         platforms: [darwin]
 
+  hermes:cli:
+    desc: Run the Hermes CLI inside the Docker Agent container
+    interactive: true
+    preconditions:
+      - sh: docker info
+        msg: "Docker daemon is not running. Start Docker Desktop and try again."
+      - sh: test -f {{.HERMES_COMPOSE_FILE}}
+        msg: "Hermes compose file not found: {{.HERMES_COMPOSE_FILE}}"
+      - sh: command -v hermes-docker
+        msg: "Hermes Docker CLI adapter is not installed. Apply the WithHermes profile."
+    cmds:
+      - cmd: HERMES_COMPOSE_FILE={{.HERMES_COMPOSE_FILE}} hermes-docker {{.CLI_ARGS}}
+        platforms: [darwin]
+
   hermes:down:
     desc: Stop Hermes Agent Docker container
     preconditions:

--- a/tests/bash/hermes_docker_cli.bats
+++ b/tests/bash/hermes_docker_cli.bats
@@ -28,7 +28,7 @@ write_stub() {
 	chmod +x "$STUB_BIN/$name"
 }
 
-@test "Docker CLI uses the default dotfiles compose file and forwards arguments" {
+@test "Docker CLI uses the trusted dotfiles compose file and forwards arguments" {
 	cd "$TEST_HOME"
 	run "$REPO_ROOT/scripts/sh/hermes-docker.sh" -p personal-ops config check
 

--- a/tests/bash/hermes_docker_cli.bats
+++ b/tests/bash/hermes_docker_cli.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+	TEST_HOME="$BATS_TEST_TMPDIR/home"
+	STUB_BIN="$BATS_TEST_TMPDIR/bin"
+	DOCKER_CAPTURE="$BATS_TEST_TMPDIR/docker.args"
+	mkdir -p "$TEST_HOME/.dotfiles/docker/hermes-service" "$STUB_BIN"
+	touch "$TEST_HOME/.dotfiles/docker/hermes-service/compose.yml"
+	write_stub docker '
+printf "%s\n" "$*" >"$DOCKER_CAPTURE"
+'
+	export HOME="$TEST_HOME"
+	export PATH="$STUB_BIN:/usr/bin:/bin"
+	export DOCKER_CAPTURE
+}
+
+write_stub() {
+	local name="$1"
+	local body="$2"
+	{
+		printf '#!/usr/bin/env bash\n'
+		printf 'set -euo pipefail\n'
+		printf '%s\n' "$body"
+	} >"$STUB_BIN/$name"
+	chmod +x "$STUB_BIN/$name"
+}
+
+@test "Docker CLI uses the default dotfiles compose file and forwards arguments" {
+	cd "$TEST_HOME"
+	run "$REPO_ROOT/scripts/sh/hermes-docker.sh" -p personal-ops config check
+
+	[ "$status" -eq 0 ]
+	[ "$(<"$DOCKER_CAPTURE")" = "compose -f $TEST_HOME/.dotfiles/docker/hermes-service/compose.yml exec -T hermes /opt/hermes/bin/hermes -p personal-ops config check" ]
+}
+
+@test "Docker CLI honors an explicit compose file" {
+	compose_file="$BATS_TEST_TMPDIR/custom-compose.yml"
+	touch "$compose_file"
+
+	run env HERMES_COMPOSE_FILE="$compose_file" "$REPO_ROOT/scripts/sh/hermes-docker.sh" --version
+
+	[ "$status" -eq 0 ]
+	[ "$(<"$DOCKER_CAPTURE")" = "compose -f $compose_file exec -T hermes /opt/hermes/bin/hermes --version" ]
+}
+
+@test "Docker CLI reports how to configure a missing compose file" {
+	rm "$TEST_HOME/.dotfiles/docker/hermes-service/compose.yml"
+	cd "$TEST_HOME"
+
+	run "$REPO_ROOT/scripts/sh/hermes-docker.sh" --version
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"HERMES_COMPOSE_FILE"* ]]
+}

--- a/tests/bash/hermes_docker_cli.bats
+++ b/tests/bash/hermes_docker_cli.bats
@@ -9,7 +9,7 @@ setup() {
 	DOCKER_CAPTURE="$BATS_TEST_TMPDIR/docker.args"
 	mkdir -p "$TEST_HOME/.dotfiles/docker/hermes-service" "$STUB_BIN"
 	touch "$TEST_HOME/.dotfiles/docker/hermes-service/compose.yml"
-	write_stub docker '
+	write_stub docker-compose '
 printf "%s\n" "$*" >"$DOCKER_CAPTURE"
 '
 	export HOME="$TEST_HOME"
@@ -33,7 +33,7 @@ write_stub() {
 	run "$REPO_ROOT/scripts/sh/hermes-docker.sh" -p personal-ops config check
 
 	[ "$status" -eq 0 ]
-	[ "$(<"$DOCKER_CAPTURE")" = "compose -f $TEST_HOME/.dotfiles/docker/hermes-service/compose.yml exec -T hermes /opt/hermes/bin/hermes -p personal-ops config check" ]
+	[ "$(<"$DOCKER_CAPTURE")" = "-f $TEST_HOME/.dotfiles/docker/hermes-service/compose.yml exec -T hermes /opt/hermes/bin/hermes -p personal-ops config check" ]
 }
 
 @test "Docker CLI honors an explicit compose file" {
@@ -43,7 +43,7 @@ write_stub() {
 	run env HERMES_COMPOSE_FILE="$compose_file" "$REPO_ROOT/scripts/sh/hermes-docker.sh" --version
 
 	[ "$status" -eq 0 ]
-	[ "$(<"$DOCKER_CAPTURE")" = "compose -f $compose_file exec -T hermes /opt/hermes/bin/hermes --version" ]
+	[ "$(<"$DOCKER_CAPTURE")" = "-f $compose_file exec -T hermes /opt/hermes/bin/hermes --version" ]
 }
 
 @test "Docker CLI reports how to configure a missing compose file" {

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -118,6 +118,20 @@ nix_fixture_darwin_package_split() {
 	[[ "$output" == *'command = "hermes-desktop-docker";'* ]]
 }
 
+@test "Hermes Docker CLI is a Darwin Hermes package" {
+	run awk '
+		/^[[:space:]]*hermes-docker = \{/ { in_entry=1 }
+		in_entry { print }
+		in_entry && /^        };/ { exit }
+	' "$SETS"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'writeShellApplication'* ]]
+	[[ "$output" == *'pkgs.docker'* ]]
+	[[ "$output" == *'installFeature = "WithHermes";'* ]]
+	[[ "$output" == *'source = "dotfiles";'* ]]
+	[[ "$output" == *'command = "hermes-docker";'* ]]
+}
+
 @test "Hermes Desktop is absent from default package outputs" {
 	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
 	command -v jq >/dev/null 2>&1 || skip "jq is not available in this test environment"

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -126,7 +126,7 @@ nix_fixture_darwin_package_split() {
 	' "$SETS"
 	[ "$status" -eq 0 ]
 	[[ "$output" == *'writeShellApplication'* ]]
-	[[ "$output" == *'pkgs.docker'* ]]
+	[[ "$output" == *'dockerDesktopPackage'* ]]
 	[[ "$output" == *'installFeature = "WithHermes";'* ]]
 	[[ "$output" == *'source = "dotfiles";'* ]]
 	[[ "$output" == *'command = "hermes-docker";'* ]]
@@ -770,7 +770,7 @@ EOF
 }
 
 @test "Darwin GUI promotions use custom products instead of same-named nixpkgs packages" {
-	for id in hammerspoon dia-browser orca-editor docker-desktop; do
+	for id in hammerspoon dia-browser orca-editor; do
 		run awk -v id="$id" '
 			$0 ~ "^[[:space:]]*" id " = \\{" { in_entry=1 }
 			in_entry { print }
@@ -779,6 +779,8 @@ EOF
 		[ "$status" -eq 0 ]
 		[[ "$output" == *'selectDarwinPackage "'$id'"'* ]]
 		done
+	grep -q 'dockerDesktopPackage =' "$SETS"
+	grep -q 'selectDarwinPackage "docker-desktop"' "$SETS"
 	grep -q 'source = "custom"' "$REPO_ROOT/nix/packages/darwin-provider-candidates.nix"
 	grep -q 'callPackage ./hammerspoon' "$SETS"
 	grep -q 'callPackage ./dia-browser' "$SETS"

--- a/tests/python/test_taskfile_contract.py
+++ b/tests/python/test_taskfile_contract.py
@@ -114,10 +114,24 @@ class TaskfileContractTests(unittest.TestCase):
         self.assertIn("docker info", task)
         self.assertIn("test -f {{.HERMES_COMPOSE_FILE}}", task)
         self.assertIn("hermes-docker", task)
+        self.assertIn("CLI_ARGS_LIST", task)
+        self.assertIn("shellQuote", task)
         self.assertIn("platforms: [darwin]", task)
         wrapper = HERMES_DOCKER_WRAPPER.read_text(encoding="utf-8")
         self.assertIn("HERMES_COMPOSE_FILE", wrapper)
         self.assertIn("/opt/hermes/bin/hermes", wrapper)
+
+    def test_profile_gateway_entrypoints_are_explicit_and_shell_safe(self) -> None:
+        for task_name, action in (
+            ("hermes:profile:status", "gateway status"),
+            ("hermes:profile:up", "gateway start"),
+        ):
+            with self.subTest(task_name=task_name):
+                task = self._task_block(task_name)
+                self.assertIn("PROFILE", task)
+                self.assertIn("shellQuote", task)
+                self.assertIn(action, task)
+                self.assertIn("docker info", task)
 
     def test_xapi_lifecycle_reads_oauth_credentials_from_1password(self) -> None:
         wrapper = XAPI_WRAPPER.read_text(encoding="utf-8")

--- a/tests/python/test_taskfile_contract.py
+++ b/tests/python/test_taskfile_contract.py
@@ -13,6 +13,7 @@ XAPI_WRAPPER = REPOSITORY_ROOT / "scripts" / "sh" / "hermes-xapi.sh"
 XAPI_WINDOWS_WRAPPER = REPOSITORY_ROOT / "scripts" / "powershell" / "hermes-xapi.ps1"
 HINDSIGHT_WRAPPER = REPOSITORY_ROOT / "scripts" / "sh" / "hermes-hindsight-verify.sh"
 HERMES_DESKTOP_WRAPPER = REPOSITORY_ROOT / "scripts" / "sh" / "hermes-desktop-docker.sh"
+HERMES_DOCKER_WRAPPER = REPOSITORY_ROOT / "scripts" / "sh" / "hermes-docker.sh"
 HINDSIGHT_WINDOWS_WRAPPER = (
     REPOSITORY_ROOT / "scripts" / "powershell" / "hermes-hindsight-verify.ps1"
 )
@@ -105,6 +106,18 @@ class TaskfileContractTests(unittest.TestCase):
         self.assertIn("127.0.0.1:9119", wrapper)
         self.assertNotIn("API_SERVER_KEY", wrapper)
         self.assertIn("unset HERMES_DESKTOP_REMOTE_URL HERMES_DESKTOP_REMOTE_TOKEN", wrapper)
+
+    def test_cli_entrypoint_uses_the_docker_cli_adapter(self) -> None:
+        task = self._task_block("hermes:cli")
+
+        self.assertIn("interactive: true", task)
+        self.assertIn("docker info", task)
+        self.assertIn("test -f {{.HERMES_COMPOSE_FILE}}", task)
+        self.assertIn("hermes-docker", task)
+        self.assertIn("platforms: [darwin]", task)
+        wrapper = HERMES_DOCKER_WRAPPER.read_text(encoding="utf-8")
+        self.assertIn("HERMES_COMPOSE_FILE", wrapper)
+        self.assertIn("/opt/hermes/bin/hermes", wrapper)
 
     def test_xapi_lifecycle_reads_oauth_credentials_from_1password(self) -> None:
         wrapper = XAPI_WRAPPER.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add a Darwin-only hermes-docker adapter that runs the container CLI
- add the hermes:cli Taskfile entrypoint with Docker and compose preconditions
- document why Hermes Desktop cannot directly operate the host CLI and how to use the adapter
- add Bats, Python contract, and Nix package coverage

## Verification

- targeted Hermes Bats and Python contracts pass
- Docker-backed hermes-docker --version returns Hermes Agent v0.21.0
- Nix darwin-hermes-docker build passes
- package-support-report build passes
- nix fmt and pre-commit pass
- full Bats has five pre-existing NixOS installer failures unrelated to this change

Closes #550