### PR TITLE
fix: make Hermes storage initialization atomic

### DIFF
--- a/.github/workflows/ci-hermes-bootstrap.yml
+++ b/.github/workflows/ci-hermes-bootstrap.yml
@@ -64,6 +64,12 @@ jobs:
       - name: Run the pinned container suite
         run: docker build --target hermes-bootstrap-test -t local/hermes-bootstrap-test -f docker/hermes-agent/Dockerfile docker
 
+      - name: Build the Hermes storage integration image
+        run: docker build --target hermes-bootstrap-runtime -t local/hermes-agent-gh:latest -f docker/hermes-agent/Dockerfile docker
+
+      - name: Run the Hermes storage volume integration
+        run: docker/hermes-agent/tests/test_storage_volume_integration.sh
+
       - name: Run Hermes browser runtime contracts
         run: docker/hermes-browser/tests/test_runtime_contract.sh
 

--- a/docker/hermes-agent/hermes_storage_seed.py
+++ b/docker/hermes-agent/hermes_storage_seed.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 TRANSIENT_SQLITE_SUFFIXES = ("-wal", "-shm", "-journal")
 EXCLUDED_ROOT_ENTRIES = {".browser", ".op.env", ".xurl"}
+ALLOWED_ABSOLUTE_SYMLINK_ROOT = Path("/opt/data")
 
 
 def _is_sqlite_database(path: Path) -> bool:
@@ -24,7 +25,9 @@ def _is_sqlite_database(path: Path) -> bool:
 
 
 def _copy_sqlite_database(source: Path, destination: Path) -> None:
-    source_uri = f"file:{source.as_posix()}?mode=ro"
+    has_sidecar = any(Path(f"{source}{suffix}").exists() for suffix in TRANSIENT_SQLITE_SUFFIXES)
+    query = "mode=ro" if has_sidecar else "mode=ro&immutable=1"
+    source_uri = f"file:{source.as_posix()}?{query}"
     source_connection = sqlite3.connect(source_uri, uri=True)
     destination_connection = sqlite3.connect(destination)
     try:
@@ -38,6 +41,28 @@ def _copy_file(source: Path, destination: Path) -> None:
     source_mode = stat.S_IMODE(source.stat().st_mode)
     shutil.copy2(source, destination)
     destination.chmod(source_mode)
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _copy_symlink(source_root: Path, source: Path, destination: Path) -> None:
+    target_text = os.readlink(source)
+    target = Path(target_text)
+    if target.is_absolute():
+        normalized_target = Path(os.path.normpath(target))
+        if not _is_within(normalized_target, ALLOWED_ABSOLUTE_SYMLINK_ROOT):
+            raise ValueError(f"absolute symlink target must be below /opt/data: {source} -> {target_text}")
+    else:
+        resolved_target = (source.parent / target).resolve(strict=False)
+        if not _is_within(resolved_target, source_root.resolve()):
+            raise ValueError(f"relative symlink target escapes Hermes data: {source} -> {target_text}")
+    destination.symlink_to(target_text)
 
 
 def _validate_paths(source: Path, destination: Path) -> None:
@@ -67,7 +92,8 @@ def seed(source: Path, destination: Path) -> None:
                 continue
             source_path = source / relative_path
             if source_path.is_symlink():
-                raise ValueError(f"symlinks are not supported in Hermes data: {source_path}")
+                _copy_symlink(source, source_path, destination / relative_path)
+                continue
             retained_directories.append(directory_name)
             (destination / relative_path).mkdir(exist_ok=True)
         directory_names[:] = retained_directories
@@ -80,7 +106,8 @@ def seed(source: Path, destination: Path) -> None:
             relative_path = relative_directory / file_name
             source_path = source / relative_path
             if source_path.is_symlink():
-                raise ValueError(f"symlinks are not supported in Hermes data: {source_path}")
+                _copy_symlink(source, source_path, destination / relative_path)
+                continue
             destination_path = destination / relative_path
             if source_path.suffix == ".db" and _is_sqlite_database(source_path):
                 _copy_sqlite_database(source_path, destination_path)

--- a/docker/hermes-agent/hermes_storage_seed.py
+++ b/docker/hermes-agent/hermes_storage_seed.py
@@ -4,17 +4,22 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import os
+import re
 import shutil
 import sqlite3
 import stat
+import tempfile
 from pathlib import Path
+from typing import Iterator
 
 
 TRANSIENT_SQLITE_SUFFIXES = ("-wal", "-shm", "-journal")
 READY_MARKER_NAME = ".dotfiles-hermes-storage-ready-v1"
 EXCLUDED_ROOT_ENTRIES = {".browser", ".op.env", ".xurl", READY_MARKER_NAME}
 ALLOWED_ABSOLUTE_SYMLINK_ROOT = Path("/opt/data")
+READY_TOKEN_PATTERN = re.compile(r"^[0-9a-f]{32}$")
 
 
 def _is_sqlite_database(path: Path) -> bool:
@@ -25,17 +30,41 @@ def _is_sqlite_database(path: Path) -> bool:
         return False
 
 
+@contextlib.contextmanager
+def _open_sqlite_source(source: Path) -> Iterator[sqlite3.Connection]:
+    sidecars = [Path(f"{source}{suffix}") for suffix in TRANSIENT_SQLITE_SUFFIXES]
+    existing_sidecars = [path for path in sidecars if path.exists()]
+    if not existing_sidecars:
+        source_uri = f"{source.resolve().as_uri()}?mode=ro&immutable=1"
+        connection = sqlite3.connect(source_uri, uri=True)
+        try:
+            yield connection
+        finally:
+            connection.close()
+        return
+
+    with tempfile.TemporaryDirectory(prefix="hermes-storage-sqlite-") as temporary:
+        staged = Path(temporary) / source.name
+        shutil.copy2(source, staged)
+        staged.chmod(0o600)
+        for sidecar in existing_sidecars:
+            staged_sidecar = Path(f"{staged}{sidecar.name.removeprefix(source.name)}")
+            shutil.copy2(sidecar, staged_sidecar)
+            staged_sidecar.chmod(0o600)
+        connection = sqlite3.connect(staged)
+        try:
+            yield connection
+        finally:
+            connection.close()
+
+
 def _copy_sqlite_database(source: Path, destination: Path) -> None:
-    has_sidecar = any(Path(f"{source}{suffix}").exists() for suffix in TRANSIENT_SQLITE_SUFFIXES)
-    query = "mode=ro" if has_sidecar else "mode=ro&immutable=1"
-    source_uri = f"file:{source.as_posix()}?{query}"
-    source_connection = sqlite3.connect(source_uri, uri=True)
     destination_connection = sqlite3.connect(destination)
     try:
-        source_connection.backup(destination_connection)
+        with _open_sqlite_source(source) as source_connection:
+            source_connection.backup(destination_connection)
     finally:
         destination_connection.close()
-        source_connection.close()
 
 
 def _copy_file(source: Path, destination: Path) -> None:
@@ -70,28 +99,68 @@ def _copy_symlink(source_root: Path, source: Path, destination: Path) -> None:
     destination.symlink_to(target_text)
 
 
-def _write_ready_marker(destination: Path) -> None:
+def _fsync_tree(root: Path) -> None:
+    directories: list[Path] = []
+    for directory, directory_names, file_names in os.walk(root, followlinks=False):
+        current = Path(directory)
+        directories.append(current)
+        directory_names[:] = [name for name in directory_names if not (current / name).is_symlink()]
+        for file_name in file_names:
+            path = current / file_name
+            if path.is_symlink():
+                continue
+            descriptor = os.open(path, os.O_RDONLY)
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+    for directory in reversed(directories):
+        descriptor = os.open(directory, os.O_RDONLY)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+
+def _write_ready_marker(destination: Path, ready_token: str) -> None:
     temporary = destination / f"{READY_MARKER_NAME}.tmp-{os.getpid()}"
     with temporary.open("x", encoding="utf-8") as handle:
-        handle.write("version=1\n")
+        handle.write(f"version=1\nvolume_token={ready_token}\n")
         handle.flush()
         os.fsync(handle.fileno())
     os.replace(temporary, destination / READY_MARKER_NAME)
