### PR TITLE
test: make test:coverage actually enable PowerShell coverage

### DIFF
--- a/scripts/powershell/tests/CoverageTaskContract.Tests.ps1
+++ b/scripts/powershell/tests/CoverageTaskContract.Tests.ps1
@@ -1,0 +1,26 @@
+BeforeAll {
+    $script:repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+}
+
+Describe 'PowerShell coverage task contract' {
+    It 'should explicitly request coverage without imposing a threshold' {
+        $taskfile = Get-Content -LiteralPath (Join-Path $script:repoRoot 'taskfiles/test/taskfile.yml') -Raw
+        $coverageTask = [regex]::Match(
+            $taskfile,
+            '(?ms)^  test:coverage:\r?\n(?<body>.*?)(?=^  [a-z][^\r\n]*:\r?$)'
+        )
+
+        $coverageTask.Success | Should -BeTrue
+        $coverageTask.Groups['body'].Value | Should -Match ([regex]::Escape('-ShowCoverage'))
+        $coverageTask.Groups['body'].Value | Should -Not -Match '-MinimumCoverage\s+[1-9]'
+    }
+
+    It 'should use one coverage-request condition for discovery and Pester configuration' {
+        $runner = Get-Content -LiteralPath (Join-Path $script:repoRoot 'scripts/powershell/tests/Invoke-Tests.ps1') -Raw
+
+        $runner | Should -Match '\$coverageRequested\s*=\s*\(\$MinimumCoverage\s+-gt\s+0\)\s+-or\s+\$ShowCoverage\s+-or\s+\(-not\s+\[string\]::IsNullOrWhiteSpace\(\$CoverageOutputFile\)\)'
+        ([regex]::Matches($runner, 'if\s*\(\$coverageRequested\)')).Count | Should -Be 2
+        $runner | Should -Match '\$pesterConfig\.CodeCoverage\.CoveragePercentTarget\s*=\s*\$MinimumCoverage'
+        $runner | Should -Match 'if\s*\(\$coverage\s+-lt\s+\$MinimumCoverage\)'
+    }
+}

--- a/scripts/powershell/tests/CoverageTaskContract.Tests.ps1
+++ b/scripts/powershell/tests/CoverageTaskContract.Tests.ps1
@@ -32,4 +32,39 @@ Describe 'PowerShell coverage task contract' {
         $runner | Should -Match 'Install-Module\s+-Name\s+Pester[\s\S]*-MinimumVersion\s+5\.0\.0[\s\S]*-MaximumVersion\s+5\.999\.999'
         $runner | Should -Match 'Import-Module\s+-Name\s+Pester\s+-RequiredVersion\s+\$pesterV5\.Version'
     }
+
+    It 'should exercise the coverage-requested true path and emit coverage XML' {
+        $smokePath = Join-Path $TestDrive 'CoverageSmoke.Tests.ps1'
+        $coveragePath = Join-Path $TestDrive 'coverage.xml'
+        @'
+Describe 'coverage smoke' {
+    It 'should pass a minimal assertion' {
+        $true | Should -BeTrue
+    }
+}
+'@ | Set-Content -LiteralPath $smokePath -Encoding UTF8
+
+        $pwsh = Get-Command pwsh -ErrorAction Stop
+        $runnerPath = Join-Path $script:repoRoot 'scripts/powershell/tests/Invoke-Tests.ps1'
+        $args = @(
+            '-NoProfile'
+            '-File'
+            $runnerPath
+            '-Path'
+            $smokePath
+            '-ShowCoverage'
+            '-CoverageOutputFile'
+            $coveragePath
+        )
+        $output = & $pwsh.Source @args 2>&1
+        $exitCode = $LASTEXITCODE
+        $outputText = $output | Out-String
+        Write-Host $outputText
+
+        $exitCode | Should -Be 0
+        $outputText | Should -Match 'Source Files:\s+7'
+        (Test-Path -LiteralPath $coveragePath) | Should -BeTrue
+        [xml]$coverageXml = Get-Content -LiteralPath $coveragePath -Raw
+        $coverageXml | Should -Not -BeNullOrEmpty
+    }
 }

