### PR TITLE
fix(macos): manage Hermes Desktop with Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ Nix installer と nix-darwin がシステムを収束させ、nix-homebrew が�
 Homebrew formula/cask を管理します。Home Manager と chezmoi も同じコマンド内で
 適用します。macOS では WSL や NixOS を導入しません。
 
-`--with-hermes` の macOS 構成では、Hermes Desktop は公式 Hermes flake の Nix
-パッケージとしてホストに導入されます。Agent/gateway と Web Dashboard は既存の
-Docker Compose 側で起動し、Desktop から `http://127.0.0.1:9119` に接続します。
+`--with-hermes` の macOS 構成では、Hermes Desktop はパッケージカタログで選択した
+公式 Homebrew Cask `hermes-desktop` として nix-homebrew からホストに導入されます。
+Agent/gateway と Web Dashboard は既存の Docker Compose 側で起動し、Desktop から
+`http://127.0.0.1:9119` に接続します。
 Dashboard の認証情報、セッション、モデル、その他の runtime state は Nix store
 に保存しません。Desktop を Agent コンテナへインストールする構成ではありません。
 

--- a/docs/hermes-agent/desktop.md
+++ b/docs/hermes-agent/desktop.md
@@ -4,8 +4,8 @@
 
 macOS の `./install.sh --with-hermes` は、次の2つを別々に管理します。
 
-- ホスト: 公式 `NousResearch/hermes-agent` flake の `desktop` 出力を Nix/Home
-  Manager で導入し、`hermes-desktop` コマンドを提供する。
+- ホスト: 公式 Homebrew Cask `hermes-desktop` を nix-homebrew で宣言し、
+  `/Applications/Hermes.app` にベンダー配布版を導入する。
 - Docker: `docker/hermes-service/compose.yml` の Hermes Agent、gateway、Web
   Dashboard、Browser/MCP サービスを起動する。
 
@@ -54,8 +54,9 @@ HERMES_COMPOSE_FILE="$HOME/.dotfiles/docker/hermes-service/compose.yml" \
 設定検証の両方を同じコマンドで扱えます。
 
 公式ドキュメントでも Desktop App、CLI/TUI、Web Dashboard は同じ Agent に接続
-する別のフロントエンドとして説明されています。Desktop は `hermes-desktop`
-で起動し、Web Dashboard は `hermes dashboard` が提供します。
+する別のフロントエンドとして説明されています。Desktop は
+`hermes-desktop-docker` が macOS の `open /Applications/Hermes.app` を通して起動し、Web
+Dashboard は `hermes dashboard` が提供します。
 
 ## 接続先
 

--- a/docs/superpowers/plans/2026-09-01-hermes-desktop-nix.md
+++ b/docs/superpowers/plans/2026-09-01-hermes-desktop-nix.md
@@ -1,5 +1,10 @@
 # Hermes Desktop Nix Integration Implementation Plan
 
+> **Superseded:** This plan was replaced on 2026-09-03 by
+> [#554](https://github.com/rurusasu/dotfiles/issues/554), which manages Hermes
+> Desktop through the official Homebrew Cask. See the
+> [current operations guide](../../hermes-agent/desktop.md).
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Add the official Hermes Desktop Nix output to the `WithHermes` macOS

--- a/docs/superpowers/specs/2026-09-01-hermes-desktop-nix-design.md
+++ b/docs/superpowers/specs/2026-09-01-hermes-desktop-nix-design.md
@@ -1,5 +1,9 @@
 # Hermes Desktop Nix 管理設計
 
+> **廃止済み:** 2026-09-03 に [#554](https://github.com/rurusasu/dotfiles/issues/554)
+> で Homebrew Cask 管理へ移行しました。現行構成は
+> [Hermes Desktop の運用](../../hermes-agent/desktop.md) を参照してください。
+
 ## 目的
 
 `--with-hermes` を選んだ macOS 環境で、Hermes Desktop をホスト側の Nix

--- a/flake.lock
+++ b/flake.lock
@@ -132,53 +132,7 @@
         "type": "github"
       }
     },
