### PR TITLE
fix(hermes): exclude bootstrap transactions from seeding

### DIFF
--- a/docker/hermes-agent/hermes_storage_seed.py
+++ b/docker/hermes-agent/hermes_storage_seed.py
@@ -17,8 +17,16 @@ from typing import Iterator
 
 TRANSIENT_SQLITE_SUFFIXES = ("-wal", "-shm", "-journal")
 READY_MARKER_NAME = ".dotfiles-hermes-storage-ready-v1"
-EXCLUDED_ROOT_ENTRIES = {".browser", ".op.env", ".xurl", "gateway.sock", READY_MARKER_NAME}
+EXCLUDED_ROOT_ENTRIES = {
+    ".browser",
+    ".op.env",
+    ".xurl",
+    "gateway.sock",
+    READY_MARKER_NAME,
+}
 EXCLUDED_DIRECTORY_NAMES = {".cache"}
+EXCLUDED_RELATIVE_PATHS = {Path(".bootstrap/transactions")}
+PRIVATE_RELATIVE_DIRECTORIES = {Path(".bootstrap")}
 ALLOWED_ABSOLUTE_SYMLINK_ROOT = Path("/opt/data")
 READY_TOKEN_PATTERN = re.compile(r"^[0-9a-f]{32}$")
 
@@ -82,8 +90,12 @@ def _is_within(path: Path, root: Path) -> bool:
     return True
 
 
-def _is_excluded_entry(name: str, *, is_root: bool) -> bool:
-    return name in EXCLUDED_DIRECTORY_NAMES or (is_root and name in EXCLUDED_ROOT_ENTRIES)
+def _is_excluded_entry(relative_path: Path, *, is_root: bool) -> bool:
+    return (
+        relative_path in EXCLUDED_RELATIVE_PATHS
+        or relative_path.name in EXCLUDED_DIRECTORY_NAMES
+        or (is_root and relative_path.name in EXCLUDED_ROOT_ENTRIES)
+    )
 
 
 def _copy_symlink(source_root: Path, source: Path, destination: Path) -> None:
