### PR TITLE
fix(nix): preserve WSL postinstall user evaluation

### DIFF
--- a/nix/home/README.md
+++ b/nix/home/README.md
@@ -21,8 +21,11 @@ caller -> <os>.nix -> common.nix
 - `default.nix` と `users.nix` は作らない。入口と OS 依存方向を曖昧にするため。
 
 ユーザー名とホームディレクトリは `DOTFILES_USER` / `DOTFILES_HOME` から取得する。
-NixOS は `DOTFILES_USER` 未指定時に `nixos` を使う。WSL postinstall は同じユーザーを
-NixOS host と Home Manager に渡し、`wsl.defaultUser` と Home Manager の対象を一致させる。
+NixOS は `DOTFILES_USER` 未指定時に `nixos` を使う。WSL postinstall は `--user` で選択した
+ユーザーの `DOTFILES_USER` / `DOTFILES_HOME` / `DOTFILES_UID` / `DOTFILES_GID` /
+`DOTFILES_GROUP` を export し、`nixos-rebuild` を `--impure` 付きで実行する。これにより
+flake 評価中の `builtins.getEnv` が選択した識別情報を読み取り、NixOS host、Home Manager、
+`wsl.defaultUser` の対象を一致させる。
 `nrs` / `nrt` / `nrb` は `scripts/sh/nixos-rebuild-with-user.sh` 経由で実行し、同じ識別情報を
 flake 評価へ渡す。
 

--- a/scripts/sh/nixos-wsl-postinstall.sh
+++ b/scripts/sh/nixos-wsl-postinstall.sh
@@ -327,7 +327,7 @@ fi
 
 # Run nixos-rebuild
 NIX_CONFIG="experimental-features = nix-command flakes" \
-  nixos-rebuild switch --flake "path:$TARGET_DIR#$FLAKE_NAME"
+  nixos-rebuild switch --flake "path:$TARGET_DIR#$FLAKE_NAME" --impure
 
 # Handle sync-back
 if [[ $SYNC_BACK == "repo" && $SYNC_MODE != "link" ]]; then

