### PR TITLE
docs(nix): correct Home Manager test coverage claim

### DIFF
--- a/nix/tests/home/README.md
+++ b/nix/tests/home/README.md
@@ -2,13 +2,15 @@
 
 ## 対象
 
-`nix/tests/home/` は Home Manager の構造・import 境界・評価可能な設定を検査する。
+`nix/tests/home/` は `nix-unit` で Home Manager の構造・import 境界を静的に検査する。
+テスト式自身は評価するが、Home Manager モジュールを組み合わせた構成や activation
+package の評価は行わない。
 システムの activation、実機依存の動作、秘密情報は対象外とする。
 
 ## ファイル規則
 
 - ファイル名は `<topic>.nix` の kebab-case とする。
-- 1ファイル1責務とし、import 境界・OS 入口・設定評価などの単位で分ける。
+- 1ファイル1責務とし、import 境界・OS 入口・構造検査などの単位で分ける。
 - テストは `nix-unit` 形式の attrset とし、属性名は `test` で始める。
 - 各テストは `expr` と `expected` を持ち、評価結果を直接比較する。
 - テスト内のパスはテストファイルからの相対 Nix path を使う。
@@ -18,5 +20,28 @@
 - テストは純粋・決定的に保つ。ネットワーク、secret、環境依存の値、Home Manager activation を使わない。
 - 外部コマンドを起動せず、必要な検査は Nix 式で実装する。
 - 新しいテストは `nix/flakes/tests.nix` の `perSystem.nix-unit.tests` に登録する。
-- 標準実行は `nix flake check` とし、全対応 system の確認には `nix flake check --all-systems` を使う。
+- `nix flake check` は実行環境の system に対する flake の `checks` 全体を評価する。この README が
+  扱う `nix/flakes/tests.nix` から登録される check の保証範囲は、`nix-unit` の構造・import 境界
+  検査に限られ、Home Manager 構成、activation package、NixOS/WSL/Darwin の実機動作までは保証しない。
+- `nix flake check --all-systems` は flake の `systems.nix` が公開する各 system の `checks` 全体を
+  対象にする。この README が扱う check の保証範囲は同じ静的検査に限られる。`--no-build` を付けた
+  場合は評価のみで、derivation の build 成功も保証しない。
 - テスト変更時は対象テストと `nix flake check` を実行する。
+
+## Home Manager 構成の評価
+
+構成を実際に組み合わせて評価する経路は、`nix-unit` とは別に Bats と CI の build で確認する。
+
+| 対象 | テスト経路 | 確認する内容 |
+| --- | --- | --- |
+| NixOS / WSL | `tests/bash/flake_outputs.bats` | flake の出力と NixOS-WSL Home Manager 構成を `nix eval` で確認するケースを含む |
+| Darwin | `tests/bash/macos_config.bats` | Darwin Home Manager 構成を `nix eval` で確認するケースを含む |
+| CI の declarative build | `.github/workflows/ci-bootstrap.yml` | Bats とは別に、Linux/NixOS、NixOS-WSL、Darwin の出力を明示的な `nix build` または WSL switch で確認する |
+
+ローカルでの Bats の標準入口は `task test:bash` である。Nix を必要とするケースは `command -v nix`
+を確認し、Nix がない環境では `skip` する。CI では `.github/workflows/ci-contract.yml` が
+`tests/bash/install_linux.bats` と `tests/bash/install_macos.bats` を除外し、それ以外の
+`tests/bash/*.bats` を実行する。
+
+上記 Bats ファイルには grep による契約検査も含まれるため、Bats 全体を Home Manager 構成の
+完全評価とはみなさない。

--- a/nix/tests/home/README.md
+++ b/nix/tests/home/README.md
@@ -38,8 +38,9 @@ package の評価は行わない。
 | Darwin | `tests/bash/macos_config.bats` | Darwin Home Manager 構成を `nix eval` で確認するケースを含む |
 | CI の declarative build | `.github/workflows/ci-bootstrap.yml` | Bats とは別に、Linux/NixOS、NixOS-WSL、Darwin の出力を明示的な `nix build` または WSL switch で確認する |
 