+    descriptor = os.open(destination, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
 
-def _validate_paths(source: Path, destination: Path) -> None:
+def _validate_paths(source: Path, destination: Path, ready_token: str) -> None:
+    if not READY_TOKEN_PATTERN.fullmatch(ready_token):
+        raise ValueError("ready token must be 32 lowercase hexadecimal characters")
     if not source.is_dir() or source.is_symlink():
         raise ValueError(f"source must be a real directory: {source}")
     if not destination.is_dir() or destination.is_symlink():
         raise ValueError(f"destination must be a real directory: {destination}")
-    if any(destination.iterdir()):
+
+
+def _clear_destination(destination: Path) -> None:
+    for path in destination.iterdir():
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+
+def seed(source: Path, destination: Path, ready_token: str, *, replace_incomplete: bool = False) -> None:
+    """Copy a stopped Hermes home into a destination and publish readiness."""
+
+    _validate_paths(source, destination, ready_token)
+    if replace_incomplete:
+        _clear_destination(destination)
+    elif any(destination.iterdir()):
         raise ValueError(f"destination must be empty: {destination}")
-
-
-def seed(source: Path, destination: Path) -> None:
-    """Copy a stopped Hermes home into an empty destination directory."""
-
-    _validate_paths(source, destination)
     for source_root, directory_names, file_names in os.walk(source, followlinks=False):
         source_directory = Path(source_root)
         relative_directory = source_directory.relative_to(source)
@@ -129,16 +198,24 @@ def seed(source: Path, destination: Path) -> None:
             else:
                 _copy_file(source_path, destination_path)
 
-    _write_ready_marker(destination)
+    _fsync_tree(destination)
+    _write_ready_marker(destination, ready_token)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--source", type=Path, required=True)
     parser.add_argument("--destination", type=Path, required=True)
+    parser.add_argument("--ready-token", required=True)
+    parser.add_argument("--replace-incomplete", action="store_true")
     arguments = parser.parse_args()
     try:
-        seed(arguments.source, arguments.destination)
+        seed(
+            arguments.source,
+            arguments.destination,
+            arguments.ready_token,
+            replace_incomplete=arguments.replace_incomplete,
+        )
     except (OSError, sqlite3.Error, ValueError) as error:
         parser.error(str(error))
     return 0

--- a/docker/hermes-agent/hermes_storage_seed.py
+++ b/docker/hermes-agent/hermes_storage_seed.py
@@ -12,7 +12,8 @@ from pathlib import Path
 
 
 TRANSIENT_SQLITE_SUFFIXES = ("-wal", "-shm", "-journal")
-EXCLUDED_ROOT_ENTRIES = {".browser", ".op.env", ".xurl"}
+READY_MARKER_NAME = ".dotfiles-hermes-storage-ready-v1"
+EXCLUDED_ROOT_ENTRIES = {".browser", ".op.env", ".xurl", READY_MARKER_NAME}
 ALLOWED_ABSOLUTE_SYMLINK_ROOT = Path("/opt/data")
 
 
@@ -59,10 +60,23 @@ def _copy_symlink(source_root: Path, source: Path, destination: Path) -> None:
         if not _is_within(normalized_target, ALLOWED_ABSOLUTE_SYMLINK_ROOT):
             raise ValueError(f"absolute symlink target must be below /opt/data: {source} -> {target_text}")
     else:
+        relative_parent = source.parent.relative_to(source_root)
+        relocated_target = Path(os.path.normpath(relative_parent / target))
+        if relocated_target.parts and relocated_target.parts[0] == "..":
+            raise ValueError(f"relative symlink target escapes Hermes data after relocation: {source} -> {target_text}")
         resolved_target = (source.parent / target).resolve(strict=False)
         if not _is_within(resolved_target, source_root.resolve()):
             raise ValueError(f"relative symlink target escapes Hermes data: {source} -> {target_text}")
     destination.symlink_to(target_text)
+
+
+def _write_ready_marker(destination: Path) -> None:
+    temporary = destination / f"{READY_MARKER_NAME}.tmp-{os.getpid()}"
+    with temporary.open("x", encoding="utf-8") as handle:
+        handle.write("version=1\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, destination / READY_MARKER_NAME)
 
 
 def _validate_paths(source: Path, destination: Path) -> None:
@@ -114,6 +128,8 @@ def seed(source: Path, destination: Path) -> None:
                 destination_path.chmod(stat.S_IMODE(source_path.stat().st_mode))
             else:
                 _copy_file(source_path, destination_path)
+
+    _write_ready_marker(destination)
 
 
 def main() -> int:

--- a/docker/hermes-agent/tests/test_hermes_storage_seed.py
+++ b/docker/hermes-agent/tests/test_hermes_storage_seed.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import os
 import sqlite3
 import subprocess
@@ -9,6 +10,8 @@ import unittest
 from pathlib import Path
 
 from hermes_storage_seed import seed
+
+TEST_TOKEN = "0123456789abcdef0123456789abcdef"
 
 
 def _run_seed_without_source_write_access(source: Path, destination: Path) -> subprocess.CompletedProcess[str]:
@@ -31,9 +34,10 @@ def _run_seed_without_source_write_access(source: Path, destination: Path) -> su
             sys.executable,
             "-c",
             "from pathlib import Path; import sys; from hermes_storage_seed import seed; "
-            "seed(Path(sys.argv[1]), Path(sys.argv[2]))",
+            "seed(Path(sys.argv[1]), Path(sys.argv[2]), sys.argv[3])",
             str(source),
             str(destination),
+            TEST_TOKEN,
         ],
         check=False,
         capture_output=True,
@@ -55,9 +59,12 @@ class HermesStorageSeedTests(unittest.TestCase):
             (source / marker).write_text("spoofed\n", encoding="utf-8")
             (source / "config.yaml").write_text("gateway: docker\n", encoding="utf-8")
 
-            seed(source, destination)
+            seed(source, destination, TEST_TOKEN)
 
-            self.assertEqual((destination / marker).read_text(encoding="utf-8"), "version=1\n")
+            self.assertEqual(
+                (destination / marker).read_text(encoding="utf-8"),
+                f"version=1\nvolume_token={TEST_TOKEN}\n",
+            )
 
     @unittest.skipUnless(os.name == "posix", "requires POSIX directory permissions")
     def test_copies_clean_wal_database_from_read_only_source(self) -> None:
@@ -140,6 +147,101 @@ class HermesStorageSeedTests(unittest.TestCase):
             self.assertEqual(wal.read_bytes(), original_wal)
             self.assertEqual(shared_memory.read_bytes(), original_shared_memory)
 
+    @unittest.skipUnless(os.name == "posix", "requires POSIX directory permissions")
+    def test_copies_uncheckpointed_wal_without_shared_memory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            database = source / "wal-without-shm.db"
+            writer = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import os, sqlite3, sys; db=sqlite3.connect(sys.argv[1]); "
+                    "db.execute('pragma journal_mode=wal'); db.execute('pragma wal_autocheckpoint=0'); "
+                    "db.execute('create table messages (body text)'); db.commit(); "
+                    "db.execute('pragma wal_checkpoint(truncate)'); "
+                    "db.execute(\"insert into messages values ('wal-only')\"); db.commit(); os._exit(0)",
+                    str(database),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(writer.returncode, 0, writer.stderr)
+            wal = source / "wal-without-shm.db-wal"
+            shared_memory = source / "wal-without-shm.db-shm"
+            self.assertTrue(wal.is_file())
+            self.assertTrue(shared_memory.is_file())
+            shared_memory.unlink()
+            original_wal = wal.read_bytes()
+
+            root.chmod(0o755)
+            destination.chmod(0o777)
+            for path in (database, wal):
+                path.chmod(0o444)
+            source.chmod(0o555)
+            try:
+                result = _run_seed_without_source_write_access(source, destination)
+            finally:
+                source.chmod(0o755)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            with contextlib.closing(sqlite3.connect(destination / database.name)) as copied:
+                self.assertEqual(copied.execute("select body from messages").fetchone()[0], "wal-only")
+            self.assertEqual(wal.read_bytes(), original_wal)
+            self.assertFalse(shared_memory.exists())
+
+    @unittest.skipUnless(os.name == "posix", "requires POSIX directory permissions")
+    def test_recovers_hot_rollback_journal_without_modifying_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            database = source / "hot-journal.db"
+            writer = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import os, sqlite3, sys; db=sqlite3.connect(sys.argv[1]); "
+                    "db.execute('pragma journal_mode=delete'); "
+                    "db.execute('create table checks (value text)'); "
+                    "db.execute(\"insert into checks values ('committed')\"); db.commit(); "
+                    "db.execute('begin immediate'); db.execute(\"update checks set value='uncommitted'\"); "
+                    "assert os.path.exists(sys.argv[1] + '-journal'); os._exit(0)",
+                    str(database),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(writer.returncode, 0, writer.stderr)
+            journal = source / "hot-journal.db-journal"
+            self.assertTrue(journal.is_file())
+            original_database = database.read_bytes()
+            original_journal = journal.read_bytes()
+
+            root.chmod(0o755)
+            destination.chmod(0o777)
+            for path in (database, journal):
+                path.chmod(0o444)
+            source.chmod(0o555)
+            try:
+                result = _run_seed_without_source_write_access(source, destination)
+            finally:
+                source.chmod(0o755)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            with contextlib.closing(sqlite3.connect(destination / database.name)) as copied:
+                self.assertEqual(copied.execute("select value from checks").fetchone()[0], "committed")
+            self.assertEqual(database.read_bytes(), original_database)
+            self.assertEqual(journal.read_bytes(), original_journal)
+
     def test_preserves_relative_directory_symlink_within_hermes_data(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -155,7 +257,7 @@ class HermesStorageSeedTests(unittest.TestCase):
             (profile_skills / "green").symlink_to(link_target, target_is_directory=True)
 
             try:
-                seed(source, destination)
+                seed(source, destination, TEST_TOKEN)
             except ValueError as error:
                 self.fail(f"safe relative symlink was rejected: {error}")
 
@@ -175,7 +277,7 @@ class HermesStorageSeedTests(unittest.TestCase):
             (source / "model.bin").symlink_to(link_target)
 
             try:
-                seed(source, destination)
+                seed(source, destination, TEST_TOKEN)
             except ValueError as error:
                 self.fail(f"safe absolute symlink was rejected: {error}")
 
@@ -195,7 +297,7 @@ class HermesStorageSeedTests(unittest.TestCase):
             (links / "outside.txt").symlink_to("../../outside.txt")
 
             with self.assertRaisesRegex(ValueError, "relative symlink target escapes Hermes data"):
-                seed(source, destination)
+                seed(source, destination, TEST_TOKEN)
 
     def test_rejects_relative_symlink_that_escapes_after_relocation(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -208,7 +310,7 @@ class HermesStorageSeedTests(unittest.TestCase):
             (source / "secret-link").symlink_to("../source/secret.txt")
 
             with self.assertRaisesRegex(ValueError, "relative symlink target escapes Hermes data after relocation"):
-                seed(source, destination)
+                seed(source, destination, TEST_TOKEN)
 
     def test_rejects_absolute_symlink_outside_opt_data(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -220,7 +322,7 @@ class HermesStorageSeedTests(unittest.TestCase):
             (source / "passwd").symlink_to("/etc/passwd")
 
             with self.assertRaisesRegex(ValueError, "absolute symlink target must be below /opt/data"):
-                seed(source, destination)
+                seed(source, destination, TEST_TOKEN)
 
     def test_copies_regular_files_and_sqlite_databases_without_sidecars(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -241,17 +343,17 @@ class HermesStorageSeedTests(unittest.TestCase):
             connection.execute("insert into messages values ('kept')")
             connection.commit()
             connection.close()
-            (source / "state.db-wal").write_text("do not copy", encoding="utf-8")
-            (source / "state.db-shm").write_text("do not copy", encoding="utf-8")
+            (source / "orphan.db-wal").write_text("do not copy", encoding="utf-8")
+            (source / "orphan.db-shm").write_text("do not copy", encoding="utf-8")
 
-            seed(source, destination)
+            seed(source, destination, TEST_TOKEN)
 
             self.assertEqual((destination / "config.yaml").read_text(encoding="utf-8"), "gateway: docker\n")
             self.assertFalse((destination / ".op.env").exists())
             self.assertFalse((destination / ".xurl").exists())
             self.assertFalse((destination / ".browser").exists())
-            self.assertFalse((destination / "state.db-wal").exists())
-            self.assertFalse((destination / "state.db-shm").exists())
+            self.assertFalse((destination / "orphan.db-wal").exists())
+            self.assertFalse((destination / "orphan.db-shm").exists())
             copied = sqlite3.connect(destination / "state.db")
             self.assertEqual(copied.execute("select body from messages").fetchone()[0], "kept")
             copied.close()
@@ -266,7 +368,57 @@ class HermesStorageSeedTests(unittest.TestCase):
             (destination / "existing").write_text("keep", encoding="utf-8")
 
             with self.assertRaisesRegex(ValueError, "destination must be empty"):
-                seed(source, destination)
+                seed(source, destination, TEST_TOKEN)
+
+    def test_replaces_an_incomplete_destination(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            (source / "current").write_text("new\n", encoding="utf-8")
+            (destination / "partial").write_text("old\n", encoding="utf-8")
+            (destination / ".dotfiles-hermes-storage-ready-v1").symlink_to("partial")
+
+            seed(source, destination, TEST_TOKEN, replace_incomplete=True)
+
+            self.assertFalse((destination / "partial").exists())
+            self.assertEqual((destination / "current").read_text(encoding="utf-8"), "new\n")
+            self.assertFalse((destination / ".dotfiles-hermes-storage-ready-v1").is_symlink())
+
+    def test_rejects_an_invalid_ready_token_before_clearing_destination(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            existing = destination / "partial"
+            existing.write_text("keep\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "ready token"):
+                seed(source, destination, "not-a-token", replace_incomplete=True)
+
+            self.assertEqual(existing.read_text(encoding="utf-8"), "keep\n")
+
+    def test_copies_sqlite_database_with_uri_reserved_characters(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            database = source / "state?#%.db"
+            with contextlib.closing(sqlite3.connect(database)) as connection:
+                connection.execute("create table checks (value text)")
+                connection.execute("insert into checks values ('reserved-name')")
+                connection.commit()
+
+            seed(source, destination, TEST_TOKEN)
+
+            with contextlib.closing(sqlite3.connect(destination / database.name)) as copied:
+                self.assertEqual(copied.execute("select value from checks").fetchone()[0], "reserved-name")
 
 
 if __name__ == "__main__":

--- a/docker/hermes-agent/tests/test_hermes_storage_seed.py
+++ b/docker/hermes-agent/tests/test_hermes_storage_seed.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sqlite3
 import tempfile
 import unittest
@@ -9,6 +10,105 @@ from hermes_storage_seed import seed
 
 
 class HermesStorageSeedTests(unittest.TestCase):
+    def test_copies_clean_wal_database_from_read_only_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            database = source / "clean-wal.db"
+            connection = sqlite3.connect(database)
+            self.assertEqual(connection.execute("pragma journal_mode=wal").fetchone()[0], "wal")
+            connection.execute("create table messages (body text)")
+            connection.execute("insert into messages values ('kept')")
+            connection.commit()
+            connection.close()
+            self.assertFalse((source / "clean-wal.db-wal").exists())
+            self.assertFalse((source / "clean-wal.db-shm").exists())
+
+            source.chmod(0o555)
+            try:
+                try:
+                    seed(source, destination)
+                except sqlite3.OperationalError as error:
+                    self.fail(f"clean WAL database was not copied from read-only source: {error}")
+            finally:
+                source.chmod(0o755)
+
+            copied = sqlite3.connect(destination / "clean-wal.db")
+            self.assertEqual(copied.execute("select body from messages").fetchone()[0], "kept")
+            copied.close()
+
+    def test_preserves_relative_directory_symlink_within_hermes_data(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            skill = source / "shared" / "skills" / "green"
+            profile_skills = source / "profiles" / "shiraishi" / "skills"
+            skill.mkdir(parents=True)
+            profile_skills.mkdir(parents=True)
+            destination.mkdir()
+            (skill / "SKILL.md").write_text("green\n", encoding="utf-8")
+            link_target = "../../../shared/skills/green"
+            (profile_skills / "green").symlink_to(link_target, target_is_directory=True)
+
+            try:
+                seed(source, destination)
+            except ValueError as error:
+                self.fail(f"safe relative symlink was rejected: {error}")
+
+            copied_link = destination / "profiles" / "shiraishi" / "skills" / "green"
+            self.assertTrue(copied_link.is_symlink())
+            self.assertEqual(os.readlink(copied_link), link_target)
+            self.assertEqual((copied_link / "SKILL.md").read_text(encoding="utf-8"), "green\n")
+
+    def test_preserves_absolute_symlink_below_opt_data(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            link_target = "/opt/data/hindsight/models/model.bin"
+            (source / "model.bin").symlink_to(link_target)
+
+            try:
+                seed(source, destination)
+            except ValueError as error:
+                self.fail(f"safe absolute symlink was rejected: {error}")
+
+            copied_link = destination / "model.bin"
+            self.assertTrue(copied_link.is_symlink())
+            self.assertEqual(os.readlink(copied_link), link_target)
+
+    def test_rejects_relative_symlink_that_escapes_hermes_data(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            links = source / "links"
+            links.mkdir(parents=True)
+            destination.mkdir()
+            (root / "outside.txt").write_text("private\n", encoding="utf-8")
+            (links / "outside.txt").symlink_to("../../outside.txt")
+
+            with self.assertRaisesRegex(ValueError, "relative symlink target escapes Hermes data"):
+                seed(source, destination)
+
+    def test_rejects_absolute_symlink_outside_opt_data(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            (source / "passwd").symlink_to("/etc/passwd")
+
+            with self.assertRaisesRegex(ValueError, "absolute symlink target must be below /opt/data"):
+                seed(source, destination)
+
     def test_copies_regular_files_and_sqlite_databases_without_sidecars(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/docker/hermes-agent/tests/test_hermes_storage_seed.py
+++ b/docker/hermes-agent/tests/test_hermes_storage_seed.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import os
 import sqlite3
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -9,7 +11,55 @@ from pathlib import Path
 from hermes_storage_seed import seed
 
 
+def _run_seed_without_source_write_access(source: Path, destination: Path) -> subprocess.CompletedProcess[str]:
+    environment = os.environ.copy()
+    module_root = str(Path(__file__).resolve().parents[1])
+    environment["PYTHONPATH"] = os.pathsep.join(filter(None, (module_root, environment.get("PYTHONPATH", ""))))
+
+    def drop_root_privileges() -> None:
+        if os.geteuid() != 0:
+            return
+        import pwd
+
+        nobody = pwd.getpwnam("nobody")
+        os.setgroups([])
+        os.setgid(nobody.pw_gid)
+        os.setuid(nobody.pw_uid)
+
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from pathlib import Path; import sys; from hermes_storage_seed import seed; "
+            "seed(Path(sys.argv[1]), Path(sys.argv[2]))",
+            str(source),
+            str(destination),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+        preexec_fn=drop_root_privileges,
+    )
+
+
 class HermesStorageSeedTests(unittest.TestCase):
+    def test_replaces_source_ready_marker_only_after_successful_seed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            marker = ".dotfiles-hermes-storage-ready-v1"
+            (source / marker).write_text("spoofed\n", encoding="utf-8")
+            (source / "config.yaml").write_text("gateway: docker\n", encoding="utf-8")
+
+            seed(source, destination)
+
+            self.assertEqual((destination / marker).read_text(encoding="utf-8"), "version=1\n")
+
+    @unittest.skipUnless(os.name == "posix", "requires POSIX directory permissions")
     def test_copies_clean_wal_database_from_read_only_source(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -27,18 +77,68 @@ class HermesStorageSeedTests(unittest.TestCase):
             self.assertFalse((source / "clean-wal.db-wal").exists())
             self.assertFalse((source / "clean-wal.db-shm").exists())
 
+            root.chmod(0o755)
+            database.chmod(0o444)
+            destination.chmod(0o777)
             source.chmod(0o555)
             try:
-                try:
-                    seed(source, destination)
-                except sqlite3.OperationalError as error:
-                    self.fail(f"clean WAL database was not copied from read-only source: {error}")
+                result = _run_seed_without_source_write_access(source, destination)
             finally:
                 source.chmod(0o755)
+            self.assertEqual(result.returncode, 0, result.stderr)
 
             copied = sqlite3.connect(destination / "clean-wal.db")
             self.assertEqual(copied.execute("select body from messages").fetchone()[0], "kept")
             copied.close()
+
+    @unittest.skipUnless(os.name == "posix", "requires POSIX directory permissions")
+    def test_copies_uncheckpointed_wal_without_modifying_source_sidecars(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            database = source / "active-wal.db"
+            writer = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import os, sqlite3, sys; db=sqlite3.connect(sys.argv[1]); "
+                    "db.execute('pragma journal_mode=wal'); db.execute('pragma wal_autocheckpoint=0'); "
+                    "db.execute('create table messages (body text)'); db.commit(); "
+                    "db.execute('pragma wal_checkpoint(truncate)'); "
+                    "db.execute(\"insert into messages values ('wal-only')\"); db.commit(); os._exit(0)",
+                    str(database),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(writer.returncode, 0, writer.stderr)
+            wal = source / "active-wal.db-wal"
+            shared_memory = source / "active-wal.db-shm"
+            self.assertTrue(wal.is_file())
+            self.assertTrue(shared_memory.is_file())
+            original_wal = wal.read_bytes()
+            original_shared_memory = shared_memory.read_bytes()
+
+            root.chmod(0o755)
+            destination.chmod(0o777)
+            for path in (database, wal, shared_memory):
+                path.chmod(0o444)
+            source.chmod(0o555)
+            try:
+                result = _run_seed_without_source_write_access(source, destination)
+            finally:
+                source.chmod(0o755)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            copied = sqlite3.connect(destination / "active-wal.db")
+            self.assertEqual(copied.execute("select body from messages").fetchone()[0], "wal-only")
+            copied.close()
+            self.assertEqual(wal.read_bytes(), original_wal)
+            self.assertEqual(shared_memory.read_bytes(), original_shared_memory)
 
     def test_preserves_relative_directory_symlink_within_hermes_data(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -95,6 +195,19 @@ class HermesStorageSeedTests(unittest.TestCase):
             (links / "outside.txt").symlink_to("../../outside.txt")
 
             with self.assertRaisesRegex(ValueError, "relative symlink target escapes Hermes data"):
+                seed(source, destination)
+
+    def test_rejects_relative_symlink_that_escapes_after_relocation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            (source / "secret.txt").write_text("private\n", encoding="utf-8")
+            (source / "secret-link").symlink_to("../source/secret.txt")
+
+            with self.assertRaisesRegex(ValueError, "relative symlink target escapes Hermes data after relocation"):
                 seed(source, destination)
 
     def test_rejects_absolute_symlink_outside_opt_data(self) -> None:

--- a/docker/hermes-agent/tests/test_storage_volume_integration.sh
+++ b/docker/hermes-agent/tests/test_storage_volume_integration.sh
@@ -98,6 +98,26 @@ unlink "$fixture_dir/nested/bad-link"
 
 dotfiles_hermes_initialize_storage_volume docker
 lock_name=""
+
+lock_name="$(dotfiles_hermes_storage_lock_name "$volume_name")"
+stale_created_id="$(docker create \
+  --name "$lock_name" \
+  --label "com.rurusasu.dotfiles.hermes-storage.lock=1" \
+  --label "com.rurusasu.dotfiles.hermes-storage.init-token=$volume_token" \
+  --label "com.rurusasu.dotfiles.hermes-storage.lock-created-at=0" \
+  --entrypoint /usr/local/bin/hermes-storage-seed \
+  --mount "type=bind,src=$fixture_dir,dst=/source,readonly" \
+  --mount "type=volume,src=$volume_name,dst=/target" \
+  local/hermes-agent-gh:latest \
+  --source /source --destination /target \
+  --ready-token "$volume_token" --replace-incomplete)"
+dotfiles_hermes_initialize_storage_volume docker
+if docker inspect "$stale_created_id" >/dev/null 2>&1; then
+  printf 'an aged created lock was not reclaimed by immutable ID\n' >&2
+  exit 1
+fi
+lock_name=""
+
 dotfiles_hermes_initialize_storage_volume docker
 
 marker="$(docker run --rm \

--- a/docker/hermes-agent/tests/test_storage_volume_integration.sh
+++ b/docker/hermes-agent/tests/test_storage_volume_integration.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd)"
+fixture_dir="$(mktemp -d)"
+volume_name="hermes-storage-integration-$(python3 -c 'import uuid; print(uuid.uuid4().hex)')"
+lock_name=""
+
+cleanup() {
+  if [[ -n $lock_name ]]; then
+    docker rm -f "$lock_name" >/dev/null 2>&1 || true
+  fi
+  docker volume rm "$volume_name" >/dev/null 2>&1 || true
+  rm -r "$fixture_dir"
+}
+trap cleanup EXIT
+
+FIXTURE_DIR="$fixture_dir" python3 - <<'PY'
+import os
+import sqlite3
+from pathlib import Path
+
+root = Path(os.environ["FIXTURE_DIR"])
+(root / "nested").mkdir()
+(root / "config.yaml").write_text("profile: integration\n", encoding="utf-8")
+with sqlite3.connect(root / "state?#%.db") as database:
+    database.execute("create table checks (value text not null)")
+    database.execute("insert into checks values ('atomic-ready')")
+(root / "nested" / "config-link").symlink_to("../config.yaml")
+PY
+
+# shellcheck source=../../../scripts/sh/install-common.sh
+source "$repository_root/scripts/sh/install-common.sh"
+# shellcheck source=../../../scripts/sh/hermes-agent.sh
+source "$repository_root/scripts/sh/hermes-agent.sh"
+export HERMES_DATA_DIR="$fixture_dir"
+export HERMES_DATA_VOLUME="$volume_name"
+
+dotfiles_hermes_initialize_storage_volume docker
+volume_token="$(docker volume inspect --format '{{ index .Labels "com.rurusasu.dotfiles.hermes-storage.init-token" }}' "$volume_name")"
+lock_name="$(dotfiles_hermes_storage_lock_name "$volume_name")"
+
+docker run -d --rm \
+  --name "$lock_name" \
+  --entrypoint sleep \
+  --mount "type=volume,src=$volume_name,dst=/locked,readonly" \
+  local/hermes-agent-gh:latest \
+  21600 >/dev/null
+if docker volume rm "$volume_name" >/dev/null 2>&1; then
+  printf 'volume deletion unexpectedly succeeded while guarded\n' >&2
+  exit 1
+fi
+if dotfiles_hermes_initialize_storage_volume docker >/dev/null 2>&1; then
+  printf 'a second initializer unexpectedly acquired the guard\n' >&2
+  exit 1
+fi
+docker rm -f "$lock_name" >/dev/null
+lock_name=""
+
+docker run --rm \
+  --entrypoint sh \
+  --mount "type=volume,src=$volume_name,dst=/target" \
+  local/hermes-agent-gh:latest \
+  -c 'printf "spoofed\n" > /target/.dotfiles-hermes-storage-ready-v1'
+dotfiles_hermes_initialize_storage_volume docker
+
+ln -s ../../outside "$fixture_dir/nested/bad-link"
+docker run --rm \
+  --entrypoint sh \
+  --mount "type=volume,src=$volume_name,dst=/target" \
+  local/hermes-agent-gh:latest \
+  -c 'printf "invalid\n" > /target/.dotfiles-hermes-storage-ready-v1'
+if dotfiles_hermes_initialize_storage_volume docker >/dev/null 2>&1; then
+  printf 'an unsafe source symlink unexpectedly seeded\n' >&2
+  exit 1
+fi
+[[ "$(docker volume inspect --format '{{ index .Labels "com.rurusasu.dotfiles.hermes-storage.init-token" }}' "$volume_name")" == "$volume_token" ]]
+[[ -z "$(docker ps -aq --filter "name=^/$(dotfiles_hermes_storage_lock_name "$volume_name")$")" ]]
+
+lock_name="$(dotfiles_hermes_storage_lock_name "$volume_name")"
+docker create \
+  --name "$lock_name" \
+  --label "com.rurusasu.dotfiles.hermes-storage.lock=1" \
+  --label "com.rurusasu.dotfiles.hermes-storage.init-token=$volume_token" \
+  --entrypoint /usr/local/bin/hermes-storage-seed \
+  --mount "type=bind,src=$fixture_dir,dst=/source,readonly" \
+  --mount "type=volume,src=$volume_name,dst=/target" \
+  local/hermes-agent-gh:latest \
+  --source /source --destination /target \
+  --ready-token "$volume_token" --replace-incomplete >/dev/null
+if docker start -a "$lock_name" >/dev/null 2>&1; then
+  printf 'the intentionally invalid stale-lock seed unexpectedly succeeded\n' >&2
+  exit 1
+fi
+[[ "$(docker inspect --format '{{ .State.Status }}' "$lock_name")" == exited ]]
+unlink "$fixture_dir/nested/bad-link"
+
+dotfiles_hermes_initialize_storage_volume docker
+lock_name=""
+dotfiles_hermes_initialize_storage_volume docker
+
+marker="$(docker run --rm \
+  --entrypoint sh \
+  --mount "type=volume,src=$volume_name,dst=/target,readonly" \
+  local/hermes-agent-gh:latest \
+  -c 'cat /target/.dotfiles-hermes-storage-ready-v1')"
+row="$(docker run --rm \
+  --entrypoint python \
+  --mount "type=volume,src=$volume_name,dst=/target,readonly" \
+  local/hermes-agent-gh:latest \
+  -c 'import sqlite3; print(sqlite3.connect("/target/state?#%.db").execute("select value from checks").fetchone()[0])')"
+
+[[ $marker == $'version=1\nvolume_token='"$volume_token" ]]
+[[ $row == atomic-ready ]]
+printf 'Hermes storage volume integration passed.\n'

--- a/scripts/powershell/lib/HermesStorage.ps1
+++ b/scripts/powershell/lib/HermesStorage.ps1
@@ -40,18 +40,53 @@ function Test-HermesStorageVolumeReady {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$VolumeName
+        [string]$VolumeName,
+
+        [Parameter(Mandatory)]
+        [string]$VolumeToken
     )
 
     $arguments = @(
         'run', '--rm',
-        '--entrypoint', 'test',
+        '--entrypoint', 'python',
         '--mount', "type=volume,source=$VolumeName,target=/target,readonly",
         'local/hermes-agent-gh:latest',
-        '-f', '/target/.dotfiles-hermes-storage-ready-v1'
+        '-c', 'import pathlib, sys; marker=pathlib.Path("/target/.dotfiles-hermes-storage-ready-v1"); expected=f"version=1\nvolume_token={sys.argv[1]}\n"; raise SystemExit(0 if marker.is_file() and not marker.is_symlink() and marker.read_text(encoding="utf-8") == expected else 1)',
+        $VolumeToken
     )
     $null = @(Invoke-Docker -Arguments $arguments 2>$null)
     return $LASTEXITCODE -eq 0
+}
+
+function Get-HermesStorageLockName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$VolumeName
+    )
+
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($VolumeName)
+    $hash = [System.Security.Cryptography.SHA256]::HashData($bytes)
+    $hex = [System.Convert]::ToHexString($hash).ToLowerInvariant()
+    return 'dotfiles-hermes-storage-' + $hex.Substring(0, 20)
+}
+
+function Get-HermesStorageLockState {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$LockName,
+
+        [Parameter(Mandatory)]
+        [string]$LockLabel,
+
+        [Parameter(Mandatory)]
+        [string]$TokenLabel
+    )
+
+    $format = '{{ index .Config.Labels "' + $LockLabel + '" }}|{{ index .Config.Labels "' + $TokenLabel + '" }}|{{ .State.Status }}'
+    $output = @(Invoke-Docker -Arguments @('inspect', '--format', $format, $LockName) 2>$null)
+    return [PSCustomObject]@{ Status = $LASTEXITCODE; Value = (($output -join "`n").Trim()) }
 }
 
 function Initialize-HermesStorageVolume {
@@ -64,94 +99,119 @@ function Initialize-HermesStorageVolume {
     $volumeName = Get-HermesStorageVolumeName
     $schemaLabel = 'com.rurusasu.dotfiles.hermes-storage.schema'
     $tokenLabel = 'com.rurusasu.dotfiles.hermes-storage.init-token'
+    $lockLabel = 'com.rurusasu.dotfiles.hermes-storage.lock'
+    $existing = $true
     $schema = Get-HermesStorageVolumeLabel -VolumeName $volumeName -Label $schemaLabel
     if ($schema.Status -eq 0) {
         if ($schema.Value -ne '1') {
             return [PSCustomObject]@{ Success = $true; Existing = $true; Message = '' }
         }
-        if (Test-HermesStorageVolumeReady -VolumeName $volumeName) {
-            return [PSCustomObject]@{ Success = $true; Existing = $true; Message = '' }
+        $owner = Get-HermesStorageVolumeLabel -VolumeName $volumeName -Label $tokenLabel
+        if ($owner.Status -ne 0) {
+            return [PSCustomObject]@{ Success = $false; Existing = $true; Message = 'Hermes data volume token inspection failed.' }
         }
-        return [PSCustomObject]@{
-            Success  = $false
-            Existing = $true
-            Message  = 'Hermes Docker data volume is managed but incomplete.'
-        }
+        $volumeToken = $owner.Value
     }
-    if ($schema.Status -ne 1) {
+    elseif ($schema.Status -ne 1) {
         return [PSCustomObject]@{ Success = $false; Existing = $false; Message = 'Hermes data volume inspection failed.' }
     }
-
-    $initToken = [guid]::NewGuid().ToString('N')
-    $createArguments = @(
-        'volume', 'create',
-        '--label', "$schemaLabel=1",
-        '--label', "$tokenLabel=$initToken",
-        $volumeName
-    )
-    $null = @(Invoke-Docker -Arguments $createArguments 2>$null)
-    if ($LASTEXITCODE -ne 0) {
-        return [PSCustomObject]@{ Success = $false; Existing = $false; Message = 'Hermes data volume creation failed.' }
-    }
-    $owner = Get-HermesStorageVolumeLabel -VolumeName $volumeName -Label $tokenLabel
-    if ($owner.Status -ne 0) {
-        return [PSCustomObject]@{
-            Success  = $false
-            Existing = $true
-            Message  = 'Hermes Docker data volume ownership could not be verified.'
-        }
-    }
-    if ($owner.Value -ne $initToken) {
-        return [PSCustomObject]@{
-            Success  = $false
-            Existing = $true
-            Message  = 'Hermes Docker data volume was created concurrently; refusing to seed or remove it.'
+    else {
+        $existing = $false
+        $volumeToken = [guid]::NewGuid().ToString('N')
+        $createArguments = @(
+            'volume', 'create',
+            '--label', "$schemaLabel=1",
+            '--label', "$tokenLabel=$volumeToken",
+            $volumeName
+        )
+        $null = @(Invoke-Docker -Arguments $createArguments 2>$null)
+        if ($LASTEXITCODE -ne 0) {
+            return [PSCustomObject]@{ Success = $false; Existing = $false; Message = 'Hermes data volume creation failed.' }
         }
     }
 
+    if ($volumeToken -notmatch '^[0-9a-f]{32}$') {
+        return [PSCustomObject]@{ Success = $false; Existing = $existing; Message = 'Hermes data volume has an invalid initialization token.' }
+    }
+
+    $lockName = Get-HermesStorageLockName -VolumeName $volumeName
     $seedArguments = @(
-        'run', '--rm',
+        'create',
+        '--name', $lockName,
+        '--label', "$lockLabel=1",
+        '--label', "$tokenLabel=$volumeToken",
         '--entrypoint', '/usr/local/bin/hermes-storage-seed',
         '--mount', "type=bind,source=$DataDir,target=/source,readonly",
         '--mount', "type=volume,source=$volumeName,target=/target",
         'local/hermes-agent-gh:latest',
         '--source', '/source',
-        '--destination', '/target'
+        '--destination', '/target',
+        '--ready-token', $volumeToken,
+        '--replace-incomplete'
     )
     $null = @(Invoke-Docker -Arguments $seedArguments 2>$null)
-    $seedStatus = $LASTEXITCODE
-    $failureMessage = 'Hermes data volume initialization failed.'
-    if ($seedStatus -eq 0) {
-        if (Test-HermesStorageVolumeReady -VolumeName $volumeName) {
-            return [PSCustomObject]@{ Success = $true; Existing = $false; Message = '' }
+    if ($LASTEXITCODE -ne 0) {
+        $lockState = Get-HermesStorageLockState -LockName $lockName -LockLabel $lockLabel -TokenLabel $tokenLabel
+        if ($lockState.Status -eq 0 -and
+            $lockState.Value -match ('^1\|' + [regex]::Escape($volumeToken) + '\|(exited|dead)$')) {
+            $null = @(Invoke-Docker -Arguments @('rm', '-f', $lockName) 2>$null)
+            if ($LASTEXITCODE -ne 0) {
+                return [PSCustomObject]@{ Success = $false; Existing = $existing; Message = 'Hermes data volume stale lock could not be reclaimed.' }
+            }
+            $null = @(Invoke-Docker -Arguments $seedArguments 2>$null)
+            if ($LASTEXITCODE -ne 0) {
+                return [PSCustomObject]@{ Success = $false; Existing = $existing; Message = 'Hermes data volume lock could not be acquired after stale-lock cleanup.' }
+            }
         }
-        $seedStatus = 1
-        $failureMessage = 'Hermes Docker data volume seed completed without its ready marker.'
+        else {
+            return [PSCustomObject]@{ Success = $false; Existing = $existing; Message = 'Hermes data volume initialization is already locked.' }
+        }
     }
 
-    $owner = Get-HermesStorageVolumeLabel -VolumeName $volumeName -Label $tokenLabel
-    if ($owner.Status -ne 0) {
-        return [PSCustomObject]@{
+    $lockedSchema = Get-HermesStorageVolumeLabel -VolumeName $volumeName -Label $schemaLabel
+    $lockedOwner = Get-HermesStorageVolumeLabel -VolumeName $volumeName -Label $tokenLabel
+    if ($lockedSchema.Status -ne 0 -or $lockedOwner.Status -ne 0 -or
+        $lockedSchema.Value -ne '1' -or $lockedOwner.Value -ne $volumeToken) {
+        $result = [PSCustomObject]@{
             Success  = $false
-            Existing = $true
-            Message  = "$failureMessage Ownership could not be reverified; refusing removal."
+            Existing = $existing
+            Message  = 'Hermes data volume changed before its lock was acquired; refusing access.'
         }
     }
-    if ($owner.Value -ne $initToken) {
-        return [PSCustomObject]@{
-            Success  = $false
-            Existing = $true
-            Message  = "$failureMessage Ownership changed; refusing removal."
+    elseif (Test-HermesStorageVolumeReady -VolumeName $volumeName -VolumeToken $volumeToken) {
+        $result = [PSCustomObject]@{ Success = $true; Existing = $true; Message = '' }
+    }
+    else {
+        $null = @(Invoke-Docker -Arguments @('start', '-a', $lockName) 2>$null)
+        $seedStatus = $LASTEXITCODE
+        if ($seedStatus -eq 0 -and
+            (Test-HermesStorageVolumeReady -VolumeName $volumeName -VolumeToken $volumeToken)) {
+            $result = [PSCustomObject]@{ Success = $true; Existing = $existing; Message = '' }
+        }
+        elseif ($seedStatus -eq 0) {
+            $result = [PSCustomObject]@{
+                Success  = $false
+                Existing = $existing
+                Message  = 'Hermes data volume seed completed without its valid ready marker.'
+            }
+        }
+        else {
+            $result = [PSCustomObject]@{
+                Success  = $false
+                Existing = $existing
+                Message  = "Hermes data volume initialization failed with status $seedStatus; it remains incomplete for a safe retry."
+            }
         }
     }
-    $null = @(Invoke-Docker -Arguments @('volume', 'rm', $volumeName) 2>$null)
-    $cleanupStatus = $LASTEXITCODE
-    if ($cleanupStatus -ne 0) {
+
+    $null = @(Invoke-Docker -Arguments @('rm', '-f', $lockName) 2>$null)
+    $releaseStatus = $LASTEXITCODE
+    if ($releaseStatus -ne 0) {
         return [PSCustomObject]@{
             Success  = $false
-            Existing = $true
-            Message  = "$failureMessage The owned partial volume could not be removed (seed status $seedStatus, cleanup status $cleanupStatus)."
+            Existing = $existing
+            Message  = "Hermes data volume operation completed but its lock could not be released (status $releaseStatus)."
         }
     }
-    return [PSCustomObject]@{ Success = $false; Existing = $false; Message = $failureMessage }
+    return $result
 }

--- a/scripts/powershell/lib/HermesStorage.ps1
+++ b/scripts/powershell/lib/HermesStorage.ps1
@@ -51,11 +51,24 @@ function Test-HermesStorageVolumeReady {
         '--entrypoint', 'python',
         '--mount', "type=volume,source=$VolumeName,target=/target,readonly",
         'local/hermes-agent-gh:latest',
-        '-c', 'import pathlib, sys; marker=pathlib.Path("/target/.dotfiles-hermes-storage-ready-v1"); expected=f"version=1\nvolume_token={sys.argv[1]}\n"; raise SystemExit(0 if marker.is_file() and not marker.is_symlink() and marker.read_text(encoding="utf-8") == expected else 1)',
+        '-c', 'import pathlib, stat, sys; marker=pathlib.Path("/target/.dotfiles-hermes-storage-ready-v1"); expected=f"version=1\nvolume_token={sys.argv[1]}\n";
+try:
+ mode=marker.lstat().st_mode
+except FileNotFoundError:
+ raise SystemExit(3)
+except OSError as error:
+ print(f"Hermes ready marker could not be inspected: {error}", file=sys.stderr); raise SystemExit(2)
+if stat.S_ISLNK(mode) or not stat.S_ISREG(mode): raise SystemExit(3)
+try:
+ actual=marker.read_text(encoding="utf-8")
+except (OSError, UnicodeError) as error:
+ print(f"Hermes ready marker could not be read: {error}", file=sys.stderr); raise SystemExit(2)
+raise SystemExit(0 if actual == expected else 3)',
         $VolumeToken
     )
     $null = @(Invoke-Docker -Arguments $arguments 2>$null)
-    return $LASTEXITCODE -eq 0
+    $status = $LASTEXITCODE
+    return [PSCustomObject]@{ Status = $status; Ready = $status -eq 0 }
 }
 
 function Get-HermesStorageLockName {
@@ -219,21 +232,43 @@ function Initialize-HermesStorageVolume {
             Message  = 'Hermes data volume changed before its lock was acquired; refusing access.'
         }
     }
-    elseif (Test-HermesStorageVolumeReady -VolumeName $volumeName -VolumeToken $volumeToken) {
+    else {
+        $probe = Test-HermesStorageVolumeReady -VolumeName $volumeName -VolumeToken $volumeToken
+    }
+    if ($null -ne $result) {
+        # The locked volume identity check already produced the result.
+    }
+    elseif ($probe.Status -eq 0) {
         $result = [PSCustomObject]@{ Success = $true; Existing = $true; Message = '' }
+    }
+    elseif ($probe.Status -ne 3) {
+        $result = [PSCustomObject]@{
+            Success  = $false
+            Existing = $existing
+            Message  = "Hermes data volume ready marker probe failed with status $($probe.Status); preserving it unchanged."
+        }
     }
     else {
         $null = @(Invoke-Docker -Arguments @('start', '-a', $lockId) 2>$null)
         $seedStatus = $LASTEXITCODE
-        if ($seedStatus -eq 0 -and
-            (Test-HermesStorageVolumeReady -VolumeName $volumeName -VolumeToken $volumeToken)) {
-            $result = [PSCustomObject]@{ Success = $true; Existing = $existing; Message = '' }
-        }
-        elseif ($seedStatus -eq 0) {
-            $result = [PSCustomObject]@{
-                Success  = $false
-                Existing = $existing
-                Message  = 'Hermes data volume seed completed without its valid ready marker.'
+        if ($seedStatus -eq 0) {
+            $postSeedProbe = Test-HermesStorageVolumeReady -VolumeName $volumeName -VolumeToken $volumeToken
+            if ($postSeedProbe.Status -eq 0) {
+                $result = [PSCustomObject]@{ Success = $true; Existing = $existing; Message = '' }
+            }
+            elseif ($postSeedProbe.Status -eq 3) {
+                $result = [PSCustomObject]@{
+                    Success  = $false
+                    Existing = $existing
+                    Message  = 'Hermes data volume seed completed without its valid ready marker.'
+                }
+            }
+            else {
+                $result = [PSCustomObject]@{
+                    Success  = $false
+                    Existing = $existing
+                    Message  = "Hermes data volume post-seed ready marker probe failed with status $($postSeedProbe.Status)."
+                }
             }
         }
         else {

--- a/scripts/powershell/lib/HermesStorage.ps1
+++ b/scripts/powershell/lib/HermesStorage.ps1
@@ -71,6 +71,13 @@ function Get-HermesStorageLockName {
     return 'dotfiles-hermes-storage-' + $hex.Substring(0, 20)
 }
 
+function Get-HermesStorageUnixTime {
+    [CmdletBinding()]
+    param()
+
+    return [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+}
+
 function Get-HermesStorageLockState {
     [CmdletBinding()]
     param(
@@ -139,7 +146,7 @@ function Initialize-HermesStorageVolume {
     }
 
     $lockName = Get-HermesStorageLockName -VolumeName $volumeName
-    $lockCreatedAt = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    $lockCreatedAt = Get-HermesStorageUnixTime
     $seedArguments = @(
         'create',
         '--name', $lockName,
@@ -155,6 +162,7 @@ function Initialize-HermesStorageVolume {
         '--ready-token', $volumeToken,
         '--replace-incomplete'
     )
+    $lockCreatedArgument = "$lockCreatedLabel=$lockCreatedAt"
     $lockOutput = @(Invoke-Docker -Arguments $seedArguments 2>$null)
     $lockCreateStatus = $LASTEXITCODE
     $lockId = ($lockOutput -join "`n").Trim()
@@ -169,7 +177,7 @@ function Initialize-HermesStorageVolume {
                 $reclaimStale = $true
             }
             elseif ($parts[4] -eq 'created' -and $parts[3] -match '^[0-9]{1,12}$') {
-                $age = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds() - [long]$parts[3]
+                $age = (Get-HermesStorageUnixTime) - [long]$parts[3]
                 $reclaimStale = $age -ge 30
             }
         }
@@ -179,6 +187,13 @@ function Initialize-HermesStorageVolume {
             if ($LASTEXITCODE -ne 0) {
                 return [PSCustomObject]@{ Success = $false; Existing = $existing; Message = 'Hermes data volume stale lock could not be reclaimed.' }
             }
+            $lockCreatedArgumentIndex = $seedArguments.IndexOf($lockCreatedArgument)
+            if ($lockCreatedArgumentIndex -lt 0) {
+                return [PSCustomObject]@{ Success = $false; Existing = $existing; Message = 'Hermes data volume lock timestamp could not be refreshed.' }
+            }
+            $lockCreatedAt = Get-HermesStorageUnixTime
+            $lockCreatedArgument = "$lockCreatedLabel=$lockCreatedAt"
+            $seedArguments[$lockCreatedArgumentIndex] = $lockCreatedArgument
             $lockOutput = @(Invoke-Docker -Arguments $seedArguments 2>$null)
             $lockCreateStatus = $LASTEXITCODE
             $lockId = ($lockOutput -join "`n").Trim()

--- a/scripts/powershell/lib/HermesStorage.ps1
+++ b/scripts/powershell/lib/HermesStorage.ps1
@@ -19,6 +19,41 @@ function Get-HermesStorageVolumeName {
     return $name
 }
 
+function Get-HermesStorageVolumeLabel {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$VolumeName,
+
+        [Parameter(Mandatory)]
+        [string]$Label
+    )
+
+    $format = '{{ index .Labels "' + $Label + '" }}'
+    $output = @(Invoke-Docker -Arguments @('volume', 'inspect', '--format', $format, $VolumeName) 2>$null)
+    $status = $LASTEXITCODE
+    $value = ($output -join "`n").Trim()
+    return [PSCustomObject]@{ Status = $status; Value = $value }
+}
+
+function Test-HermesStorageVolumeReady {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$VolumeName
+    )
+
+    $arguments = @(
+        'run', '--rm',
+        '--entrypoint', 'test',
+        '--mount', "type=volume,source=$VolumeName,target=/target,readonly",
+        'local/hermes-agent-gh:latest',
+        '-f', '/target/.dotfiles-hermes-storage-ready-v1'
+    )
+    $null = @(Invoke-Docker -Arguments $arguments 2>$null)
+    return $LASTEXITCODE -eq 0
+}
+
 function Initialize-HermesStorageVolume {
     [CmdletBinding()]
     param(
@@ -27,17 +62,51 @@ function Initialize-HermesStorageVolume {
     )
 
     $volumeName = Get-HermesStorageVolumeName
-    $null = @(Invoke-Docker -Arguments @('volume', 'inspect', $volumeName) 2>$null)
-    if ($LASTEXITCODE -eq 0) {
-        return [PSCustomObject]@{ Success = $true; Existing = $true; Message = '' }
+    $schemaLabel = 'com.rurusasu.dotfiles.hermes-storage.schema'
+    $tokenLabel = 'com.rurusasu.dotfiles.hermes-storage.init-token'
+    $schema = Get-HermesStorageVolumeLabel -VolumeName $volumeName -Label $schemaLabel
+    if ($schema.Status -eq 0) {
+        if ($schema.Value -ne '1') {
+            return [PSCustomObject]@{ Success = $true; Existing = $true; Message = '' }
+        }
+        if (Test-HermesStorageVolumeReady -VolumeName $volumeName) {
+            return [PSCustomObject]@{ Success = $true; Existing = $true; Message = '' }
+        }
+        return [PSCustomObject]@{
+            Success  = $false
+            Existing = $true
+            Message  = 'Hermes Docker data volume is managed but incomplete.'
+        }
     }
-    if ($LASTEXITCODE -ne 1) {
+    if ($schema.Status -ne 1) {
         return [PSCustomObject]@{ Success = $false; Existing = $false; Message = 'Hermes data volume inspection failed.' }
     }
 
-    $null = @(Invoke-Docker -Arguments @('volume', 'create', $volumeName) 2>$null)
+    $initToken = [guid]::NewGuid().ToString('N')
+    $createArguments = @(
+        'volume', 'create',
+        '--label', "$schemaLabel=1",
+        '--label', "$tokenLabel=$initToken",
+        $volumeName
+    )
+    $null = @(Invoke-Docker -Arguments $createArguments 2>$null)
     if ($LASTEXITCODE -ne 0) {
         return [PSCustomObject]@{ Success = $false; Existing = $false; Message = 'Hermes data volume creation failed.' }
+    }
+    $owner = Get-HermesStorageVolumeLabel -VolumeName $volumeName -Label $tokenLabel
+    if ($owner.Status -ne 0) {
+        return [PSCustomObject]@{
+            Success  = $false
+            Existing = $true
+            Message  = 'Hermes Docker data volume ownership could not be verified.'
+        }
+    }
+    if ($owner.Value -ne $initToken) {
+        return [PSCustomObject]@{
+            Success  = $false
+            Existing = $true
+            Message  = 'Hermes Docker data volume was created concurrently; refusing to seed or remove it.'
+        }
     }
 
     $seedArguments = @(
@@ -50,10 +119,39 @@ function Initialize-HermesStorageVolume {
         '--destination', '/target'
     )
     $null = @(Invoke-Docker -Arguments $seedArguments 2>$null)
-    if ($LASTEXITCODE -eq 0) {
-        return [PSCustomObject]@{ Success = $true; Existing = $false; Message = '' }
+    $seedStatus = $LASTEXITCODE
+    $failureMessage = 'Hermes data volume initialization failed.'
+    if ($seedStatus -eq 0) {
+        if (Test-HermesStorageVolumeReady -VolumeName $volumeName) {
+            return [PSCustomObject]@{ Success = $true; Existing = $false; Message = '' }
+        }
+        $seedStatus = 1
+        $failureMessage = 'Hermes Docker data volume seed completed without its ready marker.'
     }
 
+    $owner = Get-HermesStorageVolumeLabel -VolumeName $volumeName -Label $tokenLabel
+    if ($owner.Status -ne 0) {
+        return [PSCustomObject]@{
+            Success  = $false
+            Existing = $true
+            Message  = "$failureMessage Ownership could not be reverified; refusing removal."
+        }
+    }
+    if ($owner.Value -ne $initToken) {
+        return [PSCustomObject]@{
+            Success  = $false
+            Existing = $true
+            Message  = "$failureMessage Ownership changed; refusing removal."
+        }
+    }
     $null = @(Invoke-Docker -Arguments @('volume', 'rm', $volumeName) 2>$null)
-    return [PSCustomObject]@{ Success = $false; Existing = $false; Message = 'Hermes data volume initialization failed.' }
+    $cleanupStatus = $LASTEXITCODE
+    if ($cleanupStatus -ne 0) {
+        return [PSCustomObject]@{
+            Success  = $false
+            Existing = $true
+            Message  = "$failureMessage The owned partial volume could not be removed (seed status $seedStatus, cleanup status $cleanupStatus)."
+        }
+    }
+    return [PSCustomObject]@{ Success = $false; Existing = $false; Message = $failureMessage }
 }

--- a/scripts/powershell/lib/HermesStorage.ps1
+++ b/scripts/powershell/lib/HermesStorage.ps1
@@ -81,10 +81,13 @@ function Get-HermesStorageLockState {
         [string]$LockLabel,
 
         [Parameter(Mandatory)]
-        [string]$TokenLabel
+        [string]$TokenLabel,
+
+        [Parameter(Mandatory)]
+        [string]$CreatedLabel
     )
 
-    $format = '{{ index .Config.Labels "' + $LockLabel + '" }}|{{ index .Config.Labels "' + $TokenLabel + '" }}|{{ .State.Status }}'
+    $format = '{{ .Id }}|{{ index .Config.Labels "' + $LockLabel + '" }}|{{ index .Config.Labels "' + $TokenLabel + '" }}|{{ index .Config.Labels "' + $CreatedLabel + '" }}|{{ .State.Status }}'
     $output = @(Invoke-Docker -Arguments @('inspect', '--format', $format, $LockName) 2>$null)
     return [PSCustomObject]@{ Status = $LASTEXITCODE; Value = (($output -join "`n").Trim()) }
 }
@@ -100,6 +103,7 @@ function Initialize-HermesStorageVolume {
     $schemaLabel = 'com.rurusasu.dotfiles.hermes-storage.schema'
     $tokenLabel = 'com.rurusasu.dotfiles.hermes-storage.init-token'
     $lockLabel = 'com.rurusasu.dotfiles.hermes-storage.lock'
+    $lockCreatedLabel = 'com.rurusasu.dotfiles.hermes-storage.lock-created-at'
     $existing = $true
     $schema = Get-HermesStorageVolumeLabel -VolumeName $volumeName -Label $schemaLabel
     if ($schema.Status -eq 0) {
@@ -135,11 +139,13 @@ function Initialize-HermesStorageVolume {
     }
 
     $lockName = Get-HermesStorageLockName -VolumeName $volumeName
+    $lockCreatedAt = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
     $seedArguments = @(
         'create',
         '--name', $lockName,
         '--label', "$lockLabel=1",
         '--label', "$tokenLabel=$volumeToken",
+        '--label', "$lockCreatedLabel=$lockCreatedAt",
         '--entrypoint', '/usr/local/bin/hermes-storage-seed',
         '--mount', "type=bind,source=$DataDir,target=/source,readonly",
         '--mount', "type=volume,source=$volumeName,target=/target",
@@ -149,23 +155,43 @@ function Initialize-HermesStorageVolume {
         '--ready-token', $volumeToken,
         '--replace-incomplete'
     )
-    $null = @(Invoke-Docker -Arguments $seedArguments 2>$null)
-    if ($LASTEXITCODE -ne 0) {
-        $lockState = Get-HermesStorageLockState -LockName $lockName -LockLabel $lockLabel -TokenLabel $tokenLabel
-        if ($lockState.Status -eq 0 -and
-            $lockState.Value -match ('^1\|' + [regex]::Escape($volumeToken) + '\|(exited|dead)$')) {
-            $null = @(Invoke-Docker -Arguments @('rm', '-f', $lockName) 2>$null)
+    $lockOutput = @(Invoke-Docker -Arguments $seedArguments 2>$null)
+    $lockCreateStatus = $LASTEXITCODE
+    $lockId = ($lockOutput -join "`n").Trim()
+    if ($lockCreateStatus -ne 0) {
+        $lockState = Get-HermesStorageLockState -LockName $lockName -LockLabel $lockLabel -TokenLabel $tokenLabel -CreatedLabel $lockCreatedLabel
+        $parts = $lockState.Value -split '\|', 5
+        $reclaimStale = $false
+        if ($lockState.Status -eq 0 -and $parts.Count -eq 5 -and
+            $parts[0] -match '^[0-9a-f]{12,64}$' -and $parts[1] -eq '1' -and
+            $parts[2] -eq $volumeToken) {
+            if ($parts[4] -in @('exited', 'dead')) {
+                $reclaimStale = $true
+            }
+            elseif ($parts[4] -eq 'created' -and $parts[3] -match '^[0-9]{1,12}$') {
+                $age = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds() - [long]$parts[3]
+                $reclaimStale = $age -ge 30
+            }
+        }
+        if ($reclaimStale) {
+            $staleLockId = $parts[0]
+            $null = @(Invoke-Docker -Arguments @('rm', '-f', $staleLockId) 2>$null)
             if ($LASTEXITCODE -ne 0) {
                 return [PSCustomObject]@{ Success = $false; Existing = $existing; Message = 'Hermes data volume stale lock could not be reclaimed.' }
             }
-            $null = @(Invoke-Docker -Arguments $seedArguments 2>$null)
-            if ($LASTEXITCODE -ne 0) {
+            $lockOutput = @(Invoke-Docker -Arguments $seedArguments 2>$null)
+            $lockCreateStatus = $LASTEXITCODE
+            $lockId = ($lockOutput -join "`n").Trim()
+            if ($lockCreateStatus -ne 0) {
                 return [PSCustomObject]@{ Success = $false; Existing = $existing; Message = 'Hermes data volume lock could not be acquired after stale-lock cleanup.' }
             }
         }
         else {
             return [PSCustomObject]@{ Success = $false; Existing = $existing; Message = 'Hermes data volume initialization is already locked.' }
         }
+    }
+    if ($lockId -notmatch '^[0-9a-f]{12,64}$') {
+        return [PSCustomObject]@{ Success = $false; Existing = $existing; Message = 'Hermes data volume lock returned an invalid container ID.' }
     }
 
     $lockedSchema = Get-HermesStorageVolumeLabel -VolumeName $volumeName -Label $schemaLabel
@@ -182,7 +208,7 @@ function Initialize-HermesStorageVolume {
         $result = [PSCustomObject]@{ Success = $true; Existing = $true; Message = '' }
     }
     else {
-        $null = @(Invoke-Docker -Arguments @('start', '-a', $lockName) 2>$null)
+        $null = @(Invoke-Docker -Arguments @('start', '-a', $lockId) 2>$null)
         $seedStatus = $LASTEXITCODE
         if ($seedStatus -eq 0 -and
             (Test-HermesStorageVolumeReady -VolumeName $volumeName -VolumeToken $volumeToken)) {
@@ -204,7 +230,7 @@ function Initialize-HermesStorageVolume {
         }
     }
 
-    $null = @(Invoke-Docker -Arguments @('rm', '-f', $lockName) 2>$null)
+    $null = @(Invoke-Docker -Arguments @('rm', '-f', $lockId) 2>$null)
     $releaseStatus = $LASTEXITCODE
     if ($releaseStatus -ne 0) {
         return [PSCustomObject]@{

--- a/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
+++ b/scripts/powershell/tests/HermesBootstrapEntrypoint.Tests.ps1
@@ -144,7 +144,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             "compose -f $script:composeFile build hermes hermes-bootstrap chromium xapi-mcp",
             "compose -f $script:composeFile ps --all --services hermes",
             "compose -f $script:composeFile stop hermes",
-            'volume inspect hermes-data',
+            'volume inspect --format {{ index .Labels "com.rurusasu.dotfiles.hermes-storage.schema" }} hermes-data',
             "compose -f $script:composeFile up -d --force-recreate"
         )
         $script:environmentObservations.Phase | Should -Be @(
@@ -154,7 +154,7 @@ Describe 'Hermes bootstrap PowerShell entrypoint' {
             'build',
             'ps',
             'stop',
-            'volume inspect hermes-data',
+            'volume inspect --format {{ index .Labels "com.rurusasu.dotfiles.hermes-storage.schema" }} hermes-data',
             'bootstrap',
             'up'
         )

--- a/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.HermesAgent.Tests.ps1
@@ -179,7 +179,7 @@ Describe 'HermesAgentHandler' {
                 "compose -f $script:composeFile build --pull hermes hermes-bootstrap chromium browser-mcp xapi-mcp",
                 "compose -f $script:composeFile ps --all --services hermes",
                 "compose -f $script:composeFile stop hermes",
-                "volume inspect hermes-data",
+                "volume inspect --format {{ index .Labels `"com.rurusasu.dotfiles.hermes-storage.schema`" }} hermes-data",
                 "compose -f $script:composeFile up -d --force-recreate --remove-orphans hermes chromium browser-mcp xapi-mcp"
             )
             $script:eventLog | Should -Be @('config', 'build', 'stop', 'bootstrap', 'xapi-credentials', 'up', 'health')

--- a/scripts/powershell/tests/lib/HermesStorage.Tests.ps1
+++ b/scripts/powershell/tests/lib/HermesStorage.Tests.ps1
@@ -9,23 +9,49 @@ Describe 'Hermes Docker storage initialization' {
     BeforeEach {
         $script:dockerCalls = [System.Collections.Generic.List[string]]::new()
         $script:volumeExists = $true
+        $script:volumeSchema = ''
+        $script:volumeToken = ''
+        $script:createdToken = ''
+        $script:raceToken = ''
+        $script:volumeReady = $true
         $script:seedExitCode = 0
+        $script:removeExitCode = 0
         $script:oldVolume = $env:HERMES_DATA_VOLUME
         Remove-Item Env:\HERMES_DATA_VOLUME -ErrorAction SilentlyContinue
 
         Mock Invoke-Docker {
             $script:dockerCalls.Add(($Arguments -join ' '))
             if ($Arguments[0] -eq 'volume' -and $Arguments[1] -eq 'inspect') {
-                    $global:LASTEXITCODE = if ($script:volumeExists) { 0 } else { 1 }
+                $global:LASTEXITCODE = if ($script:volumeExists) { 0 } else { 1 }
+                if ($global:LASTEXITCODE -eq 0 -and $Arguments -contains '--format') {
+                    $format = $Arguments[$Arguments.IndexOf('--format') + 1]
+                    if ($format -match 'hermes-storage\.schema') {
+                        $script:volumeSchema
+                    }
+                    elseif ($format -match 'hermes-storage\.init-token') {
+                        $script:volumeToken
+                    }
+                }
             }
             elseif ($Arguments[0] -eq 'volume' -and $Arguments[1] -eq 'create') {
+                $script:volumeExists = $true
+                $script:volumeSchema = '1'
+                $tokenArgument = $Arguments | Where-Object { $_ -like 'com.rurusasu.dotfiles.hermes-storage.init-token=*' }
+                $script:createdToken = ($tokenArgument -split '=', 2)[1]
+                $script:volumeToken = if ([string]::IsNullOrEmpty($script:raceToken)) { $script:createdToken } else { $script:raceToken }
                 $global:LASTEXITCODE = 0
             }
             elseif ($Arguments[0] -eq 'run') {
-                $global:LASTEXITCODE = $script:seedExitCode
+                $entrypointIndex = $Arguments.IndexOf('--entrypoint')
+                if ($entrypointIndex -ge 0 -and $Arguments[$entrypointIndex + 1] -eq 'test') {
+                    $global:LASTEXITCODE = if ($script:volumeReady) { 0 } else { 1 }
+                }
+                else {
+                    $global:LASTEXITCODE = $script:seedExitCode
+                }
             }
             elseif ($Arguments[0] -eq 'volume' -and $Arguments[1] -eq 'rm') {
-                $global:LASTEXITCODE = 0
+                $global:LASTEXITCODE = $script:removeExitCode
             }
         }
     }
@@ -44,7 +70,7 @@ Describe 'Hermes Docker storage initialization' {
 
         $result.Success | Should -BeTrue
         $result.Existing | Should -BeTrue
-        $script:dockerCalls | Should -Be @('volume inspect hermes-data')
+        $script:dockerCalls | Should -Be @('volume inspect --format {{ index .Labels "com.rurusasu.dotfiles.hermes-storage.schema" }} hermes-data')
     }
 
     It 'seeds a missing volume and does not remove it after success' {
@@ -54,9 +80,10 @@ Describe 'Hermes Docker storage initialization' {
 
         $result.Success | Should -BeTrue
         $result.Existing | Should -BeFalse
-        $script:dockerCalls[0] | Should -Be 'volume inspect hermes-data'
-        $script:dockerCalls[1] | Should -Be 'volume create hermes-data'
-        $script:dockerCalls[2] | Should -Match 'run --rm --entrypoint /usr/local/bin/hermes-storage-seed --mount .*local/hermes-agent-gh:latest'
+        $script:dockerCalls[0] | Should -Match 'volume inspect --format .*hermes-storage\.schema.* hermes-data'
+        $script:dockerCalls[1] | Should -Match 'volume create --label com\.rurusasu\.dotfiles\.hermes-storage\.schema=1 --label com\.rurusasu\.dotfiles\.hermes-storage\.init-token=.+ hermes-data'
+        ($script:dockerCalls -join "`n") | Should -Match 'volume inspect --format .*hermes-storage\.init-token.* hermes-data'
+        ($script:dockerCalls -join "`n") | Should -Match 'run --rm --entrypoint /usr/local/bin/hermes-storage-seed --mount .*local/hermes-agent-gh:latest'
         $script:dockerCalls | Should -Not -Contain 'volume rm hermes-data'
     }
 
@@ -67,6 +94,67 @@ Describe 'Hermes Docker storage initialization' {
         $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
 
         $result.Success | Should -BeFalse
+        $script:dockerCalls[-1] | Should -Be 'volume rm hermes-data'
+    }
+
+    It 'does not seed or remove a volume won by a concurrent creator' {
+        $script:volumeExists = $false
+        $script:raceToken = 'another-initializer'
+
+        $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
+
+        $result.Success | Should -BeFalse
+        $result.Message | Should -Match 'created concurrently'
+        ($script:dockerCalls -join "`n") | Should -Not -Match 'run --rm --entrypoint /usr/local/bin/hermes-storage-seed'
+        $script:dockerCalls | Should -Not -Contain 'volume rm hermes-data'
+    }
+
+    It 'rejects a managed volume without the ready marker' {
+        $script:volumeSchema = '1'
+        $script:volumeToken = 'previous-initializer'
+        $script:volumeReady = $false
+
+        $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
+
+        $result.Success | Should -BeFalse
+        $result.Existing | Should -BeTrue
+        $result.Message | Should -Match 'incomplete'
+        ($script:dockerCalls -join "`n") | Should -Match 'run --rm --entrypoint test'
+        ($script:dockerCalls -join "`n") | Should -Not -Match 'run --rm --entrypoint /usr/local/bin/hermes-storage-seed'
+    }
+
+    It 'accepts a managed volume with the ready marker' {
+        $script:volumeSchema = '1'
+        $script:volumeToken = 'previous-initializer'
+
+        $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
+
+        $result.Success | Should -BeTrue
+        $result.Existing | Should -BeTrue
+        ($script:dockerCalls -join "`n") | Should -Match 'run --rm --entrypoint test'
+        ($script:dockerCalls -join "`n") | Should -Not -Match 'run --rm --entrypoint /usr/local/bin/hermes-storage-seed'
+    }
+
+    It 'surfaces failure to remove an owned partial volume' {
+        $script:volumeExists = $false
+        $script:seedExitCode = 42
+        $script:removeExitCode = 17
+
+        $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
+
+        $result.Success | Should -BeFalse
+        $result.Message | Should -Match 'could not be removed'
+        $script:dockerCalls[-1] | Should -Be 'volume rm hermes-data'
+    }
+
+    It 'removes an owned volume when seed returns without a ready marker' {
+        $script:volumeExists = $false
+        $script:volumeReady = $false
+
+        $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
+
+        $result.Success | Should -BeFalse
+        $result.Message | Should -Match 'ready marker'
         $script:dockerCalls[-1] | Should -Be 'volume rm hermes-data'
     }
 

--- a/scripts/powershell/tests/lib/HermesStorage.Tests.ps1
+++ b/scripts/powershell/tests/lib/HermesStorage.Tests.ps1
@@ -22,9 +22,15 @@ Describe 'Hermes Docker storage initialization' {
         $script:lockState = ''
         $script:lockId = '1111111111111111111111111111111111111111111111111111111111111111'
         $script:replacementLockId = '2222222222222222222222222222222222222222222222222222222222222222'
+        $script:unixTime = 0
         $script:lockReleaseExitCode = 0
         $script:oldVolume = $env:HERMES_DATA_VOLUME
         Remove-Item Env:\HERMES_DATA_VOLUME -ErrorAction SilentlyContinue
+
+        Mock Get-HermesStorageUnixTime {
+            $script:unixTime += 100
+            return $script:unixTime
+        }
 
         Mock Invoke-Docker {
             $script:dockerCalls.Add(($Arguments -join ' '))
@@ -226,6 +232,9 @@ Describe 'Hermes Docker storage initialization' {
         $script:lockCreateAttempts | Should -Be 2
         ($script:dockerCalls -join "`n") | Should -Match "rm -f $($script:lockId)"
         ($script:dockerCalls -join "`n") | Should -Match "start -a $($script:replacementLockId)"
+        $createCalls = @($script:dockerCalls | Where-Object { $_ -like 'create *' })
+        $createCalls[0] | Should -Match 'lock-created-at=100'
+        $createCalls[1] | Should -Match 'lock-created-at=300'
     }
 
     It 'does not touch a replacement after losing stale ID removal' {

--- a/scripts/powershell/tests/lib/HermesStorage.Tests.ps1
+++ b/scripts/powershell/tests/lib/HermesStorage.Tests.ps1
@@ -15,7 +15,12 @@ Describe 'Hermes Docker storage initialization' {
         $script:raceToken = ''
         $script:volumeReady = $true
         $script:seedExitCode = 0
-        $script:removeExitCode = 0
+        $script:seedWritesMarker = $true
+        $script:lockCreateExitCode = 0
+        $script:lockCreateFailOnce = $false
+        $script:lockCreateAttempts = 0
+        $script:lockState = ''
+        $script:lockReleaseExitCode = 0
         $script:oldVolume = $env:HERMES_DATA_VOLUME
         Remove-Item Env:\HERMES_DATA_VOLUME -ErrorAction SilentlyContinue
 
@@ -38,20 +43,51 @@ Describe 'Hermes Docker storage initialization' {
                 $script:volumeSchema = '1'
                 $tokenArgument = $Arguments | Where-Object { $_ -like 'com.rurusasu.dotfiles.hermes-storage.init-token=*' }
                 $script:createdToken = ($tokenArgument -split '=', 2)[1]
-                $script:volumeToken = if ([string]::IsNullOrEmpty($script:raceToken)) { $script:createdToken } else { $script:raceToken }
+                $script:volumeToken = if ([string]::IsNullOrEmpty($script:raceToken)) {
+                    $script:createdToken
+                }
+                else {
+                    $script:raceToken
+                }
+                $script:volumeReady = $false
                 $global:LASTEXITCODE = 0
             }
             elseif ($Arguments[0] -eq 'run') {
                 $entrypointIndex = $Arguments.IndexOf('--entrypoint')
-                if ($entrypointIndex -ge 0 -and $Arguments[$entrypointIndex + 1] -eq 'test') {
+                $entrypoint = if ($entrypointIndex -ge 0) { $Arguments[$entrypointIndex + 1] } else { '' }
+                if ($entrypoint -eq 'python') {
                     $global:LASTEXITCODE = if ($script:volumeReady) { 0 } else { 1 }
                 }
                 else {
-                    $global:LASTEXITCODE = $script:seedExitCode
+                    $global:LASTEXITCODE = 1
                 }
             }
-            elseif ($Arguments[0] -eq 'volume' -and $Arguments[1] -eq 'rm') {
-                $global:LASTEXITCODE = $script:removeExitCode
+            elseif ($Arguments[0] -eq 'create') {
+                $script:lockCreateAttempts++
+                if ($script:lockCreateFailOnce -and $script:lockCreateAttempts -eq 1) {
+                    $global:LASTEXITCODE = 125
+                }
+                else {
+                    $global:LASTEXITCODE = $script:lockCreateExitCode
+                }
+            }
+            elseif ($Arguments[0] -eq 'inspect') {
+                if ([string]::IsNullOrEmpty($script:lockState)) {
+                    $global:LASTEXITCODE = 1
+                }
+                else {
+                    $script:lockState
+                    $global:LASTEXITCODE = 0
+                }
+            }
+            elseif ($Arguments[0] -eq 'start' -and $Arguments[1] -eq '-a') {
+                if ($script:seedExitCode -eq 0 -and $script:seedWritesMarker) {
+                    $script:volumeReady = $true
+                }
+                $global:LASTEXITCODE = $script:seedExitCode
+            }
+            elseif ($Arguments[0] -eq 'rm' -and $Arguments[1] -eq '-f') {
+                $global:LASTEXITCODE = $script:lockReleaseExitCode
             }
         }
     }
@@ -65,7 +101,7 @@ Describe 'Hermes Docker storage initialization' {
         }
     }
 
-    It 'leaves an existing volume untouched' {
+    It 'leaves an existing legacy volume untouched' {
         $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
 
         $result.Success | Should -BeTrue
@@ -73,89 +109,129 @@ Describe 'Hermes Docker storage initialization' {
         $script:dockerCalls | Should -Be @('volume inspect --format {{ index .Labels "com.rurusasu.dotfiles.hermes-storage.schema" }} hermes-data')
     }
 
-    It 'seeds a missing volume and does not remove it after success' {
+    It 'locks and seeds a missing volume with its token' {
         $script:volumeExists = $false
 
         $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
 
         $result.Success | Should -BeTrue
         $result.Existing | Should -BeFalse
-        $script:dockerCalls[0] | Should -Match 'volume inspect --format .*hermes-storage\.schema.* hermes-data'
         $script:dockerCalls[1] | Should -Match 'volume create --label com\.rurusasu\.dotfiles\.hermes-storage\.schema=1 --label com\.rurusasu\.dotfiles\.hermes-storage\.init-token=.+ hermes-data'
-        ($script:dockerCalls -join "`n") | Should -Match 'volume inspect --format .*hermes-storage\.init-token.* hermes-data'
-        ($script:dockerCalls -join "`n") | Should -Match 'run --rm --entrypoint /usr/local/bin/hermes-storage-seed --mount .*local/hermes-agent-gh:latest'
-        $script:dockerCalls | Should -Not -Contain 'volume rm hermes-data'
+        ($script:dockerCalls -join "`n") | Should -Match 'create --name dotfiles-hermes-storage-[0-9a-f]{20} .*--entrypoint /usr/local/bin/hermes-storage-seed'
+        ($script:dockerCalls -join "`n") | Should -Match 'create .* --ready-token [0-9a-f]{32} --replace-incomplete'
+        ($script:dockerCalls -join "`n") | Should -Match 'run --rm --entrypoint python .*volume_token='
+        $script:dockerCalls[-1] | Should -Match '^rm -f dotfiles-hermes-storage-'
+        ($script:dockerCalls -join "`n") | Should -Not -Match 'volume rm'
     }
 
-    It 'removes only the newly created volume after a seed failure' {
+    It 'leaves failed seed data incomplete and releases the lock' {
         $script:volumeExists = $false
         $script:seedExitCode = 42
 
         $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
 
         $result.Success | Should -BeFalse
-        $script:dockerCalls[-1] | Should -Be 'volume rm hermes-data'
+        $result.Message | Should -Match 'safe retry'
+        $script:dockerCalls[-1] | Should -Match '^rm -f dotfiles-hermes-storage-'
+        ($script:dockerCalls -join "`n") | Should -Not -Match 'volume rm'
     }
 
-    It 'does not seed or remove a volume won by a concurrent creator' {
+    It 'does not seed a volume whose token changed before lock verification' {
         $script:volumeExists = $false
-        $script:raceToken = 'another-initializer'
+        $script:raceToken = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
         $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
 
         $result.Success | Should -BeFalse
-        $result.Message | Should -Match 'created concurrently'
-        ($script:dockerCalls -join "`n") | Should -Not -Match 'run --rm --entrypoint /usr/local/bin/hermes-storage-seed'
-        $script:dockerCalls | Should -Not -Contain 'volume rm hermes-data'
+        $result.Message | Should -Match 'changed before its lock was acquired'
+        ($script:dockerCalls -join "`n") | Should -Not -Match 'start -a'
+        ($script:dockerCalls -join "`n") | Should -Not -Match 'volume rm'
     }
 
-    It 'rejects a managed volume without the ready marker' {
+    It 'safely reseeds a managed incomplete volume while locked' {
         $script:volumeSchema = '1'
-        $script:volumeToken = 'previous-initializer'
+        $script:volumeToken = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
         $script:volumeReady = $false
-
-        $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
-
-        $result.Success | Should -BeFalse
-        $result.Existing | Should -BeTrue
-        $result.Message | Should -Match 'incomplete'
-        ($script:dockerCalls -join "`n") | Should -Match 'run --rm --entrypoint test'
-        ($script:dockerCalls -join "`n") | Should -Not -Match 'run --rm --entrypoint /usr/local/bin/hermes-storage-seed'
-    }
-
-    It 'accepts a managed volume with the ready marker' {
-        $script:volumeSchema = '1'
-        $script:volumeToken = 'previous-initializer'
 
         $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
 
         $result.Success | Should -BeTrue
         $result.Existing | Should -BeTrue
-        ($script:dockerCalls -join "`n") | Should -Match 'run --rm --entrypoint test'
-        ($script:dockerCalls -join "`n") | Should -Not -Match 'run --rm --entrypoint /usr/local/bin/hermes-storage-seed'
+        ($script:dockerCalls -join "`n") | Should -Match 'create .* /usr/local/bin/hermes-storage-seed .*--replace-incomplete'
+        ($script:dockerCalls -join "`n") | Should -Match 'start -a dotfiles-hermes-storage-'
     }
 
-    It 'surfaces failure to remove an owned partial volume' {
+    It 'accepts an exactly matching regular marker while locked' {
+        $script:volumeSchema = '1'
+        $script:volumeToken = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+        $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
+
+        $result.Success | Should -BeTrue
+        $result.Existing | Should -BeTrue
+        ($script:dockerCalls -join "`n") | Should -Match '--entrypoint python'
+        ($script:dockerCalls -join "`n") | Should -Not -Match 'start -a'
+    }
+
+    It 'rejects a concurrent running lock before marker access' {
+        $script:volumeSchema = '1'
+        $script:volumeToken = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        $script:lockCreateExitCode = 125
+        $script:lockState = '1|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|running'
+
+        $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
+
+        $result.Success | Should -BeFalse
+        $result.Message | Should -Match 'already locked'
+        ($script:dockerCalls -join "`n") | Should -Not -Match '--entrypoint python'
+        ($script:dockerCalls -join "`n") | Should -Not -Match 'start -a'
+    }
+
+    It 'reclaims an exited owned lock before retrying atomically' {
+        $script:volumeSchema = '1'
+        $script:volumeToken = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        $script:lockCreateFailOnce = $true
+        $script:lockState = '1|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|exited'
+
+        $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
+
+        $result.Success | Should -BeTrue
+        $script:lockCreateAttempts | Should -Be 2
+        ($script:dockerCalls -join "`n") | Should -Match 'inspect --format .*State.Status.*dotfiles-hermes-storage-'
+    }
+
+    It 'surfaces lock release failure without deleting the volume' {
         $script:volumeExists = $false
         $script:seedExitCode = 42
-        $script:removeExitCode = 17
+        $script:lockReleaseExitCode = 17
 
         $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
 
         $result.Success | Should -BeFalse
-        $result.Message | Should -Match 'could not be removed'
-        $script:dockerCalls[-1] | Should -Be 'volume rm hermes-data'
+        $result.Message | Should -Match 'lock could not be released'
+        ($script:dockerCalls -join "`n") | Should -Not -Match 'volume rm'
     }
 
-    It 'removes an owned volume when seed returns without a ready marker' {
+    It 'rejects a successful seed without an exact ready marker' {
         $script:volumeExists = $false
-        $script:volumeReady = $false
+        $script:seedWritesMarker = $false
 
         $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
 
         $result.Success | Should -BeFalse
-        $result.Message | Should -Match 'ready marker'
-        $script:dockerCalls[-1] | Should -Be 'volume rm hermes-data'
+        $result.Message | Should -Match 'valid ready marker'
+        $script:dockerCalls[-1] | Should -Match '^rm -f dotfiles-hermes-storage-'
+    }
+
+    It 'rejects a malformed managed volume token before locking' {
+        $script:volumeSchema = '1'
+        $script:volumeToken = 'malformed'
+
+        $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
+
+        $result.Success | Should -BeFalse
+        $result.Message | Should -Match 'invalid initialization token'
+        ($script:dockerCalls -join "`n") | Should -Not -Match '^create --name'
     }
 
     It 'rejects an unsafe volume name before Docker work' {

--- a/scripts/powershell/tests/lib/HermesStorage.Tests.ps1
+++ b/scripts/powershell/tests/lib/HermesStorage.Tests.ps1
@@ -20,6 +20,8 @@ Describe 'Hermes Docker storage initialization' {
         $script:lockCreateFailOnce = $false
         $script:lockCreateAttempts = 0
         $script:lockState = ''
+        $script:lockId = '1111111111111111111111111111111111111111111111111111111111111111'
+        $script:replacementLockId = '2222222222222222222222222222222222222222222222222222222222222222'
         $script:lockReleaseExitCode = 0
         $script:oldVolume = $env:HERMES_DATA_VOLUME
         Remove-Item Env:\HERMES_DATA_VOLUME -ErrorAction SilentlyContinue
@@ -68,6 +70,14 @@ Describe 'Hermes Docker storage initialization' {
                     $global:LASTEXITCODE = 125
                 }
                 else {
+                    if ($script:lockCreateExitCode -eq 0) {
+                        if ($script:lockCreateAttempts -gt 1) {
+                            $script:replacementLockId
+                        }
+                        else {
+                            $script:lockId
+                        }
+                    }
                     $global:LASTEXITCODE = $script:lockCreateExitCode
                 }
             }
@@ -120,7 +130,7 @@ Describe 'Hermes Docker storage initialization' {
         ($script:dockerCalls -join "`n") | Should -Match 'create --name dotfiles-hermes-storage-[0-9a-f]{20} .*--entrypoint /usr/local/bin/hermes-storage-seed'
         ($script:dockerCalls -join "`n") | Should -Match 'create .* --ready-token [0-9a-f]{32} --replace-incomplete'
         ($script:dockerCalls -join "`n") | Should -Match 'run --rm --entrypoint python .*volume_token='
-        $script:dockerCalls[-1] | Should -Match '^rm -f dotfiles-hermes-storage-'
+        $script:dockerCalls[-1] | Should -Be "rm -f $($script:lockId)"
         ($script:dockerCalls -join "`n") | Should -Not -Match 'volume rm'
     }
 
@@ -132,7 +142,7 @@ Describe 'Hermes Docker storage initialization' {
 
         $result.Success | Should -BeFalse
         $result.Message | Should -Match 'safe retry'
-        $script:dockerCalls[-1] | Should -Match '^rm -f dotfiles-hermes-storage-'
+        $script:dockerCalls[-1] | Should -Be "rm -f $($script:lockId)"
         ($script:dockerCalls -join "`n") | Should -Not -Match 'volume rm'
     }
 
@@ -158,7 +168,7 @@ Describe 'Hermes Docker storage initialization' {
         $result.Success | Should -BeTrue
         $result.Existing | Should -BeTrue
         ($script:dockerCalls -join "`n") | Should -Match 'create .* /usr/local/bin/hermes-storage-seed .*--replace-incomplete'
-        ($script:dockerCalls -join "`n") | Should -Match 'start -a dotfiles-hermes-storage-'
+        ($script:dockerCalls -join "`n") | Should -Match "start -a $($script:lockId)"
     }
 
     It 'accepts an exactly matching regular marker while locked' {
@@ -177,7 +187,7 @@ Describe 'Hermes Docker storage initialization' {
         $script:volumeSchema = '1'
         $script:volumeToken = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
         $script:lockCreateExitCode = 125
-        $script:lockState = '1|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|running'
+        $script:lockState = "$($script:lockId)|1|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|0|running"
 
         $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
 
@@ -190,14 +200,48 @@ Describe 'Hermes Docker storage initialization' {
     It 'reclaims an exited owned lock before retrying atomically' {
         $script:volumeSchema = '1'
         $script:volumeToken = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        $script:volumeReady = $false
         $script:lockCreateFailOnce = $true
-        $script:lockState = '1|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|exited'
+        $script:lockState = "$($script:lockId)|1|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|0|exited"
 
         $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
 
         $result.Success | Should -BeTrue
         $script:lockCreateAttempts | Should -Be 2
         ($script:dockerCalls -join "`n") | Should -Match 'inspect --format .*State.Status.*dotfiles-hermes-storage-'
+        ($script:dockerCalls -join "`n") | Should -Match "rm -f $($script:lockId)"
+        ($script:dockerCalls -join "`n") | Should -Match "start -a $($script:replacementLockId)"
+    }
+
+    It 'reclaims an aged created lock by immutable container ID' {
+        $script:volumeSchema = '1'
+        $script:volumeToken = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        $script:volumeReady = $false
+        $script:lockCreateFailOnce = $true
+        $script:lockState = "$($script:lockId)|1|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|0|created"
+
+        $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
+
+        $result.Success | Should -BeTrue
+        $script:lockCreateAttempts | Should -Be 2
+        ($script:dockerCalls -join "`n") | Should -Match "rm -f $($script:lockId)"
+        ($script:dockerCalls -join "`n") | Should -Match "start -a $($script:replacementLockId)"
+    }
+
+    It 'does not touch a replacement after losing stale ID removal' {
+        $script:volumeSchema = '1'
+        $script:volumeToken = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        $script:lockCreateFailOnce = $true
+        $script:lockState = "$($script:lockId)|1|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|0|exited"
+        $script:lockReleaseExitCode = 17
+
+        $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
+
+        $result.Success | Should -BeFalse
+        $result.Message | Should -Match 'stale lock could not be reclaimed'
+        $script:lockCreateAttempts | Should -Be 1
+        ($script:dockerCalls -join "`n") | Should -Not -Match $script:replacementLockId
+        ($script:dockerCalls -join "`n") | Should -Not -Match 'start -a'
     }
 
     It 'surfaces lock release failure without deleting the volume' {
@@ -220,7 +264,7 @@ Describe 'Hermes Docker storage initialization' {
 
         $result.Success | Should -BeFalse
         $result.Message | Should -Match 'valid ready marker'
-        $script:dockerCalls[-1] | Should -Match '^rm -f dotfiles-hermes-storage-'
+        $script:dockerCalls[-1] | Should -Be "rm -f $($script:lockId)"
     }
 
     It 'rejects a malformed managed volume token before locking' {

--- a/scripts/powershell/tests/lib/HermesStorage.Tests.ps1
+++ b/scripts/powershell/tests/lib/HermesStorage.Tests.ps1
@@ -14,6 +14,7 @@ Describe 'Hermes Docker storage initialization' {
         $script:createdToken = ''
         $script:raceToken = ''
         $script:volumeReady = $true
+        $script:volumeProbeStatus = $null
         $script:seedExitCode = 0
         $script:seedWritesMarker = $true
         $script:lockCreateExitCode = 0
@@ -64,7 +65,11 @@ Describe 'Hermes Docker storage initialization' {
                 $entrypointIndex = $Arguments.IndexOf('--entrypoint')
                 $entrypoint = if ($entrypointIndex -ge 0) { $Arguments[$entrypointIndex + 1] } else { '' }
                 if ($entrypoint -eq 'python') {
-                    $global:LASTEXITCODE = if ($script:volumeReady) { 0 } else { 1 }
+                    $global:LASTEXITCODE = if ($null -ne $script:volumeProbeStatus) {
+                        $script:volumeProbeStatus
+                    }
+                    elseif ($script:volumeReady) { 0 }
+                    else { 3 }
                 }
                 else {
                     $global:LASTEXITCODE = 1
@@ -187,6 +192,20 @@ Describe 'Hermes Docker storage initialization' {
         $result.Existing | Should -BeTrue
         ($script:dockerCalls -join "`n") | Should -Match '--entrypoint python'
         ($script:dockerCalls -join "`n") | Should -Not -Match 'start -a'
+    }
+
+    It 'preserves a ready managed volume when its marker probe cannot run' {
+        $script:volumeSchema = '1'
+        $script:volumeToken = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        $script:volumeReady = $true
+        $script:volumeProbeStatus = 125
+
+        $result = Initialize-HermesStorageVolume -DataDir 'C:\Users\test\.hermes'
+
+        $result.Success | Should -BeFalse
+        $result.Message | Should -Match 'ready marker probe failed with status 125'
+        ($script:dockerCalls -join "`n") | Should -Not -Match 'start -a'
+        $script:dockerCalls[-1] | Should -Be "rm -f $($script:lockId)"
     }
 
     It 'rejects a concurrent running lock before marker access' {

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -28,39 +28,95 @@ dotfiles_hermes_storage_volume_name() {
   printf '%s\n' "$volume_name"
 }
 
+dotfiles_hermes_storage_volume_label() {
+  local docker_runner="$1" volume_name="$2" label="$3"
+
+  "$docker_runner" volume inspect --format "{{ index .Labels \"$label\" }}" "$volume_name"
+}
+
+dotfiles_hermes_storage_volume_ready() {
+  local docker_runner="$1" volume_name="$2"
+
+  "$docker_runner" run --rm \
+    --entrypoint test \
+    --mount "type=volume,src=$volume_name,dst=/target,readonly" \
+    local/hermes-agent-gh:latest \
+    -f /target/.dotfiles-hermes-storage-ready-v1
+}
+
 dotfiles_hermes_initialize_storage_volume() {
   local docker_runner="$1"
-  local volume_name data_dir
-  local volume_status create_status
+  local volume_name data_dir volume_schema init_token actual_token
+  local volume_status seed_status cleanup_status
+  local schema_label="com.rurusasu.dotfiles.hermes-storage.schema"
+  local token_label="com.rurusasu.dotfiles.hermes-storage.init-token"
 
   volume_name="$(dotfiles_hermes_storage_volume_name)" ||
     dotfiles_die "HERMES_DATA_VOLUME contains an invalid Docker volume name."
   data_dir="$(dotfiles_hermes_data_dir)"
 
-  if "$docker_runner" volume inspect "$volume_name" >/dev/null 2>&1; then
-    printf 'Hermes Docker data volume already exists; leaving it untouched: %s\n' "$volume_name" >&2
-    return 0
+  if volume_schema="$(dotfiles_hermes_storage_volume_label "$docker_runner" "$volume_name" "$schema_label" 2>/dev/null)"; then
+    if [[ $volume_schema != 1 ]]; then
+      printf 'Legacy Hermes Docker data volume already exists; leaving it untouched: %s\n' "$volume_name" >&2
+      return 0
+    fi
+    if dotfiles_hermes_storage_volume_ready "$docker_runner" "$volume_name"; then
+      printf 'Hermes Docker data volume is ready: %s\n' "$volume_name" >&2
+      return 0
+    fi
+    printf 'Hermes Docker data volume is managed but incomplete; remove it after confirming no initialization is active: %s\n' "$volume_name" >&2
+    return 1
   else
     volume_status=$?
     ((volume_status == 1)) || return "$volume_status"
   fi
 
-  "$docker_runner" volume create "$volume_name" >/dev/null || return $?
+  init_token="$(python3 -c 'import uuid; print(uuid.uuid4().hex)')" || return $?
+  "$docker_runner" volume create \
+    --label "$schema_label=1" \
+    --label "$token_label=$init_token" \
+    "$volume_name" >/dev/null || return $?
+  actual_token="$(dotfiles_hermes_storage_volume_label "$docker_runner" "$volume_name" "$token_label" 2>/dev/null)" || {
+    printf 'Hermes Docker data volume ownership could not be verified: %s\n' "$volume_name" >&2
+    return 1
+  }
+  if [[ $actual_token != "$init_token" ]]; then
+    printf 'Hermes Docker data volume was created concurrently; refusing to seed or remove it: %s\n' "$volume_name" >&2
+    return 1
+  fi
+
   if "$docker_runner" run --rm \
     --entrypoint /usr/local/bin/hermes-storage-seed \
     --mount "type=bind,src=$data_dir,dst=/source,readonly" \
     --mount "type=volume,src=$volume_name,dst=/target" \
     local/hermes-agent-gh:latest \
     --source /source --destination /target; then
-    printf 'Hermes Docker data volume initialized: %s\n' "$volume_name" >&2
-    return 0
+    if dotfiles_hermes_storage_volume_ready "$docker_runner" "$volume_name"; then
+      printf 'Hermes Docker data volume initialized: %s\n' "$volume_name" >&2
+      return 0
+    fi
+    seed_status=1
+    printf 'Hermes Docker data volume seed completed without its ready marker: %s\n' "$volume_name" >&2
   else
-    create_status=$?
-    # The volume was created by this invocation and is still empty or partial.
-    # Do not touch an existing volume; only remove this new initialization.
-    "$docker_runner" volume rm "$volume_name" >/dev/null 2>&1 || true
-    return "$create_status"
+    seed_status=$?
   fi
+
+  actual_token="$(dotfiles_hermes_storage_volume_label "$docker_runner" "$volume_name" "$token_label" 2>/dev/null)" || {
+    printf 'Hermes Docker data volume initialization failed and ownership could not be reverified: %s\n' "$volume_name" >&2
+    return "$seed_status"
+  }
+  if [[ $actual_token != "$init_token" ]]; then
+    printf 'Hermes Docker data volume initialization failed after ownership changed; refusing removal: %s\n' "$volume_name" >&2
+    return "$seed_status"
+  fi
+  if "$docker_runner" volume rm "$volume_name" >/dev/null 2>&1; then
+    return "$seed_status"
+  else
+    cleanup_status=$?
+  fi
+  printf 'Hermes Docker data volume initialization failed and the owned partial volume could not be removed: %s (seed status %s, cleanup status %s)\n' \
+    "$volume_name" "$seed_status" "$cleanup_status" >&2
+  return "$cleanup_status"
 }
 
 dotfiles_hermes_prepare_runtime_home() {
@@ -221,6 +277,7 @@ dotfiles_hermes_require_secret_tools() {
     dotfiles_die "1Password CLI (op) is required for Hermes bootstrap."
   dotfiles_have jq || dotfiles_die "jq is required for Hermes bootstrap."
   dotfiles_have curl || dotfiles_die "curl is required for Hermes readiness checks."
+  dotfiles_have python3 || dotfiles_die "python3 is required for Hermes storage initialization."
 }
 
 dotfiles_hermes_xapi_secret_item() {

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -52,27 +52,46 @@ dotfiles_hermes_storage_volume_ready() {
 }
 
 dotfiles_hermes_release_storage_lock() {
-  local docker_runner="$1" lock_name="$2"
+  local docker_runner="$1" lock_id="$2"
 
-  "$docker_runner" rm -f "$lock_name" >/dev/null 2>&1
+  "$docker_runner" rm -f "$lock_id" >/dev/null 2>&1
 }
 
 dotfiles_hermes_storage_lock_state() {
-  local docker_runner="$1" lock_name="$2" lock_label="$3" token_label="$4"
+  local docker_runner="$1" lock_name="$2" lock_label="$3" token_label="$4" created_label="$5"
 
   "$docker_runner" inspect --format \
-    "{{ index .Config.Labels \"$lock_label\" }}|{{ index .Config.Labels \"$token_label\" }}|{{ .State.Status }}" \
+    "{{ .Id }}|{{ index .Config.Labels \"$lock_label\" }}|{{ index .Config.Labels \"$token_label\" }}|{{ index .Config.Labels \"$created_label\" }}|{{ .State.Status }}" \
     "$lock_name"
+}
+
+dotfiles_hermes_create_storage_lock() {
+  local docker_runner="$1" lock_name="$2" lock_label="$3" token_label="$4" created_label="$5"
+  local volume_token="$6" created_at="$7" data_dir="$8" volume_name="$9"
+
+  "$docker_runner" create \
+    --name "$lock_name" \
+    --label "$lock_label=1" \
+    --label "$token_label=$volume_token" \
+    --label "$created_label=$created_at" \
+    --entrypoint /usr/local/bin/hermes-storage-seed \
+    --mount "type=bind,src=$data_dir,dst=/source,readonly" \
+    --mount "type=volume,src=$volume_name,dst=/target" \
+    local/hermes-agent-gh:latest \
+    --source /source --destination /target \
+    --ready-token "$volume_token" --replace-incomplete
 }
 
 dotfiles_hermes_initialize_storage_volume() {
   local docker_runner="$1"
-  local volume_name data_dir volume_schema volume_token actual_schema actual_token lock_name
+  local volume_name data_dir volume_schema volume_token actual_schema actual_token lock_name lock_id
   local volume_status seed_status release_status
   local schema_label="com.rurusasu.dotfiles.hermes-storage.schema"
   local token_label="com.rurusasu.dotfiles.hermes-storage.init-token"
   local lock_label="com.rurusasu.dotfiles.hermes-storage.lock"
-  local lock_state
+  local lock_created_label="com.rurusasu.dotfiles.hermes-storage.lock-created-at"
+  local lock_state stale_lock_id stale_lock_marker stale_lock_token stale_lock_created stale_lock_status
+  local lock_created_at now reclaim_stale=0
 
   volume_name="$(dotfiles_hermes_storage_volume_name)" ||
     dotfiles_die "HERMES_DATA_VOLUME contains an invalid Docker volume name."
@@ -99,63 +118,61 @@ dotfiles_hermes_initialize_storage_volume() {
     return 1
   }
   lock_name="$(dotfiles_hermes_storage_lock_name "$volume_name")" || return $?
-  if ! "$docker_runner" create \
-    --name "$lock_name" \
-    --label "$lock_label=1" \
-    --label "$token_label=$volume_token" \
-    --entrypoint /usr/local/bin/hermes-storage-seed \
-    --mount "type=bind,src=$data_dir,dst=/source,readonly" \
-    --mount "type=volume,src=$volume_name,dst=/target" \
-    local/hermes-agent-gh:latest \
-    --source /source --destination /target \
-    --ready-token "$volume_token" --replace-incomplete >/dev/null 2>&1; then
-    lock_state="$(dotfiles_hermes_storage_lock_state "$docker_runner" "$lock_name" "$lock_label" "$token_label" 2>/dev/null)" || lock_state=""
-    case "$lock_state" in
-    "1|$volume_token|exited" | "1|$volume_token|dead")
-      dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_name" || return $?
-      "$docker_runner" create \
-        --name "$lock_name" \
-        --label "$lock_label=1" \
-        --label "$token_label=$volume_token" \
-        --entrypoint /usr/local/bin/hermes-storage-seed \
-        --mount "type=bind,src=$data_dir,dst=/source,readonly" \
-        --mount "type=volume,src=$volume_name,dst=/target" \
-        local/hermes-agent-gh:latest \
-        --source /source --destination /target \
-        --ready-token "$volume_token" --replace-incomplete >/dev/null || return $?
-      ;;
-    *)
+  lock_created_at="$(python3 -c 'import time; print(int(time.time()))')" || return $?
+  if ! lock_id="$(dotfiles_hermes_create_storage_lock \
+    "$docker_runner" "$lock_name" "$lock_label" "$token_label" "$lock_created_label" \
+    "$volume_token" "$lock_created_at" "$data_dir" "$volume_name" 2>/dev/null)"; then
+    lock_state="$(dotfiles_hermes_storage_lock_state \
+      "$docker_runner" "$lock_name" "$lock_label" "$token_label" "$lock_created_label" 2>/dev/null)" || lock_state=""
+    IFS='|' read -r stale_lock_id stale_lock_marker stale_lock_token stale_lock_created stale_lock_status <<<"$lock_state"
+    if [[ $stale_lock_id =~ ^[0-9a-f]{12,64}$ && $stale_lock_marker == 1 && $stale_lock_token == "$volume_token" ]]; then
+      case "$stale_lock_status" in
+      exited | dead) reclaim_stale=1 ;;
+      created)
+        now="$(python3 -c 'import time; print(int(time.time()))')" || return $?
+        if [[ $stale_lock_created =~ ^[0-9]{1,12}$ ]] && ((now - stale_lock_created >= 30)); then
+          reclaim_stale=1
+        fi
+        ;;
+      esac
+    fi
+    if ((reclaim_stale == 0)); then
       printf 'Hermes Docker data volume initialization is already locked: %s\n' "$volume_name" >&2
       return 1
-      ;;
-    esac
+    fi
+    dotfiles_hermes_release_storage_lock "$docker_runner" "$stale_lock_id" || return $?
+    lock_created_at="$(python3 -c 'import time; print(int(time.time()))')" || return $?
+    lock_id="$(dotfiles_hermes_create_storage_lock \
+      "$docker_runner" "$lock_name" "$lock_label" "$token_label" "$lock_created_label" \
+      "$volume_token" "$lock_created_at" "$data_dir" "$volume_name")" || return $?
   fi
+  [[ $lock_id =~ ^[0-9a-f]{12,64}$ ]] || return 1
 
   actual_schema="$(dotfiles_hermes_storage_volume_label "$docker_runner" "$volume_name" "$schema_label" 2>/dev/null)" || {
-    dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_name" || true
+    dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_id" || true
     printf 'Hermes Docker data volume identity could not be verified while locked: %s\n' "$volume_name" >&2
     return 1
   }
   actual_token="$(dotfiles_hermes_storage_volume_label "$docker_runner" "$volume_name" "$token_label" 2>/dev/null)" || {
-    dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_name" || true
+    dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_id" || true
     printf 'Hermes Docker data volume identity could not be verified while locked: %s\n' "$volume_name" >&2
     return 1
   }
   if [[ $actual_schema != 1 || $actual_token != "$volume_token" ]]; then
-    dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_name" || true
+    dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_id" || true
     printf 'Hermes Docker data volume changed before its lock was acquired; refusing to access it: %s\n' "$volume_name" >&2
     return 1
   fi
 
   if dotfiles_hermes_storage_volume_ready "$docker_runner" "$volume_name" "$volume_token"; then
-    dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_name" || return $?
+    dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_id" || return $?
     printf 'Hermes Docker data volume is ready: %s\n' "$volume_name" >&2
     return 0
   fi
 
-  if "$docker_runner" start -a "$lock_name"; then
+  if "$docker_runner" start -a "$lock_id"; then
     if dotfiles_hermes_storage_volume_ready "$docker_runner" "$volume_name" "$volume_token"; then
-      dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_name" || return $?
+      dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_id" || return $?
       printf 'Hermes Docker data volume initialized: %s\n' "$volume_name" >&2
       return 0
     fi
@@ -165,7 +182,7 @@ dotfiles_hermes_initialize_storage_volume() {
     seed_status=$?
   fi
 
-  if dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_name"; then
+  if dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_id"; then
     printf 'Hermes Docker data volume remains incomplete and will be safely replaced on retry: %s\n' "$volume_name" >&2
     return "$seed_status"
   else

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -47,7 +47,19 @@ dotfiles_hermes_storage_volume_ready() {
     --entrypoint python \
     --mount "type=volume,src=$volume_name,dst=/target,readonly" \
     local/hermes-agent-gh:latest \
-    -c 'import pathlib, sys; marker=pathlib.Path("/target/.dotfiles-hermes-storage-ready-v1"); expected=f"version=1\nvolume_token={sys.argv[1]}\n"; raise SystemExit(0 if marker.is_file() and not marker.is_symlink() and marker.read_text(encoding="utf-8") == expected else 1)' \
+    -c 'import pathlib, stat, sys; marker=pathlib.Path("/target/.dotfiles-hermes-storage-ready-v1"); expected=f"version=1\nvolume_token={sys.argv[1]}\n";
+try:
+ mode=marker.lstat().st_mode
+except FileNotFoundError:
+ raise SystemExit(3)
+except OSError as error:
+ print(f"Hermes ready marker could not be inspected: {error}", file=sys.stderr); raise SystemExit(2)
+if stat.S_ISLNK(mode) or not stat.S_ISREG(mode): raise SystemExit(3)
+try:
+ actual=marker.read_text(encoding="utf-8")
+except (OSError, UnicodeError) as error:
+ print(f"Hermes ready marker could not be read: {error}", file=sys.stderr); raise SystemExit(2)
+raise SystemExit(0 if actual == expected else 3)' \
     "$volume_token"
 }
 
@@ -85,7 +97,7 @@ dotfiles_hermes_create_storage_lock() {
 dotfiles_hermes_initialize_storage_volume() {
   local docker_runner="$1"
   local volume_name data_dir volume_schema volume_token actual_schema actual_token lock_name lock_id
-  local volume_status seed_status release_status
+  local volume_status probe_status seed_status release_status
   local schema_label="com.rurusasu.dotfiles.hermes-storage.schema"
   local token_label="com.rurusasu.dotfiles.hermes-storage.init-token"
   local lock_label="com.rurusasu.dotfiles.hermes-storage.lock"
@@ -168,6 +180,20 @@ dotfiles_hermes_initialize_storage_volume() {
     dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_id" || return $?
     printf 'Hermes Docker data volume is ready: %s\n' "$volume_name" >&2
     return 0
+  else
+    probe_status=$?
+  fi
+  if ((probe_status != 3)); then
+    if dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_id"; then
+      printf 'Hermes Docker data volume ready marker probe failed with status %s; preserving it unchanged: %s\n' \
+        "$probe_status" "$volume_name" >&2
+      return "$probe_status"
+    else
+      release_status=$?
+      printf 'Hermes Docker data volume ready marker probe failed with status %s and its lock could not be released: %s\n' \
+        "$probe_status" "$volume_name" >&2
+      return "$release_status"
+    fi
   fi
 
   if "$docker_runner" start -a "$lock_id"; then
@@ -175,9 +201,17 @@ dotfiles_hermes_initialize_storage_volume() {
       dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_id" || return $?
       printf 'Hermes Docker data volume initialized: %s\n' "$volume_name" >&2
       return 0
+    else
+      probe_status=$?
     fi
-    seed_status=1
-    printf 'Hermes Docker data volume seed completed without its ready marker: %s\n' "$volume_name" >&2
+    if ((probe_status == 3)); then
+      seed_status=1
+      printf 'Hermes Docker data volume seed completed without its ready marker: %s\n' "$volume_name" >&2
+    else
+      seed_status=$probe_status
+      printf 'Hermes Docker data volume post-seed ready marker probe failed with status %s: %s\n' \
+        "$probe_status" "$volume_name" >&2
+    fi
   else
     seed_status=$?
   fi

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -34,22 +34,45 @@ dotfiles_hermes_storage_volume_label() {
   "$docker_runner" volume inspect --format "{{ index .Labels \"$label\" }}" "$volume_name"
 }
 
+dotfiles_hermes_storage_lock_name() {
+  local volume_name="$1"
+
+  python3 -c 'import hashlib, sys; print("dotfiles-hermes-storage-" + hashlib.sha256(sys.argv[1].encode()).hexdigest()[:20])' "$volume_name"
+}
+
 dotfiles_hermes_storage_volume_ready() {
-  local docker_runner="$1" volume_name="$2"
+  local docker_runner="$1" volume_name="$2" volume_token="$3"
 
   "$docker_runner" run --rm \
-    --entrypoint test \
+    --entrypoint python \
     --mount "type=volume,src=$volume_name,dst=/target,readonly" \
     local/hermes-agent-gh:latest \
-    -f /target/.dotfiles-hermes-storage-ready-v1
+    -c 'import pathlib, sys; marker=pathlib.Path("/target/.dotfiles-hermes-storage-ready-v1"); expected=f"version=1\nvolume_token={sys.argv[1]}\n"; raise SystemExit(0 if marker.is_file() and not marker.is_symlink() and marker.read_text(encoding="utf-8") == expected else 1)' \
+    "$volume_token"
+}
+
+dotfiles_hermes_release_storage_lock() {
+  local docker_runner="$1" lock_name="$2"
+
+  "$docker_runner" rm -f "$lock_name" >/dev/null 2>&1
+}
+
+dotfiles_hermes_storage_lock_state() {
+  local docker_runner="$1" lock_name="$2" lock_label="$3" token_label="$4"
+
+  "$docker_runner" inspect --format \
+    "{{ index .Config.Labels \"$lock_label\" }}|{{ index .Config.Labels \"$token_label\" }}|{{ .State.Status }}" \
+    "$lock_name"
 }
 
 dotfiles_hermes_initialize_storage_volume() {
   local docker_runner="$1"
-  local volume_name data_dir volume_schema init_token actual_token
-  local volume_status seed_status cleanup_status
+  local volume_name data_dir volume_schema volume_token actual_schema actual_token lock_name
+  local volume_status seed_status release_status
   local schema_label="com.rurusasu.dotfiles.hermes-storage.schema"
   local token_label="com.rurusasu.dotfiles.hermes-storage.init-token"
+  local lock_label="com.rurusasu.dotfiles.hermes-storage.lock"
+  local lock_state
 
   volume_name="$(dotfiles_hermes_storage_volume_name)" ||
     dotfiles_die "HERMES_DATA_VOLUME contains an invalid Docker volume name."
@@ -60,38 +83,79 @@ dotfiles_hermes_initialize_storage_volume() {
       printf 'Legacy Hermes Docker data volume already exists; leaving it untouched: %s\n' "$volume_name" >&2
       return 0
     fi
-    if dotfiles_hermes_storage_volume_ready "$docker_runner" "$volume_name"; then
-      printf 'Hermes Docker data volume is ready: %s\n' "$volume_name" >&2
-      return 0
-    fi
-    printf 'Hermes Docker data volume is managed but incomplete; remove it after confirming no initialization is active: %s\n' "$volume_name" >&2
-    return 1
+    volume_token="$(dotfiles_hermes_storage_volume_label "$docker_runner" "$volume_name" "$token_label" 2>/dev/null)" || return $?
   else
     volume_status=$?
     ((volume_status == 1)) || return "$volume_status"
+    volume_token="$(python3 -c 'import uuid; print(uuid.uuid4().hex)')" || return $?
+    "$docker_runner" volume create \
+      --label "$schema_label=1" \
+      --label "$token_label=$volume_token" \
+      "$volume_name" >/dev/null || return $?
   fi
 
-  init_token="$(python3 -c 'import uuid; print(uuid.uuid4().hex)')" || return $?
-  "$docker_runner" volume create \
-    --label "$schema_label=1" \
-    --label "$token_label=$init_token" \
-    "$volume_name" >/dev/null || return $?
-  actual_token="$(dotfiles_hermes_storage_volume_label "$docker_runner" "$volume_name" "$token_label" 2>/dev/null)" || {
-    printf 'Hermes Docker data volume ownership could not be verified: %s\n' "$volume_name" >&2
+  [[ $volume_token =~ ^[0-9a-f]{32}$ ]] || {
+    printf 'Hermes Docker data volume has an invalid initialization token: %s\n' "$volume_name" >&2
     return 1
   }
-  if [[ $actual_token != "$init_token" ]]; then
-    printf 'Hermes Docker data volume was created concurrently; refusing to seed or remove it: %s\n' "$volume_name" >&2
-    return 1
-  fi
-
-  if "$docker_runner" run --rm \
+  lock_name="$(dotfiles_hermes_storage_lock_name "$volume_name")" || return $?
+  if ! "$docker_runner" create \
+    --name "$lock_name" \
+    --label "$lock_label=1" \
+    --label "$token_label=$volume_token" \
     --entrypoint /usr/local/bin/hermes-storage-seed \
     --mount "type=bind,src=$data_dir,dst=/source,readonly" \
     --mount "type=volume,src=$volume_name,dst=/target" \
     local/hermes-agent-gh:latest \
-    --source /source --destination /target; then
-    if dotfiles_hermes_storage_volume_ready "$docker_runner" "$volume_name"; then
+    --source /source --destination /target \
+    --ready-token "$volume_token" --replace-incomplete >/dev/null 2>&1; then
+    lock_state="$(dotfiles_hermes_storage_lock_state "$docker_runner" "$lock_name" "$lock_label" "$token_label" 2>/dev/null)" || lock_state=""
+    case "$lock_state" in
+    "1|$volume_token|exited" | "1|$volume_token|dead")
+      dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_name" || return $?
+      "$docker_runner" create \
+        --name "$lock_name" \
+        --label "$lock_label=1" \
+        --label "$token_label=$volume_token" \
+        --entrypoint /usr/local/bin/hermes-storage-seed \
+        --mount "type=bind,src=$data_dir,dst=/source,readonly" \
+        --mount "type=volume,src=$volume_name,dst=/target" \
+        local/hermes-agent-gh:latest \
+        --source /source --destination /target \
+        --ready-token "$volume_token" --replace-incomplete >/dev/null || return $?
+      ;;
+    *)
+      printf 'Hermes Docker data volume initialization is already locked: %s\n' "$volume_name" >&2
+      return 1
+      ;;
+    esac
+  fi
+
+  actual_schema="$(dotfiles_hermes_storage_volume_label "$docker_runner" "$volume_name" "$schema_label" 2>/dev/null)" || {
+    dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_name" || true
+    printf 'Hermes Docker data volume identity could not be verified while locked: %s\n' "$volume_name" >&2
+    return 1
+  }
+  actual_token="$(dotfiles_hermes_storage_volume_label "$docker_runner" "$volume_name" "$token_label" 2>/dev/null)" || {
+    dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_name" || true
+    printf 'Hermes Docker data volume identity could not be verified while locked: %s\n' "$volume_name" >&2
+    return 1
+  }
+  if [[ $actual_schema != 1 || $actual_token != "$volume_token" ]]; then
+    dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_name" || true
+    printf 'Hermes Docker data volume changed before its lock was acquired; refusing to access it: %s\n' "$volume_name" >&2
+    return 1
+  fi
+
+  if dotfiles_hermes_storage_volume_ready "$docker_runner" "$volume_name" "$volume_token"; then
+    dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_name" || return $?
+    printf 'Hermes Docker data volume is ready: %s\n' "$volume_name" >&2
+    return 0
+  fi
+
+  if "$docker_runner" start -a "$lock_name"; then
+    if dotfiles_hermes_storage_volume_ready "$docker_runner" "$volume_name" "$volume_token"; then
+      dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_name" || return $?
       printf 'Hermes Docker data volume initialized: %s\n' "$volume_name" >&2
       return 0
     fi
@@ -101,22 +165,15 @@ dotfiles_hermes_initialize_storage_volume() {
     seed_status=$?
   fi
 
-  actual_token="$(dotfiles_hermes_storage_volume_label "$docker_runner" "$volume_name" "$token_label" 2>/dev/null)" || {
-    printf 'Hermes Docker data volume initialization failed and ownership could not be reverified: %s\n' "$volume_name" >&2
-    return "$seed_status"
-  }
-  if [[ $actual_token != "$init_token" ]]; then
-    printf 'Hermes Docker data volume initialization failed after ownership changed; refusing removal: %s\n' "$volume_name" >&2
-    return "$seed_status"
-  fi
-  if "$docker_runner" volume rm "$volume_name" >/dev/null 2>&1; then
+  if dotfiles_hermes_release_storage_lock "$docker_runner" "$lock_name"; then
+    printf 'Hermes Docker data volume remains incomplete and will be safely replaced on retry: %s\n' "$volume_name" >&2
     return "$seed_status"
   else
-    cleanup_status=$?
+    release_status=$?
   fi
-  printf 'Hermes Docker data volume initialization failed and the owned partial volume could not be removed: %s (seed status %s, cleanup status %s)\n' \
-    "$volume_name" "$seed_status" "$cleanup_status" >&2
-  return "$cleanup_status"
+  printf 'Hermes Docker data volume initialization failed and its lock could not be released: %s (seed status %s, release status %s)\n' \
+    "$volume_name" "$seed_status" "$release_status" >&2
+  return "$release_status"
 }
 
 dotfiles_hermes_prepare_runtime_home() {

--- a/taskfiles/hermes/taskfile.yml
+++ b/taskfiles/hermes/taskfile.yml
@@ -63,6 +63,9 @@ tasks:
         msg: "Docker daemon is not running. Start Docker Desktop and try again."
     cmds:
       - docker build --target hermes-bootstrap-test -t local/hermes-bootstrap-test -f docker/hermes-agent/Dockerfile docker
+      - docker build --target hermes-bootstrap-runtime -t local/hermes-agent-gh:latest -f docker/hermes-agent/Dockerfile docker
+      - cmd: docker/hermes-agent/tests/test_storage_volume_integration.sh
+        platforms: [linux, darwin]
       - docker/hermes-agent/bootstrap/tests/test_gh_wrapper.sh
       - cmd: python docker/hermes-agent/bootstrap/tests/profile_sync_provenance_gate_contract.py
         platforms: [windows]

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -10,6 +10,8 @@ setup() {
 	READY_ATTEMPT_FILE="$BATS_TEST_TMPDIR/ready-attempts"
 	OLLAMA_READY_ATTEMPT_FILE="$BATS_TEST_TMPDIR/ollama-ready-attempts"
 	HINDSIGHT_READY_ATTEMPT_FILE="$BATS_TEST_TMPDIR/hindsight-ready-attempts"
+	VOLUME_SCHEMA_FILE="$BATS_TEST_TMPDIR/hermes-volume-schema"
+	VOLUME_TOKEN_FILE="$BATS_TEST_TMPDIR/hermes-volume-token"
 	COMPOSE_FILE="$BATS_TEST_TMPDIR/compose file.yml"
 	REAL_JQ="$(command -v jq)"
 	REAL_PYTHON3="$(command -v python3)"
@@ -17,6 +19,8 @@ setup() {
 	mkdir -p "$TEST_HOME/.hermes" "$STUB_BIN"
 	: >"$COMMAND_LOG"
 	: >"$PAYLOAD_CAPTURE"
+	: >"$VOLUME_SCHEMA_FILE"
+	: >"$VOLUME_TOKEN_FILE"
 	printf '0\n' >"$READY_ATTEMPT_FILE"
 	printf '0\n' >"$OLLAMA_READY_ATTEMPT_FILE"
 	printf '0\n' >"$HINDSIGHT_READY_ATTEMPT_FILE"
@@ -30,7 +34,7 @@ EOF
 	unset DOTFILES_USER SUDO_USER
 	unset DOTFILES_HERMES_OLLAMA_EXECUTABLE DOTFILES_HERMES_CURL_EXECUTABLE OLLAMA_HOST
 	export HINDSIGHT_OLLAMA_URL=http://127.0.0.1:11434
-	export COMMAND_LOG EDIT_CAPTURE PAYLOAD_CAPTURE READY_ATTEMPT_FILE OLLAMA_READY_ATTEMPT_FILE HINDSIGHT_READY_ATTEMPT_FILE COMPOSE_FILE REAL_JQ REAL_PYTHON3 SECRET_MARKER
+	export COMMAND_LOG EDIT_CAPTURE PAYLOAD_CAPTURE READY_ATTEMPT_FILE OLLAMA_READY_ATTEMPT_FILE HINDSIGHT_READY_ATTEMPT_FILE VOLUME_SCHEMA_FILE VOLUME_TOKEN_FILE COMPOSE_FILE REAL_JQ REAL_PYTHON3 SECRET_MARKER
 	export DOTFILES_SKIP_HERDR_INSTALL=1
 	export PLAN_JSON="$(valid_secret_plan)"
 	export OP_ITEM_JSON='{"id":"item-id","fields":[{"label":"credential","value":"adapter-secret-marker"}]}'
@@ -45,6 +49,11 @@ EOF
 	export BOOTSTRAP_EXIT_EARLY=0
 	export HERMES_RUNTIME_EXISTS=1
 	export HERMES_VOLUME_EXISTS=1
+	export HERMES_VOLUME_SCHEMA_LABEL=""
+	export HERMES_VOLUME_TOKEN_LABEL=""
+	export HERMES_VOLUME_READY=1
+	export HERMES_CREATE_RACE_TOKEN=""
+	export HERMES_VOLUME_RM_STATUS=0
 	export API_READY_AFTER=1
 	export OLLAMA_READY_AFTER=1
 	export HINDSIGHT_API_DATABASE=connected
@@ -112,12 +121,33 @@ fi
 if [ "${1:-}" = "volume" ]; then
   case "${2:-}" in
     inspect)
-      [[ ${HERMES_VOLUME_EXISTS:-1} == 1 ]] && printf '[{}]\n' || exit 1
+	  if [[ ${HERMES_VOLUME_EXISTS:-1} != 1 && ! -s $VOLUME_SCHEMA_FILE && ! -s $VOLUME_TOKEN_FILE ]]; then
+	    exit 1
+	  fi
+	  case " $* " in
+	    *"com.rurusasu.dotfiles.hermes-storage.schema"*)
+	      if [[ -s $VOLUME_SCHEMA_FILE ]]; then cat "$VOLUME_SCHEMA_FILE"; else printf "%s\n" "${HERMES_VOLUME_SCHEMA_LABEL:-}"; fi
+	      ;;
+	    *"com.rurusasu.dotfiles.hermes-storage.init-token"*)
+	      if [[ -s $VOLUME_TOKEN_FILE ]]; then cat "$VOLUME_TOKEN_FILE"; else printf "%s\n" "${HERMES_VOLUME_TOKEN_LABEL:-}"; fi
+	      ;;
+	    *) printf "[{}]\n" ;;
+	  esac
       ;;
     create)
-      printf 'hermes-data\n'
+	  token=""
+	  for argument in "$@"; do
+	    case "$argument" in
+	      com.rurusasu.dotfiles.hermes-storage.schema=*) printf "%s\n" "${argument#*=}" >"$VOLUME_SCHEMA_FILE" ;;
+	      com.rurusasu.dotfiles.hermes-storage.init-token=*) token="${argument#*=}" ;;
+	    esac
+	  done
+	  if [[ -n ${HERMES_CREATE_RACE_TOKEN:-} ]]; then token="$HERMES_CREATE_RACE_TOKEN"; fi
+	  if [[ -n $token ]]; then printf "%s\n" "$token" >"$VOLUME_TOKEN_FILE"; fi
+      printf "hermes-data\n"
       ;;
     rm)
+	  exit "${HERMES_VOLUME_RM_STATUS:-0}"
       ;;
     *)
       exit 1
@@ -126,6 +156,13 @@ if [ "${1:-}" = "volume" ]; then
   exit 0
 fi
 if [ "${1:-}" = "run" ]; then
+	previous=""
+	for argument in "$@"; do
+	  if [[ $previous == --entrypoint && $argument == test ]]; then
+	    exit "$((HERMES_VOLUME_READY == 1 ? 0 : 1))"
+	  fi
+	  previous="$argument"
+	done
   exit "${HERMES_STORAGE_SEED_STATUS:-0}"
 fi
 if [ "${1:-}" != "compose" ]; then
@@ -228,7 +265,9 @@ printf "sleep <%s>\n" "$*" >>"$COMMAND_LOG"
 	run_start_stack
 
 	[ "$status" -eq 0 ]
-	assert_log_order '<stop> <hermes>' '<volume> <inspect> <hermes-data>' '<volume> <create> <hermes-data>' '<run> <--rm>' '<secret-plan>'
+	assert_log_order '<stop> <hermes>' '<volume> <inspect>' '<volume> <create>' '<run> <--rm>' '<secret-plan>'
+	grep -Fq '<--label> <com.rurusasu.dotfiles.hermes-storage.schema=1>' "$COMMAND_LOG"
+	grep -Fq '<--label> <com.rurusasu.dotfiles.hermes-storage.init-token=' "$COMMAND_LOG"
 	grep -Fq '<run> <--rm> <--entrypoint> </usr/local/bin/hermes-storage-seed>' "$COMMAND_LOG"
 }
 
@@ -239,6 +278,70 @@ printf "sleep <%s>\n" "$*" >>"$COMMAND_LOG"
 	run_start_stack
 
 	[ "$status" -eq 42 ]
+	grep -Fq '<volume> <rm> <hermes-data>' "$COMMAND_LOG"
+	! grep -q '<secret-plan>' "$COMMAND_LOG"
+}
+
+@test "does not seed or remove a volume won by a concurrent creator" {
+	export HERMES_VOLUME_EXISTS=0
+	export HERMES_CREATE_RACE_TOKEN=another-initializer
+
+	run_start_stack
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"created concurrently"* ]]
+	! grep -Fq '<--entrypoint> </usr/local/bin/hermes-storage-seed>' "$COMMAND_LOG"
+	! grep -Fq '<volume> <rm>' "$COMMAND_LOG"
+	! grep -q '<secret-plan>' "$COMMAND_LOG"
+}
+
+@test "rejects a managed volume without the ready marker" {
+	export HERMES_VOLUME_SCHEMA_LABEL=1
+	export HERMES_VOLUME_TOKEN_LABEL=previous-initializer
+	export HERMES_VOLUME_READY=0
+
+	run_start_stack
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"incomplete"* ]]
+	grep -Fq '<--entrypoint> <test>' "$COMMAND_LOG"
+	! grep -Fq '<--entrypoint> </usr/local/bin/hermes-storage-seed>' "$COMMAND_LOG"
+	! grep -q '<secret-plan>' "$COMMAND_LOG"
+}
+
+@test "accepts a managed volume with the ready marker" {
+	export HERMES_VOLUME_SCHEMA_LABEL=1
+	export HERMES_VOLUME_TOKEN_LABEL=previous-initializer
+	export HERMES_VOLUME_READY=1
+
+	run_start_stack
+
+	[ "$status" -eq 0 ]
+	grep -Fq '<--entrypoint> <test>' "$COMMAND_LOG"
+	! grep -Fq '<--entrypoint> </usr/local/bin/hermes-storage-seed>' "$COMMAND_LOG"
+}
+
+@test "surfaces failure to remove an owned partial volume" {
+	export HERMES_VOLUME_EXISTS=0
+	export HERMES_STORAGE_SEED_STATUS=42
+	export HERMES_VOLUME_RM_STATUS=17
+
+	run_start_stack
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"could not be removed"* ]]
+	grep -Fq '<volume> <rm> <hermes-data>' "$COMMAND_LOG"
+	! grep -q '<secret-plan>' "$COMMAND_LOG"
+}
+
+@test "removes an owned volume when seed returns without a ready marker" {
+	export HERMES_VOLUME_EXISTS=0
+	export HERMES_VOLUME_READY=0
+
+	run_start_stack
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"ready marker"* ]]
 	grep -Fq '<volume> <rm> <hermes-data>' "$COMMAND_LOG"
 	! grep -q '<secret-plan>' "$COMMAND_LOG"
 }
@@ -926,6 +1029,14 @@ esac
 
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"jq is required"* ]]
+	[ ! -s "$COMMAND_LOG" ]
+}
+
+@test "fails preflight before Compose when python3 is unavailable" {
+	run_start_stack python3
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"python3 is required"* ]]
 	[ ! -s "$COMMAND_LOG" ]
 }
 

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -60,6 +60,8 @@ EOF
 	export HERMES_LOCK_CREATE_STATUS=0
 	export HERMES_LOCK_CREATE_FAIL_ONCE=0
 	export HERMES_LOCK_STATE=""
+	export HERMES_LOCK_ID=1111111111111111111111111111111111111111111111111111111111111111
+	export HERMES_REPLACEMENT_LOCK_ID=2222222222222222222222222222222222222222222222222222222222222222
 	export HERMES_LOCK_RELEASE_STATUS=0
 	export HERMES_SEED_WRITES_MARKER=1
 	export API_READY_AFTER=1
@@ -187,7 +189,9 @@ if [ "${1:-}" = "create" ]; then
 	attempt=$((attempt + 1))
 	printf "%s\n" "$attempt" >"$LOCK_CREATE_ATTEMPT_FILE"
 	if [[ ${HERMES_LOCK_CREATE_FAIL_ONCE:-0} == 1 && $attempt == 1 ]]; then exit 125; fi
-	exit "${HERMES_LOCK_CREATE_STATUS:-0}"
+	if [[ ${HERMES_LOCK_CREATE_STATUS:-0} != 0 ]]; then exit "$HERMES_LOCK_CREATE_STATUS"; fi
+	if ((attempt > 1)); then printf "%s\n" "$HERMES_REPLACEMENT_LOCK_ID"; else printf "%s\n" "$HERMES_LOCK_ID"; fi
+	exit 0
 fi
 if [ "${1:-}" = "inspect" ]; then
 	if [[ -n ${HERMES_LOCK_STATE:-} ]]; then printf "%s\n" "$HERMES_LOCK_STATE"; exit 0; fi
@@ -319,7 +323,7 @@ printf "sleep <%s>\n" "$*" >>"$COMMAND_LOG"
 
 	[ "$status" -eq 42 ]
 	[[ "$output" == *"will be safely replaced on retry"* ]]
-	grep -Fq '<rm> <-f> <dotfiles-hermes-storage-' "$COMMAND_LOG"
+	grep -Fq "<rm> <-f> <$HERMES_LOCK_ID>" "$COMMAND_LOG"
 	! grep -Fq '<volume> <rm>' "$COMMAND_LOG"
 	! grep -q '<secret-plan>' "$COMMAND_LOG"
 }
@@ -358,14 +362,14 @@ printf "sleep <%s>\n" "$*" >>"$COMMAND_LOG"
 	[ "$status" -eq 0 ]
 	grep -Fq '<--entrypoint> <python>' "$COMMAND_LOG"
 	! grep -Fq '<start> <-a>' "$COMMAND_LOG"
-	grep -Fq '<rm> <-f> <dotfiles-hermes-storage-' "$COMMAND_LOG"
+	grep -Fq "<rm> <-f> <$HERMES_LOCK_ID>" "$COMMAND_LOG"
 }
 
 @test "rejects a concurrent storage lock before marker or seed access" {
 	export HERMES_VOLUME_SCHEMA_LABEL=1
 	export HERMES_VOLUME_TOKEN_LABEL=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 	export HERMES_LOCK_CREATE_STATUS=125
-	export HERMES_LOCK_STATE='1|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|running'
+	export HERMES_LOCK_STATE="$HERMES_LOCK_ID|1|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|0|running"
 
 	run_start_stack
 
@@ -380,15 +384,46 @@ printf "sleep <%s>\n" "$*" >>"$COMMAND_LOG"
 	export HERMES_VOLUME_SCHEMA_LABEL=1
 	export HERMES_VOLUME_TOKEN_LABEL=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 	export HERMES_LOCK_CREATE_FAIL_ONCE=1
-	export HERMES_LOCK_STATE='1|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|exited'
+	export HERMES_LOCK_STATE="$HERMES_LOCK_ID|1|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|0|exited"
 
 	run_start_stack
 
 	[ "$status" -eq 0 ]
 	[ "$(cat "$LOCK_CREATE_ATTEMPT_FILE")" -eq 2 ]
 	grep -Fq '<inspect> <--format>' "$COMMAND_LOG"
-	grep -Fq '<rm> <-f> <dotfiles-hermes-storage-' "$COMMAND_LOG"
+	grep -Fq "<rm> <-f> <$HERMES_LOCK_ID>" "$COMMAND_LOG"
 	grep -Fq '<run> <--rm> <--entrypoint> <python>' "$COMMAND_LOG"
+}
+
+@test "reclaims an aged created lock by immutable ID" {
+	export HERMES_VOLUME_SCHEMA_LABEL=1
+	export HERMES_VOLUME_TOKEN_LABEL=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+	export HERMES_LOCK_CREATE_FAIL_ONCE=1
+	export HERMES_LOCK_STATE="$HERMES_LOCK_ID|1|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|0|created"
+	export HERMES_VOLUME_READY=0
+
+	run_start_stack
+
+	[ "$status" -eq 0 ]
+	[ "$(cat "$LOCK_CREATE_ATTEMPT_FILE")" -eq 2 ]
+	grep -Fq "<rm> <-f> <$HERMES_LOCK_ID>" "$COMMAND_LOG"
+	grep -Fq "<start> <-a> <$HERMES_REPLACEMENT_LOCK_ID>" "$COMMAND_LOG"
+}
+
+@test "does not acquire or touch a replacement lock after losing stale ID removal" {
+	export HERMES_VOLUME_SCHEMA_LABEL=1
+	export HERMES_VOLUME_TOKEN_LABEL=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+	export HERMES_LOCK_CREATE_FAIL_ONCE=1
+	export HERMES_LOCK_STATE="$HERMES_LOCK_ID|1|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|0|exited"
+	export HERMES_LOCK_RELEASE_STATUS=17
+
+	run_start_stack
+
+	[ "$status" -eq 17 ]
+	[ "$(cat "$LOCK_CREATE_ATTEMPT_FILE")" -eq 1 ]
+	grep -Fq "<rm> <-f> <$HERMES_LOCK_ID>" "$COMMAND_LOG"
+	! grep -Fq "<$HERMES_REPLACEMENT_LOCK_ID>" "$COMMAND_LOG"
+	! grep -Fq '<start> <-a>' "$COMMAND_LOG"
 }
 
 @test "surfaces a lock release failure after seed failure without deleting the volume" {

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -56,6 +56,7 @@ EOF
 	export HERMES_VOLUME_SCHEMA_LABEL=""
 	export HERMES_VOLUME_TOKEN_LABEL=""
 	export HERMES_VOLUME_READY=1
+	export HERMES_VOLUME_PROBE_STATUS=""
 	export HERMES_CREATE_RACE_TOKEN=""
 	export HERMES_LOCK_CREATE_STATUS=0
 	export HERMES_LOCK_CREATE_FAIL_ONCE=0
@@ -167,12 +168,15 @@ if [ "${1:-}" = "run" ]; then
 	previous=""
 	for argument in "$@"; do
 	  if [[ $previous == --entrypoint && $argument == python ]]; then
+	    if [[ -n ${HERMES_VOLUME_PROBE_STATUS:-} ]]; then
+	      exit "$HERMES_VOLUME_PROBE_STATUS"
+	    fi
 	    if [[ -s $VOLUME_READY_FILE ]]; then
 	      ready="$(cat "$VOLUME_READY_FILE")"
 	    else
 	      ready="$HERMES_VOLUME_READY"
 	    fi
-	    exit "$((ready == 1 ? 0 : 1))"
+	    exit "$((ready == 1 ? 0 : 3))"
 	  fi
 	  if [[ $previous == --entrypoint && $argument == /usr/local/bin/hermes-storage-seed ]]; then
 	    if [[ ${HERMES_STORAGE_SEED_STATUS:-0} == 0 && ${HERMES_SEED_WRITES_MARKER:-1} == 1 ]]; then
@@ -361,6 +365,20 @@ printf "sleep <%s>\n" "$*" >>"$COMMAND_LOG"
 
 	[ "$status" -eq 0 ]
 	grep -Fq '<--entrypoint> <python>' "$COMMAND_LOG"
+	! grep -Fq '<start> <-a>' "$COMMAND_LOG"
+	grep -Fq "<rm> <-f> <$HERMES_LOCK_ID>" "$COMMAND_LOG"
+}
+
+@test "preserves a ready managed volume when its marker probe cannot run" {
+	export HERMES_VOLUME_SCHEMA_LABEL=1
+	export HERMES_VOLUME_TOKEN_LABEL=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+	export HERMES_VOLUME_READY=1
+	export HERMES_VOLUME_PROBE_STATUS=125
+
+	run_start_stack
+
+	[ "$status" -eq 125 ]
+	[[ "$output" == *"ready marker probe failed with status 125"* ]]
 	! grep -Fq '<start> <-a>' "$COMMAND_LOG"
 	grep -Fq "<rm> <-f> <$HERMES_LOCK_ID>" "$COMMAND_LOG"
 }

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -12,6 +12,8 @@ setup() {
 	HINDSIGHT_READY_ATTEMPT_FILE="$BATS_TEST_TMPDIR/hindsight-ready-attempts"
 	VOLUME_SCHEMA_FILE="$BATS_TEST_TMPDIR/hermes-volume-schema"
 	VOLUME_TOKEN_FILE="$BATS_TEST_TMPDIR/hermes-volume-token"
+	VOLUME_READY_FILE="$BATS_TEST_TMPDIR/hermes-volume-ready"
+	LOCK_CREATE_ATTEMPT_FILE="$BATS_TEST_TMPDIR/hermes-lock-create-attempts"
 	COMPOSE_FILE="$BATS_TEST_TMPDIR/compose file.yml"
 	REAL_JQ="$(command -v jq)"
 	REAL_PYTHON3="$(command -v python3)"
@@ -21,6 +23,8 @@ setup() {
 	: >"$PAYLOAD_CAPTURE"
 	: >"$VOLUME_SCHEMA_FILE"
 	: >"$VOLUME_TOKEN_FILE"
+	: >"$VOLUME_READY_FILE"
+	printf '0\n' >"$LOCK_CREATE_ATTEMPT_FILE"
 	printf '0\n' >"$READY_ATTEMPT_FILE"
 	printf '0\n' >"$OLLAMA_READY_ATTEMPT_FILE"
 	printf '0\n' >"$HINDSIGHT_READY_ATTEMPT_FILE"
@@ -34,7 +38,7 @@ EOF
 	unset DOTFILES_USER SUDO_USER
 	unset DOTFILES_HERMES_OLLAMA_EXECUTABLE DOTFILES_HERMES_CURL_EXECUTABLE OLLAMA_HOST
 	export HINDSIGHT_OLLAMA_URL=http://127.0.0.1:11434
-	export COMMAND_LOG EDIT_CAPTURE PAYLOAD_CAPTURE READY_ATTEMPT_FILE OLLAMA_READY_ATTEMPT_FILE HINDSIGHT_READY_ATTEMPT_FILE VOLUME_SCHEMA_FILE VOLUME_TOKEN_FILE COMPOSE_FILE REAL_JQ REAL_PYTHON3 SECRET_MARKER
+	export COMMAND_LOG EDIT_CAPTURE PAYLOAD_CAPTURE READY_ATTEMPT_FILE OLLAMA_READY_ATTEMPT_FILE HINDSIGHT_READY_ATTEMPT_FILE VOLUME_SCHEMA_FILE VOLUME_TOKEN_FILE VOLUME_READY_FILE LOCK_CREATE_ATTEMPT_FILE COMPOSE_FILE REAL_JQ REAL_PYTHON3 SECRET_MARKER
 	export DOTFILES_SKIP_HERDR_INSTALL=1
 	export PLAN_JSON="$(valid_secret_plan)"
 	export OP_ITEM_JSON='{"id":"item-id","fields":[{"label":"credential","value":"adapter-secret-marker"}]}'
@@ -53,7 +57,11 @@ EOF
 	export HERMES_VOLUME_TOKEN_LABEL=""
 	export HERMES_VOLUME_READY=1
 	export HERMES_CREATE_RACE_TOKEN=""
-	export HERMES_VOLUME_RM_STATUS=0
+	export HERMES_LOCK_CREATE_STATUS=0
+	export HERMES_LOCK_CREATE_FAIL_ONCE=0
+	export HERMES_LOCK_STATE=""
+	export HERMES_LOCK_RELEASE_STATUS=0
+	export HERMES_SEED_WRITES_MARKER=1
 	export API_READY_AFTER=1
 	export OLLAMA_READY_AFTER=1
 	export HINDSIGHT_API_DATABASE=connected
@@ -144,10 +152,8 @@ if [ "${1:-}" = "volume" ]; then
 	  done
 	  if [[ -n ${HERMES_CREATE_RACE_TOKEN:-} ]]; then token="$HERMES_CREATE_RACE_TOKEN"; fi
 	  if [[ -n $token ]]; then printf "%s\n" "$token" >"$VOLUME_TOKEN_FILE"; fi
+	  printf "0\n" >"$VOLUME_READY_FILE"
       printf "hermes-data\n"
-      ;;
-    rm)
-	  exit "${HERMES_VOLUME_RM_STATUS:-0}"
       ;;
     *)
       exit 1
@@ -158,12 +164,43 @@ fi
 if [ "${1:-}" = "run" ]; then
 	previous=""
 	for argument in "$@"; do
-	  if [[ $previous == --entrypoint && $argument == test ]]; then
-	    exit "$((HERMES_VOLUME_READY == 1 ? 0 : 1))"
+	  if [[ $previous == --entrypoint && $argument == python ]]; then
+	    if [[ -s $VOLUME_READY_FILE ]]; then
+	      ready="$(cat "$VOLUME_READY_FILE")"
+	    else
+	      ready="$HERMES_VOLUME_READY"
+	    fi
+	    exit "$((ready == 1 ? 0 : 1))"
+	  fi
+	  if [[ $previous == --entrypoint && $argument == /usr/local/bin/hermes-storage-seed ]]; then
+	    if [[ ${HERMES_STORAGE_SEED_STATUS:-0} == 0 && ${HERMES_SEED_WRITES_MARKER:-1} == 1 ]]; then
+	      printf "1\n" >"$VOLUME_READY_FILE"
+	    fi
+	    exit "${HERMES_STORAGE_SEED_STATUS:-0}"
 	  fi
 	  previous="$argument"
 	done
-  exit "${HERMES_STORAGE_SEED_STATUS:-0}"
+  exit 1
+fi
+if [ "${1:-}" = "create" ]; then
+	attempt="$(cat "$LOCK_CREATE_ATTEMPT_FILE")"
+	attempt=$((attempt + 1))
+	printf "%s\n" "$attempt" >"$LOCK_CREATE_ATTEMPT_FILE"
+	if [[ ${HERMES_LOCK_CREATE_FAIL_ONCE:-0} == 1 && $attempt == 1 ]]; then exit 125; fi
+	exit "${HERMES_LOCK_CREATE_STATUS:-0}"
+fi
+if [ "${1:-}" = "inspect" ]; then
+	if [[ -n ${HERMES_LOCK_STATE:-} ]]; then printf "%s\n" "$HERMES_LOCK_STATE"; exit 0; fi
+	exit 1
+fi
+if [ "${1:-}" = "start" ] && [ "${2:-}" = "-a" ]; then
+	if [[ ${HERMES_STORAGE_SEED_STATUS:-0} == 0 && ${HERMES_SEED_WRITES_MARKER:-1} == 1 ]]; then
+	  printf "1\n" >"$VOLUME_READY_FILE"
+	fi
+	exit "${HERMES_STORAGE_SEED_STATUS:-0}"
+fi
+if [ "${1:-}" = "rm" ] && [ "${2:-}" = "-f" ]; then
+	exit "${HERMES_LOCK_RELEASE_STATUS:-0}"
 fi
 if [ "${1:-}" != "compose" ]; then
 	exit 1
@@ -265,84 +302,117 @@ printf "sleep <%s>\n" "$*" >>"$COMMAND_LOG"
 	run_start_stack
 
 	[ "$status" -eq 0 ]
-	assert_log_order '<stop> <hermes>' '<volume> <inspect>' '<volume> <create>' '<run> <--rm>' '<secret-plan>'
+	assert_log_order '<stop> <hermes>' '<volume> <inspect>' '<volume> <create>' '<create> <--name>' '<run> <--rm> <--entrypoint> <python>' '<start> <-a>' '<rm> <-f>' '<secret-plan>'
 	grep -Fq '<--label> <com.rurusasu.dotfiles.hermes-storage.schema=1>' "$COMMAND_LOG"
 	grep -Fq '<--label> <com.rurusasu.dotfiles.hermes-storage.init-token=' "$COMMAND_LOG"
-	grep -Fq '<run> <--rm> <--entrypoint> </usr/local/bin/hermes-storage-seed>' "$COMMAND_LOG"
+	grep -Fq '<create> <--name> <dotfiles-hermes-storage-' "$COMMAND_LOG"
+	grep -Fq '<--entrypoint> </usr/local/bin/hermes-storage-seed>' "$COMMAND_LOG"
+	grep -Fq '<--ready-token>' "$COMMAND_LOG"
+	grep -Fq '<--replace-incomplete>' "$COMMAND_LOG"
 }
 
-@test "removes only a newly created volume when storage seeding fails" {
+@test "keeps a failed managed volume incomplete for a safe retry" {
 	export HERMES_VOLUME_EXISTS=0
 	export HERMES_STORAGE_SEED_STATUS=42
 
 	run_start_stack
 
 	[ "$status" -eq 42 ]
-	grep -Fq '<volume> <rm> <hermes-data>' "$COMMAND_LOG"
+	[[ "$output" == *"will be safely replaced on retry"* ]]
+	grep -Fq '<rm> <-f> <dotfiles-hermes-storage-' "$COMMAND_LOG"
+	! grep -Fq '<volume> <rm>' "$COMMAND_LOG"
 	! grep -q '<secret-plan>' "$COMMAND_LOG"
 }
 
 @test "does not seed or remove a volume won by a concurrent creator" {
 	export HERMES_VOLUME_EXISTS=0
-	export HERMES_CREATE_RACE_TOKEN=another-initializer
+	export HERMES_CREATE_RACE_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 	run_start_stack
 
 	[ "$status" -ne 0 ]
-	[[ "$output" == *"created concurrently"* ]]
-	! grep -Fq '<--entrypoint> </usr/local/bin/hermes-storage-seed>' "$COMMAND_LOG"
+	[[ "$output" == *"changed before its lock was acquired"* ]]
+	! grep -Fq '<start> <-a>' "$COMMAND_LOG"
 	! grep -Fq '<volume> <rm>' "$COMMAND_LOG"
 	! grep -q '<secret-plan>' "$COMMAND_LOG"
 }
 
-@test "rejects a managed volume without the ready marker" {
+@test "safely replaces a managed incomplete volume while holding its lock" {
 	export HERMES_VOLUME_SCHEMA_LABEL=1
-	export HERMES_VOLUME_TOKEN_LABEL=previous-initializer
+	export HERMES_VOLUME_TOKEN_LABEL=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 	export HERMES_VOLUME_READY=0
 
 	run_start_stack
 
-	[ "$status" -ne 0 ]
-	[[ "$output" == *"incomplete"* ]]
-	grep -Fq '<--entrypoint> <test>' "$COMMAND_LOG"
-	! grep -Fq '<--entrypoint> </usr/local/bin/hermes-storage-seed>' "$COMMAND_LOG"
-	! grep -q '<secret-plan>' "$COMMAND_LOG"
+	[ "$status" -eq 0 ]
+	assert_log_order '<create> <--name>' '<run> <--rm> <--entrypoint> <python>' '<start> <-a>' '<rm> <-f>' '<secret-plan>'
 }
 
 @test "accepts a managed volume with the ready marker" {
 	export HERMES_VOLUME_SCHEMA_LABEL=1
-	export HERMES_VOLUME_TOKEN_LABEL=previous-initializer
+	export HERMES_VOLUME_TOKEN_LABEL=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 	export HERMES_VOLUME_READY=1
 
 	run_start_stack
 
 	[ "$status" -eq 0 ]
-	grep -Fq '<--entrypoint> <test>' "$COMMAND_LOG"
-	! grep -Fq '<--entrypoint> </usr/local/bin/hermes-storage-seed>' "$COMMAND_LOG"
+	grep -Fq '<--entrypoint> <python>' "$COMMAND_LOG"
+	! grep -Fq '<start> <-a>' "$COMMAND_LOG"
+	grep -Fq '<rm> <-f> <dotfiles-hermes-storage-' "$COMMAND_LOG"
 }
 
-@test "surfaces failure to remove an owned partial volume" {
-	export HERMES_VOLUME_EXISTS=0
-	export HERMES_STORAGE_SEED_STATUS=42
-	export HERMES_VOLUME_RM_STATUS=17
+@test "rejects a concurrent storage lock before marker or seed access" {
+	export HERMES_VOLUME_SCHEMA_LABEL=1
+	export HERMES_VOLUME_TOKEN_LABEL=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+	export HERMES_LOCK_CREATE_STATUS=125
+	export HERMES_LOCK_STATE='1|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|running'
 
 	run_start_stack
 
 	[ "$status" -ne 0 ]
-	[[ "$output" == *"could not be removed"* ]]
-	grep -Fq '<volume> <rm> <hermes-data>' "$COMMAND_LOG"
+	[[ "$output" == *"already locked"* ]]
+	! grep -Fq '<--entrypoint> <python>' "$COMMAND_LOG"
+	! grep -Fq '<start> <-a>' "$COMMAND_LOG"
 	! grep -q '<secret-plan>' "$COMMAND_LOG"
 }
 
-@test "removes an owned volume when seed returns without a ready marker" {
+@test "reclaims an exited owned storage lock and retries atomically" {
+	export HERMES_VOLUME_SCHEMA_LABEL=1
+	export HERMES_VOLUME_TOKEN_LABEL=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+	export HERMES_LOCK_CREATE_FAIL_ONCE=1
+	export HERMES_LOCK_STATE='1|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|exited'
+
+	run_start_stack
+
+	[ "$status" -eq 0 ]
+	[ "$(cat "$LOCK_CREATE_ATTEMPT_FILE")" -eq 2 ]
+	grep -Fq '<inspect> <--format>' "$COMMAND_LOG"
+	grep -Fq '<rm> <-f> <dotfiles-hermes-storage-' "$COMMAND_LOG"
+	grep -Fq '<run> <--rm> <--entrypoint> <python>' "$COMMAND_LOG"
+}
+
+@test "surfaces a lock release failure after seed failure without deleting the volume" {
 	export HERMES_VOLUME_EXISTS=0
-	export HERMES_VOLUME_READY=0
+	export HERMES_STORAGE_SEED_STATUS=42
+	export HERMES_LOCK_RELEASE_STATUS=17
+
+	run_start_stack
+
+	[ "$status" -eq 17 ]
+	[[ "$output" == *"lock could not be released"* ]]
+	! grep -Fq '<volume> <rm>' "$COMMAND_LOG"
+	! grep -q '<secret-plan>' "$COMMAND_LOG"
+}
+
+@test "rejects a managed volume with a malformed initialization token before locking" {
+	export HERMES_VOLUME_SCHEMA_LABEL=1
+	export HERMES_VOLUME_TOKEN_LABEL=malformed
 
 	run_start_stack
 
 	[ "$status" -ne 0 ]
-	[[ "$output" == *"ready marker"* ]]
-	grep -Fq '<volume> <rm> <hermes-data>' "$COMMAND_LOG"
+	[[ "$output" == *"invalid initialization token"* ]]
+	! grep -Fq '<create> <--name>' "$COMMAND_LOG"
 	! grep -q '<secret-plan>' "$COMMAND_LOG"
 }
 


### PR DESCRIPTION
## Summary

- migrate Hermes runtime state into a Docker-managed named volume without mutating read-only SQLite/WAL/journal sources
- pin each managed volume with a fixed-name seed container, then use immutable container IDs for verify/start/release and safe stale-lock recovery
- bind readiness to the volume token with an exact regular-file marker written only after durable seed completion
- safely replace incomplete managed state on retry while leaving legacy/unmanaged volumes untouched
- keep Bash and PowerShell adapters behaviorally aligned
- run real Docker race/retry coverage in the Hermes CI workflow

## Verification

- `task lint`
- Bash adapter suite: 54 tests
- PowerShell storage suite: 14 tests
- Python storage suite: 15 tests
- Hermes bootstrap container suite: 595 tests, 12 skipped
- Hermes transaction suite: 53 tests
- real Docker storage integration: guard exclusion, deletion pinning, marker spoof rejection, partial retry, exited/created stale-lock recovery, immutable-ID cleanup

Closes #548
