### PR TITLE
docs(nix): clarify hardware configuration scope

### DIFF
--- a/nix/hosts/AGENTS.md
+++ b/nix/hosts/AGENTS.md
@@ -4,7 +4,6 @@
 
 - `<host>/default.nix`: host の entrypoint。`configuration.nix` と共通 module を import する
 - `<host>/configuration.nix`: system、service、user、cask、activation などのホスト固有設定
-- `<host>/hardware-configuration.nix`: NixOS ハードウェア設定
 
 標準レイアウトは次のとおりです。
 
@@ -16,6 +15,11 @@ nix/hosts/<host>/
 
 Darwin も例外にせず、`nix/hosts/darwin/default.nix` を flake の entrypoint とし、実体は
 `nix/hosts/darwin/configuration.nix` に置く。`default.nix` に system option を直接追加しない。
+
+`hardware-configuration.nix` は全 host に必要な標準ファイルではない。native NixOS の実機では、
+マシンごとの `/etc/nixos/hardware-configuration.nix` を `DOTFILES_NIXOS_HARDWARE_CONFIG` 経由で
+読み込む。複数の実機で同じ host profile を使う場合も、hardware configuration は各マシン固有にする。
+NixOS-WSL では通常不要で、Darwin では使用しない。
 
 ## ルール
 


### PR DESCRIPTION
## Description

Clarify that `hardware-configuration.nix` is not required in every `nix/hosts/<host>/` directory. Native NixOS uses a machine-specific external `/etc/nixos/hardware-configuration.nix`; NixOS-WSL normally does not need it, and Darwin does not use it.

## Type of change

- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works (documentation-only change)
- [x] New and existing relevant checks pass locally

## Related Issues

Fixes #598

## Local validation

- `git diff --check`
- pre-commit `treefmt` hook
- targeted repository/reference review