### PR TITLE
fix(codex): update skill for current CLI syntax

### DIFF
--- a/chezmoi/dot_agents/skills/codex/SKILL.md
+++ b/chezmoi/dot_agents/skills/codex/SKILL.md
@@ -14,7 +14,7 @@ Skill for running code review and analysis via Codex CLI.
 ## Command
 
 ```bash
-codex exec --full-auto --sandbox read-only --cd <project_directory> "<request>"
+codex exec --sandbox read-only --cd <project_directory> "<request>"
 ```
 
 ## Prompt Rules
@@ -27,7 +27,6 @@ codex exec --full-auto --sandbox read-only --cd <project_directory> "<request>"
 
 | Parameter             | Description                          |
 | --------------------- | ------------------------------------ |
-| `--full-auto`         | Run in fully automatic mode          |
 | `--sandbox read-only` | Read-only sandbox (safe analysis)    |
 | `--cd <dir>`          | Target project directory             |
 | `"<request>"`         | Request content (Japanese supported) |
@@ -37,31 +36,31 @@ codex exec --full-auto --sandbox read-only --cd <project_directory> "<request>"
 ### Code Review
 
 ```bash
-codex exec --full-auto --sandbox read-only --cd /path/to/project "Review this project's code and point out improvements. No confirmation or questions needed. Provide concrete fixes and code examples proactively."
+codex exec --sandbox read-only --cd /path/to/project "Review this project's code and point out improvements. No confirmation or questions needed. Provide concrete fixes and code examples proactively."
 ```
 
 ### Bug Investigation
 
 ```bash
-codex exec --full-auto --sandbox read-only --cd /path/to/project "Investigate the cause of the authentication error. No confirmation or questions needed. Identify the root cause and provide concrete fixes proactively."
+codex exec --sandbox read-only --cd /path/to/project "Investigate the cause of the authentication error. No confirmation or questions needed. Identify the root cause and provide concrete fixes proactively."
 ```
 
 ### Architecture Analysis
 
 ```bash
-codex exec --full-auto --sandbox read-only --cd /path/to/project "Analyze and explain this project's architecture. No confirmation or questions needed. Provide improvement suggestions proactively."
+codex exec --sandbox read-only --cd /path/to/project "Analyze and explain this project's architecture. No confirmation or questions needed. Provide improvement suggestions proactively."
 ```
 
 ### Refactoring Proposal
 
 ```bash
-codex exec --full-auto --sandbox read-only --cd /path/to/project "Identify technical debt and propose a refactoring plan. No confirmation or questions needed. Provide concrete code examples proactively."
+codex exec --sandbox read-only --cd /path/to/project "Identify technical debt and propose a refactoring plan. No confirmation or questions needed. Provide concrete code examples proactively."
 ```
 
 ### Design Consultation (UI/UX)
 
 ```bash
-codex exec --full-auto --sandbox read-only --cd /path/to/project "As a world-class UI designer, evaluate this project's UI from these perspectives: (1) visual hierarchy and typography, (2) spacing rhythm, (3) color palette contrast and accessibility, (4) interaction pattern consistency, (5) cognitive load reduction. No confirmation or questions needed. Provide concrete improvements with code examples proactively."
+codex exec --sandbox read-only --cd /path/to/project "As a world-class UI designer, evaluate this project's UI from these perspectives: (1) visual hierarchy and typography, (2) spacing rhythm, (3) color palette contrast and accessibility, (4) interaction pattern consistency, (5) cognitive load reduction. No confirmation or questions needed. Provide concrete improvements with code examples proactively."
 ```
 
 ## Execution Steps
@@ -69,5 +68,5 @@ codex exec --full-auto --sandbox read-only --cd /path/to/project "As a world-cla
 1. Receive the request from the user
 2. Determine the target project directory (current working directory or user-specified)
 3. Compose the prompt and append "No confirmation or questions needed. Provide concrete suggestions proactively."
-4. Run Codex with the command format above
+4. Run Codex with the command format above. `codex exec` is already non-interactive; do not add the removed `--full-auto` flag.
 5. Report the results to the user


### PR DESCRIPTION
Closes #563

## Summary
- remove the retired `--full-auto` option from all documented Codex commands
- keep read-only reviews explicit with `--sandbox read-only`
- document that `codex exec` is already non-interactive

## Verification
- current `codex exec --sandbox read-only --cd <repo> --help` exits successfully
- all bash command blocks are free of `--full-auto`
- SKILL.md YAML frontmatter parses successfully
- `task lint`