--- a/tests/bash/nixos_wsl_postinstall.bats
+++ b/tests/bash/nixos_wsl_postinstall.bats
@@ -5,20 +5,25 @@ setup() {
 	INSTALLER="$REPO_ROOT/scripts/sh/nixos-wsl-postinstall.sh"
 	TEST_HOME="$BATS_TEST_TMPDIR/home"
 	USER_HOME="$TEST_HOME/alice"
+	SYNC_SOURCE="$BATS_TEST_TMPDIR/sync-source"
 	STUB_BIN="$BATS_TEST_TMPDIR/bin"
 	COMMAND_LOG="$BATS_TEST_TMPDIR/commands.log"
 	NIXOS_ARGV_CAPTURE="$BATS_TEST_TMPDIR/nixos-rebuild.argv"
 	NIX_EVAL_CAPTURE="$BATS_TEST_TMPDIR/nix-eval.result"
 	REAL_NIX="$(command -v nix || true)"
 
-	mkdir -p "$USER_HOME" "$STUB_BIN"
+	mkdir -p "$USER_HOME" "$SYNC_SOURCE" "$STUB_BIN"
+	git -C "$REPO_ROOT" archive --format=tar HEAD | (
+		cd "$SYNC_SOURCE"
+		tar -xf -
+	)
 	: >"$COMMAND_LOG"
 	: >"$NIXOS_ARGV_CAPTURE"
 	: >"$NIX_EVAL_CAPTURE"
 
 	export HOME="$TEST_HOME"
 	export PATH="$STUB_BIN:/usr/bin:/bin"
-	export COMMAND_LOG NIXOS_ARGV_CAPTURE NIX_EVAL_CAPTURE REAL_NIX REPO_ROOT USER_HOME
+	export COMMAND_LOG NIXOS_ARGV_CAPTURE NIX_EVAL_CAPTURE REAL_NIX REPO_ROOT USER_HOME SYNC_SOURCE
 	export DOTFILES_SKIP_HERDR_INSTALL=1
 
 	write_stub id '
@@ -74,7 +79,7 @@ if [[ -n ${REAL_NIX:-} ]]; then
 	if ((${#nix_eval_args[@]} == 1)); then
 		nix_eval_expr=$(cat <<NIX_EXPR
       let
-        flake = builtins.getFlake ("path:" + builtins.getEnv "REPO_ROOT");
+        flake = builtins.getFlake ("path:" + builtins.getEnv "SYNC_SOURCE");
         config = flake.nixosConfigurations.nixos.config;
         homeManager = builtins.getAttr "home-manager" config;
       in
@@ -114,7 +119,7 @@ EOF
 	run bash "$INSTALLER" \
 		--user alice \
 		--sync-mode link \
-		--sync-source "$REPO_ROOT" \
+		--sync-source "$SYNC_SOURCE" \
 		--repo-dir "$RUN_REPO_DIR" \
 		--sync-back none \
 		--skip-flake-update
@@ -122,7 +127,7 @@ EOF
 	[ "$status" -eq 0 ]
 	grep -Fqx "nixos-rebuild user=alice home=$USER_HOME uid=4242 gid=4343 group=alicegrp" "$COMMAND_LOG"
 
-	expected_args=(switch --flake "path:$REPO_ROOT#nixos" --impure)
+	expected_args=(switch --flake "path:$SYNC_SOURCE#nixos" --impure)
 	mapfile -t actual_args <"$NIXOS_ARGV_CAPTURE"
 	[ "${#actual_args[@]}" -eq "${#expected_args[@]}" ]
 	for index in "${!expected_args[@]}"; do

--- a/tests/bash/nixos_wsl_postinstall.bats
+++ b/tests/bash/nixos_wsl_postinstall.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+	INSTALLER="$REPO_ROOT/scripts/sh/nixos-wsl-postinstall.sh"
+	TEST_HOME="$BATS_TEST_TMPDIR/home"
+	USER_HOME="$TEST_HOME/alice"
+	STUB_BIN="$BATS_TEST_TMPDIR/bin"
+	COMMAND_LOG="$BATS_TEST_TMPDIR/commands.log"
+	NIXOS_ARGV_CAPTURE="$BATS_TEST_TMPDIR/nixos-rebuild.argv"
+	NIX_EVAL_CAPTURE="$BATS_TEST_TMPDIR/nix-eval.result"
+	REAL_NIX="$(command -v nix || true)"
+
+	mkdir -p "$USER_HOME" "$STUB_BIN"
+	: >"$COMMAND_LOG"
+	: >"$NIXOS_ARGV_CAPTURE"
+	: >"$NIX_EVAL_CAPTURE"
+
+	export HOME="$TEST_HOME"
+	export PATH="$STUB_BIN:/usr/bin:/bin"
+	export COMMAND_LOG NIXOS_ARGV_CAPTURE NIX_EVAL_CAPTURE REAL_NIX REPO_ROOT USER_HOME
+	export DOTFILES_SKIP_HERDR_INSTALL=1
+
+	write_stub id '
+case "$*" in
+  "-u") printf "0\n" ;;
+  "-u alice") printf "4242\n" ;;
+  "-g alice") printf "4343\n" ;;
+  "-gn alice") printf "alicegrp\n" ;;
+  "alice") exit 0 ;;
+  *) exit 2 ;;
+esac
+'
+	write_stub getent '
+if [[ ${1:-} == passwd && ${2:-} == alice ]]; then
+  printf "alice:x:4242:4343:Alice:%s:/bin/bash\n" "$USER_HOME"
+  exit 0
+fi
+exit 2
+'
+	write_stub uname '
+case "${1:-}" in
+  -m) printf "x86_64\n" ;;
+  -s) printf "Linux\n" ;;
+  *) exit 2 ;;
+esac
+'
+	write_stub runuser '
+printf "runuser %s\n" "$*" >>"$COMMAND_LOG"
+while (($# > 0)); do
+  if [[ $1 == -- ]]; then
+    shift
+    break
+  fi
+  shift
+done
+exec "$@"
+'
+	write_stub chown '
+printf "chown %s\n" "$*" >>"$COMMAND_LOG"
+'
+	write_stub nixos-rebuild '
+printf "%s\n" "$@" >"$NIXOS_ARGV_CAPTURE"
+printf "nixos-rebuild user=%s home=%s uid=%s gid=%s group=%s\n" \
+  "${DOTFILES_USER:-}" "${DOTFILES_HOME:-}" "${DOTFILES_UID:-}" \
+  "${DOTFILES_GID:-}" "${DOTFILES_GROUP:-}" >>"$COMMAND_LOG"
+
+if [[ -n ${REAL_NIX:-} ]]; then
+  nix_eval_args=()
+  for arg in "$@"; do
+    [[ $arg == --impure ]] && nix_eval_args+=("$arg")
+  done
+
+	if ((${#nix_eval_args[@]} == 1)); then
+		nix_eval_expr=$(cat <<NIX_EXPR
+      let
+        flake = builtins.getFlake ("path:" + builtins.getEnv "REPO_ROOT");
+        config = flake.nixosConfigurations.nixos.config;
+        homeManager = builtins.getAttr "home-manager" config;
+      in
+        if config.wsl.defaultUser != "alice" then
+          throw "wsl.defaultUser is not alice"
+        else if !builtins.hasAttr "alice" config.users.users then
+          throw "users.users is missing alice"
+        else if !builtins.hasAttr "alice" homeManager.users then
+          throw "home-manager.users is missing alice"
+        else
+          "ok"
+
+NIX_EXPR
+		)
+		"$REAL_NIX" eval "${nix_eval_args[@]}" --raw --no-write-lock-file --expr "$nix_eval_expr" >"$NIX_EVAL_CAPTURE"
+  else
+    printf "nix eval skipped: nixos-rebuild argv has no --impure\n" >>"$COMMAND_LOG"
+  fi
+fi
+'
+}
+
+write_stub() {
+	local name="$1"
+	local body="$2"
+	cat >"$STUB_BIN/$name" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+$body
+EOF
+	chmod +x "$STUB_BIN/$name"
+}
+
+@test "postinstall preserves the selected WSL user and runs an impure flake rebuild" {
+	RUN_REPO_DIR="$BATS_TEST_TMPDIR/repo"
+
+	run bash "$INSTALLER" \
+		--user alice \
+		--sync-mode link \
+		--sync-source "$REPO_ROOT" \
+		--repo-dir "$RUN_REPO_DIR" \
+		--sync-back none \
+		--skip-flake-update
+
+	[ "$status" -eq 0 ]
+	grep -Fqx "nixos-rebuild user=alice home=$USER_HOME uid=4242 gid=4343 group=alicegrp" "$COMMAND_LOG"
+
+	expected_args=(switch --flake "path:$REPO_ROOT#nixos" --impure)
+	mapfile -t actual_args <"$NIXOS_ARGV_CAPTURE"
+	[ "${#actual_args[@]}" -eq "${#expected_args[@]}" ]
+	for index in "${!expected_args[@]}"; do
+		[ "${actual_args[$index]}" = "${expected_args[$index]}" ]
+	done
+
+	if [[ -n $REAL_NIX ]]; then
+		[ "$(<"$NIX_EVAL_CAPTURE")" = ok ]
+	fi
+}


### PR DESCRIPTION
Closes #567

## 調査結果

WSL postinstall は `DOTFILES_USER` / `DOTFILES_HOME` / UID / GID / group を export していましたが、flake を使う `nixos-rebuild` が pure evaluation のままでした。これらを読む `builtins.getEnv` は値を取得できず、非 `nixos` ユーザーを選んでも NixOS host、Home Manager、`wsl.defaultUser` が既定の `nixos` へフォールバックする経路でした。

## 根本原因

`scripts/sh/nixos-wsl-postinstall.sh` の実 rebuild 引数に `--impure` がなく、export 済みの識別情報が flake evaluation に届いていませんでした。

## 変更

- WSL postinstall の実 `nixos-rebuild switch --flake …` に `--impure` を追加
- 実 postinstall スクリプトを非既定ユーザー `alice` で起動し、export 値と rebuild argv を捕捉する Bats テストを追加
- Nix が利用可能な環境では、その実 argv から渡された `--impure` を使って `wsl.defaultUser`、NixOS host user、Home Manager user がすべて `alice` になることを評価
- README を実装済みの propagation と evaluation mode に合わせて修正

## 検証

変更前:
- 新規 Bats は実 rebuild argv が4要素しかなく `--impure` がないため失敗

変更後:
- `bash -n scripts/sh/nixos-wsl-postinstall.sh`: 成功
- `oxfmt --check nix/home/README.md`: 成功
- 対象・関連 Bats 28件: 成功（Nix が必要な既存2件は環境上 skip）
- CI routing Python テスト 50件: 成功
- `git diff --check`: 成功
- Bash 全体: 409件中408件成功/skip、1件はクラウド環境に Nix がないため winget export で失敗
- Python 全体: 80件中70件成功、10件はクラウド環境に Ruby がないため MLflow contract setup で error

## 影響範囲

WSL postinstall の rebuild path と、その identity propagation のテスト・説明だけです。install.sh、Taskfile/Nix rebuild route、NixOS host/Home Manager/WSL expressions、Actions routing を追跡し、式側の変更は不要と判断しました。

## 残存リスク

- ローカルクラウド環境には Nix がないため、追加テストの実 `nix eval` 分岐は未実行です。Nix を導入する required CI の成功をマージ条件とします。
- PowerShell の別 rebuild helper は pure evaluation のままですが、Issue が対象とする WSL postinstall 経路ではなく、本PRでは変更しません。