-    "hermes-agent": {
-      "inputs": {
-        "flake-parts": [
-          "flake-parts"
-        ],
-        "home-manager": "home-manager",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "npm-lockfile-fix": "npm-lockfile-fix",
-        "pyproject-build-systems": "pyproject-build-systems",
-        "pyproject-nix": "pyproject-nix",
-        "uv2nix": "uv2nix"
-      },
-      "locked": {
-        "lastModified": 1788189266,
-        "narHash": "sha256-KRDA43R7XkCDnJFliAcIuTj4/dek8GL/zZlfmJPSgiI=",
-        "type": "tarball",
-        "url": "https://codeload.github.com/NousResearch/hermes-agent/tar.gz/a071fc80da30ffc4311ae1a6fb4f86f6947cf655"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://codeload.github.com/NousResearch/hermes-agent/tar.gz/a071fc80da30ffc4311ae1a6fb4f86f6947cf655"
-      }
-    },
     "home-manager": {
-      "inputs": {
-        "nixpkgs": [
-          "hermes-agent",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786487128,
-        "narHash": "sha256-ad60hrRVhH/bo3Jl1YLzO+QcS3mUNZr9LNJdzhMO2P4=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "f404edbfa4117810c96b97048299242fc50e5362",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "home-manager_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
@@ -350,27 +304,6 @@
         "type": "github"
       }
     },
-    "npm-lockfile-fix": {
-      "inputs": {
-        "nixpkgs": [
-          "hermes-agent",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775903712,
-        "narHash": "sha256-2GV79U6iVH4gKAPWYrxUReB0S41ty/Y3dBLquU8AlaA=",
-        "owner": "jeslie0",
-        "repo": "npm-lockfile-fix",
-        "rev": "c6093acb0c0548e0f9b8b3d82918823721930fe8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "jeslie0",
-        "repo": "npm-lockfile-fix",
-        "type": "github"
-      }
-    },
     "pre-commit-hooks-nix": {
       "inputs": {
         "flake-compat": [
@@ -399,61 +332,10 @@
         "type": "github"
       }
     },
-    "pyproject-build-systems": {
-      "inputs": {
-        "nixpkgs": [
-          "hermes-agent",
-          "nixpkgs"
-        ],
-        "pyproject-nix": [
-          "hermes-agent",
-          "pyproject-nix"
-        ],
-        "uv2nix": [
-          "hermes-agent",
-          "uv2nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1785115949,
-        "narHash": "sha256-8AM37BfyGaL2v/SZyg4PupRxJ01Y4htvM+WrTjWrPpo=",
-        "owner": "pyproject-nix",
-        "repo": "build-system-pkgs",
-        "rev": "62c0d86027edb1c4f39a5facc09876348144f7c9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "build-system-pkgs",
-        "type": "github"
-      }
-    },
-    "pyproject-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "hermes-agent",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1784591072,
-        "narHash": "sha256-zP/WaDxrRu8GANZM61+V2LT/7ycEEdoyLWn7M6WzU7M=",
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "rev": "e3b599ca2e7fcf93d4edf65d7f19bbf6491724f3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "hermes-agent": "hermes-agent",
-        "home-manager": "home-manager_2",
+        "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
         "nix-unit": "nix-unit",
@@ -585,31 +467,6 @@
         "owner": "jfroche",
         "ref": "system-manager",
         "repo": "userborn",
-        "type": "github"
-      }
-    },
-    "uv2nix": {
-      "inputs": {
-        "nixpkgs": [
-          "hermes-agent",
-          "nixpkgs"
-        ],
-        "pyproject-nix": [
-          "hermes-agent",
-          "pyproject-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1785277507,
-        "narHash": "sha256-9Tq3UDX2hD/aveW/HvkBlAmEwJTOlY5HQXJM+L5BGmE=",
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
-        "rev": "5a836d395cbf5fc22670eb98dd4aa4fc4d406977",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -36,11 +36,6 @@
       url = "github:raine/workmux";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    hermes-agent = {
-      url = "https://codeload.github.com/NousResearch/hermes-agent/tar.gz/a071fc80da30ffc4311ae1a6fb4f86f6947cf655";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-parts.follows = "flake-parts";
-    };
   };
 
   outputs =

--- a/nix/flakes/home.nix
+++ b/nix/flakes/home.nix
@@ -22,12 +22,6 @@ let
     };
     extraSpecialArgs = {
       inherit inputs installFeatures;
-      hermesDesktopPackage = inputs.nixpkgs.lib.attrByPath [
-        "hermes-agent"
-        "packages"
-        system
-        "desktop"
-      ] null inputs;
       isWSL = false;
     };
   };

--- a/nix/flakes/home.nix
+++ b/nix/flakes/home.nix
@@ -3,6 +3,8 @@
 #   home-manager switch --flake .#aarch64-darwin
 #   home-manager switch --flake .#x86_64-linux
 #   home-manager switch --flake .#aarch64-linux
+# Hermes Desktop is a Homebrew Cask and therefore requires the nix-darwin
+# installer instead of this standalone Home Manager output.
 { inputs, ... }:
 let
   withHermes = builtins.getEnv "DOTFILES_WITH_HERMES" == "1";
@@ -27,10 +29,13 @@ let
   };
   mkDarwinHome =
     system:
-    inputs.home-manager.lib.homeManagerConfiguration {
-      inherit (mkHome system) pkgs extraSpecialArgs;
-      modules = [ ../home/darwin.nix ];
-    };
+    if withHermes then
+      throw "Hermes Desktop requires the nix-darwin installer; run ./install.sh --with-hermes"
+    else
+      inputs.home-manager.lib.homeManagerConfiguration {
+        inherit (mkHome system) pkgs extraSpecialArgs;
+        modules = [ ../home/darwin.nix ];
+      };
   mkLinuxHome =
     system:
     inputs.home-manager.lib.homeManagerConfiguration {

--- a/nix/flakes/packages.nix
+++ b/nix/flakes/packages.nix
@@ -27,32 +27,14 @@
       sets = import ../packages/sets.nix {
         pkgs = pkgs.extend workmuxOverlay;
         inherit lib;
-        hermesDesktopPackage = lib.attrByPath [
-          "hermes-agent"
-          "packages"
-          pkgs.system
-          "desktop"
-        ] null inputs;
       };
       unfreeSets = import ../packages/sets.nix {
         pkgs = unfreePkgs;
         inherit lib;
-        hermesDesktopPackage = lib.attrByPath [
-          "hermes-agent"
-          "packages"
-          pkgs.system
-          "desktop"
-        ] null inputs;
       };
       packageSupportReport = import ../packages/support-report.nix {
         pkgs = unfreePkgs;
         inherit lib;
-        hermesDesktopPackage = lib.attrByPath [
-          "hermes-agent"
-          "packages"
-          pkgs.system
-          "desktop"
-        ] null inputs;
       };
     in
     {

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -11,13 +11,12 @@
   lib,
   inputs ? null,
   installFeatures ? [ ],
-  hermesDesktopPackage ? null,
   isWSL,
   ...
 }:
 let
   sets = import ../packages/sets.nix {
-    inherit pkgs lib hermesDesktopPackage;
+    inherit pkgs lib;
   };
   bootstrapUser = builtins.getEnv "DOTFILES_USER";
   bootstrapHome = builtins.getEnv "DOTFILES_HOME";

--- a/nix/hosts/darwin/default.nix
+++ b/nix/hosts/darwin/default.nix
@@ -7,10 +7,8 @@
 let
   user = builtins.getEnv "DOTFILES_USER";
   home = builtins.getEnv "DOTFILES_HOME";
-  hermesDesktopPackage = inputs.hermes-agent.packages.${pkgs.system}.desktop;
   sets = import ../../packages/sets.nix {
     inherit pkgs lib;
-    inherit hermesDesktopPackage;
   };
   discordPackage = sets.darwinDiscordPackage;
   withHermes = builtins.getEnv "DOTFILES_WITH_HERMES" == "1";
@@ -208,7 +206,7 @@ in
       imports = [ ../../home/darwin.nix ];
     };
     extraSpecialArgs = {
-      inherit inputs installFeatures hermesDesktopPackage;
+      inherit inputs installFeatures;
       isWSL = false;
     };
   };

