### PR TITLE
fix(hermes): use bundled Docker Compose plugin

### DIFF
--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -775,7 +775,10 @@ let
               pkgs.writeShellApplication {
                 name = "hermes-docker";
                 runtimeInputs = [ dockerDesktopPackage ];
-                text = builtins.readFile ../../scripts/sh/hermes-docker.sh;
+                text = ''
+                  export HERMES_DOCKER_COMPOSE_PLUGIN="${dockerDesktopPackage}/libexec/docker/cli-plugins/docker-compose"
+                  ${builtins.readFile ../../scripts/sh/hermes-docker.sh}
+                '';
               }
             else
               null;

--- a/scripts/sh/hermes-docker.sh
+++ b/scripts/sh/hermes-docker.sh
@@ -8,12 +8,17 @@ hermes_docker_die() {
 }
 
 compose_file="${HERMES_COMPOSE_FILE:-${HOME}/.dotfiles/docker/hermes-service/compose.yml}"
+if [[ -n ${HERMES_DOCKER_COMPOSE_PLUGIN:-} ]]; then
+  compose_command=("$HERMES_DOCKER_COMPOSE_PLUGIN")
+else
+  compose_command=(docker compose)
+fi
 
 [[ -n $compose_file && -f $compose_file ]] ||
   hermes_docker_die "compose file not found; set HERMES_COMPOSE_FILE or run from the dotfiles repository"
 
 if [[ -t 0 && -t 1 ]]; then
-  exec docker-compose -f "$compose_file" exec hermes /opt/hermes/bin/hermes "$@"
+  exec "${compose_command[@]}" -f "$compose_file" exec hermes /opt/hermes/bin/hermes "$@"
 else
-  exec docker-compose -f "$compose_file" exec -T hermes /opt/hermes/bin/hermes "$@"
+  exec "${compose_command[@]}" -f "$compose_file" exec -T hermes /opt/hermes/bin/hermes "$@"
 fi

--- a/tests/bash/hermes_docker_cli.bats
+++ b/tests/bash/hermes_docker_cli.bats
@@ -9,7 +9,7 @@ setup() {
 	DOCKER_CAPTURE="$BATS_TEST_TMPDIR/docker.args"
 	mkdir -p "$TEST_HOME/.dotfiles/docker/hermes-service" "$STUB_BIN"
 	touch "$TEST_HOME/.dotfiles/docker/hermes-service/compose.yml"
-	write_stub docker-compose '
+	write_stub docker '
 printf "%s\n" "$*" >"$DOCKER_CAPTURE"
 '
 	export HOME="$TEST_HOME"
@@ -33,7 +33,7 @@ write_stub() {
 	run "$REPO_ROOT/scripts/sh/hermes-docker.sh" -p personal-ops config check
 
 	[ "$status" -eq 0 ]
-	[ "$(<"$DOCKER_CAPTURE")" = "-f $TEST_HOME/.dotfiles/docker/hermes-service/compose.yml exec -T hermes /opt/hermes/bin/hermes -p personal-ops config check" ]
+	[ "$(<"$DOCKER_CAPTURE")" = "compose -f $TEST_HOME/.dotfiles/docker/hermes-service/compose.yml exec -T hermes /opt/hermes/bin/hermes -p personal-ops config check" ]
 }
 
 @test "Docker CLI honors an explicit compose file" {
@@ -43,7 +43,7 @@ write_stub() {
 	run env HERMES_COMPOSE_FILE="$compose_file" "$REPO_ROOT/scripts/sh/hermes-docker.sh" --version
 
 	[ "$status" -eq 0 ]
-	[ "$(<"$DOCKER_CAPTURE")" = "-f $compose_file exec -T hermes /opt/hermes/bin/hermes --version" ]
+	[ "$(<"$DOCKER_CAPTURE")" = "compose -f $compose_file exec -T hermes /opt/hermes/bin/hermes --version" ]
 }
 
 @test "Docker CLI reports how to configure a missing compose file" {

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -127,6 +127,7 @@ nix_fixture_darwin_package_split() {
 	[ "$status" -eq 0 ]
 	[[ "$output" == *'writeShellApplication'* ]]
 	[[ "$output" == *'dockerDesktopPackage'* ]]
+	[[ "$output" == *'HERMES_DOCKER_COMPOSE_PLUGIN'* ]]
 	[[ "$output" == *'installFeature = "WithHermes";'* ]]
 	[[ "$output" == *'source = "dotfiles";'* ]]
 	[[ "$output" == *'command = "hermes-docker";'* ]]


### PR DESCRIPTION
## Summary
- use `docker compose` for the standalone Hermes wrapper
- use the Nix-managed Docker Desktop Compose plugin when provided
- add regression coverage for both the wrapper and package wiring

## Verification
- `bats tests/bash/hermes_docker_cli.bats tests/bash/package_catalog.bats`
- `python3 -m unittest -q tests/python/test_taskfile_contract.py`
- `nix build path:.#darwin-hermes-docker --no-link --print-out-paths --impure`
- `task fmt:check`
- `task lint`
- WezTerm: `hermes-docker --version` and `hermes-docker -p personal-ops config check`

Closes #552