### PR TITLE
docs(nixos-wsl): update WSL setup and system version

### DIFF
--- a/docs/nix/nixos-wsl-install.md
+++ b/docs/nix/nixos-wsl-install.md
@@ -80,7 +80,7 @@ install.cmd
      （WSL 2.4.4 未満または失敗時は wsl --import --version 2）
   -> scripts/sh/nixos-wsl-postinstall.sh
   -> nix flake update
-  -> nixos-rebuild switch --flake ...#nixos --impure
+  -> user-aware nixos-rebuild-with-user.sh switch --flake ...#nixos --impure
 ```
 
 release asset は通常 `nixos.wsl` を優先し、古い release 形式では
@@ -143,10 +143,15 @@ Windows 側 checkout に戻す場合だけ使用します。通常の初回 setu
 
 # 対話的な終了待ちを抑止
 .\install.cmd -NoPause
+
+# 既存の ~/.dotfiles を意図的に置き換える場合だけ明示的に許可
+.\install.cmd -ForcePostInstall
 ```
 
 通常は `-ReleaseTag` を指定せず、NixOS-WSL の latest release を使用します。`InstallDir` は
-新規インストール時に空のディレクトリである必要があります。
+新規インストール時に空のディレクトリである必要があります。`-ForcePostInstall` は既存 checkout
+を削除または上書きし得るため、通常は指定しないでください。必要な場合も、先に checkout と
+VHD/stateful data のバックアップを作成してください。
 
 ## 手動 postinstall
 
@@ -181,7 +186,7 @@ nrs
 
 # 状態を確認してから明示的に rebuild
 nix flake update --flake ~/.dotfiles
-nixos-rebuild switch --flake ~/.dotfiles#nixos --impure
+~/.dotfiles/scripts/sh/nixos-rebuild-with-user.sh switch --flake ~/.dotfiles#nixos --impure
 ```
 
 一方、`nix/hosts/wsl/configuration.nix` の次の値は、パッケージの最新版を選択する値ではありません。
@@ -198,6 +203,18 @@ generation、`/run/current-system`、Docker、データベース、各種 statef
 パッケージや system の実体は引き続き `flake.lock` の `nixpkgs` input で決まります。
 このリポジトリの flake は `nixos-unstable` を使用するため、stable の `system.stateVersion` と
 unstable の実体 version が異なることがあります。
+
+既存の 25.05 環境では、`nrs` や `install.cmd` の通常更新を先に実行せず、次の順で移行を承認します。
+`dry-build` が成功しても runtime data の互換性を保証するものではないため、バックアップと rollback
+generation を確認してから `switch` してください。
+
+```bash
+nix flake update --flake ~/.dotfiles
+~/.dotfiles/scripts/sh/nixos-rebuild-with-user.sh dry-build --flake ~/.dotfiles#nixos --impure
+~/.dotfiles/scripts/sh/nixos-rebuild-with-user.sh switch --flake ~/.dotfiles#nixos --impure
+nixos-rebuild list-generations
+readlink -f /run/current-system
+```
 
 - [NixOS Wiki: When do I update stateVersion?](https://wiki.nixos.org/wiki/FAQ/When_do_I_update_stateVersion)
 - [NixOS 26.05 release](https://nixos.org/blog/announcements/2026/nixos-2605/)

--- a/docs/nix/nixos-wsl-install.md
+++ b/docs/nix/nixos-wsl-install.md
@@ -189,32 +189,38 @@ nix flake update --flake ~/.dotfiles
 ~/.dotfiles/scripts/sh/nixos-rebuild-with-user.sh switch --flake ~/.dotfiles#nixos --impure
 ```
 
-一方、`nix/hosts/wsl/configuration.nix` の次の値は、パッケージの最新版を選択する値ではありません。
-このリポジトリでは WSL の初期構成・移行先を現行 stable の NixOS 26.05 に合わせています。
+一方、`nix/hosts/wsl/configuration.nix` の `system.stateVersion` は、パッケージの最新版を選択する値では
+ありません。新規 WSL インストールの既定値と、明示的に承認した移行先は現行 stable の NixOS 26.05 です。
+既存環境は、元の state schema を維持するため 25.05 を既定にします。
 
 ```nix
-system.stateVersion = "26.05";
+system.stateVersion = stateVersion;
 ```
 
-これは新規構成の基準を 26.05 に移行する明示設定です。既存の 25.05 WSL 環境では、単なる
-パッケージ更新ではなく state schema の移行として扱ってください。適用前に VHD、Docker、データベース、
-各種 `/var/lib` のデータをバックアップし、使用中のモジュールの移行可否を確認してください。適用後は
-generation、`/run/current-system`、Docker、データベース、各種 stateful data の runtime を検証します。
+新規構成では installer が `DOTFILES_STATE_VERSION=26.05` を渡します。既存の 25.05 WSL 環境では、
+通常の `nrs` や `install.cmd` が stateVersion を勝手に変更しないよう、25.05 を保持します。26.05 へ
+移行する場合は、単なるパッケージ更新ではなく state schema の移行として扱ってください。適用前に VHD、
+Docker、データベース、各種 `/var/lib` のデータをバックアップし、使用中のモジュールの移行可否を確認して
+ください。適用後は generation、`/run/current-system`、Docker、データベース、各種 stateful data の
+runtime を検証します。
 パッケージや system の実体は引き続き `flake.lock` の `nixpkgs` input で決まります。
 このリポジトリの flake は `nixos-unstable` を使用するため、stable の `system.stateVersion` と
 unstable の実体 version が異なることがあります。
 
-既存の 25.05 環境では、`nrs` や `install.cmd` の通常更新を先に実行せず、次の順で移行を承認します。
-`dry-build` が成功しても runtime data の互換性を保証するものではないため、バックアップと rollback
-generation を確認してから `switch` してください。
+既存の 25.05 環境から明示的に移行する場合は、次の順で承認します。`dry-build` が成功しても runtime
+data の互換性を保証するものではないため、バックアップと rollback generation を確認してから `switch`
+してください。
 
 ```bash
 nix flake update --flake ~/.dotfiles
-~/.dotfiles/scripts/sh/nixos-rebuild-with-user.sh dry-build --flake ~/.dotfiles#nixos --impure
-~/.dotfiles/scripts/sh/nixos-rebuild-with-user.sh switch --flake ~/.dotfiles#nixos --impure
+DOTFILES_STATE_VERSION=26.05 ~/.dotfiles/scripts/sh/nixos-rebuild-with-user.sh dry-build --flake ~/.dotfiles#nixos --impure
+DOTFILES_STATE_VERSION=26.05 ~/.dotfiles/scripts/sh/nixos-rebuild-with-user.sh switch --flake ~/.dotfiles#nixos --impure
 nixos-rebuild list-generations
 readlink -f /run/current-system
 ```