--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -35,7 +35,6 @@
   pkgs,
   lib,
   catalogOverride ? null,
-  hermesDesktopPackage ? null,
 }:
 let
   darwinProviderCandidates = import ./darwin-provider-candidates.nix;
@@ -718,18 +717,15 @@ let
           };
         };
         hermes-desktop = {
-          pkg = if pkgs.stdenv.hostPlatform.isDarwin then hermesDesktopPackage else null;
           winget = null;
           category = "terminal";
           installFeature = "WithHermes";
           support = {
             darwin = {
-              provider = "nix";
-              source = "hermes-agent";
-              identity = {
-                command = "hermes-desktop";
-                versionArgs = [ "--version" ];
-              };
+              provider = "homebrew-cask";
+              source = "homebrew";
+              identity = "hermes-desktop";
+              cask = "hermes-desktop";
             };
             linux = {
               unsupported = "Hermes Desktop is provisioned by the native macOS profile";

--- a/nix/packages/support-report.nix
+++ b/nix/packages/support-report.nix
@@ -1,10 +1,9 @@
 {
   pkgs,
   lib,
-  hermesDesktopPackage ? null,
 }:
 let
-  sets = import ./sets.nix { inherit pkgs lib hermesDesktopPackage; };
+  sets = import ./sets.nix { inherit pkgs lib; };
   reportFile = pkgs.writeText "package-support.json" (builtins.toJSON sets.supportReport);
   darwinPackagesFile = pkgs.writeText "darwin-packages.json" (
     builtins.toJSON (builtins.attrNames sets.darwinPackages)

--- a/scripts/sh/hermes-desktop-docker.sh
+++ b/scripts/sh/hermes-desktop-docker.sh
@@ -41,5 +41,5 @@ if ! jq -e --arg url "$remote_url" '
 fi
 
 unset HERMES_DESKTOP_REMOTE_URL HERMES_DESKTOP_REMOTE_TOKEN
-command -v hermes-desktop >/dev/null 2>&1 || hermes_desktop_docker_die "hermes-desktop is not installed; apply the WithHermes profile"
-exec hermes-desktop "$@"
+command -v open >/dev/null 2>&1 || hermes_desktop_docker_die "macOS open command is unavailable"
+exec open /Applications/Hermes.app --args "$@"

--- a/tests/bash/hermes_desktop.bats
+++ b/tests/bash/hermes_desktop.bats
@@ -15,8 +15,8 @@ setup() {
 	write_stub curl '
 printf "%s\n" "$*" >"$CURL_CAPTURE"
 '
-	write_stub hermes-desktop '
-	: >"$DESKTOP_CAPTURE"
+	write_stub open '
+: >"$DESKTOP_CAPTURE"
 printf "%s\n" "$*" >"$DESKTOP_ARGS"
 '
 	write_stub jq 'exec "$REAL_JQ" "$@"'
@@ -42,7 +42,7 @@ write_stub() {
 	run "$REPO_ROOT/scripts/sh/hermes-desktop-docker.sh" --profile default
 
 	[ "$status" -eq 0 ]
-	[ "$(<"$DESKTOP_ARGS")" = "--profile default" ]
+	[ "$(<"$DESKTOP_ARGS")" = "/Applications/Hermes.app --args --profile default" ]
 	! grep -Fq 'HERMES_DESKTOP_REMOTE_TOKEN' "$DESKTOP_ARGS"
 	! grep -Fq 'hermes-bootstrap-v1_' "$DESKTOP_ARGS"
 	! grep -Fq 'opaque' <<<"$output"

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -202,6 +202,17 @@ setup() {
 	[ "$status" -eq 0 ]
 }
 
+@test "standalone Darwin Home Manager rejects Hermes without nix-homebrew" {
+	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
+
+	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex DOTFILES_WITH_HERMES=1 \
+		nix eval --impure --raw \
+		"$REPO_ROOT#homeConfigurations.aarch64-darwin.config.home.username"
+
+	[ "$status" -ne 0 ]
+	[[ "$stderr" == *"Hermes Desktop requires the nix-darwin installer"* ]]
+}
+
 @test "Darwin Ollama profile uses a nix-darwin launchd agent" {
 	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
 

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -175,6 +175,33 @@ setup() {
 	[ "$status" -eq 0 ]
 }
 
+@test "Darwin Hermes profile installs Hermes Desktop only through Homebrew" {
+	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
+	command -v jq >/dev/null 2>&1 || skip "jq is not available in this test environment"
+
+	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex DOTFILES_WITH_HERMES=1 \
+		nix eval --impure --json --expr "
+			let
+				flake = builtins.getFlake (toString $REPO_ROOT);
+				config = flake.darwinConfigurations.macos.config;
+			in {
+				casks = config.homebrew.casks;
+				system = builtins.map (package: package.name) config.environment.systemPackages;
+				home = builtins.map (package: package.name) config.home-manager.users.codex.home.packages;
+				hasHermesFlakeInput = builtins.hasAttr \"hermes-agent\" flake.inputs;
+			}
+		"
+
+	[ "$status" -eq 0 ]
+	run jq -e '
+		any(.casks[]; .name == "hermes-desktop")
+		and all(.system[]; test("^hermes-desktop($|-[0-9])") | not)
+		and all(.home[]; test("^hermes-desktop($|-[0-9])") | not)
+		and .hasHermesFlakeInput == false
+	' <<<"$output"
+	[ "$status" -eq 0 ]
+}
+
 @test "Darwin Ollama profile uses a nix-darwin launchd agent" {
 	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
 

--- a/tests/bash/package_catalog.bats
+++ b/tests/bash/package_catalog.bats
@@ -89,20 +89,38 @@ nix_fixture_darwin_package_split() {
 	grep -q 'linuxSystemModules' "$SETS"
 }
 
-@test "Hermes Desktop uses the official Nix output only with the Hermes profile" {
-	run awk '
-		/^[[:space:]]*hermes-desktop = \{/ { in_entry=1 }
-		in_entry { print }
-		in_entry && /^        };/ { exit }
-	' "$SETS"
+@test "Hermes Desktop uses the official Homebrew cask only with the Hermes profile" {
+	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
+	command -v jq >/dev/null 2>&1 || skip "jq is not available in this test environment"
+
+	run --separate-stderr nix eval --impure --json --expr "
+		let
+			flake = builtins.getFlake (toString $REPO_ROOT);
+			pkgs = import flake.inputs.nixpkgs {
+				system = \"aarch64-darwin\";
+				config.allowUnfree = true;
+				overlays = [ (_: _: { workmux = flake.inputs.workmux.packages.aarch64-darwin.default; }) ];
+			};
+			sets = import $SETS { inherit pkgs; lib = pkgs.lib; };
+		in {
+			support = sets.supportReport.hermes-desktop;
+			defaultCasks = sets.darwinCasksForInstallFeatures [ ];
+			hermesCasks = sets.darwinCasksForInstallFeatures [ \"WithHermes\" ];
+		}
+	"
 	[ "$status" -eq 0 ]
-	[[ "$output" == *'hermesDesktopPackage'* ]]
-	[[ "$output" == *'installFeature = "WithHermes";'* ]]
-	[[ "$output" == *'provider = "nix"'* ]]
-	[[ "$output" == *'source = "hermes-agent";'* ]]
-	[[ "$output" == *'command = "hermes-desktop";'* ]]
-	[[ "$output" != *'appName = '* ]]
-	grep -q 'inherit inputs installFeatures;' "$REPO_ROOT/nix/flakes/home.nix"
+	run jq -e '
+		.support.installFeature == "WithHermes"
+		and .support.darwin == {
+			"provider": "homebrew-cask",
+			"source": "homebrew",
+			"identity": "hermes-desktop",
+			"cask": "hermes-desktop"
+		}
+		and (.defaultCasks | index("hermes-desktop")) == null
+		and (.hermesCasks | index("hermes-desktop")) != null
+	' <<<"$output"
+	[ "$status" -eq 0 ]
 }
 
 @test "Hermes Desktop Docker launcher is a Darwin Hermes package" {


### PR DESCRIPTION
## Summary

- migrate Hermes Desktop from the upstream Nix/Electron derivation to the official Homebrew Cask
- preserve WithHermes gating and Docker Agent/gateway integration
- launch the Cask-managed app by its exact /Applications path and retire the obsolete Nix design documentation

## Verification

- bats tests/bash/package_catalog.bats tests/bash/hermes_desktop.bats tests/bash/macos_config.bats (84 passed)
- task lint / pre-commit run --all-files
- nix flake check --no-build --impure
- WithHermes nix-darwin system build on Apple Silicon
- independent code review: Ready to merge

Closes #554