--- a/scripts/powershell/tests/CoverageTaskContract.Tests.ps1
+++ b/scripts/powershell/tests/CoverageTaskContract.Tests.ps1
@@ -46,7 +46,7 @@ Describe 'coverage smoke' {
 
         $pwsh = Get-Command pwsh -ErrorAction Stop
         $runnerPath = Join-Path $script:repoRoot 'scripts/powershell/tests/Invoke-Tests.ps1'
-        $args = @(
+        $childArguments = @(
             '-NoProfile'
             '-File'
             $runnerPath
@@ -56,7 +56,7 @@ Describe 'coverage smoke' {
             '-CoverageOutputFile'
             $coveragePath
         )
-        $output = & $pwsh.Source @args 2>&1
+        $output = & $pwsh.Source @childArguments 2>&1
         $exitCode = $LASTEXITCODE
         $outputText = $output | Out-String
         Write-Host $outputText

--- a/scripts/powershell/tests/CoverageTaskContract.Tests.ps1
+++ b/scripts/powershell/tests/CoverageTaskContract.Tests.ps1
@@ -23,4 +23,13 @@ Describe 'PowerShell coverage task contract' {
         $runner | Should -Match '\$pesterConfig\.CodeCoverage\.CoveragePercentTarget\s*=\s*\$MinimumCoverage'
         $runner | Should -Match 'if\s*\(\$coverage\s+-lt\s+\$MinimumCoverage\)'
     }
+
+    It 'should pin Pester to v5 and import the selected version' {
+        $runner = Get-Content -LiteralPath (Join-Path $script:repoRoot 'scripts/powershell/tests/Invoke-Tests.ps1') -Raw
+
+        $runner | Should -Match '\$pesterV5\s*=\s*Get-Module\s+-ListAvailable\s+-Name\s+Pester'
+        $runner | Should -Match '\$_.Version\s+-ge\s+\[Version\]"5\.0\.0"\s+-and\s+\$_.Version\s+-lt\s+\[Version\]"6\.0\.0"'
+        $runner | Should -Match 'Install-Module\s+-Name\s+Pester[\s\S]*-MinimumVersion\s+5\.0\.0[\s\S]*-MaximumVersion\s+5\.999\.999'
+        $runner | Should -Match 'Import-Module\s+-Name\s+Pester\s+-RequiredVersion\s+\$pesterV5\.Version'
+    }
 }

--- a/scripts/powershell/tests/CoverageTaskContract.Tests.ps1
+++ b/scripts/powershell/tests/CoverageTaskContract.Tests.ps1
@@ -44,7 +44,11 @@ Describe 'coverage smoke' {
 }
 '@ | Set-Content -LiteralPath $smokePath -Encoding UTF8
 
-        $pwsh = Get-Command pwsh -ErrorAction Stop
+        $pwsh = Get-Command pwsh -ErrorAction SilentlyContinue
+        if ($null -eq $pwsh) {
+            Set-ItResult -Skipped -Because 'PowerShell 7 (pwsh) is not installed on this host'
+            return
+        }
         $runnerPath = Join-Path $script:repoRoot 'scripts/powershell/tests/Invoke-Tests.ps1'
         $childArguments = @(
             '-NoProfile'

--- a/scripts/powershell/tests/CoverageTaskContract.Tests.ps1
+++ b/scripts/powershell/tests/CoverageTaskContract.Tests.ps1
@@ -44,11 +44,15 @@ Describe 'coverage smoke' {
 }
 '@ | Set-Content -LiteralPath $smokePath -Encoding UTF8
 
-        $pwsh = Get-Command pwsh -ErrorAction SilentlyContinue
-        if ($null -eq $pwsh) {
-            Set-ItResult -Skipped -Because 'PowerShell 7 (pwsh) is not installed on this host'
+        $shell = Get-Command pwsh -ErrorAction SilentlyContinue
+        if ($null -eq $shell) {
+            $shell = Get-Command powershell.exe -ErrorAction SilentlyContinue
+        }
+        if ($null -eq $shell) {
+            Set-ItResult -Skipped -Because 'No compatible PowerShell executable is installed on this host'
             return
         }
+        $shellPath = if ($shell.Source) { $shell.Source } else { $shell.Path }
         $runnerPath = Join-Path $script:repoRoot 'scripts/powershell/tests/Invoke-Tests.ps1'
         $childArguments = @(
             '-NoProfile'
@@ -60,7 +64,7 @@ Describe 'coverage smoke' {
             '-CoverageOutputFile'
             $coveragePath
         )
-        $output = & $pwsh.Source @childArguments 2>&1
+        $output = & $shellPath @childArguments 2>&1
         $exitCode = $LASTEXITCODE
         $outputText = $output | Out-String
         Write-Host $outputText

--- a/scripts/powershell/tests/Invoke-Tests.ps1
+++ b/scripts/powershell/tests/Invoke-Tests.ps1
@@ -67,6 +67,7 @@ else {
     $scriptRoot = (Get-Location).ProviderPath
 }
 $projectRoot = Split-Path -Parent $scriptRoot
+$coverageRequested = ($MinimumCoverage -gt 0) -or $ShowCoverage -or (-not [string]::IsNullOrWhiteSpace($CoverageOutputFile))
 
 # Pester v3 が自動ロードされるのを防ぐ
 if (Get-Module -Name Pester) {
@@ -106,7 +107,7 @@ Write-Host ""
 
 # テスト対象ファイルの収集（カバレッジ有効時のみ）
 $sourceFiles = @()
-if ($MinimumCoverage -gt 0) {
+if ($coverageRequested) {
     $sourceFiles = @(
         "$projectRoot\lib\SetupHandler.ps1",
         "$projectRoot\lib\Invoke-ExternalCommand.ps1",
@@ -145,8 +146,12 @@ $pesterConfig.Output.Verbosity = "Detailed"
 $pesterConfig.Output.CIFormat = "Auto"
 
 # カバレッジ設定
-if ($sourceFiles.Count -gt 0 -and $MinimumCoverage -gt 0) {
-    $pesterConfig.CodeCoverage.Enabled = $true
+if ($coverageRequested) {
+    if ($sourceFiles.Count -eq 0) {
+        $pesterConfig.CodeCoverage.Enabled = $false
+    }
+    else {
+        $pesterConfig.CodeCoverage.Enabled = $true
     $pesterConfig.CodeCoverage.Path = $sourceFiles
     $pesterConfig.CodeCoverage.CoveragePercentTarget = $MinimumCoverage
     $pesterConfig.CodeCoverage.OutputFormat = "CoverageGutters"
@@ -155,9 +160,10 @@ if ($sourceFiles.Count -gt 0 -and $MinimumCoverage -gt 0) {
     # カバレッジでモックを使用可能にする（ブレークポイント方式を無効化）
     $pesterConfig.CodeCoverage.UseBreakpoints = $false
 
-    if ($CoverageOutputFile) {
-        $pesterConfig.CodeCoverage.OutputPath = $CoverageOutputFile
-        $pesterConfig.CodeCoverage.OutputFormat = "CoverageGutters"
+        if ($CoverageOutputFile) {
+            $pesterConfig.CodeCoverage.OutputPath = $CoverageOutputFile
+            $pesterConfig.CodeCoverage.OutputFormat = "CoverageGutters"
+        }
     }
 }
 else {

--- a/scripts/powershell/tests/Invoke-Tests.ps1
+++ b/scripts/powershell/tests/Invoke-Tests.ps1
@@ -152,13 +152,13 @@ if ($coverageRequested) {
     }
     else {
         $pesterConfig.CodeCoverage.Enabled = $true
-    $pesterConfig.CodeCoverage.Path = $sourceFiles
-    $pesterConfig.CodeCoverage.CoveragePercentTarget = $MinimumCoverage
-    $pesterConfig.CodeCoverage.OutputFormat = "CoverageGutters"
-    # 外部コマンド直接呼び出しはカバレッジから除外
-    $pesterConfig.CodeCoverage.ExcludeTests = $true
-    # カバレッジでモックを使用可能にする（ブレークポイント方式を無効化）
-    $pesterConfig.CodeCoverage.UseBreakpoints = $false
+        $pesterConfig.CodeCoverage.Path = $sourceFiles
+        $pesterConfig.CodeCoverage.CoveragePercentTarget = $MinimumCoverage
+        $pesterConfig.CodeCoverage.OutputFormat = "CoverageGutters"
+        # 外部コマンド直接呼び出しはカバレッジから除外
+        $pesterConfig.CodeCoverage.ExcludeTests = $true
+        # カバレッジでモックを使用可能にする（ブレークポイント方式を無効化）
+        $pesterConfig.CodeCoverage.UseBreakpoints = $false
 
         if ($CoverageOutputFile) {
             $pesterConfig.CodeCoverage.OutputPath = $CoverageOutputFile

--- a/scripts/powershell/tests/Invoke-Tests.ps1
+++ b/scripts/powershell/tests/Invoke-Tests.ps1
@@ -69,23 +69,30 @@ else {
 $projectRoot = Split-Path -Parent $scriptRoot
 $coverageRequested = ($MinimumCoverage -gt 0) -or $ShowCoverage -or (-not [string]::IsNullOrWhiteSpace($CoverageOutputFile))
 
-# Pester v3 が自動ロードされるのを防ぐ
-if (Get-Module -Name Pester) {
-    $currentVersion = (Get-Module -Name Pester).Version
-    if ($currentVersion -lt [Version]"5.0.0") {
-        Write-Host "Pester v$currentVersion がロードされています。v5 に切り替えます..." -ForegroundColor Yellow
+# Pester v3 / v6 が自動ロードされるのを防ぐ
+$currentPester = Get-Module -Name Pester | Select-Object -First 1
+if ($currentPester) {
+    $currentVersion = $currentPester.Version
+    if ($currentVersion -lt [Version]"5.0.0" -or $currentVersion -ge [Version]"6.0.0") {
+        Write-Host "Pester v$currentVersion がロードされています。Pester v5 に切り替えます..." -ForegroundColor Yellow
         Remove-Module -Name Pester -Force -ErrorAction SilentlyContinue
     }
 }
 
-# Pester モジュールの確認とインストール
-$pesterV5 = Get-Module -ListAvailable -Name Pester | Where-Object { $_.Version -ge [Version]"5.0.0" } | Select-Object -First 1
+# Pester v5 モジュールの確認とインストール
+$pesterV5 = Get-Module -ListAvailable -Name Pester |
+    Where-Object { $_.Version -ge [Version]"5.0.0" -and $_.Version -lt [Version]"6.0.0" } |
+    Sort-Object Version -Descending |
+    Select-Object -First 1
 
 if (-not $pesterV5) {
     Write-Host "Pester v5 がインストールされていません。自動インストールします..." -ForegroundColor Yellow
     try {
-        Install-Module -Name Pester -MinimumVersion 5.0.0 -Scope CurrentUser -Force -SkipPublisherCheck
-        $pesterV5 = Get-Module -ListAvailable -Name Pester | Where-Object { $_.Version -ge [Version]"5.0.0" } | Select-Object -First 1
+        Install-Module -Name Pester -MinimumVersion 5.0.0 -MaximumVersion 5.999.999 -Scope CurrentUser -Force -SkipPublisherCheck
+        $pesterV5 = Get-Module -ListAvailable -Name Pester |
+            Where-Object { $_.Version -ge [Version]"5.0.0" -and $_.Version -lt [Version]"6.0.0" } |
+            Sort-Object Version -Descending |
+            Select-Object -First 1
         if (-not $pesterV5) {
             throw "インストール後もモジュールが見つかりません"
         }
@@ -93,13 +100,13 @@ if (-not $pesterV5) {
     }
     catch {
         Write-Error "Pester v5 の自動インストールに失敗しました: $($_.Exception.Message)"
-        Write-Error "手動でインストールしてください: Install-Module -Name Pester -MinimumVersion 5.0.0 -Scope CurrentUser -Force"
+        Write-Error "手動でインストールしてください: Install-Module -Name Pester -MinimumVersion 5.0.0 -MaximumVersion 5.999.999 -Scope CurrentUser -Force"
         exit 1
     }
 }
 
 # Pester v5 を強制ロード
-Import-Module -Name Pester -MinimumVersion 5.0.0 -Force
+Import-Module -Name Pester -RequiredVersion $pesterV5.Version -Force
 
 $loadedVersion = (Get-Module -Name Pester).Version
 Write-Host "Pester v$loadedVersion を使用します" -ForegroundColor Cyan

--- a/taskfiles/test/taskfile.yml
+++ b/taskfiles/test/taskfile.yml
@@ -14,7 +14,7 @@ tasks:
   test:coverage:
     desc: Run PowerShell tests with coverage
     cmds:
-      - pwsh -NoProfile -Command "& ./scripts/powershell/tests/Invoke-Tests.ps1 -IncludeIntegration"
+      - pwsh -NoProfile -Command "& ./scripts/powershell/tests/Invoke-Tests.ps1 -IncludeIntegration -ShowCoverage"
 
   test:bash:
     desc: Run bats unit tests for shell helpers


### PR DESCRIPTION
Closes #579

## Summary

- `$coverageRequested` is shared by source discovery and Pester configuration, and is true for positive `MinimumCoverage`, `ShowCoverage`, or a nonblank `CoverageOutputFile`.
- `test:coverage` adds `-ShowCoverage` without imposing a coverage threshold.
- The seven-file coverage scope and output format are preserved; normal test routes remain unchanged.

## TDD RED

- Contract tests: commit `6ae9586`.
- PowerShell CI run `33974011348`: 1157 passed / 2 failed / 1 skipped; the two new contracts failed as expected.

## GREEN

- Implementation/style head before main integration: `dc050ef7e42aebf979e2914f951e4a24649103c0`.
- PowerShell CI run `33974336500`: 1159 passed / 0 failed / 1 skipped; coverage 81.26%.
- Windows PowerShell 5.1: 59 passed. Source Files: 0.
- Main integration commit: `a6a3cd3f1eef4b2870035ab2827f78148ead1a59`, with parents `dc050ef7e42aebf979e2914f951e4a24649103c0` and `af86caa4d6db3699aac6d47ebea5bab8f811ba7c`.
- Pester 6 follow-up head: `389f77db530ac483a1691e968c1a621f9deaaf1d`.
- The runner now removes loaded Pester versions outside 5.x, selects the highest available 5.x version only, constrains installation to `5.0.0` through `5.999.999`, and imports the selected version with `-RequiredVersion`.
- `CoverageTaskContract.Tests.ps1` includes regression contracts for those Pester 5 constraints and a behavioral smoke that invokes the same runner with `-ShowCoverage` and `-CoverageOutputFile`.
- Latest follow-up head: `1c89462d28bde6ed5a1acada0fdca5c24ee2fce9`; the smoke now uses `$childArguments` instead of PowerShell's automatic `$args` variable.

## Verification limits

GitHub Actions did not execute the real `task test:coverage` full end-to-end path in the earlier GREEN run. The 81.26% figure comes from an independent inline Pester route.

The new behavioral smoke exercises the same runner true path, seven-file discovery, and coverage artifact XML parsing, but its GitHub Actions execution is pending. It is evidence for the runner path, not a claim that the full `task test:coverage` E2E has run. No local behavioral-smoke result is claimed.

## Blocker follow-up

The Pester 6 compatibility blocker is addressed in code by pinning the runner to Pester 5.x while preserving `CoverageGutters`. The automatic-variable review finding was fixed in `1c89462d28bde6ed5a1acada0fdca5c24ee2fce9`, and review thread `PRRT_kwDOQRp34s6fnAF4` is resolved. Newly triggered Actions, including the behavioral smoke, are pending verification. The pull request remains draft and is intentionally not being marked ready for review or merged.

## Safety boundary

Normal `task test:powershell`, CI routing, Windows PowerShell 5.1 behavior, the seven-file coverage scope, output format, and threshold behavior remain unchanged.