@@ -172,11 +184,13 @@ def seed(source: Path, destination: Path, ready_token: str, *, replace_incomplet
         is_root = relative_directory == Path(".")
         destination_directory = destination / relative_directory
         destination_directory.mkdir(parents=True, exist_ok=True)
+        if relative_directory in PRIVATE_RELATIVE_DIRECTORIES:
+            destination_directory.chmod(0o700)
 
         retained_directories: list[str] = []
         for directory_name in directory_names:
             relative_path = relative_directory / directory_name
-            if _is_excluded_entry(directory_name, is_root=is_root):
+            if _is_excluded_entry(relative_path, is_root=is_root):
                 continue
             source_path = source / relative_path
             if source_path.is_symlink():
@@ -189,9 +203,9 @@ def seed(source: Path, destination: Path, ready_token: str, *, replace_incomplet
         for file_name in file_names:
             if file_name.endswith(TRANSIENT_SQLITE_SUFFIXES):
                 continue
-            if _is_excluded_entry(file_name, is_root=is_root):
-                continue
             relative_path = relative_directory / file_name
+            if _is_excluded_entry(relative_path, is_root=is_root):
+                continue
             source_path = source / relative_path
             source_metadata = source_path.lstat()
             if stat.S_ISLNK(source_metadata.st_mode):

--- a/docker/hermes-agent/hermes_storage_seed.py
+++ b/docker/hermes-agent/hermes_storage_seed.py
@@ -162,6 +162,33 @@ def _validate_paths(source: Path, destination: Path, ready_token: str) -> None:
         raise ValueError(f"destination must be a real directory: {destination}")
 
 
+def _validate_source_transaction_state(source: Path) -> None:
+    store = source / ".bootstrap" / "transactions"
+    descriptor: int | None = None
+    try:
+        flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_DIRECTORY", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(store, flags)
+        opened = os.fstat(descriptor)
+        if not stat.S_ISDIR(opened.st_mode):
+            raise OSError
+        with os.scandir(descriptor) as entries:
+            if any(entry.name != ".lock" for entry in entries):
+                raise ValueError(
+                    "source contains bootstrap transaction recovery state; "
+                    "recover the source before seeding"
+                )
+    except FileNotFoundError:
+        return
+    except ValueError:
+        raise
+    except OSError:
+        raise ValueError(f"source bootstrap transaction store is unsafe: {store}") from None
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
 def _clear_destination(destination: Path) -> None:
     for path in destination.iterdir():
         if path.is_dir() and not path.is_symlink():
@@ -174,6 +201,7 @@ def seed(source: Path, destination: Path, ready_token: str, *, replace_incomplet
     """Copy a stopped Hermes home into a destination and publish readiness."""
 
     _validate_paths(source, destination, ready_token)
+    _validate_source_transaction_state(source)
     if replace_incomplete:
         _clear_destination(destination)
     elif any(destination.iterdir()):

--- a/docker/hermes-agent/tests/test_hermes_storage_seed.py
+++ b/docker/hermes-agent/tests/test_hermes_storage_seed.py
@@ -51,7 +51,32 @@ def _run_seed_without_source_write_access(source: Path, destination: Path) -> su
 
 
 class HermesStorageSeedTests(unittest.TestCase):
-    def test_skips_root_bootstrap_transaction_state(self) -> None:
+    def test_rejects_unfinished_root_bootstrap_transaction_state(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            transaction = source / ".bootstrap" / "transactions"
+            transaction.mkdir(parents=True)
+            destination.mkdir()
+            sentinel = destination / "existing.txt"
+            sentinel.write_text("preserved\n", encoding="utf-8")
+            (source / "config.yaml").write_text("gateway: docker\n", encoding="utf-8")
+            state = source / ".bootstrap" / "root-distribution-state.json"
+            state.write_text('{"version": 1}\n', encoding="utf-8")
+            state.chmod(0o600)
+            (transaction / "unsafe").symlink_to("/outside-hermes-data")
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "source contains bootstrap transaction recovery state",
+            ):
+                seed(source, destination, TEST_TOKEN, replace_incomplete=True)
+
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "preserved\n")
+            self.assertFalse((destination / ".dotfiles-hermes-storage-ready-v1").exists())
+
+    def test_skips_idle_root_bootstrap_transaction_store(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             source = root / "source"
@@ -63,7 +88,7 @@ class HermesStorageSeedTests(unittest.TestCase):
             state = source / ".bootstrap" / "root-distribution-state.json"
             state.write_text('{"version": 1}\n', encoding="utf-8")
             state.chmod(0o600)
-            (transaction / "unsafe").symlink_to("/outside-hermes-data")
+            (transaction / ".lock").write_text("", encoding="utf-8")
 
             seed(source, destination, TEST_TOKEN)
 
@@ -89,7 +114,8 @@ class HermesStorageSeedTests(unittest.TestCase):
             bootstrap = source / ".bootstrap"
             bootstrap.mkdir()
             transactions = bootstrap / "transactions"
-            transactions.symlink_to(source / "missing-transactions", target_is_directory=True)
+            transactions.mkdir()
+            (transactions / ".lock").touch()
             original_lstat = Path.lstat
 
             def docker_desktop_lstat(path: Path) -> os.stat_result:

--- a/docker/hermes-agent/tests/test_hermes_storage_seed.py
+++ b/docker/hermes-agent/tests/test_hermes_storage_seed.py
@@ -51,6 +51,58 @@ def _run_seed_without_source_write_access(source: Path, destination: Path) -> su
 
 
 class HermesStorageSeedTests(unittest.TestCase):
+    def test_skips_root_bootstrap_transaction_state(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            transaction = source / ".bootstrap" / "transactions"
+            transaction.mkdir(parents=True)
+            destination.mkdir()
+            (source / "config.yaml").write_text("gateway: docker\n", encoding="utf-8")
+            state = source / ".bootstrap" / "root-distribution-state.json"
+            state.write_text('{"version": 1}\n', encoding="utf-8")
+            state.chmod(0o600)
+            (transaction / "unsafe").symlink_to("/outside-hermes-data")
+
+            seed(source, destination, TEST_TOKEN)
+
+            copied_bootstrap = destination / ".bootstrap"
+            self.assertEqual(copied_bootstrap.stat().st_mode & 0o777, 0o700)
+            self.assertFalse((copied_bootstrap / "transactions").exists())
+            self.assertEqual(
+                (copied_bootstrap / "root-distribution-state.json").read_text(encoding="utf-8"),
+                '{"version": 1}\n',
+            )
+            self.assertEqual(
+                (destination / "config.yaml").read_text(encoding="utf-8"),
+                "gateway: docker\n",
+            )
+
+    def test_skips_root_bootstrap_transactions_before_lstat(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            bootstrap = source / ".bootstrap"
+            bootstrap.mkdir()
+            transactions = bootstrap / "transactions"
+            transactions.symlink_to(source / "missing-transactions", target_is_directory=True)
+            original_lstat = Path.lstat
+
+            def docker_desktop_lstat(path: Path) -> os.stat_result:
+                if path == transactions:
+                    raise OSError(errno.ENOTSUP, "Operation not supported", str(path))
+                return original_lstat(path)
+
+            with mock.patch.object(Path, "lstat", docker_desktop_lstat):
+                seed(source, destination, TEST_TOKEN)
+
+            self.assertTrue((destination / ".bootstrap").is_dir())
+            self.assertFalse((destination / ".bootstrap" / "transactions").exists())
+
     def test_skips_nested_cache_directories_with_external_symlinks(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
Closes #561

## Summary
- preflight the stopped host transaction store before any destination clearing
- reject unfinished recovery state instead of publishing a partially mutated volume
- exclude only an idle `.bootstrap/transactions` store from host-to-volume migration
- preserve `.bootstrap/root-distribution-state.json` and create `.bootstrap` with mode `0700`
- test unsafe recovery state, destination preservation, and pre-`lstat` exclusion

## Verification
- `PYTHONPATH=docker/hermes-agent python3 -m unittest docker/hermes-agent/tests/test_hermes_storage_seed.py -v` (25 passed)
- `task hermes:bootstrap:test` (595 bootstrap tests, 25 storage tests, 53 transaction tests, integration and provenance passed)
- `task lint`