-ローカルでの Bats の標準入口は `task test:bash` である。Nix を必要とするケースは `command -v nix`
-を確認し、Nix がない環境では `skip` する。CI では `.github/workflows/ci-contract.yml` が
+ローカルでの Bats の標準入口は `task test:bash` であり、全スイートを完走するには Nix が必要である。
+一部の Nix 依存ケースは `command -v nix` を確認し、Nix がない環境では `skip` するが、Nix なしで
+`task test:bash` 全体を完走できることは意味しない。CI では `.github/workflows/ci-contract.yml` が
 `tests/bash/install_linux.bats` と `tests/bash/install_macos.bats` を除外し、それ以外の
 `tests/bash/*.bats` を実行する。
 

--- a/nix/tests/home/README.md
+++ b/nix/tests/home/README.md
@@ -32,10 +32,10 @@ package の評価は行わない。
 
 構成を実際に組み合わせて評価する経路は、`nix-unit` とは別に Bats と CI の build で確認する。
 
-| 対象 | テスト経路 | 確認する内容 |
-| --- | --- | --- |
-| NixOS / WSL | `tests/bash/flake_outputs.bats` | flake の出力と NixOS-WSL Home Manager 構成を `nix eval` で確認するケースを含む |
-| Darwin | `tests/bash/macos_config.bats` | Darwin Home Manager 構成を `nix eval` で確認するケースを含む |
+| 対象                    | テスト経路                           | 確認する内容                                                                                            |
+| ----------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| NixOS / WSL             | `tests/bash/flake_outputs.bats`      | flake の出力と NixOS-WSL Home Manager 構成を `nix eval` で確認するケースを含む                          |
+| Darwin                  | `tests/bash/macos_config.bats`       | Darwin Home Manager 構成を `nix eval` で確認するケースを含む                                            |
 | CI の declarative build | `.github/workflows/ci-bootstrap.yml` | Bats とは別に、Linux/NixOS、NixOS-WSL、Darwin の出力を明示的な `nix build` または WSL switch で確認する |
 
 ローカルでの Bats の標準入口は `task test:bash` であり、全スイートを完走するには Nix が必要である。


### PR DESCRIPTION
## 概要

Issue #525 の Home Manager テスト範囲に関する過大な記述を、現行実装と一致するよう訂正します。

Closes #525

## 調査結果・根本原因

- `nix/flakes/tests.nix` が `nix-unit.tests` に登録するのは `nix/tests/home/import-boundary.nix` だけです。
- 登録済み4テストは `builtins.pathExists`、`builtins.readFile`、文字列・import境界検査であり、Home Manager module/configuration を評価しません。
- 構成評価は別経路の `tests/bash/flake_outputs.bats`、`tests/bash/macos_config.bats` と、Bootstrap CI の明示buildに分散しています。
- READMEがこれらを区別せず「評価可能な設定」を検査すると記載していたことが根本原因です。

## 変更

`nix/tests/home/README.md` のみを変更しました。

- 現在のnix-unit suiteを構造・import境界の静的検査と明記
- Home Manager構成評価との違いを明記
- `nix flake check`、`--all-systems`、`--no-build` の保証範囲を限定して説明
- NixOS/WSL・DarwinのBats test path、ローカルの `task test:bash`、CI Contractの実行経路を記載
- Bootstrap CIの直接build経路をBatsと分離して記載
- Nix不在時にNix依存Bats caseがskipされる制約を記載

## 検証

- 変更前: READMEに「評価可能な設定」「設定評価」が残り、Bats/CI経路の記載がないことを再現
- `git diff --check`: 成功
- CI routing tests: 19件成功
- README記述を `nix/flakes/tests.nix`、`import-boundary.nix`、両Bats、`.github/workflows/ci-contract.yml`、`.github/workflows/ci-bootstrap.yml` と再照合
- GPT-5.6 Sol high の最終敵対レビュー: blocking findingなし、Acceptance criteria 1–4充足

## 影響範囲

文書1ファイルのみです。runtime、テスト実装、CI workflow、対応OS、権限、security設定は変更していません。

## 残存リスク・未検証

クラウド実装環境にNixとBatsがなかったため、`nix flake check`、`nix flake check --all-systems`、対象Batsの実行はローカルでは未検証です。これらを成功扱いにはしておらず、現在のhead SHAに対するGitHub Actionsで確認します。README-only routingで実行されないOS別jobは未検証のまま明示します。

## モデル分担

- 調査計画・統合判断・最終敵対レビュー: GPT-5.6 Sol / high
- 修正実装・検証: GPT-5.6 Luna / high