+
+新規インストール時に値を変更する場合は、Windows 側で `.install.cmd -StateVersion 26.05` を指定できます。
+手動 postinstall では `--state-version 26.05` を指定してください。
 
 - [NixOS Wiki: When do I update stateVersion?](https://wiki.nixos.org/wiki/FAQ/When_do_I_update_stateVersion)
 - [NixOS 26.05 release](https://nixos.org/blog/announcements/2026/nixos-2605/)

--- a/docs/nix/nixos-wsl-install.md
+++ b/docs/nix/nixos-wsl-install.md
@@ -1,133 +1,228 @@
-# NixOS WSL インストール手順
+# NixOS-WSL インストールと初期 setup
 
-このドキュメントは `windows/install-nixos-wsl.ps1` を使って NixOS を WSL に導入する手順です。
+このドキュメントは、リポジトリルートの `install.cmd` から現在の NixOS-WSL と dotfiles を導入する手順です。
+NixOS-WSL 公式の `.wsl` パッケージを使用し、初回起動後にこのリポジトリの Flake と NixOS/
+Home Manager 設定を適用します。
 
 ## 前提
 
-- Windows 10/11
-- WSL 有効化済み
-- 管理者権限の PowerShell
-- `pwsh` (PowerShell 7) を推奨
+- Windows 10 version 2004 (build 19041) 以降、または Windows 11
+- WSL 2
+- 管理者権限の PowerShell（WSL 基盤を初めて有効化するとき）
+- Git
+- PowerShell 7 (`pwsh`) 推奨
+
+NixOS-WSL は Windows Store 版 WSL 2 を推奨します。`wsl --install --from-file` を使うには
+WSL 2.4.4 以降が必要です。古い WSL では installer が `wsl --import --version 2` に
+フォールバックします。
+
+公式資料:
+
+- [NixOS-WSL Installation](https://nix-community.github.io/NixOS-WSL/install.html)
+- [Microsoft: Install WSL](https://learn.microsoft.com/en-us/windows/wsl/install)
 
 ## インストール手順
 
-1. 管理者として PowerShell を起動する。
-2. リポジトリの `windows` フォルダへ移動する。
-3. スクリプトを実行する。
+### 1. WSL 基盤を準備する
+
+管理者として PowerShell を起動し、WSL が未導入の場合だけ実行します。
 
 ```powershell
-cd D:\my_programing\dotfiles\windows
-pwsh -NoProfile -ExecutionPolicy Bypass -File .\install-nixos-wsl.ps1
+wsl --install --no-distribution
 ```
 
-## よく使うオプション
-
-- 既存の WSL 基盤を使いたい (WSL の有効化をスキップ)
+再起動を求められた場合は Windows を再起動し、PowerShell を開き直します。既存の WSL が
+動作している場合はこの手順を省略できます。WSL を更新する場合は次を実行します。
 
 ```powershell
-pwsh -NoProfile -ExecutionPolicy Bypass -File .\install-nixos-wsl.ps1 -SkipWslBaseInstall
+wsl --update
+wsl --status
 ```
 
-- チャンネル更新と再構成をスキップ
+### 2. dotfiles を取得して installer を実行する
+
+`install.cmd` はリポジトリルートから実行します。`windows` ディレクトリへ移動する必要はありません。
 
 ```powershell
-pwsh -NoProfile -ExecutionPolicy Bypass -File .\install-nixos-wsl.ps1 -SkipChannelUpdate
+git clone https://github.com/rurusasu/dotfiles.git
+cd dotfiles
+.\install.cmd
 ```
 
-- ディストリ名とインストール先を指定
+初回に WSL がまだ準備できていない場合、installer は WSL 基盤の有効化後に再起動を要求します。
+再起動後、同じ `install.cmd` を再実行してください。
+
+引数なしでは core 環境だけを適用します。追加サービスは必要な場合だけ選択します。
 
 ```powershell
-pwsh -NoProfile -ExecutionPolicy Bypass -File .\install-nixos-wsl.ps1 -DistroName NixOS -InstallDir "$env:USERPROFILE\NixOS"
+.\install.cmd -WithOllama
+.\install.cmd -WithDocker
+.\install.cmd -WithMLflow
+.\install.cmd -WithHindsight
+.\install.cmd -WithHermes
 ```
 
-## 実行後の動作
-
-`-SkipChannelUpdate` を付けない場合、インストール後に以下が自動実行されます。
-
-```sh
-nix-channel --update
-nixos-rebuild switch
-```
-
-## 環境構築の自動実行
-
-`windows/install-nixos-wsl.ps1` は既定で `scripts/nixos-wsl-postinstall.sh` を実行し、
-Flake 化と NixOS host の最小構成を作成します。Home Manager の WSL 設定は、リポジトリで管理する
-`nix/home/wsl.nix` を使用し、postinstall では生成しません。
-
-Home Manager と NixOS host のユーザー識別は、`--user <USER>` の指定または postinstall が
-自動検出したユーザーを `DOTFILES_USER` として共有します。未指定時は NixOS の fallback
-ユーザー（`nixos`）が使われます。postinstall は同じユーザーの home、UID、GID、group も
-`DOTFILES_HOME`、`DOTFILES_UID`、`DOTFILES_GID`、`DOTFILES_GROUP` として rebuild に渡します。
-以後の `nrs`、`nrt`、`nrb` も同じラッパーを使うため、通常の再構成でユーザーが `nixos` に戻りません。
-
-### 同期の仕組み (図)
-
-```
-Windows (D:\my_programing\dotfiles)
-        |
-        |  (postinstall --sync-mode repo)
-        v
-WSL (/home/<user>/.dotfiles)
-        |
-        |  nixos-rebuild switch --flake
-        v
-NixOS の設定が反映される
-```
-
-既定では Windows 側のリポジトリを WSL 側へ同期してからビルドします。
-これにより WSL 側で `flake.lock` が作成されます。
-
-同期方式を変えたい場合:
-
-```powershell
-# repo: リポジトリ全体を同期 (既定)
-pwsh -NoProfile -ExecutionPolicy Bypass -File .\install-nixos-wsl.ps1 -SyncMode repo
-
-# nix: nix ディレクトリだけ同期
-pwsh -NoProfile -ExecutionPolicy Bypass -File .\install-nixos-wsl.ps1 -SyncMode nix
-
-# none: 同期しない (既存の ~/.dotfiles を使う)
-pwsh -NoProfile -ExecutionPolicy Bypass -File .\install-nixos-wsl.ps1 -SyncMode none
-```
-
-スキップしたい場合:
-
-```powershell
-pwsh -NoProfile -ExecutionPolicy Bypass -File .\install-nixos-wsl.ps1 -SkipPostInstallSetup
-```
-
-手動で実行したい場合:
-
-```sh
-sudo bash /mnt/d/my_programing/dotfiles/scripts/nixos-wsl-postinstall.sh --user <USER> --hostname <HOST>
-```
-
-生成される主なファイル:
-
-- `~/.dotfiles/nix/hosts/wsl/default.nix`
-- `~/.dotfiles/nix/hosts/wsl/configuration.nix`
-- `~/.dotfiles/nix/hosts/wsl/hardware-configuration.nix`
-
-`default.nix` は host entrypoint、`configuration.nix` は WSL 固有の system 設定です。新しい
-option は `configuration.nix` に追加し、`default.nix` には import 以外の設定を置きません。
-
-Home Manager の WSL 固有設定は生成物ではなく、`~/.dotfiles/nix/home/wsl.nix` を編集します。
-
-## パッケージ追加方法
-
-パッケージ追加は別ドキュメントに分離しました:
-
-- `docs/nix/package-management.md`
-
-## 起動方法
+### 3. NixOS を起動する
 
 ```powershell
 wsl -d NixOS
 ```
 
-## 注意点
+## installer の実際の処理
 
-- Windows PowerShell 5.1 だと文字化けする場合があるため、`pwsh` を推奨します。
-- `InstallDir` は空ディレクトリである必要があります。
-- 既に同名のディストリが登録済みの場合、インポートはスキップされます。
+現在の Windows の処理経路は次のとおりです。
+
+```text
+install.cmd
+  -> scripts/powershell/install.ps1
+  -> NixOS-WSL の latest release asset を GitHub API から取得
+  -> nixos.wsl が使える場合は wsl --install --from-file
+     （WSL 2.4.4 未満または失敗時は wsl --import --version 2）
+  -> scripts/sh/nixos-wsl-postinstall.sh
+  -> nix flake update
+  -> nixos-rebuild switch --flake ...#nixos --impure
+```
+
+release asset は通常 `nixos.wsl` を優先し、古い release 形式では
+`nixos-wsl.tar.gz` または `nixos-wsl-legacy.tar.gz` を使用します。既に同名の WSL
+ディストリビューションが登録されている場合は再インストールせず、既存の状態を使います。
+
+postinstall は `--user` がなければ UID 1000 の通常ユーザーを検出します。検出したユーザーの
+名前、home、UID、GID、primary group を NixOS、Home Manager、`wsl.defaultUser` に渡すため、
+通常の再構成でユーザーが `nixos` に戻ることはありません。
+
+## リポジトリ同期方式
+
+既定値は `link` です。Windows 側の checkout を WSL から参照し、`~/.dotfiles` をその checkout
+へリンクします。
+
+```text
+Windows checkout
+    |
+    | sync-mode=link (既定)
+    v
+WSL ~/.dotfiles -> /mnt/<drive>/<path>/dotfiles
+    |
+    | nixos-rebuild switch --flake ...#nixos
+    v
+NixOS system + Home Manager
+```
+
+PowerShell から方式を指定できます。
+
+```powershell
+# link: Windows 側 checkout を直接参照（既定）
+.\install.cmd -SyncMode link -SyncBack lock
+
+# repo: リポジトリ全体を WSL の ~/.dotfiles にコピー
+.\install.cmd -SyncMode repo -SyncBack lock
+
+# nix: nix ディレクトリだけを WSL 側へコピー
+.\install.cmd -SyncMode nix -SyncBack lock
+
+# none: 既存の WSL 側 ~/.dotfiles をそのまま使用
+.\install.cmd -SyncMode none -SyncBack none
+```
+
+`-SyncBack repo` は `repo` または `nix` 方式で WSL 側の変更を Windows 側 checkout に戻す場合に
+明示します。通常の初回 setup では `lock` を使い、生成・更新された `flake.lock` だけを戻します。
+
+## 主な installer 引数
+
+```powershell
+# ディストリビューション名と VHD の保存先
+.\install.cmd -DistroName NixOS -InstallDir "$env:USERPROFILE\NixOS"
+
+# 特定の NixOS-WSL release を使う場合（例: 2605.7.2）
+.\install.cmd -ReleaseTag 2605.7.2
+
+# 対話的な終了待ちを抑止
+.\install.cmd -NoPause
+```
+
+通常は `-ReleaseTag` を指定せず、NixOS-WSL の latest release を使用します。`InstallDir` は
+新規インストール時に空のディレクトリである必要があります。
+
+## 手動 postinstall
+
+installer 全体ではなく、既存の NixOS-WSL に dotfiles の postinstall だけを適用する場合は、
+WSL 形式のパスで実行します。
+
+```bash
+sudo bash /mnt/d/path/to/dotfiles/scripts/sh/nixos-wsl-postinstall.sh \
+  --user <USER> \
+  --sync-mode link \
+  --sync-source /mnt/d/path/to/dotfiles \
+  --sync-back lock
+```
+
+`/mnt/d/path/to/dotfiles` は実際の checkout の WSL パスに置き換えてください。postinstall が
+使用する主な設定は次のとおりです。
+
+- `nix/hosts/wsl/default.nix`: NixOS-WSL host の entrypoint
+- `nix/hosts/wsl/configuration.nix`: WSL 固有の system 設定
+- `nix/home/wsl.nix`: WSL 固有の Home Manager 設定
+- `/etc/nixos/hardware-configuration.nix`: native NixOS 用。NixOS-WSL では通常不要
+
+## system version と `system.stateVersion`
+
+NixOS のパッケージや system の更新は `flake.lock` の `nixpkgs` input で決まります。この
+リポジトリは `nixos-unstable` を使用し、初回 postinstall と通常の更新経路で `nix flake update`
+を実行します。WSL 内の更新は次のいずれかを使います。
+
+```bash
+# dotfiles installer の更新経路
+nrs
+
+# 状態を確認してから明示的に rebuild
+nix flake update --flake ~/.dotfiles
+nixos-rebuild switch --flake ~/.dotfiles#nixos --impure
+```
+
+一方、`nix/hosts/wsl/configuration.nix` の次の値は、パッケージの最新版を選択する値ではありません。
+このリポジトリでは WSL の初期構成・移行先を現行 stable の NixOS 26.05 に合わせています。
+
+```nix
+system.stateVersion = "26.05";
+```
+
+これは既存の stateful data と互換性を保つための基準です。既存の WSL 環境へこの変更を適用する場合は、
+Docker、データベース、各種 `/var/lib` のデータをバックアップし、変更後の generation と runtime を
+確認してください。パッケージや system の実体は引き続き `flake.lock` の `nixpkgs` input で決まります。
+このリポジトリの flake は `nixos-unstable` を使用するため、stable の `system.stateVersion` と
+unstable の実体 version が異なることがあります。
+
+- [NixOS Wiki: When do I update stateVersion?](https://wiki.nixos.org/wiki/FAQ/When_do_I_update_stateVersion)
+- [NixOS 26.05 release](https://nixos.org/blog/announcements/2026/nixos-2605/)
+
+## 動作確認
+
+Windows 側:
+
+```powershell
+wsl --list --verbose
+wsl -d NixOS
+```
+
+WSL 側:
+
+```bash
+readlink -f /run/current-system
+nixos-rebuild list-generations
+readlink -f ~/.dotfiles
+```
+
+`nrs` を実行した後、必要な CLI と chezmoi の適用状態を確認します。Windows 側の runtime を
+確認する場合は、リポジトリルートで次を実行します。
+
+```powershell
+.\scripts\powershell\Test-Environment.ps1 -Runtime
+```
+
+installer の途中で停止した場合は、完了済みの宣言状態を再利用できるため、同じ `install.cmd` を
+再実行してください。既存のディストリビューションや install directory を変更する場合は、
+対象の VHD とデータを確認してから操作してください。
+
+## パッケージ追加方法
+
+パッケージ追加は [Nix package management](./package-management.md) を参照してください。

--- a/docs/nix/nixos-wsl-install.md
+++ b/docs/nix/nixos-wsl-install.md
@@ -117,15 +117,20 @@ PowerShell から方式を指定できます。
 # repo: リポジトリ全体を WSL の ~/.dotfiles にコピー
 .\install.cmd -SyncMode repo -SyncBack lock
 
-# nix: nix ディレクトリだけを WSL 側へコピー
-.\install.cmd -SyncMode nix -SyncBack lock
+# nix: 既存の完全な WSL 側 checkout に nix ディレクトリだけを同期
+#      （fresh install では link または repo を使用）
+.\install.cmd -SyncMode nix -SyncBack none
 
 # none: 既存の WSL 側 ~/.dotfiles をそのまま使用
 .\install.cmd -SyncMode none -SyncBack none
 ```
 
-`-SyncBack repo` は `repo` または `nix` 方式で WSL 側の変更を Windows 側 checkout に戻す場合に
-明示します。通常の初回 setup では `lock` を使い、生成・更新された `flake.lock` だけを戻します。
+`nix` 方式は既存の完全な WSL 側 checkout に対する差分同期です。`flake.nix`、`flake.lock`、
+`scripts/` などが既に存在する必要があり、fresh install では使用しないでください。
+また、部分同期した `nix` 方式では `-SyncBack repo` を使わないでください。Windows 側 checkout
+全体を上書きする対象ではありません。`-SyncBack repo` は完全な `repo` 方式で WSL 側の変更を
+Windows 側 checkout に戻す場合だけ使用します。通常の初回 setup では `lock` を使い、生成・更新
+された `flake.lock` だけを戻します。
 
 ## 主な installer 引数
 
@@ -186,9 +191,11 @@ nixos-rebuild switch --flake ~/.dotfiles#nixos --impure
 system.stateVersion = "26.05";
 ```
 
-これは既存の stateful data と互換性を保つための基準です。既存の WSL 環境へこの変更を適用する場合は、
-Docker、データベース、各種 `/var/lib` のデータをバックアップし、変更後の generation と runtime を
-確認してください。パッケージや system の実体は引き続き `flake.lock` の `nixpkgs` input で決まります。
+これは新規構成の基準を 26.05 に移行する明示設定です。既存の 25.05 WSL 環境では、単なる
+パッケージ更新ではなく state schema の移行として扱ってください。適用前に VHD、Docker、データベース、
+各種 `/var/lib` のデータをバックアップし、使用中のモジュールの移行可否を確認してください。適用後は
+generation、`/run/current-system`、Docker、データベース、各種 stateful data の runtime を検証します。
+パッケージや system の実体は引き続き `flake.lock` の `nixpkgs` input で決まります。
 このリポジトリの flake は `nixos-unstable` を使用するため、stable の `system.stateVersion` と
 unstable の実体 version が異なることがあります。
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1786945682,
-        "narHash": "sha256-VBESSoJccikdhxh3vp3SQeG7cZXTOulMvVkoSqNDEhs=",
+        "lastModified": 1787796349,
+        "narHash": "sha256-5s+MJAFyemD6lvrtL2c0jQ7P/XChdx1MPXzoCaQY+ic=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "5b90e281d4e0c8fbd6ca4d8358276fb305b8d0bd",
+        "rev": "3e3da86e4eaccd23f4ce43df9b0a31b16c707347",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.18",
+        "ref": "6.0.20",
         "repo": "brew",
         "type": "github"
       }
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787559586,
-        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
+        "lastModified": 1788450739,
+        "narHash": "sha256-glZLQlzIn1fXH6PazR2iUmTo7kzzyYSshrWhLS9TqCU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
+        "rev": "31729ca8cbdb4fa927b34e5f4353e6a83f39e993",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787797243,
-        "narHash": "sha256-8+Q7NOB7RPajRjA4pbCDLzqH+MTjnG9x6LUPLfL2joA=",
+        "lastModified": 1788651960,
+        "narHash": "sha256-v9wJd32eZ2bvhBzVOd7TIjLQd011P7nwOhjKtWlci5I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "99c9ec63390f1d8c14d95d9e8b17cc29cfbd4e11",
+        "rev": "2c0350c759688177331b8f5242311fae8877bdb3",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1788607843,
-        "narHash": "sha256-J8TPHUiEY/EmxBTKD4KGX9nunyD8dXq83//p/9QPNaM=",
+        "lastModified": 1788684345,
+        "narHash": "sha256-+3tYyzbgr5LdaqPDQ9tHM1JuXx7DVQqZH8MeQ7ooStI=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "896d09ccef580902e01e716e6f4646421087c252",
+        "rev": "76e610601903fd31e82b996b28a49c6d1adb559c",
         "type": "github"
       },
       "original": {
@@ -276,11 +276,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1787330919,
-        "narHash": "sha256-LslMncqN7uOOH5S88WZtO/EVt2HwD8ltUnfyANk+mC0=",
+        "lastModified": 1788444135,
+        "narHash": "sha256-ChwTDZPvTmEgZdS30dUfgdXlzAPtZAUWwEH/PfDXZmg=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "b00218e4aec0e5bf07d61a0bb13f842faa582d7b",
+        "rev": "ec8417a617de4d3c739aed40837e308ebd667165",
         "type": "github"
       },
       "original": {
@@ -352,11 +352,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788400875,
-        "narHash": "sha256-JIHQ6xNAN53cdo6zZ72LRcQ9lpvnABCnNE4hldJ5uZU=",
+        "lastModified": 1788549839,
+        "narHash": "sha256-kOrCcSIA6w9J1hX5DqHy2k9pDTJymExTsbV74U9UtCA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5545adfad2e98de106a5544ca7067e03010410bd",
+        "rev": "17de0b976395537756f30a3e78f2f06e5cec89ed",
         "type": "github"
       },
       "original": {
@@ -383,11 +383,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1787900134,
-        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {
@@ -451,11 +451,11 @@
         "userborn": "userborn"
       },
       "locked": {
-        "lastModified": 1786747314,
-        "narHash": "sha256-L8GneKBeYOStPrLUAypI8bDGNjntcH2AngxSig/ul8c=",
+        "lastModified": 1788643028,
+        "narHash": "sha256-llyR4NuuJLDS49y8j9zbGi5pzjSuuc6CB8ipPJlXfIk=",
         "owner": "numtide",
         "repo": "system-manager",
-        "rev": "64748b62d6ae74c069234103ce368626bcad8c70",
+        "rev": "41d9628959faa2d12f65057aeb6f566c4ccfbd3d",
         "type": "github"
       },
       "original": {
@@ -607,11 +607,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788085765,
-        "narHash": "sha256-twHAd8m9tSoskIl7BUxYuY1p3+bqO38haKQUflsEbhg=",
+        "lastModified": 1788594423,
+        "narHash": "sha256-Ye0Z9bLfxa9lxCdzeslB3O5cW2VhQO4vFYBWd+hCoVw=",
         "owner": "raine",
         "repo": "workmux",
-        "rev": "a72be9426136aa7af36c2bd7b3d92155b7be114e",
+        "rev": "17f168366bb1dd15514aff0c18ca42a758e0c139",
         "type": "github"
       },
       "original": {

--- a/nix/hosts/wsl/configuration.nix
+++ b/nix/hosts/wsl/configuration.nix
@@ -26,5 +26,5 @@ in
   # this value at the release version of the first install of this system.
   # Before changing this value read the documentation for this option
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-  system.stateVersion = "25.05"; # Did you read the comment?
+  system.stateVersion = "26.05"; # Did you read the comment?
 }

--- a/nix/hosts/wsl/configuration.nix
+++ b/nix/hosts/wsl/configuration.nix
@@ -10,6 +10,8 @@
 let
   configuredUser = builtins.getEnv "DOTFILES_USER";
   user = if configuredUser == "" then "nixos" else configuredUser;
+  configuredStateVersion = builtins.getEnv "DOTFILES_STATE_VERSION";
+  stateVersion = if configuredStateVersion == "" then "25.05" else configuredStateVersion;
 in
 
 {
@@ -26,5 +28,7 @@ in
   # this value at the release version of the first install of this system.
   # Before changing this value read the documentation for this option
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-  system.stateVersion = "26.05"; # Did you read the comment?
+  # New installs and explicitly approved migrations pass 26.05 through
+  # DOTFILES_STATE_VERSION. Existing systems remain on 25.05 by default.
+  system.stateVersion = stateVersion; # Did you read the comment?
 }

--- a/scripts/powershell/handlers/Handler.NixOSWSL.ps1
+++ b/scripts/powershell/handlers/Handler.NixOSWSL.ps1
@@ -467,7 +467,12 @@ class NixOSWSLHandler : SetupHandlerBase {
         $syncMode = $ctx.GetOption("SyncMode", "link")
         $syncBack = $ctx.GetOption("SyncBack", "lock")
         $timeoutSeconds = $ctx.GetOption("PostInstallTimeoutSeconds", 1800)
-        $cmd = "bash `"$wslPath`" --force --sync-mode $syncMode --sync-back $syncBack"
+        $forcePostInstall = [bool]$ctx.GetOption("ForcePostInstall", $false)
+        $cmd = "bash `"$wslPath`""
+        if ($forcePostInstall) {
+            $cmd += " --force"
+        }
+        $cmd += " --sync-mode $syncMode --sync-back $syncBack"
         if ($ctx.GetOption("SkipFlakeUpdate", $false)) {
             $cmd += " --skip-flake-update"
         }

--- a/scripts/powershell/handlers/Handler.NixOSWSL.ps1
+++ b/scripts/powershell/handlers/Handler.NixOSWSL.ps1
@@ -473,6 +473,10 @@ class NixOSWSLHandler : SetupHandlerBase {
             $cmd += " --force"
         }
         $cmd += " --sync-mode $syncMode --sync-back $syncBack"
+        $stateVersion = [string]$ctx.GetOption("StateVersion", "")
+        if (-not [string]::IsNullOrWhiteSpace($stateVersion)) {
+            $cmd += " --state-version $stateVersion"
+        }
         if ($ctx.GetOption("SkipFlakeUpdate", $false)) {
             $cmd += " --skip-flake-update"
         }

--- a/scripts/powershell/handlers/Handler.NixRebuild.ps1
+++ b/scripts/powershell/handlers/Handler.NixRebuild.ps1
@@ -16,6 +16,8 @@ $libPath = Split-Path -Parent $PSScriptRoot
 
 class NixRebuildHandler : SetupHandlerBase {
     hidden [string] $PnpmHomePath = '$HOME/.local/share/pnpm'
+    hidden [string] $NixOsUser = 'nixos'
+    hidden [string] $NixOsHome = '/home/nixos'
 
     hidden [string] GetPnpmShellPrefix() {
         return "export PNPM_HOME=$($this.PnpmHomePath); export PATH=`"`$PNPM_HOME/bin:`$PNPM_HOME:`$HOME/.npm-global/bin:`$PATH`""
@@ -26,6 +28,22 @@ class NixRebuildHandler : SetupHandlerBase {
         $this.Description = "nixos-rebuild switch の実行"
         $this.Order = 55
         $this.RequiresAdmin = $false
+    }
+
+    hidden [void] ResolveNixOsIdentity([string]$distroName) {
+        $identityCommand = 'user=$(cat /var/lib/dotfiles/user 2>/dev/null || true); if [ -z "$user" ]; then user=$(awk -F= ''/^\[user\]/{in_user=1; next} /^\[/{in_user=0} in_user && $1=="default" {gsub(/[[:space:]]/,"",$2); print $2; exit}'' /etc/wsl.conf 2>/dev/null || true); fi; if [ -z "$user" ]; then user=$(getent passwd 1000 | cut -d: -f1); fi; if [ -n "$user" ]; then home=$(getent passwd "$user" | cut -d: -f6); printf "%s\t%s" "$user" "$home"; fi'
+        $identityOutput = Invoke-Wsl -Arguments @(
+            "-d", $distroName, "-u", "root", "--", "bash", "-lc", $identityCommand
+        )
+        $identityText = if ($identityOutput) { ([string]($identityOutput | Select-Object -First 1)).Trim() } else { "" }
+        if ($identityText -match '^(?<user>[a-z_][a-z0-9_-]*[$]?)\s+(?<home>/\S+)$') {
+            $this.NixOsUser = $Matches.user
+            $this.NixOsHome = $Matches.home
+        }
+        else {
+            $this.NixOsUser = 'nixos'
+            $this.NixOsHome = '/home/nixos'
+        }
     }
 
     [bool] CanApply([SetupContext]$ctx) {
@@ -68,12 +86,12 @@ class NixRebuildHandler : SetupHandlerBase {
             # core.hooksPath が設定されていると pre-commit install が拒否するため
             # local/global/system すべてのレベルで解除する
             Invoke-Wsl -Arguments @(
-                "-d", $distroName, "-u", "nixos", "--",
+                "-d", $distroName, "-u", $this.NixOsUser, "--",
                 "bash", "-lc", "cd ~/.dotfiles && git config --unset-all core.hooksPath 2>/dev/null; git config --global --unset-all core.hooksPath 2>/dev/null; true"
             )
 
             $output = Invoke-Wsl -Arguments @(
-                "-d", $distroName, "-u", "nixos", "--",
+                "-d", $distroName, "-u", $this.NixOsUser, "--",
                 "bash", "-lc", "cd ~/.dotfiles && pre-commit install --install-hooks"
             )
             $preCommitExitCode = $LASTEXITCODE
@@ -100,7 +118,7 @@ class NixRebuildHandler : SetupHandlerBase {
         # WSL interop 経由で Windows 版 pnpm が /mnt/ 配下に見えることがある。
         # Linux ネイティブの pnpm のみを有効とみなすため /mnt/ 配下を除外して確認する。
         Invoke-Wsl -Arguments @(
-            "-d", $distroName, "-u", "nixos", "--",
+            "-d", $distroName, "-u", $this.NixOsUser, "--",
             "bash", "-lc", "$($this.GetPnpmShellPrefix()); command -v pnpm 2>/dev/null | grep -qv '^/mnt/'"
         ) | Out-Null
         if ($LASTEXITCODE -ne 0) {
@@ -108,7 +126,7 @@ class NixRebuildHandler : SetupHandlerBase {
             # NixOS では npm のグローバルプレフィックスが read-only nix store を指すため
             # ~/.npm-global に変更してからインストールする
             Invoke-Wsl -Arguments @(
-                "-d", $distroName, "-u", "nixos", "--",
+                "-d", $distroName, "-u", $this.NixOsUser, "--",
                 "bash", "-lc", "mkdir -p ~/.npm-global && npm config set prefix ~/.npm-global && npm install -g pnpm && grep -q npm-global ~/.bashrc || echo 'export PATH=~/.npm-global/bin:`$PATH' >> ~/.bashrc"
             )
             if ($LASTEXITCODE -ne 0) {
@@ -119,19 +137,19 @@ class NixRebuildHandler : SetupHandlerBase {
 
         # PNPM_HOME が未設定なら pnpm setup を実行してグローバル bin ディレクトリを作成
         $pnpmHomeCheck = Invoke-Wsl -Arguments @(
-            "-d", $distroName, "-u", "nixos", "--",
+            "-d", $distroName, "-u", $this.NixOsUser, "--",
             "bash", "-lc", "$($this.GetPnpmShellPrefix()); [ -d `"`$PNPM_HOME`" ] && [ -d `"`$PNPM_HOME/bin`" ] && echo exists"
         )
         if (-not $pnpmHomeCheck -or $pnpmHomeCheck -notmatch 'exists') {
             $this.Log("PNPM_HOME を設定しています...")
             Invoke-Wsl -Arguments @(
-                "-d", $distroName, "-u", "nixos", "--",
+                "-d", $distroName, "-u", $this.NixOsUser, "--",
                 "bash", "-lc", "$($this.GetPnpmShellPrefix()); mkdir -p `"`$PNPM_HOME`" `"`$PNPM_HOME/bin`"; pnpm setup 2>/dev/null || true"
             )
         }
         # .bashrc に PNPM_HOME/bin が無ければ追加
         Invoke-Wsl -Arguments @(
-            "-d", $distroName, "-u", "nixos", "--",
+            "-d", $distroName, "-u", $this.NixOsUser, "--",
             "bash", "-lc", "grep -q 'PNPM_HOME/bin' ~/.bashrc || echo 'export PNPM_HOME=$($this.PnpmHomePath); export PATH=`$PNPM_HOME/bin:`$PNPM_HOME:`$PATH' >> ~/.bashrc"
         )
     }
@@ -155,7 +173,7 @@ class NixRebuildHandler : SetupHandlerBase {
 
             # インストール済みパッケージを取得してフィルタリング
             $installedOutput = Invoke-Wsl -Arguments @(
-                "-d", $distroName, "-u", "nixos", "--",
+                "-d", $distroName, "-u", $this.NixOsUser, "--",
                 "bash", "-lc", "$($this.GetPnpmShellPrefix()); pnpm ls -g --depth=0 2>/dev/null"
             )
             $toInstall = @()
@@ -221,7 +239,7 @@ class NixRebuildHandler : SetupHandlerBase {
 
             # PNPM_HOME と ~/.npm-global/bin を PATH に追加
             $pnpmExitCode = $this.InvokeWslPnpmInstall(@(
-                    "-d", $distroName, "-u", "nixos", "--",
+                    "-d", $distroName, "-u", $this.NixOsUser, "--",
                     "bash", "-lc", "$($this.GetPnpmShellPrefix()); pnpm add -g --reporter=append-only --yes $quotedInstallArgs $quotedPkgs"
                 ))
 
@@ -302,7 +320,7 @@ class NixRebuildHandler : SetupHandlerBase {
             }
 
             Invoke-Wsl -Arguments @(
-                "-d", $distroName, "-u", "nixos", "--",
+                "-d", $distroName, "-u", $this.NixOsUser, "--",
                 "bash", "-lc", "$($this.GetPnpmShellPrefix()); timeout ${timeoutSeconds}s $cmdLine"
             ) | ForEach-Object {
                 if ($_ -notmatch '^\s*$') {
@@ -329,9 +347,9 @@ class NixRebuildHandler : SetupHandlerBase {
         $driveLetter = $dotfilesPath.Substring(0, 1).ToLower()
         $wslMountPath = '/mnt/' + $driveLetter + ($dotfilesPath.Substring(2) -replace '\\', '/')
 
-        $dotfilesLinkPath = "/home/nixos/.dotfiles"
+        $dotfilesLinkPath = "$($this.NixOsHome)/.dotfiles"
         $existingTarget = Invoke-Wsl -Arguments @(
-            "-d", $distroName, "-u", "nixos", "--",
+            "-d", $distroName, "-u", $this.NixOsUser, "--",
             "bash", "-lc", "if [ -L $dotfilesLinkPath ]; then readlink -f $dotfilesLinkPath 2>/dev/null; elif [ -e $dotfilesLinkPath ]; then printf '__non_symlink__'; fi"
         )
         $existingTargetText = if ($existingTarget) { ([string]($existingTarget | Select-Object -First 1)).Trim() } else { "" }
@@ -343,10 +361,10 @@ class NixRebuildHandler : SetupHandlerBase {
         }
 
         # Windows dotfiles が WSL からアクセスできるか確認
-        Invoke-Wsl -Arguments @("-d", $distroName, "-u", "nixos", "--", "bash", "-lc", "test -d `"$wslMountPath`"") | Out-Null
+        Invoke-Wsl -Arguments @("-d", $distroName, "-u", $this.NixOsUser, "--", "bash", "-lc", "test -d `"$wslMountPath`"") | Out-Null
         if ($LASTEXITCODE -eq 0) {
             $this.Log("dotfiles を WSL マウント経由でリンクします: $wslMountPath")
-            Invoke-Wsl -Arguments @("-d", $distroName, "-u", "nixos", "--", "bash", "-lc", "ln -sfn `"$wslMountPath`" $dotfilesLinkPath")
+            Invoke-Wsl -Arguments @("-d", $distroName, "-u", $this.NixOsUser, "--", "bash", "-lc", "ln -sfn `"$wslMountPath`" $dotfilesLinkPath")
             if ($LASTEXITCODE -ne 0) {
                 throw "dotfiles のシンボリックリンク作成に失敗しました"
             }
@@ -364,13 +382,14 @@ class NixRebuildHandler : SetupHandlerBase {
 
         try {
             $distroName = $ctx.DistroName
+            $this.ResolveNixOsIdentity($distroName)
 
             # dotfiles が NixOS 内に存在しなければ Windows マウント経由でリンク
             $this.EnsureDotfilesAvailable($distroName, $ctx.DotfilesPath)
 
             $this.Log("nix flake update を実行しています...")
-            $flakeUpdateCommand = 'user=$(getent passwd 1000 | cut -d: -f1); home=$(getent passwd 1000 | cut -d: -f6); cd $home/.dotfiles && nix flake update 2>&1'
-            $flakeUpdateOutput = Invoke-Wsl -Arguments @("-d", $distroName, "-u", "nixos", "--", "bash", "-lc", $flakeUpdateCommand)
+            $flakeUpdateCommand = "cd $($this.QuoteShellArg("$($this.NixOsHome)/.dotfiles")) && nix flake update 2>&1"
+            $flakeUpdateOutput = Invoke-Wsl -Arguments @("-d", $distroName, "-u", $this.NixOsUser, "--", "bash", "-lc", $flakeUpdateCommand)
             $flakeUpdateExitCode = $LASTEXITCODE
             $flakeUpdateErrors = [System.Collections.Generic.List[string]]::new()
             $flakeUpdateOutput | ForEach-Object {
@@ -402,7 +421,7 @@ class NixRebuildHandler : SetupHandlerBase {
 
             # 実ユーザーの identity を wrapper に渡して nixos-rebuild switch を実行する。
             # 2>&1 で stderr も捕捉しエラー詳細をログに残す。
-            $rebuildCommand = 'user=$(getent passwd 1000 | cut -d: -f1); home=$(getent passwd 1000 | cut -d: -f6); uid=$(id -u $user); gid=$(id -g $user); group=$(id -gn $user); cd $home/.dotfiles && DOTFILES_USER=$user DOTFILES_HOME=$home DOTFILES_UID=$uid DOTFILES_GID=$gid DOTFILES_GROUP=$group bash scripts/sh/nixos-rebuild-with-user.sh switch --flake . --impure 2>&1'
+            $rebuildCommand = "cd $($this.QuoteShellArg("$($this.NixOsHome)/.dotfiles")) && DOTFILES_USER=$($this.QuoteShellArg($this.NixOsUser)) DOTFILES_HOME=$($this.QuoteShellArg($this.NixOsHome)) bash scripts/sh/nixos-rebuild-with-user.sh switch --flake . --impure 2>&1"
             $output = Invoke-Wsl -Arguments @("-d", $distroName, "-u", "root", "--", "bash", "-lc", $rebuildCommand)
             $nixosExitCode = $LASTEXITCODE
 

--- a/scripts/powershell/handlers/Handler.NixRebuild.ps1
+++ b/scripts/powershell/handlers/Handler.NixRebuild.ps1
@@ -369,7 +369,8 @@ class NixRebuildHandler : SetupHandlerBase {
             $this.EnsureDotfilesAvailable($distroName, $ctx.DotfilesPath)
 
             $this.Log("nix flake update を実行しています...")
-            $flakeUpdateOutput = Invoke-Wsl -Arguments @("-d", $distroName, "-u", "nixos", "--", "bash", "-lc", "cd /home/nixos/.dotfiles && nix flake update 2>&1")
+            $flakeUpdateCommand = 'user=$(getent passwd 1000 | cut -d: -f1); home=$(getent passwd 1000 | cut -d: -f6); cd $home/.dotfiles && nix flake update 2>&1'
+            $flakeUpdateOutput = Invoke-Wsl -Arguments @("-d", $distroName, "-u", "nixos", "--", "bash", "-lc", $flakeUpdateCommand)
             $flakeUpdateExitCode = $LASTEXITCODE
             $flakeUpdateErrors = [System.Collections.Generic.List[string]]::new()
             $flakeUpdateOutput | ForEach-Object {
@@ -399,8 +400,10 @@ class NixRebuildHandler : SetupHandlerBase {
                 "bash", "-lc", "grep -qs 'directory = \*' /root/.gitconfig 2>/dev/null || printf '[safe]\n\tdirectory = *\n' >> /root/.gitconfig"
             ) | Out-Null
 
-            # root で nixos-rebuild switch を実行。2>&1 で stderr も捕捉しエラー詳細をログに残す。
-            $output = Invoke-Wsl -Arguments @("-d", $distroName, "-u", "root", "--", "bash", "-lc", "cd /home/nixos/.dotfiles && nixos-rebuild switch --flake .#nixos 2>&1")
+            # 実ユーザーの identity を wrapper に渡して nixos-rebuild switch を実行する。
+            # 2>&1 で stderr も捕捉しエラー詳細をログに残す。
+            $rebuildCommand = 'user=$(getent passwd 1000 | cut -d: -f1); home=$(getent passwd 1000 | cut -d: -f6); uid=$(id -u $user); gid=$(id -g $user); group=$(id -gn $user); cd $home/.dotfiles && DOTFILES_USER=$user DOTFILES_HOME=$home DOTFILES_UID=$uid DOTFILES_GID=$gid DOTFILES_GROUP=$group bash scripts/sh/nixos-rebuild-with-user.sh switch --flake . --impure 2>&1'
+            $output = Invoke-Wsl -Arguments @("-d", $distroName, "-u", "root", "--", "bash", "-lc", $rebuildCommand)
             $nixosExitCode = $LASTEXITCODE
 
             # error: で始まる行は LogError（赤）、それ以外は Gray で表示

--- a/scripts/powershell/install.admin.ps1
+++ b/scripts/powershell/install.admin.ps1
@@ -15,6 +15,8 @@ param(
     [string]$InstallDir = "$env:USERPROFILE\NixOS",
     [string]$ReleaseTag = "",
     [string]$PostInstallScript = "",
+    [ValidatePattern('^\d{2}\.\d{2}$')]
+    [string]$StateVersion = "26.05",
     [hashtable]$Options = @{},
     [string]$OptionsJson = "",
     [string]$OptionsBase64 = "",
@@ -156,6 +158,7 @@ foreach ($key in $effectiveOptions.Keys) {
 
 $context.Options["ReleaseTag"] = $ReleaseTag
 $context.Options["PostInstallScript"] = $PostInstallScript
+$context.Options["StateVersion"] = $StateVersion
 $context.Options["SyncMode"] = $SyncMode
 $context.Options["SyncBack"] = $SyncBack
 

--- a/scripts/powershell/install.ps1
+++ b/scripts/powershell/install.ps1
@@ -21,6 +21,8 @@ param(
     [string]$InstallDir = "$env:USERPROFILE\NixOS",
     [string]$ReleaseTag = "",
     [string]$PostInstallScript = "",
+    [ValidatePattern('^\d{2}\.\d{2}$')]
+    [string]$StateVersion = "26.05",
     [hashtable]$Options = @{},
     [ValidateSet("link", "repo", "nix", "none")]
     [string]$SyncMode = "link",
@@ -79,6 +81,7 @@ function Get-PhaseParameters {
         InstallDir        = $InstallDir
         ReleaseTag        = $ReleaseTag
         PostInstallScript = $PostInstallScript
+        StateVersion      = $StateVersion
         Options           = $Options
         SyncMode          = $SyncMode
         SyncBack          = $SyncBack
@@ -200,6 +203,10 @@ if ($adminRequired) {
         if (-not [string]::IsNullOrWhiteSpace($PostInstallScript)) {
             $argList += "-PostInstallScript"
             $argList += $PostInstallScript
+        }
+        if (-not [string]::IsNullOrWhiteSpace($StateVersion)) {
+            $argList += "-StateVersion"
+            $argList += $StateVersion
         }
 
         # 管理者昇格プロセスの出力をログファイルに記録し、終了後に表示

--- a/scripts/powershell/install.ps1
+++ b/scripts/powershell/install.ps1
@@ -33,6 +33,7 @@ param(
     [switch]$WithMLflow,
     [switch]$WithHindsight,
     [switch]$WithHermes,
+    [switch]$ForcePostInstall,
     [switch]$NoPause
 )
 
@@ -122,6 +123,10 @@ if ($UserPhaseOnly) {
         Read-Host | Out-Null
     }
     exit 0
+}
+
+if ($ForcePostInstall) {
+    $Options["ForcePostInstall"] = $true
 }
 
 # Phase 2a: 管理者不要の Phase 2 ハンドラーを非昇格で実行

--- a/scripts/powershell/install.user.ps1
+++ b/scripts/powershell/install.user.ps1
@@ -12,6 +12,8 @@ param(
     [string]$InstallDir = "$env:USERPROFILE\NixOS",
     [string]$ReleaseTag = "",
     [string]$PostInstallScript = "",
+    [ValidatePattern('^\d{2}\.\d{2}$')]
+    [string]$StateVersion = "26.05",
     [hashtable]$Options = @{},
     [ValidateSet("link", "repo", "nix", "none")]
     [string]$SyncMode = "link",
@@ -53,6 +55,7 @@ foreach ($key in $Options.Keys) {
 $context.Options["WingetMode"] = "import"
 $context.Options["ReleaseTag"] = $ReleaseTag
 $context.Options["PostInstallScript"] = $PostInstallScript
+$context.Options["StateVersion"] = $StateVersion
 $context.Options["SyncMode"] = $SyncMode
 $context.Options["SyncBack"] = $SyncBack
 

--- a/scripts/powershell/tests/Install.Entrypoint.Tests.ps1
+++ b/scripts/powershell/tests/Install.Entrypoint.Tests.ps1
@@ -208,6 +208,7 @@ param(
     [string]$InstallDir = "",
     [string]$ReleaseTag = "",
     [string]$PostInstallScript = "",
+    [string]$StateVersion = "26.05",
     [hashtable]$Options = @{},
     [string]$SyncMode = "link",
     [string]$SyncBack = "lock"
@@ -222,6 +223,7 @@ param(
     [string]$InstallDir = "",
     [string]$ReleaseTag = "",
     [string]$PostInstallScript = "",
+    [string]$StateVersion = "26.05",
     [hashtable]$Options = @{},
     [string]$OptionsJson = "",
     [string]$SyncMode = "link",

--- a/scripts/powershell/tests/handlers/Handler.NixOSWSL.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.NixOSWSL.Tests.ps1
@@ -649,6 +649,49 @@ Describe 'NixOSWSLHandler' {
             $script:timeoutSeconds | Should -Be 123
         }
 
+        It 'should not force removal of an existing repo by default' {
+            $scriptFile = Join-Path $TestDrive "postinstall.sh"
+            New-Item $scriptFile -ItemType File -Force | Out-Null
+            $ctx.Options["PostInstallScript"] = $scriptFile
+            $script:execCmd = ""
+            Mock Invoke-Wsl {
+                param($Arguments)
+                if ($Arguments -contains "wslpath") {
+                    $global:LASTEXITCODE = 0
+                    return "/mnt/c/test/postinstall.sh"
+                }
+                $script:execCmd = $Arguments[-1]
+                $global:LASTEXITCODE = 0
+            }
+            Mock Write-Host { }
+
+            $handler.ExecutePostInstall($ctx)
+
+            $script:execCmd | Should -Not -Match '--force'
+        }
+
+        It 'should pass force only when explicitly requested' {
+            $scriptFile = Join-Path $TestDrive "postinstall.sh"
+            New-Item $scriptFile -ItemType File -Force | Out-Null
+            $ctx.Options["PostInstallScript"] = $scriptFile
+            $ctx.Options["ForcePostInstall"] = $true
+            $script:execCmd = ""
+            Mock Invoke-Wsl {
+                param($Arguments)
+                if ($Arguments -contains "wslpath") {
+                    $global:LASTEXITCODE = 0
+                    return "/mnt/c/test/postinstall.sh"
+                }
+                $script:execCmd = $Arguments[-1]
+                $global:LASTEXITCODE = 0
+            }
+            Mock Write-Host { }
+
+            $handler.ExecutePostInstall($ctx)
+
+            $script:execCmd | Should -Match '--force'
+        }
+
         It 'should pass skip-flake-update when requested' {
             $scriptFile = Join-Path $TestDrive "postinstall.sh"
             New-Item $scriptFile -ItemType File -Force | Out-Null

--- a/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
@@ -1037,5 +1037,32 @@ Describe 'NixRebuildHandler' {
 
             $script:mountPath | Should -Be "/mnt/c/Users/foo/dotfiles"
         }
+
+        It 'should resolve the configured WSL user and home instead of assuming nixos' {
+            $script:identityArgs = ""
+            $script:userArgs = ""
+            Mock Invoke-Wsl {
+                param($Arguments)
+                $argStr = $Arguments -join " "
+                if ($argStr -match "/var/lib/dotfiles/user") {
+                    $script:identityArgs = $argStr
+                    $global:LASTEXITCODE = 0
+                    return "alice`t/home/alice"
+                }
+                if ($argStr -match "-u alice") {
+                    $script:userArgs = $argStr
+                }
+                $global:LASTEXITCODE = 0
+                return ""
+            }
+
+            $handler.ResolveNixOsIdentity("NixOS")
+            $handler.EnsureDotfilesAvailable("NixOS", "D:\ruru\dotfiles")
+
+            $handler.NixOsUser | Should -Be "alice"
+            $handler.NixOsHome | Should -Be "/home/alice"
+            $script:identityArgs | Should -Match "-u root"
+            $script:userArgs | Should -Match "-u alice"
+        }
     }
 }

--- a/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
+++ b/scripts/powershell/tests/handlers/Handler.NixRebuild.Tests.ps1
@@ -129,6 +129,9 @@ Describe 'NixRebuildHandler' {
             Should -Invoke Write-Host -ParameterFilter {
                 $ForegroundColor -eq 'Gray' -and ([string]$Object) -match 'building NixOS'
             } -Times 1
+            Should -Invoke Invoke-Wsl -ParameterFilter {
+                ($Arguments -join " ") -match "nixos-rebuild-with-user"
+            } -Times 1
         }
 
         It 'should fail when nixos-rebuild switch fails' {
@@ -556,8 +559,7 @@ Describe 'NixRebuildHandler' {
 
             $script:wslArgs | Should -Match "-d NixOS"
             $script:wslArgs | Should -Match "-u root"
-            $script:wslArgs | Should -Match "cd /home/nixos/.dotfiles"
-            $script:wslArgs | Should -Match "nixos-rebuild switch --flake"
+            $script:wslArgs | Should -Match "nixos-rebuild-with-user.sh switch --flake . --impure"
         }
 
         It 'should update the flake lock before nixos-rebuild so Nix packages use latest inputs' {

--- a/scripts/sh/hermes-agent.sh
+++ b/scripts/sh/hermes-agent.sh
@@ -765,7 +765,7 @@ dotfiles_hermes_sync_xapi_refresh_token_to_onepassword() {
       "$op_command" item get "$item" --account "$account" --vault "$vault" --format json >"$item_file" || status=$?
   fi
   if ((status == 0)); then
-    if python3 - "$item_file" "$cache_path" >"$template_file" <<'PY'; then
+    if python3 - "$item_file" "$cache_path" >"$template_file" <<'PY'
 import json
 import re
 import sys
@@ -791,6 +791,7 @@ if fields[0].get("value") == refresh_token:
 fields[0]["value"] = refresh_token
 sys.stdout.write(json.dumps(item, separators=(",", ":")))
 PY
+    then
       render_status=0
     else
       render_status=$?

--- a/scripts/sh/nixos-rebuild-with-user.sh
+++ b/scripts/sh/nixos-rebuild-with-user.sh
@@ -27,16 +27,50 @@ uid="${DOTFILES_UID:-$(id -u "$user")}"
 gid="${DOTFILES_GID:-$(id -g "$user")}"
 group="${DOTFILES_GROUP:-$(id -gn "$user")}"
 
+state_dir="${DOTFILES_STATE_DIR:-/var/lib/dotfiles}"
+state_version_file="$state_dir/system-state-version"
+if [[ -n ${DOTFILES_STATE_VERSION:-} ]]; then
+  state_version="$DOTFILES_STATE_VERSION"
+elif [[ -r $state_version_file ]]; then
+  state_version="$(cat "$state_version_file")"
+elif [[ -e /run/current-system ]]; then
+  # Existing systems keep their original state schema unless migration is
+  # explicitly requested. Fresh installers pass 26.05 explicitly.
+  state_version="25.05"
+else
+  state_version="26.05"
+fi
+[[ $state_version =~ ^[0-9]{2}\.[0-9]{2}$ ]] || {
+  echo "Invalid DOTFILES_STATE_VERSION: $state_version (expected YY.MM)." >&2
+  exit 1
+}
+
 rebuild_env=(
   "DOTFILES_USER=$user"
   "DOTFILES_HOME=$home"
   "DOTFILES_UID=$uid"
   "DOTFILES_GID=$gid"
   "DOTFILES_GROUP=$group"
+  "DOTFILES_STATE_VERSION=$state_version"
 )
 
 if [[ $(id -u) -eq 0 ]]; then
-  exec /usr/bin/env "${rebuild_env[@]}" nixos-rebuild "$@"
+  /usr/bin/env "${rebuild_env[@]}" nixos-rebuild "$@"
+  rebuild_status=$?
+else
+  sudo /usr/bin/env "${rebuild_env[@]}" nixos-rebuild "$@"
+  rebuild_status=$?
 fi
 
-exec sudo /usr/bin/env "${rebuild_env[@]}" nixos-rebuild "$@"
+if [[ $rebuild_status -eq 0 && ${1:-} == "switch" ]]; then
+  if [[ $(id -u) -eq 0 ]]; then
+    install -d -m 0755 "$state_dir"
+    printf '%s\n' "$state_version" >"$state_version_file"
+    chmod 0644 "$state_version_file"
+  else
+    sudo install -d -m 0755 "$state_dir"
+    printf '%s\n' "$state_version" | sudo tee "$state_version_file" >/dev/null
+  fi
+fi
+
+exit "$rebuild_status"

--- a/scripts/sh/nixos-rebuild-with-user.sh
+++ b/scripts/sh/nixos-rebuild-with-user.sh
@@ -27,10 +27,16 @@ uid="${DOTFILES_UID:-$(id -u "$user")}"
 gid="${DOTFILES_GID:-$(id -g "$user")}"
 group="${DOTFILES_GROUP:-$(id -gn "$user")}"
 
-exec sudo /usr/bin/env \
-  "DOTFILES_USER=$user" \
-  "DOTFILES_HOME=$home" \
-  "DOTFILES_UID=$uid" \
-  "DOTFILES_GID=$gid" \
-  "DOTFILES_GROUP=$group" \
-  nixos-rebuild "$@"
+rebuild_env=(
+  "DOTFILES_USER=$user"
+  "DOTFILES_HOME=$home"
+  "DOTFILES_UID=$uid"
+  "DOTFILES_GID=$gid"
+  "DOTFILES_GROUP=$group"
+)
+
+if [[ $(id -u) -eq 0 ]]; then
+  exec /usr/bin/env "${rebuild_env[@]}" nixos-rebuild "$@"
+fi
+
+exec sudo /usr/bin/env "${rebuild_env[@]}" nixos-rebuild "$@"

--- a/scripts/sh/nixos-wsl-postinstall.sh
+++ b/scripts/sh/nixos-wsl-postinstall.sh
@@ -17,6 +17,7 @@ Options:
   --sync-mode <mode>   Sync mode: link|repo|nix|none (default: link)
   --sync-source <path> Source dir for sync (default: script repo root)
   --sync-back <mode>   Sync back: lock|none (default: lock when sync-mode=link)
+  --state-version <v>  State version for new or explicitly migrated systems (default: preserve)
   --skip-flake-update  Do not update flake inputs before nixos-rebuild
   --force              Allow non-empty repo dir (no deletion)
   -h, --help           Show help
@@ -37,6 +38,8 @@ SYNC_MODE="link"
 SYNC_SOURCE=""
 SYNC_BACK=""
 SKIP_FLAKE_UPDATE=0
+STATE_VERSION=""
+DOTFILES_STATE_DIR="${DOTFILES_STATE_DIR:-/var/lib/dotfiles}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -68,6 +71,10 @@ while [[ $# -gt 0 ]]; do
     SYNC_BACK="${2:-}"
     shift 2
     ;;
+  --state-version)
+    STATE_VERSION="${2:-}"
+    shift 2
+    ;;
   --skip-flake-update)
     SKIP_FLAKE_UPDATE=1
     shift
@@ -87,6 +94,11 @@ while [[ $# -gt 0 ]]; do
     ;;
   esac
 done
+
+if [[ -n $STATE_VERSION && ! $STATE_VERSION =~ ^[0-9]{2}\.[0-9]{2}$ ]]; then
+  echo "Invalid --state-version: $STATE_VERSION (expected YY.MM)." >&2
+  exit 1
+fi
 
 if [[ -z $USER_NAME ]]; then
   USER_NAME="$(getent passwd 1000 | cut -d: -f1 || true)"
@@ -112,10 +124,18 @@ export DOTFILES_HOME="$USER_HOME"
 export DOTFILES_UID="$(id -u "$USER_NAME")"
 export DOTFILES_GID="$(id -g "$USER_NAME")"
 export DOTFILES_GROUP="$(id -gn "$USER_NAME")"
+export DOTFILES_STATE_DIR
+if [[ -n $STATE_VERSION ]]; then
+  export DOTFILES_STATE_VERSION="$STATE_VERSION"
+fi
 
 if [[ -z $REPO_DIR ]]; then
   REPO_DIR="/home/$USER_NAME/.dotfiles"
 fi
+
+install -d -m 0755 "$DOTFILES_STATE_DIR"
+printf '%s\n' "$USER_NAME" >"$DOTFILES_STATE_DIR/user"
+chmod 0644 "$DOTFILES_STATE_DIR/user"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"

--- a/scripts/sh/nixos-wsl-postinstall.sh
+++ b/scripts/sh/nixos-wsl-postinstall.sh
@@ -132,6 +132,17 @@ if [[ -z $SYNC_BACK ]]; then
   fi
 fi
 
+if [[ $SYNC_MODE == "nix" ]]; then
+  if [[ $SYNC_BACK == "repo" ]]; then
+    echo "cannot use --sync-back repo with --sync-mode nix; use --sync-back none or lock." >&2
+    exit 1
+  fi
+  if [[ ! -f "$REPO_DIR/flake.nix" || ! -f "$REPO_DIR/flake.lock" || ! -d "$REPO_DIR/scripts" ]]; then
+    echo "Sync mode nix requires an existing complete WSL checkout with flake.nix, flake.lock, and scripts/." >&2
+    exit 1
+  fi
+fi
+
 # Handle sync mode
 if [[ $SYNC_MODE == "link" ]]; then
   # Create symlink to Windows-side dotfiles
@@ -219,6 +230,12 @@ if [[ $SYNC_MODE == "link" ]]; then
   TARGET_DIR="$SYNC_SOURCE"
 else
   TARGET_DIR="$REPO_DIR"
+fi
+
+REBUILD_HELPER="$TARGET_DIR/scripts/sh/nixos-rebuild-with-user.sh"
+if [[ ! -f $REBUILD_HELPER ]]; then
+  echo "User-aware rebuild helper not found: $REBUILD_HELPER" >&2
+  exit 1
 fi
 
 case "$(uname -m)" in
@@ -330,7 +347,7 @@ NIX_CONFIG="$(printf '%s\n' \
   'experimental-features = nix-command flakes' \
   'extra-substituters = https://cache.numtide.com' \
   'extra-trusted-public-keys = niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g=')" \
-  nixos-rebuild switch --flake "path:$TARGET_DIR#$FLAKE_NAME" --impure
+  bash "$REBUILD_HELPER" switch --flake "path:$TARGET_DIR#$FLAKE_NAME" --impure
 
 # Handle sync-back
 if [[ $SYNC_BACK == "repo" && $SYNC_MODE != "link" ]]; then

--- a/scripts/sh/update.sh
+++ b/scripts/sh/update.sh
@@ -32,7 +32,7 @@ if [ ! -f /etc/NIXOS ]; then
   echo ""
   if grep -qi microsoft /proc/version 2>/dev/null; then
     echo "WSL で NixOS をセットアップするには、Windows PowerShell (管理者) から:"
-    echo '  .\scripts\powershell\install-nixos-wsl.ps1'
+    echo '  dotfiles リポジトリのルートで: .\install.cmd'
   fi
   exit 1
 fi

--- a/scripts/sh/update.sh
+++ b/scripts/sh/update.sh
@@ -51,7 +51,7 @@ nix flake update --flake ~/.dotfiles
 info "NixOS 設定をビルドしています..."
 echo ""
 
-if sudo nixos-rebuild switch --flake ~/.dotfiles#nixos --impure; then
+if ~/.dotfiles/scripts/sh/nixos-rebuild-with-user.sh switch --flake ~/.dotfiles#nixos --impure; then
   success "NixOS 設定が適用されました"
 else
   error "NixOS rebuild に失敗しました"
@@ -109,5 +109,5 @@ echo ""
 success "Dotfiles が正常にインストールされました"
 echo ""
 echo "次回以降の更新は:"
-echo "  nrs  # または: nix flake update --flake ~/.dotfiles && sudo nixos-rebuild switch --flake ~/.dotfiles#nixos --impure"
+echo "  nrs  # または: nix flake update --flake ~/.dotfiles && ~/.dotfiles/scripts/sh/nixos-rebuild-with-user.sh switch --flake ~/.dotfiles#nixos --impure"
 echo ""

--- a/tests/bash/nixos_wsl_postinstall.bats
+++ b/tests/bash/nixos_wsl_postinstall.bats
@@ -65,6 +65,9 @@ exec "$@"
 	write_stub chown '
 printf "chown %s\n" "$*" >>"$COMMAND_LOG"
 '
+	write_stub sudo '
+exec "$@"
+'
 	write_stub nixos-rebuild '
 printf "%s\n" "$@" >"$NIXOS_ARGV_CAPTURE"
 printf "nixos-rebuild user=%s home=%s uid=%s gid=%s group=%s\n" \
@@ -138,4 +141,35 @@ EOF
 	if [[ -n $REAL_NIX ]]; then
 		[ "$(<"$NIX_EVAL_CAPTURE")" = ok ]
 	fi
+}
+
+@test "nix sync requires an existing complete WSL checkout" {
+	RUN_REPO_DIR="$BATS_TEST_TMPDIR/partial-repo"
+
+	run bash "$INSTALLER" \
+		--user alice \
+		--sync-mode nix \
+		--sync-source "$SYNC_SOURCE" \
+		--repo-dir "$RUN_REPO_DIR" \
+		--sync-back none \
+		--skip-flake-update
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"complete WSL checkout"* ]]
+}
+
+@test "nix sync refuses repository sync-back" {
+	RUN_REPO_DIR="$BATS_TEST_TMPDIR/partial-repo"
+
+	run bash "$INSTALLER" \
+		--user alice \
+		--sync-mode nix \
+		--sync-source "$SYNC_SOURCE" \
+		--repo-dir "$RUN_REPO_DIR" \
+		--sync-back repo \
+		--skip-flake-update
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"cannot use --sync-back repo with --sync-mode nix"* ]]
+	[ -f "$SYNC_SOURCE/flake.nix" ]
 }

--- a/tests/bash/nixos_wsl_postinstall.bats
+++ b/tests/bash/nixos_wsl_postinstall.bats
@@ -10,6 +10,7 @@ setup() {
 	COMMAND_LOG="$BATS_TEST_TMPDIR/commands.log"
 	NIXOS_ARGV_CAPTURE="$BATS_TEST_TMPDIR/nixos-rebuild.argv"
 	NIX_EVAL_CAPTURE="$BATS_TEST_TMPDIR/nix-eval.result"
+	DOTFILES_STATE_DIR="$BATS_TEST_TMPDIR/state"
 	REAL_NIX="$(command -v nix || true)"
 
 	mkdir -p "$USER_HOME" "$SYNC_SOURCE" "$STUB_BIN"
@@ -24,7 +25,7 @@ setup() {
 
 	export HOME="$TEST_HOME"
 	export PATH="$STUB_BIN:/usr/bin:/bin"
-	export COMMAND_LOG NIXOS_ARGV_CAPTURE NIX_EVAL_CAPTURE REAL_NIX REPO_ROOT USER_HOME SYNC_SOURCE
+	export COMMAND_LOG NIXOS_ARGV_CAPTURE NIX_EVAL_CAPTURE REAL_NIX REPO_ROOT USER_HOME SYNC_SOURCE DOTFILES_STATE_DIR
 	export DOTFILES_SKIP_HERDR_INSTALL=1
 
 	write_stub id '
@@ -126,6 +127,7 @@ EOF
 		--sync-source "$SYNC_SOURCE" \
 		--repo-dir "$RUN_REPO_DIR" \
 		--sync-back none \
+		--state-version 26.05 \
 		--skip-flake-update
 
 	[ "$status" -eq 0 ]

--- a/tests/bash/taskfile_test_routing.bats
+++ b/tests/bash/taskfile_test_routing.bats
@@ -132,6 +132,7 @@ EOF
 	grep -Fq 'scripts/sh/nixos-rebuild-with-user.sh' "$REPO_ROOT/taskfiles/nix/taskfile.yml"
 	grep -Fq 'nrt = "~/.dotfiles/scripts/sh/nixos-rebuild-with-user.sh test' "$REPO_ROOT/nix/home/wsl.nix"
 	grep -Fq 'nrb = "~/.dotfiles/scripts/sh/nixos-rebuild-with-user.sh boot' "$REPO_ROOT/nix/home/wsl.nix"
+	grep -Fq 'scripts/sh/nixos-rebuild-with-user.sh switch --flake ~/.dotfiles#nixos --impure' "$REPO_ROOT/scripts/sh/update.sh"
 }
 
 @test "Hermes restart reuses the transactional bootstrap up task" {


### PR DESCRIPTION
## Summary

- Refresh NixOS-WSL installation/setup documentation to match the current `install.cmd` flow.
- Update WSL `system.stateVersion` from `25.05` to `26.05` as requested.
- Update flake inputs and fix the stale WSL setup hint.
- Link this work to Issue #595.

## Validation

- `task commit` (format, pre-commit, PowerShell tests, Hermes bootstrap tests)
- `task test`
- `bats tests/bash/bootstrap_docs.bats`
- `nix flake check --all-systems --no-build --no-write-lock-file --impure` with bootstrap environment variables unset
- `git diff --check`

Closes #595