### PR TITLE
fix(hermes): handle macOS bind mount entries

### DIFF
--- a/docker/hermes-agent/hermes_storage_seed.py
+++ b/docker/hermes-agent/hermes_storage_seed.py
@@ -17,7 +17,8 @@ from typing import Iterator
 
 TRANSIENT_SQLITE_SUFFIXES = ("-wal", "-shm", "-journal")
 READY_MARKER_NAME = ".dotfiles-hermes-storage-ready-v1"
-EXCLUDED_ROOT_ENTRIES = {".browser", ".op.env", ".xurl", READY_MARKER_NAME}
+EXCLUDED_ROOT_ENTRIES = {".browser", ".op.env", ".xurl", "gateway.sock", READY_MARKER_NAME}
+EXCLUDED_DIRECTORY_NAMES = {".cache"}
 ALLOWED_ABSOLUTE_SYMLINK_ROOT = Path("/opt/data")
 READY_TOKEN_PATTERN = re.compile(r"^[0-9a-f]{32}$")
 
@@ -79,6 +80,10 @@ def _is_within(path: Path, root: Path) -> bool:
     except ValueError:
         return False
     return True
+
+
+def _is_excluded_entry(name: str, *, is_root: bool) -> bool:
+    return name in EXCLUDED_DIRECTORY_NAMES or (is_root and name in EXCLUDED_ROOT_ENTRIES)
 
 
 def _copy_symlink(source_root: Path, source: Path, destination: Path) -> None:
@@ -171,7 +176,7 @@ def seed(source: Path, destination: Path, ready_token: str, *, replace_incomplet
         retained_directories: list[str] = []
         for directory_name in directory_names:
             relative_path = relative_directory / directory_name
-            if is_root and directory_name in EXCLUDED_ROOT_ENTRIES:
+            if _is_excluded_entry(directory_name, is_root=is_root):
                 continue
             source_path = source / relative_path
             if source_path.is_symlink():
@@ -184,14 +189,15 @@ def seed(source: Path, destination: Path, ready_token: str, *, replace_incomplet
         for file_name in file_names:
             if file_name.endswith(TRANSIENT_SQLITE_SUFFIXES):
                 continue
-            if is_root and file_name in EXCLUDED_ROOT_ENTRIES:
+            if _is_excluded_entry(file_name, is_root=is_root):
                 continue
             relative_path = relative_directory / file_name
             source_path = source / relative_path
-            if source_path.is_symlink():
+            source_metadata = source_path.lstat()
+            if stat.S_ISLNK(source_metadata.st_mode):
                 _copy_symlink(source, source_path, destination / relative_path)
                 continue
-            if not stat.S_ISREG(source_path.lstat().st_mode):
+            if not stat.S_ISREG(source_metadata.st_mode):
                 continue
             destination_path = destination / relative_path
             if source_path.suffix == ".db" and _is_sqlite_database(source_path):

--- a/docker/hermes-agent/tests/test_hermes_storage_seed.py
+++ b/docker/hermes-agent/tests/test_hermes_storage_seed.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import errno
 import os
 import socket
 import sqlite3
@@ -9,6 +10,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from hermes_storage_seed import seed
 
@@ -49,6 +51,111 @@ def _run_seed_without_source_write_access(source: Path, destination: Path) -> su
 
 
 class HermesStorageSeedTests(unittest.TestCase):
+    def test_skips_nested_cache_directories_with_external_symlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            profile_home = source / "profiles" / "nancy" / "home"
+            cache = profile_home / ".cache" / "uv" / "bin"
+            cache.mkdir(parents=True)
+            destination.mkdir()
+            (profile_home / "persistent.txt").write_text("kept\n", encoding="utf-8")
+            (cache / "python").symlink_to("/nix/store/unavailable-python")
+
+            seed(source, destination, TEST_TOKEN)
+
+            self.assertFalse((destination / "profiles" / "nancy" / "home" / ".cache").exists())
+            self.assertEqual(
+                (destination / "profiles" / "nancy" / "home" / "persistent.txt").read_text(
+                    encoding="utf-8"
+                ),
+                "kept\n",
+            )
+
+    def test_skips_nested_cache_symlink_classified_as_a_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            profile_home = source / "profiles" / "nancy" / "home"
+            profile_home.mkdir(parents=True)
+            destination.mkdir()
+            (profile_home / ".cache").symlink_to("/opt/data/missing-cache", target_is_directory=True)
+
+            seed(source, destination, TEST_TOKEN)
+
+            self.assertFalse((destination / "profiles" / "nancy" / "home" / ".cache").is_symlink())
+
+    def test_skips_entry_when_bind_mount_cannot_lstat_special_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            (source / "config.yaml").write_text("gateway: docker\n", encoding="utf-8")
+            socket_path = source / "gateway.sock"
+            socket_path.touch()
+            original_lstat = Path.lstat
+
+            def docker_desktop_lstat(path: Path) -> os.stat_result:
+                if path == socket_path:
+                    raise OSError(errno.ENOTSUP, "Operation not supported", str(path))
+                return original_lstat(path)
+
+            with mock.patch.object(Path, "lstat", docker_desktop_lstat):
+                seed(source, destination, TEST_TOKEN)
+
+            self.assertFalse((destination / "gateway.sock").exists())
+            self.assertEqual((destination / "config.yaml").read_text(encoding="utf-8"), "gateway: docker\n")
+            self.assertEqual(
+                (destination / ".dotfiles-hermes-storage-ready-v1").read_text(encoding="utf-8"),
+                f"version=1\nvolume_token={TEST_TOKEN}\n",
+            )
+
+    def test_propagates_unrelated_lstat_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            blocked_path = source / "blocked.txt"
+            blocked_path.touch()
+            original_lstat = Path.lstat
+
+            def denied_lstat(path: Path) -> os.stat_result:
+                if path == blocked_path:
+                    raise OSError(errno.EACCES, "Permission denied", str(path))
+                return original_lstat(path)
+
+            with mock.patch.object(Path, "lstat", denied_lstat):
+                with self.assertRaisesRegex(OSError, "Permission denied"):
+                    seed(source, destination, TEST_TOKEN)
+
+    def test_does_not_skip_persistent_file_when_lstat_is_unsupported(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            state_database = source / "state.db"
+            state_database.touch()
+            original_lstat = Path.lstat
+
+            def unsupported_lstat(path: Path) -> os.stat_result:
+                if path == state_database:
+                    raise OSError(errno.ENOTSUP, "Operation not supported", str(path))
+                return original_lstat(path)
+
+            with mock.patch.object(Path, "lstat", unsupported_lstat):
+                with self.assertRaisesRegex(OSError, "Operation not supported"):
+                    seed(source, destination, TEST_TOKEN)
+
+            self.assertFalse((destination / ".dotfiles-hermes-storage-ready-v1").exists())
+
     @unittest.skipUnless(hasattr(socket, "AF_UNIX"), "requires Unix domain sockets")
     def test_skips_unix_socket_and_publishes_ready_marker(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary

- exclude the root Hermes gateway socket before Docker Desktop metadata access
- exclude nested .cache entries regardless of whether os.walk classifies them as directories or symlink files
- keep persistent-file metadata failures fail-closed so the readiness marker cannot certify incomplete data

## Verification

- 22 Hermes storage seeder unit tests passed
- task lint passed, including Hermes bootstrap container tests
- real macOS ~/.hermes read-only bind mount seeded into a disposable Docker volume
- marker matched exactly; state.db/config.yaml present; gateway.sock and nested .cache absent
- independent Codex re-review: no remaining actionable findings

Closes #559