### PR TITLE
fix(macos): make Hermes Desktop setup atomic

### DIFF
--- a/docker/hermes-agent/Dockerfile
+++ b/docker/hermes-agent/Dockerfile
@@ -32,12 +32,26 @@ def replace_once(path: Path, old: str, new: str) -> None:
     path.write_text(text.replace(old, new), encoding="utf-8")
 
 
-def replace_pattern_once(path: Path, pattern: str, replacement: str) -> None:
+def replace_pattern_variant_once(path: Path, variants: list[tuple[str, str]]) -> None:
     text = path.read_text(encoding="utf-8")
-    updated, count = re.subn(pattern, replacement, text, count=1)
-    if count != 1:
-        raise SystemExit(f"expected exactly one pinned source match in {path}")
-    path.write_text(updated, encoding="utf-8")
+    matches = [
+        (pattern, replacement)
+        for pattern, replacement in variants
+        if len(re.findall(pattern, text)) == 1
+    ]
+    if len(matches) != 1:
+        raise SystemExit(f"expected exactly one pinned source variant in {path}")
+    pattern, replacement = matches[0]
+    path.write_text(re.sub(pattern, replacement, text, count=1), encoding="utf-8")
+
+
+def replace_variant_once(path: Path, variants: list[tuple[str, str]]) -> None:
+    text = path.read_text(encoding="utf-8")
+    matches = [(old, new) for old, new in variants if text.count(old) == 1]
+    if len(matches) != 1:
+        raise SystemExit(f"expected exactly one pinned source variant in {path}")
+    old, new = matches[0]
+    path.write_text(text.replace(old, new), encoding="utf-8")
 
 
 replace_once(
@@ -45,14 +59,24 @@ replace_once(
     'types="public_channel,private_channel",',
     'types="public_channel",',
 )
-replace_pattern_once(
+replace_pattern_variant_once(
     Path("/opt/hermes/toolsets.py"),
-    r'("browser_dialog"(?:,\s*"browser_exec")?),\s*"web_search"',
-    r'\1',
+    [
+        (
+            r'("browser_dialog"(?:,\s*"browser_exec")?),\s*"web_search"',
+            r'\1',
+        ),
+        (
+            r'(\[t for t in _HERMES_CORE_TOOLS if t\.startswith\("browser_"\)\])\s*\+\s*\["web_search"\]',
+            r'\1',
+        ),
+    ],
 )
-replace_once(
+replace_variant_once(
     Path("/opt/hermes/plugins/platforms/discord/adapter.py"),
-    '''    def _self_is_explicitly_mentioned(self, message: Any) -> bool:
+    [
+        (
+            '''    def _self_is_explicitly_mentioned(self, message: Any) -> bool:
         """Return True when this bot is explicitly @mentioned in the message.
 
         Treats the bot as mentioned if it is either present in the resolved
@@ -65,7 +89,7 @@ replace_once(
             return True
         return str(self._client.user.id) in self._raw_mentioned_user_ids(message)
 ''',
-    '''    def _self_is_explicitly_mentioned(self, message: Any) -> bool:
+            '''    def _self_is_explicitly_mentioned(self, message: Any) -> bool:
         """Return True when this bot is explicitly @mentioned in the message.
 
         In addition to direct user mentions, Discord creates a managed role
@@ -97,6 +121,50 @@ replace_once(
             for role in role_mentions
         )
 ''',
+        ),
+        (
+            '''    def _self_is_explicitly_mentioned(self, message: Any) -> bool:
+        """True when the bot is in ``message.mentions`` or raw-mentioned in the content."""
+        if not self._client or not self._client.user:
+            return False
+        if self._client.user in getattr(message, "mentions", []):
+            return True
+        return str(self._client.user.id) in self._raw_mentioned_user_ids(message)
+''',
+            '''    def _self_is_explicitly_mentioned(self, message: Any) -> bool:
+        """Return True when this bot is explicitly @mentioned in the message.
+
+        In addition to direct user mentions, Discord creates a managed role
+        for each bot.  Discord renders that role as the bot's display name,
+        but sends it as ``<@&ROLE_ID>`` and leaves ``message.mentions`` empty.
+        Treat only a managed role owned by this bot as an equivalent mention;
+        ordinary role mentions must not wake the bot.
+        """
+        if not self._client or not self._client.user:
+            return False
+        if self._client.user in getattr(message, "mentions", []):
+            return True
+        if str(self._client.user.id) in self._raw_mentioned_user_ids(message):
+            return True
+
+        bot_id = int(self._client.user.id)
+        role_mentions = list(getattr(message, "role_mentions", []))
+        raw_role_ids = re.findall(r"<@&([0-9]+)>", getattr(message, "content", "") or "")
+        guild = getattr(message, "guild", None)
+        get_role = getattr(guild, "get_role", None)
+        if callable(get_role):
+            for raw_role_id in raw_role_ids:
+                role = get_role(int(raw_role_id))
+                if role is not None:
+                    role_mentions.append(role)
+
+        return any(
+            getattr(getattr(role, "tags", None), "bot_id", None) == bot_id
+            for role in role_mentions
+        )
+''',
+        ),
+    ],
 )
 PY
 

--- a/docs/hermes-agent/desktop.md
+++ b/docs/hermes-agent/desktop.md
@@ -5,19 +5,34 @@
 macOS の `./install.sh --with-hermes` は、次の2つを別々に管理します。
 
 - ホスト: 公式 Homebrew Cask `hermes-desktop` を nix-homebrew で宣言し、
-  `/Applications/Hermes.app` にベンダー配布版を導入する。
+  `/Applications/Hermes.app` に公式セットアップアプリを導入する。セットアップは
+  Hermes の管理runtime、CLI、packaged Desktopをユーザー領域へ導入する。
 - Docker: `docker/hermes-service/compose.yml` の Hermes Agent、gateway、Web
   Dashboard、Browser/MCP サービスを起動する。
 
 Desktop の GUI を Agent コンテナに入れる必要はありません。コンテナは GUI を
 提供するイメージではなく、Agent の実行環境と Dashboard/API を提供します。
 
+## 公式セットアップ
+
+`./install.sh --with-hermes` はcaskの配置だけでは成功扱いにしません。
+`task hermes:desktop:install` が公式セットアップを起動し、次のすべてが揃うまで
+待機します。
+
+- `~/.local/bin/hermes`
+- `~/.hermes/hermes-agent/.hermes-bootstrap-complete`
+- `~/.hermes/hermes-agent/apps/desktop/release/.../Hermes.app/Contents/MacOS/Hermes`
+
+セットアップ起動時は、呼び出し元だけに有効な
+`GIT_CONFIG_COUNT`、`GIT_CONFIG_KEY_*`、`GIT_CONFIG_VALUE_*`を継承しません。
+これにより、欠けたcommand-scope設定でセットアップ内部の`git clone`が毎回失敗する
+状態を防ぎます。完了済みの場合はセットアップを再起動せず、成果物を再検証します。
+
 ## CLI の実行
 
-Hermes Desktop は GUI フロントエンドであり、macOS ホストのシェルで CLI を
-実行する機能はありません。また、この構成では公式の CLI は Docker コンテナ内に
-だけ存在します。そのため `WithHermes` プロファイルでは、ホストの
-`hermes-docker` が既存の `hermes` サービスへコマンドを転送します。
+公式セットアップはmacOSホストに`~/.local/bin/hermes`を導入します。これはDesktop
+自身が使うローカルruntimeを操作します。Docker上の既存Hermes Agentを明示的に
+操作する場合は、`WithHermes`プロファイルの`hermes-docker`を使用します。
 
 リポジトリからは、次のように実行できます。引数はコンテナ内の CLI へそのまま
 渡されます。

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -70,6 +70,7 @@ in
 
     # PATH: bun and pnpm global binaries
     sessionPath = [
+      "$HOME/.local/bin"
       "$HOME/.bun/bin"
       "$HOME/.local/share/pnpm/bin"
       "$HOME/.local/share/pnpm"

--- a/scripts/sh/hermes-desktop-install.sh
+++ b/scripts/sh/hermes-desktop-install.sh
@@ -31,7 +31,8 @@ hermes_desktop_executable() {
 hermes_desktop_install_is_complete() {
   [[ -x $HERMES_CLI_PATH ]] || return 1
   [[ -f $HERMES_ROOT/.hermes-bootstrap-complete ]] || return 1
-  hermes_desktop_executable >/dev/null
+  hermes_desktop_executable >/dev/null || return 1
+  "$HERMES_CLI_PATH" --version >/dev/null 2>&1
 }
 
 launch_official_hermes_setup() {

--- a/scripts/sh/hermes-desktop-install.sh
+++ b/scripts/sh/hermes-desktop-install.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+export DOTFILES_LOG_PREFIX="hermes-desktop-install"
+# shellcheck source=/dev/null
+. "$ROOT/scripts/sh/install-common.sh"
+
+HERMES_APP_PATH="${DOTFILES_HERMES_APP_PATH:-/Applications/Hermes.app}"
+HERMES_CLI_PATH="${DOTFILES_HERMES_CLI_PATH:-$HOME/.local/bin/hermes}"
+HERMES_ROOT="${DOTFILES_HERMES_ROOT:-$HOME/.hermes/hermes-agent}"
+HERMES_OPEN_COMMAND="${DOTFILES_HERMES_OPEN_COMMAND:-/usr/bin/open}"
+HERMES_SETUP_WAIT_ATTEMPTS="${DOTFILES_HERMES_SETUP_WAIT_ATTEMPTS:-900}"
+HERMES_CLI_DIR="$(dirname "$HERMES_CLI_PATH")"
+export PATH="$HERMES_CLI_DIR:$PATH"
+
+hermes_desktop_executable() {
+  local candidate
+  for candidate in \
+    "$HERMES_ROOT/apps/desktop/release/mac/Hermes.app/Contents/MacOS/Hermes" \
+    "$HERMES_ROOT/apps/desktop/release/mac-arm64/Hermes.app/Contents/MacOS/Hermes"; do
+    if [[ -x $candidate ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+hermes_desktop_install_is_complete() {
+  [[ -x $HERMES_CLI_PATH ]] || return 1
+  [[ -f $HERMES_ROOT/.hermes-bootstrap-complete ]] || return 1
+  hermes_desktop_executable >/dev/null
+}
+
+launch_official_hermes_setup() {
+  local setup_executable="$HERMES_APP_PATH/Contents/MacOS/Hermes-Setup"
+  [[ -x $setup_executable ]] ||
+    dotfiles_die "Official Hermes setup is unavailable: $setup_executable"
+
+  if [[ $HERMES_OPEN_COMMAND == */* ]]; then
+    [[ -x $HERMES_OPEN_COMMAND ]] ||
+      dotfiles_die "macOS open command is unavailable: $HERMES_OPEN_COMMAND"
+  else
+    dotfiles_have "$HERMES_OPEN_COMMAND" ||
+      dotfiles_die "macOS open command is unavailable: $HERMES_OPEN_COMMAND"
+  fi
+
+  # Git's command-scope config is meaningful only to the process that created
+  # it. Desktop setup launches later through LaunchServices, so inheriting the
+  # numbered tuple can leak credentials or leave an incomplete tuple that makes
+  # every internal git command fail before cloning Hermes.
+  dotfiles_unset_git_command_config_environment
+  "$HERMES_OPEN_COMMAND" -n "$HERMES_APP_PATH"
+}
+
+main() {
+  if ! hermes_desktop_install_is_complete; then
+    dotfiles_log "Launching the official Hermes Desktop setup. Complete the visible installer window..."
+    launch_official_hermes_setup
+    dotfiles_wait_for \
+      "$HERMES_SETUP_WAIT_ATTEMPTS" \
+      "Hermes Desktop setup completion" \
+      hermes_desktop_install_is_complete
+  fi
+
+  "$HERMES_CLI_PATH" --version >/dev/null
+  hermes_desktop_executable >/dev/null
+  dotfiles_log "Official Hermes Desktop runtime and CLI are ready."
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/sh/install-common.sh
+++ b/scripts/sh/install-common.sh
@@ -27,7 +27,7 @@ dotfiles_unset_git_command_config_environment() {
 }
 
 dotfiles_sanitize_incomplete_git_config_environment() {
-  local count="${GIT_CONFIG_COUNT:-}" index
+  local count="${GIT_CONFIG_COUNT:-}" index key
   [[ -n $count ]] || return 0
 
   if [[ ! $count =~ ^[0-9]+$ ]]; then
@@ -36,7 +36,8 @@ dotfiles_sanitize_incomplete_git_config_environment() {
   fi
 
   for ((index = 0; index < count; index++)); do
-    if ! /usr/bin/printenv "GIT_CONFIG_KEY_$index" >/dev/null 2>&1 ||
+    if ! key="$(/usr/bin/printenv "GIT_CONFIG_KEY_$index")" ||
+      [[ -z $key ]] ||
       ! /usr/bin/printenv "GIT_CONFIG_VALUE_$index" >/dev/null 2>&1; then
       dotfiles_unset_git_command_config_environment
       return 0

--- a/scripts/sh/install-common.sh
+++ b/scripts/sh/install-common.sh
@@ -17,6 +17,33 @@ dotfiles_have() {
   command -v "$1" >/dev/null 2>&1
 }
 
+dotfiles_unset_git_command_config_environment() {
+  local name
+  while IFS='=' read -r name _; do
+    case "$name" in
+    GIT_CONFIG_COUNT | GIT_CONFIG_KEY_* | GIT_CONFIG_VALUE_*) unset "$name" ;;
+    esac
+  done < <(/usr/bin/env)
+}
+
+dotfiles_sanitize_incomplete_git_config_environment() {
+  local count="${GIT_CONFIG_COUNT:-}" index
+  [[ -n $count ]] || return 0
+
+  if [[ ! $count =~ ^[0-9]+$ ]]; then
+    dotfiles_unset_git_command_config_environment
+    return 0
+  fi
+
+  for ((index = 0; index < count; index++)); do
+    if ! /usr/bin/printenv "GIT_CONFIG_KEY_$index" >/dev/null 2>&1 ||
+      ! /usr/bin/printenv "GIT_CONFIG_VALUE_$index" >/dev/null 2>&1; then
+      dotfiles_unset_git_command_config_environment
+      return 0
+    fi
+  done
+}
+
 dotfiles_herdr_command() {
   local candidate
 

--- a/scripts/sh/install-macos.sh
+++ b/scripts/sh/install-macos.sh
@@ -465,6 +465,7 @@ migrate_darwin_providers() {
 }
 
 main() {
+  dotfiles_sanitize_incomplete_git_config_environment
   resolve_install_profile "$@"
   preflight
   ensure_command_line_tools
@@ -482,6 +483,9 @@ main() {
   dotfiles_install_herdr
   ensure_homebrew_cask_link_directories
   apply_chezmoi
+  if ((DOTFILES_WITH_HERMES == 1)); then
+    dotfiles_run_task hermes:desktop:install
+  fi
   if ((DOTFILES_WITH_OLLAMA == 1)); then
     setup_ollama_runtime
   fi

--- a/taskfiles/hermes/taskfile.yml
+++ b/taskfiles/hermes/taskfile.yml
@@ -206,6 +206,12 @@ tasks:
       - cmd: hermes-desktop-docker
         platforms: [darwin]
 
+  hermes:desktop:install:
+    desc: Complete and verify the official Hermes Desktop installation
+    cmds:
+      - cmd: scripts/sh/hermes-desktop-install.sh
+        platforms: [darwin]
+
   hermes:cli:
     desc: Run the Hermes CLI inside the Docker Agent container
     interactive: true

--- a/tests/bash/hermes_desktop_install.bats
+++ b/tests/bash/hermes_desktop_install.bats
@@ -79,6 +79,22 @@ chmod +x "$DOTFILES_HERMES_CLI_PATH" "$desktop"
 	[ ! -s "$COMMAND_LOG" ]
 }
 
+@test "a corrupt CLI causes the official setup to repair the install" {
+	write_completed_install
+	printf '#!/usr/bin/env bash\nexit 17\n' >"$DOTFILES_HERMES_CLI_PATH"
+	chmod +x "$DOTFILES_HERMES_CLI_PATH"
+	write_stub open '
+printf "open %s\n" "$*" >>"$COMMAND_LOG"
+printf "#!/usr/bin/env bash\nprintf \\"Hermes 0.21.0\\\\n\\"\n" >"$DOTFILES_HERMES_CLI_PATH"
+chmod +x "$DOTFILES_HERMES_CLI_PATH"
+'
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 0 ]
+	grep -Fqx "open -n $DOTFILES_HERMES_APP_PATH" "$COMMAND_LOG"
+}
+
 @test "setup does not succeed without the packaged Desktop artifact" {
 	write_stub open '
 mkdir -p "$(dirname "$DOTFILES_HERMES_CLI_PATH")" "$DOTFILES_HERMES_ROOT"

--- a/tests/bash/hermes_desktop_install.bats
+++ b/tests/bash/hermes_desktop_install.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+	INSTALLER="$REPO_ROOT/scripts/sh/hermes-desktop-install.sh"
+	TEST_HOME="$BATS_TEST_TMPDIR/home"
+	STUB_BIN="$BATS_TEST_TMPDIR/bin"
+	COMMAND_LOG="$BATS_TEST_TMPDIR/commands.log"
+	export HOME="$TEST_HOME"
+	export PATH="$STUB_BIN:/usr/bin:/bin"
+	export COMMAND_LOG
+	export DOTFILES_HERMES_APP_PATH="$BATS_TEST_TMPDIR/Applications/Hermes.app"
+	export DOTFILES_HERMES_CLI_PATH="$TEST_HOME/.local/bin/hermes"
+	export DOTFILES_HERMES_ROOT="$TEST_HOME/.hermes/hermes-agent"
+	export DOTFILES_HERMES_OPEN_COMMAND="$STUB_BIN/open"
+	export DOTFILES_HERMES_SETUP_WAIT_ATTEMPTS=2
+	export DOTFILES_WAIT_SLEEP_SECONDS=0
+
+	mkdir -p "$DOTFILES_HERMES_APP_PATH/Contents/MacOS" "$STUB_BIN"
+	printf '#!/usr/bin/env bash\nexit 0\n' >"$DOTFILES_HERMES_APP_PATH/Contents/MacOS/Hermes-Setup"
+	chmod +x "$DOTFILES_HERMES_APP_PATH/Contents/MacOS/Hermes-Setup"
+	: >"$COMMAND_LOG"
+}
+
+write_stub() {
+	local name="$1"
+	local body="$2"
+	{
+		printf '#!/usr/bin/env bash\n'
+		printf 'set -euo pipefail\n'
+		printf '%s\n' "$body"
+	} >"$STUB_BIN/$name"
+	chmod +x "$STUB_BIN/$name"
+}
+
+write_completed_install() {
+	local desktop="$DOTFILES_HERMES_ROOT/apps/desktop/release/mac-arm64/Hermes.app/Contents/MacOS/Hermes"
+	mkdir -p "$(dirname "$DOTFILES_HERMES_CLI_PATH")" "$(dirname "$desktop")"
+	touch "$DOTFILES_HERMES_ROOT/.hermes-bootstrap-complete"
+	printf '#!/usr/bin/env bash\nprintf "Hermes 0.21.0\\n"\n' >"$DOTFILES_HERMES_CLI_PATH"
+	printf '#!/usr/bin/env bash\nexit 0\n' >"$desktop"
+	chmod +x "$DOTFILES_HERMES_CLI_PATH" "$desktop"
+}
+
+@test "official setup is launched without inherited Git command config" {
+	write_stub open '
+env | grep -Eq "^GIT_CONFIG_(COUNT|KEY_[0-9]+|VALUE_[0-9]+)=" && exit 41
+printf "%s\n" "$PATH" | tr ":" "\n" | grep -Fx "$(dirname "$DOTFILES_HERMES_CLI_PATH")" >/dev/null || exit 42
+printf "open %s\n" "$*" >>"$COMMAND_LOG"
+desktop="$DOTFILES_HERMES_ROOT/apps/desktop/release/mac-arm64/Hermes.app/Contents/MacOS/Hermes"
+mkdir -p "$(dirname "$DOTFILES_HERMES_CLI_PATH")" "$(dirname "$desktop")"
+touch "$DOTFILES_HERMES_ROOT/.hermes-bootstrap-complete"
+printf "#!/usr/bin/env bash\nprintf \\"Hermes 0.21.0\\\\n\\"\n" >"$DOTFILES_HERMES_CLI_PATH"
+printf "#!/usr/bin/env bash\nexit 0\n" >"$desktop"
+chmod +x "$DOTFILES_HERMES_CLI_PATH" "$desktop"
+'
+
+	run env \
+		GIT_CONFIG_COUNT=2 \
+		GIT_CONFIG_KEY_0=credential.helper \
+		GIT_CONFIG_VALUE_0=one \
+		GIT_CONFIG_KEY_1=url.example.insteadOf \
+		GIT_CONFIG_VALUE_1=two \
+		"$INSTALLER"
+
+	[ "$status" -eq 0 ]
+	grep -Fqx "open -n $DOTFILES_HERMES_APP_PATH" "$COMMAND_LOG"
+}
+
+@test "completed official install is an idempotent no-op" {
+	write_completed_install
+	write_stub open 'printf "open %s\n" "$*" >>"$COMMAND_LOG"; exit 42'
+
+	run "$INSTALLER"
+
+	[ "$status" -eq 0 ]
+	[ ! -s "$COMMAND_LOG" ]
+}
+
+@test "setup does not succeed without the packaged Desktop artifact" {
+	write_stub open '
+mkdir -p "$(dirname "$DOTFILES_HERMES_CLI_PATH")" "$DOTFILES_HERMES_ROOT"
+touch "$DOTFILES_HERMES_ROOT/.hermes-bootstrap-complete"
+printf "#!/usr/bin/env bash\nprintf \\"Hermes 0.21.0\\\\n\\"\n" >"$DOTFILES_HERMES_CLI_PATH"
+chmod +x "$DOTFILES_HERMES_CLI_PATH"
+'
+
+	run "$INSTALLER"
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Timed out waiting for Hermes Desktop setup completion"* ]]
+}

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -476,6 +476,21 @@ printf "nix %s\n" "$*" >>"$COMMAND_LOG"
 	[ "$status" -eq 0 ]
 }
 
+@test "macOS installer clears an inherited Git command config with an empty key" {
+	write_installed_stubs
+	write_stub nix '
+env | grep -Eq "^GIT_CONFIG_(COUNT|KEY_[0-9]+|VALUE_[0-9]+)=" && exit 43
+printf "nix %s\n" "$*" >>"$COMMAND_LOG"
+'
+	export GIT_CONFIG_COUNT=1
+	export GIT_CONFIG_KEY_0=''
+	export GIT_CONFIG_VALUE_0=one
+
+	run_macos_installer
+
+	[ "$status" -eq 0 ]
+}
+
 @test "WithOllama starts its API after chezmoi without starting Docker" {
 	write_installed_stubs
 	write_stub launchctl 'printf "launchctl %s\\n" "$*" >>"$COMMAND_LOG"'

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -461,6 +461,21 @@ run_macos_installer() {
 	! grep -q '^task .*\(hindsight:up\|hermes:bootstrap\)' "$COMMAND_LOG"
 }
 
+@test "macOS installer clears an incomplete inherited Git command config" {
+	write_installed_stubs
+	write_stub nix '
+env | grep -Eq "^GIT_CONFIG_(COUNT|KEY_[0-9]+|VALUE_[0-9]+)=" && exit 43
+printf "nix %s\n" "$*" >>"$COMMAND_LOG"
+'
+	export GIT_CONFIG_COUNT=2
+	export GIT_CONFIG_VALUE_0=one
+	export GIT_CONFIG_VALUE_1=two
+
+	run_macos_installer
+
+	[ "$status" -eq 0 ]
+}
+
 @test "WithOllama starts its API after chezmoi without starting Docker" {
 	write_installed_stubs
 	write_stub launchctl 'printf "launchctl %s\\n" "$*" >>"$COMMAND_LOG"'
@@ -546,6 +561,7 @@ exit 1
 		"migrate-darwin-provider --all --feature WithOllama --feature WithDocker --feature WithHermes" \
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
 		"chezmoi apply --force" \
+		"task --dir $REPO_ROOT hermes:desktop:install" \
 		"docker info" \
 		"docker compose -f $REPO_ROOT/docker/hermes-service/compose.yml config --quiet" \
 		"docker compose -f $REPO_ROOT/docker/hermes-service/compose.yml build --pull hermes hermes-bootstrap chromium xapi-mcp" \

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -499,6 +499,21 @@ setup() {
 	[ "$status" -eq 0 ]
 }
 
+@test "Darwin Home Manager exposes official per-user CLI launchers" {
+	command -v nix >/dev/null 2>&1 || skip "nix is not available in this test environment"
+	command -v jq >/dev/null 2>&1 || skip "jq is not available in this test environment"
+
+	run --separate-stderr env DOTFILES_USER=codex DOTFILES_HOME=/Users/codex \
+		nix eval --impure --json --expr "
+			let config = (builtins.getFlake (toString $REPO_ROOT)).darwinConfigurations.macos.config;
+			in config.home-manager.users.codex.home.sessionPath
+		"
+
+	[ "$status" -eq 0 ]
+	run jq -e 'index("$HOME/.local/bin") != null' <<<"$output"
+	[ "$status" -eq 0 ]
+}
+
 @test "Darwin provisions GNU timeout for native Ollama" {
 	grep -Fq 'pkgs.coreutils' "$REPO_ROOT/nix/home/common.nix"
 }


### PR DESCRIPTION
## Summary

- keep the official Hermes Desktop bootstrap managed by nix-darwin through the Homebrew cask
- run and verify the official per-user Desktop/CLI setup during the macOS Hermes profile
- remove inherited Git command-scope configuration before setup, and repair malformed tuples before installer Git/Nix work
- make repeated installs idempotent and add the official CLI directory to Home Manager PATH
- document the setup/runtime ownership boundary
- support both prior and current Hermes upstream source layouts in the pinned container customizations

## Validation

- 139 scoped Bats tests passed
- 54 Python contract tests passed
- pre-commit / task lint passed
- ShellCheck and git diff checks passed
- current upstream Hermes container suite passed: 595 + 25 + 53 + 1 tests
- official Hermes Desktop v0.21.0 installed and launched on Apple Silicon
- repeated task hermes:desktop:install completed as a no-op

Closes #568
