### PR TITLE
fix(ci): 拡張子と依存関係で CI ジョブを選択する

### DIFF
--- a/.github/actions/detect-ci-changes/action.yml
+++ b/.github/actions/detect-ci-changes/action.yml
@@ -18,6 +18,30 @@ inputs:
     default: ci/path-routing.json
 
 outputs:
+  python:
+    description: Whether Python contracts are required.
+    value: ${{ steps.detect.outputs.python }}
+  bash:
+    description: Whether Bash contracts are required.
+    value: ${{ steps.detect.outputs.bash }}
+  actionlint:
+    description: Whether workflow lint is required.
+    value: ${{ steps.detect.outputs.actionlint }}
+  powershell_lint:
+    description: Whether PowerShell source lint is required.
+    value: ${{ steps.detect.outputs.powershell_lint }}
+  powershell_test:
+    description: Whether PowerShell contracts are required.
+    value: ${{ steps.detect.outputs.powershell_test }}
+  chezmoi_lint:
+    description: Whether chezmoi contracts are required.
+    value: ${{ steps.detect.outputs.chezmoi_lint }}
+  templates:
+    description: Whether template validation is required.
+    value: ${{ steps.detect.outputs.templates }}
+  fonts:
+    description: Whether font installer validation is required.
+    value: ${{ steps.detect.outputs.fonts }}
   linux:
     description: Whether Linux CI is required.
     value: ${{ steps.detect.outputs.linux }}
@@ -77,6 +101,9 @@ runs:
             --github-output "${GITHUB_OUTPUT}"
         else
           paths_file="${RUNNER_TEMP}/ci-changed-paths.txt"
+          if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
+            BASE_SHA="$(git merge-base "${BASE_SHA}" "${HEAD_SHA}")"
+          fi
           git diff --name-only --no-renames "${BASE_SHA}" "${HEAD_SHA}" > "${paths_file}"
           python scripts/python/detect_ci_changes.py \
             --manifest "${MANIFEST_PATH}" \

--- a/.github/workflows/ci-bootstrap.yml
+++ b/.github/workflows/ci-bootstrap.yml
@@ -35,6 +35,8 @@ on:
       - "tests/bash/install_macos.bats"
       - "ci/path-routing.json"
       - "ci/bootstrap-path-routing.json"
+      - "ci/job-path-routing.json"
+      - "tests/python/test_ci_job_routing.py"
       - "Taskfile.yml"
       - "taskfiles/**"
       - "scripts/python/detect_ci_changes.py"
@@ -45,45 +47,6 @@ on:
       - ".github/workflows/ci-bootstrap.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "flake.nix"
-      - "flake.lock"
-      - "install.sh"
-      - "install.cmd"
-      - "nix/**"
-      - "scripts/sh/**"
-      - "scripts/powershell/ci/**"
-      - "scripts/powershell/handlers/**"
-      - "scripts/powershell/handlers/Handler.NixOSWSL.ps1"
-      - "scripts/powershell/handlers/Handler.NixRebuild.ps1"
-      - "scripts/powershell/lib/**"
-      - "scripts/powershell/install.ps1"
-      - "scripts/powershell/install.user.ps1"
-      - "scripts/powershell/tests/**"
-      - "windows/**"
-      - "chezmoi/**"
-      - "docker/hermes-agent/**"
-      - "docker/hermes-service/**"
-      - "docker/hermes-browser/**"
-      - "docker/hermes-browser-mcp/**"
-      - "docker/hermes-xapi-mcp/**"
-      - "docker/hindsight/**"
-      - "docker/local-ai-services/**"
-      - "docker/mlflow/**"
-      - "docs/mlflow/**"
-      - ".github/e2e/**"
-      - "tests/bash/install_linux.bats"
-      - "tests/bash/install_macos.bats"
-      - "ci/path-routing.json"
-      - "ci/bootstrap-path-routing.json"
-      - "Taskfile.yml"
-      - "taskfiles/**"
-      - "scripts/python/detect_ci_changes.py"
-      - "tests/python/test_detect_ci_changes.py"
-      - "tests/python/test_ci_workflow_routing.py"
-      - ".github/actions/detect-ci-changes/**"
-      - ".github/workflows/ci-contract.yml"
-      - ".github/workflows/ci-bootstrap.yml"
 
 concurrency:
   group: bootstrap-${{ github.workflow }}-${{ github.ref }}
@@ -1051,8 +1014,7 @@ jobs:
           fi
 
           if [[ "${PLATFORM_REQUIRED}" != "true" ]]; then
-            echo "Bootstrap CI selected no platform job; refusing a green result."
-            exit 1
+            echo "No bootstrap runtime changes; verifying that platform jobs were skipped."
           fi
 
           check_platform() {

--- a/.github/workflows/ci-chezmoi.yml
+++ b/.github/workflows/ci-chezmoi.yml
@@ -4,14 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
-      - "chezmoi/**"
-      - ".github/workflows/ci-chezmoi.yml"
   pull_request:
-    # No paths filter: this workflow's checks are required by the main ruleset,
-    # so they must report on every PR (a path-filtered required check stays
-    # "expected" forever and blocks unrelated PRs). Jobs are fast; running them
-    # on every PR is the cost of having them be reliable required checks.
     branches: [main]
 
 concurrency:
@@ -19,13 +12,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: ci-chezmoi / Changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      chezmoi_lint: ${{ steps.detect.outputs.chezmoi_lint }}
+      templates: ${{ steps.detect.outputs.templates }}
+      fonts: ${{ steps.detect.outputs.fonts }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Detect changed job targets
+        id: detect
+        uses: ./.github/actions/detect-ci-changes
+        with:
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'push' && github.event.before || github.sha }}
+          head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          run-all: ${{ github.event_name == 'workflow_dispatch' }}
+          manifest: ci/job-path-routing.json
+
   lint:
+    needs: changes
+    if: ${{ always() && (needs.changes.result != 'success' || needs.changes.outputs.chezmoi_lint == 'true') }}
     name: Lint (Pester chezmoi)
     runs-on: windows-2025
     timeout-minutes: 10
     permissions:
       contents: read
     steps:
+      - name: Verify change detection
+        if: ${{ needs.changes.result != 'success' }}
+        shell: bash
+        run: exit 1
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -107,12 +131,18 @@ jobs:
           if-no-files-found: warn
 
   fmt:
+    needs: changes
+    if: ${{ always() && (needs.changes.result != 'success' || needs.changes.outputs.templates == 'true') }}
     name: Format (.tmpl BOM check)
     runs-on: windows-2025
     timeout-minutes: 5
     permissions:
       contents: read
     steps:
+      - name: Verify change detection
+        if: ${{ needs.changes.result != 'success' }}
+        shell: bash
+        run: exit 1
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -138,12 +168,18 @@ jobs:
           Write-Host "BOM check passed: $(@($files).Count) .tmpl file(s) checked"
 
   font-install:
+    needs: changes
+    if: ${{ always() && (needs.changes.result != 'success' || needs.changes.outputs.fonts == 'true') }}
     name: Font install smoke (Windows)
     runs-on: windows-2025
     timeout-minutes: 10
     permissions:
       contents: read
     steps:
+      - name: Verify change detection
+        if: ${{ needs.changes.result != 'success' }}
+        shell: bash
+        run: exit 1
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -179,6 +215,8 @@ jobs:
           $entries | ForEach-Object { Write-Host "Verified font: $($_.Name) -> $($_.Value)" }
 
   op-guard:
+    needs: changes
+    if: ${{ always() && (needs.changes.result != 'success' || needs.changes.outputs.templates == 'true') }}
     # Behavioral guard for the "op present but unauthenticated" environment
     # (devcontainers, CI, fresh clones). The static Pester lint only checks
     # that onepasswordRead is wrapped in *a* guard; it cannot tell whether the
@@ -193,6 +231,10 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Verify change detection
+        if: ${{ needs.changes.result != 'success' }}
+        shell: bash
+        run: exit 1
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ci-consistency.yml
+++ b/.github/workflows/ci-consistency.yml
@@ -4,44 +4,49 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
-      - "nix/packages/**"
-      - "nix/flakes/**"
-      - "nix/home/**"
-      - "flake.nix"
-      - "flake.lock"
-      - "windows/winget/packages.json"
-      - "windows/npm/packages.json"
-      - "windows/pnpm/packages.json"
-      - ".github/workflows/ci-consistency.yml"
-      - "nix/packages/darwin-provider-candidates.nix"
-      - "scripts/python/update_darwin_packages.py"
   pull_request:
     branches: [main]
-    paths:
-      - "nix/packages/**"
-      - "nix/flakes/**"
-      - "nix/home/**"
-      - "flake.nix"
-      - "flake.lock"
-      - "windows/winget/packages.json"
-      - "windows/npm/packages.json"
-      - "windows/pnpm/packages.json"
-      - ".github/workflows/ci-consistency.yml"
-      - "nix/packages/darwin-provider-candidates.nix"
-      - "scripts/python/update_darwin_packages.py"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: ci-consistency / Changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      package_catalog: ${{ steps.detect.outputs.package_catalog }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Detect changed job targets
+        id: detect
+        uses: ./.github/actions/detect-ci-changes
+        with:
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'push' && github.event.before || github.sha }}
+          head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          run-all: ${{ github.event_name == 'workflow_dispatch' }}
+          manifest: ci/job-path-routing.json
+
   check:
+    needs: changes
+    if: ${{ always() && (needs.changes.result != 'success' || needs.changes.outputs.package_catalog == 'true') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: read
     steps:
+      - name: Verify change detection
+        if: ${{ needs.changes.result != 'success' }}
+        shell: bash
+        run: exit 1
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ci-contract.yml
+++ b/.github/workflows/ci-contract.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "ci/path-routing.json"
       - "ci/bootstrap-path-routing.json"
+      - "ci/job-path-routing.json"
       - "scripts/python/detect_ci_changes.py"
       - "bootstrap.sh"
       - "install.sh"
@@ -27,6 +28,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci-contract:
     name: CI Contract
@@ -36,22 +41,35 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
+      - name: Detect changed contract targets
+        id: detect
+        uses: ./.github/actions/detect-ci-changes
+        with:
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          manifest: ci/job-path-routing.json
+
       - name: Set up Python
+        if: ${{ steps.detect.outputs.python == 'true' }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.2.0
         with:
           python-version: "3.14"
 
       - name: Install Nix
+        if: ${{ steps.detect.outputs.python == 'true' || steps.detect.outputs.bash == 'true' }}
         uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
 
       - name: Install go-task
+        if: ${{ steps.detect.outputs.python == 'true' || steps.detect.outputs.bash == 'true' }}
         run: |
           nix profile install nixpkgs#go-task
           task --version
 
       - name: Install Bats
+        if: ${{ steps.detect.outputs.bash == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -65,12 +83,15 @@ jobs:
           "$bats_prefix/bin/bats" --version
 
       - name: Run Python workflow contracts
+        if: ${{ steps.detect.outputs.python == 'true' }}
         run: python -m unittest discover -s tests/python -v
 
       - name: Run MLflow gateway contracts
+        if: ${{ steps.detect.outputs.python == 'true' }}
         run: python -m unittest docker/mlflow/tests/test_configure.py -v
 
       - name: Run Bash workflow contracts
+        if: ${{ steps.detect.outputs.bash == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -92,4 +113,5 @@ jobs:
           bats --print-output-on-failure "${bats_files[@]}"
 
       - name: Run actionlint
+        if: ${{ steps.detect.outputs.actionlint == 'true' }}
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/*.yml

--- a/.github/workflows/ci-devcontainer.yml
+++ b/.github/workflows/ci-devcontainer.yml
@@ -4,39 +4,50 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
-      - "bootstrap.sh"
-      - "install.sh"
-      - "scripts/sh/install-macos.sh"
-      - "scripts/sh/dcnvim.sh"
-      - "tests/bash/install_macos.bats"
-      - "tests/bash/install_linux.bats"
-      - ".devcontainer/**"
-      - ".github/workflows/ci-devcontainer.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "bootstrap.sh"
-      - "install.sh"
-      - "scripts/sh/install-macos.sh"
-      - "scripts/sh/dcnvim.sh"
-      - "tests/bash/install_macos.bats"
-      - "tests/bash/install_linux.bats"
-      - ".devcontainer/**"
-      - ".github/workflows/ci-devcontainer.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: ci-devcontainer / Changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      devcontainer: ${{ steps.detect.outputs.devcontainer }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Detect changed job targets
+        id: detect
+        uses: ./.github/actions/detect-ci-changes
+        with:
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'push' && github.event.before || github.sha }}
+          head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          run-all: ${{ github.event_name == 'workflow_dispatch' }}
+          manifest: ci/job-path-routing.json
+
   linux-nix:
+    needs: changes
+    if: ${{ always() && (needs.changes.result != 'success' || needs.changes.outputs.devcontainer == 'true') }}
     name: E2E (Linux + Nix CLI)
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: read
     steps:
+      - name: Verify change detection
+        if: ${{ needs.changes.result != 'success' }}
+        shell: bash
+        run: exit 1
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -94,12 +105,18 @@ jobs:
             -- bash .devcontainer/ci/e2e.sh
 
   macos:
+    needs: changes
+    if: ${{ always() && (needs.changes.result != 'success' || needs.changes.outputs.devcontainer == 'true') }}
     name: E2E (macOS)
     runs-on: macos-15-intel
     timeout-minutes: 90
     permissions:
       contents: read
     steps:
+      - name: Verify change detection
+        if: ${{ needs.changes.result != 'success' }}
+        shell: bash
+        run: exit 1
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -140,6 +157,8 @@ jobs:
             -- bash .devcontainer/ci/e2e.sh
 
   windows:
+    needs: changes
+    if: ${{ always() && (needs.changes.result != 'success' || needs.changes.outputs.devcontainer == 'true') }}
     # Full devcontainer E2E requires Linux containers, which GitHub-hosted
     # Windows runners do not support (no Docker Desktop, no WSL2 Ubuntu
     # pre-installed). This job validates the devcontainer configuration and
@@ -150,6 +169,10 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Verify change detection
+        if: ${{ needs.changes.result != 'success' }}
+        shell: bash
+        run: exit 1
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ci-hermes-bootstrap.yml
+++ b/.github/workflows/ci-hermes-bootstrap.yml
@@ -1,55 +1,53 @@
 name: Hermes Bootstrap Tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
-    paths:
-      - "docker/hermes-agent/**"
-      - "docker/hermes-service/**"
-      - "docker/hermes-browser/**"
-      - "docker/hermes-browser-mcp/**"
-      - "docker/hermes-xapi-mcp/**"
-      - "docker/hindsight/**"
-      - "docker/local-ai-services/**"
-      - "scripts/sh/hermes-agent.sh"
-      - "scripts/powershell/handlers/Handler.HermesAgent.ps1"
-      - "tests/python/test_xapi_image_contract.py"
-      - "taskfiles/hermes/taskfile.yml"
-      - ".github/workflows/ci-hermes-bootstrap.yml"
-      - ".github/workflows/ci-hermes-provenance.yml"
-      - ".pre-commit-config.yaml"
-      - "Taskfile.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "docker/hermes-agent/**"
-      - "docker/hermes-service/**"
-      - "docker/hermes-browser/**"
-      - "docker/hermes-browser-mcp/**"
-      - "docker/hermes-xapi-mcp/**"
-      - "docker/hindsight/**"
-      - "docker/local-ai-services/**"
-      - "scripts/sh/hermes-agent.sh"
-      - "scripts/powershell/handlers/Handler.HermesAgent.ps1"
-      - "tests/python/test_xapi_image_contract.py"
-      - "taskfiles/hermes/taskfile.yml"
-      - ".github/workflows/ci-hermes-bootstrap.yml"
-      - ".github/workflows/ci-hermes-provenance.yml"
-      - ".pre-commit-config.yaml"
-      - "Taskfile.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: ci-hermes-bootstrap / Changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      hermes: ${{ steps.detect.outputs.hermes }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Detect changed job targets
+        id: detect
+        uses: ./.github/actions/detect-ci-changes
+        with:
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'push' && github.event.before || github.sha }}
+          head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          run-all: ${{ github.event_name == 'workflow_dispatch' }}
+          manifest: ci/job-path-routing.json
+
   hermes-bootstrap-tests:
+    needs: changes
+    if: ${{ always() && (needs.changes.result != 'success' || needs.changes.outputs.hermes == 'true') }}
     name: Hermes Bootstrap Tests
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
     steps:
+      - name: Verify change detection
+        if: ${{ needs.changes.result != 'success' }}
+        shell: bash
+        run: exit 1
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ci-powershell.yml
+++ b/.github/workflows/ci-powershell.yml
@@ -4,33 +4,41 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
-      - "install.cmd"
-      - "docker/hermes-agent/**"
-      - "docker/hermes-service/**"
-      - "docker/local-ai-services/**"
-      - "scripts/powershell/**"
-      - "chezmoi/dot_config/plane-github-sync/**"
-      - ".github/workflows/ci-bootstrap.yml"
-      - ".github/workflows/ci-powershell.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "install.cmd"
-      - "docker/hermes-agent/**"
-      - "docker/hermes-service/**"
-      - "docker/local-ai-services/**"
-      - "scripts/powershell/**"
-      - "chezmoi/dot_config/plane-github-sync/**"
-      - ".github/workflows/ci-bootstrap.yml"
-      - ".github/workflows/ci-powershell.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: ci-powershell / Changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      powershell_lint: ${{ steps.detect.outputs.powershell_lint }}
+      powershell_test: ${{ steps.detect.outputs.powershell_test }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Detect changed job targets
+        id: detect
+        uses: ./.github/actions/detect-ci-changes
+        with:
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'push' && github.event.before || github.sha }}
+          head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          run-all: ${{ github.event_name == 'workflow_dispatch' }}
+          manifest: ci/job-path-routing.json
+
   lint:
+    needs: changes
+    if: ${{ always() && (needs.changes.result != 'success' || needs.changes.outputs.powershell_lint == 'true') }}
     name: Lint (PSScriptAnalyzer)
     runs-on: windows-2025
     timeout-minutes: 10
@@ -38,6 +46,10 @@ jobs:
       contents: read
       security-events: write
     steps:
+      - name: Verify change detection
+        if: ${{ needs.changes.result != 'success' }}
+        shell: bash
+        run: exit 1
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -166,13 +178,18 @@ jobs:
           }
 
   test:
+    needs: [changes, lint]
+    if: ${{ always() && (needs.changes.result != 'success' || needs.changes.outputs.powershell_test == 'true') }}
     name: Test (Pester + Codecov)
     runs-on: windows-2025
     timeout-minutes: 20
-    needs: lint
     permissions:
       contents: read
     steps:
+      - name: Verify change detection
+        if: ${{ needs.changes.result != 'success' || (needs.lint.result != 'success' && needs.lint.result != 'skipped') }}
+        shell: bash
+        run: exit 1
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -332,13 +349,18 @@ jobs:
           if-no-files-found: warn
 
   test-windows-powershell:
+    needs: [changes, lint]
+    if: ${{ always() && (needs.changes.result != 'success' || needs.changes.outputs.powershell_test == 'true') }}
     name: Test (Windows PowerShell 5.1 compatibility)
     runs-on: windows-2025
     timeout-minutes: 15
-    needs: lint
     permissions:
       contents: read
     steps:
+      - name: Verify change detection
+        if: ${{ needs.changes.result != 'success' || (needs.lint.result != 'success' && needs.lint.result != 'skipped') }}
+        shell: bash
+        run: exit 1
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/ci/bootstrap-path-routing.json
+++ b/ci/bootstrap-path-routing.json
@@ -13,6 +13,33 @@
     "package_catalog"
   ],
   "fallback_outputs": ["linux", "darwin", "wsl", "windows"],
+  "fallback_patterns": [
+    "nix/**",
+    "scripts/sh/**",
+    "scripts/powershell/**",
+    "windows/**",
+    "chezmoi/**",
+    "docker/**",
+    "taskfiles/**",
+    "Taskfile.yml",
+    "install.sh",
+    "install.cmd",
+    "flake.nix",
+    "flake.lock"
+  ],
+  "ignored_patterns": [
+    "docs/**",
+    "README.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "nix/**/*.md",
+    "scripts/**/*.md",
+    "windows/**/*.md",
+    "taskfiles/**/*.md",
+    "chezmoi/README.md",
+    "docker/*/README.md",
+    ".devcontainer/README.md"
+  ],
   "rules": [
     {
       "patterns": [
@@ -28,10 +55,12 @@
     {
       "patterns": [
         "ci/bootstrap-path-routing.json",
+        "ci/job-path-routing.json",
         "ci/path-routing.json",
         "scripts/python/detect_ci_changes.py",
         "tests/python/test_detect_ci_changes.py",
         "tests/python/test_ci_workflow_routing.py",
+        "tests/python/test_ci_job_routing.py",
         "tests/bash/ci_routing.bats",
         ".github/actions/detect-ci-changes/**",
         ".github/workflows/ci-contract.yml",

--- a/ci/job-path-routing.json
+++ b/ci/job-path-routing.json
@@ -1,0 +1,266 @@
+{
+  "version": 1,
+  "outputs": [
+    "python",
+    "bash",
+    "actionlint",
+    "powershell_lint",
+    "powershell_test",
+    "chezmoi_lint",
+    "templates",
+    "fonts",
+    "hermes",
+    "devcontainer",
+    "package_catalog"
+  ],
+  "rules": [
+    {
+      "patterns": [
+        "ci/**",
+        "scripts/python/detect_ci_changes.py",
+        ".github/actions/detect-ci-changes/**",
+        "tests/python/test_detect_ci*.py",
+        "tests/python/test_ci_workflow_routing.py",
+        "tests/python/test_ci_job_routing.py",
+        "tests/bash/ci_routing.bats"
+      ],
+      "outputs": [
+        "python",
+        "bash",
+        "actionlint",
+        "powershell_lint",
+        "powershell_test",
+        "chezmoi_lint",
+        "templates",
+        "fonts",
+        "hermes",
+        "devcontainer",
+        "package_catalog"
+      ]
+    },
+    {
+      "patterns": [
+        "**/*.py",
+        "**/*.nix",
+        "flake.lock",
+        "**/*.sh",
+        "**/*.bats",
+        "**/*.ps1",
+        "**/*.psm1",
+        "**/*.psd1",
+        "**/*.cmd",
+        "**/*.tmpl",
+        "**/*.yml",
+        "**/*.yaml",
+        "**/*.json",
+        "**/*.toml",
+        "**/Dockerfile",
+        ".devcontainer/**",
+        "chezmoi/**",
+        "docs/**",
+        "nix/**/*.md",
+        "windows/**"
+      ],
+      "outputs": ["python"]
+    },
+    {
+      "patterns": [
+        "**/*.sh",
+        "**/*.bats",
+        "**/*.nix",
+        "flake.lock",
+        "scripts/python/**",
+        "**/*.ps1",
+        "**/*.psm1",
+        "**/*.psd1",
+        "install.cmd",
+        "**/*.tmpl",
+        "Taskfile.yml",
+        "taskfiles/**",
+        ".github/**",
+        ".devcontainer/**",
+        "docker/**",
+        "chezmoi/**",
+        "docs/**",
+        "nix/**/*.md",
+        "windows/**",
+        "**/*.yml",
+        "**/*.yaml",
+        "**/*.json",
+        "**/*.toml"
+      ],
+      "outputs": ["bash"]
+    },
+    {
+      "patterns": [
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml",
+        ".github/actions/**",
+        ".github/actionlint.yaml"
+      ],
+      "outputs": ["actionlint"]
+    },
+    {
+      "patterns": [
+        "scripts/powershell/**/*.ps1",
+        "scripts/powershell/**/*.psm1",
+        "scripts/powershell/**/*.psd1",
+        ".github/workflows/ci-powershell.yml"
+      ],
+      "outputs": ["powershell_lint"],
+      "exclude_patterns": [
+        "docs/**",
+        "README.md",
+        "nix/**/*.md",
+        "scripts/**/*.md",
+        "windows/**/*.md",
+        "taskfiles/**/*.md",
+        "chezmoi/README.md",
+        "docker/*/README.md",
+        ".devcontainer/README.md"
+      ]
+    },
+    {
+      "patterns": [
+        "**/*.ps1",
+        "**/*.psm1",
+        "**/*.psd1",
+        "**/*.cmd",
+        "**/*.ahk",
+        "chezmoi/**",
+        "nix/**/*.nix",
+        "flake.nix",
+        "flake.lock",
+        "windows/**",
+        "Taskfile.yml",
+        "taskfiles/**",
+        "docker/**",
+        "scripts/sh/**",
+        ".github/workflows/**"
+      ],
+      "outputs": ["powershell_test"],
+      "exclude_patterns": [
+        "docs/**",
+        "README.md",
+        "nix/**/*.md",
+        "scripts/**/*.md",
+        "windows/**/*.md",
+        "taskfiles/**/*.md",
+        "chezmoi/README.md",
+        "docker/*/README.md",
+        ".devcontainer/README.md"
+      ]
+    },
+    {
+      "patterns": [
+        "chezmoi/**",
+        "scripts/powershell/tests/chezmoi/**",
+        "scripts/powershell/tests/Invoke-Tests.ps1",
+        "scripts/powershell/lib/**",
+        "nix/home/common.nix",
+        "nix/packages/**",
+        ".github/workflows/ci-chezmoi.yml"
+      ],
+      "outputs": ["chezmoi_lint"],
+      "exclude_patterns": [
+        "docs/**",
+        "README.md",
+        "nix/**/*.md",
+        "scripts/**/*.md",
+        "windows/**/*.md",
+        "taskfiles/**/*.md",
+        "chezmoi/README.md",
+        "docker/*/README.md",
+        ".devcontainer/README.md"
+      ]
+    },
+    {
+      "patterns": [
+        "chezmoi/**/*.tmpl",
+        "chezmoi/.chezmoi*",
+        "chezmoi/.chezmoidata/**",
+        "chezmoi/.chezmoitemplates/**",
+        ".github/workflows/ci-chezmoi.yml"
+      ],
+      "outputs": ["templates"]
+    },
+    {
+      "patterns": ["chezmoi/.chezmoiscripts/setup/fonts/**", ".github/workflows/ci-chezmoi.yml"],
+      "outputs": ["fonts"]
+    },
+    {
+      "patterns": [
+        "docker/hermes-agent/**",
+        "docker/hermes-service/**",
+        "docker/hermes-browser/**",
+        "docker/hermes-browser-mcp/**",
+        "docker/hermes-xapi-mcp/**",
+        "docker/hindsight/**",
+        "docker/local-ai-services/**",
+        "scripts/sh/hermes-*.sh",
+        "scripts/powershell/hermes-*.ps1",
+        "scripts/powershell/handlers/Handler.HermesAgent.ps1",
+        "scripts/powershell/lib/Hermes*.ps1",
+        "tests/python/test_xapi_image_contract.py",
+        ".github/workflows/ci-hermes-bootstrap.yml",
+        ".github/workflows/ci-hermes-provenance.yml",
+        "taskfiles/hermes/taskfile.yml",
+        ".pre-commit-config.yaml",
+        "Taskfile.yml"
+      ],
+      "outputs": ["hermes"],
+      "exclude_patterns": [
+        "docs/**",
+        "README.md",
+        "nix/**/*.md",
+        "scripts/**/*.md",
+        "windows/**/*.md",
+        "taskfiles/**/*.md",
+        "chezmoi/README.md",
+        "docker/*/README.md",
+        ".devcontainer/README.md"
+      ]
+    },
+    {
+      "patterns": [
+        ".devcontainer/**",
+        "bootstrap.sh",
+        "install.sh",
+        "scripts/sh/dcnvim.sh",
+        "chezmoi/dot_config/devcontainer/**",
+        "tests/bash/install_linux.bats",
+        "tests/bash/install_macos.bats",
+        ".github/workflows/ci-devcontainer.yml",
+        "scripts/sh/install-macos.sh"
+      ],
+      "outputs": ["devcontainer"],
+      "exclude_patterns": [
+        "docs/**",
+        "README.md",
+        "nix/**/*.md",
+        "scripts/**/*.md",
+        "windows/**/*.md",
+        "taskfiles/**/*.md",
+        "chezmoi/README.md",
+        "docker/*/README.md",
+        ".devcontainer/README.md"
+      ]
+    },
+    {
+      "patterns": [
+        "nix/packages/**/*.nix",
+        "nix/flakes/**/*.nix",
+        "nix/lib/**/*.nix",
+        "nix/home/**/*.nix",
+        "flake.nix",
+        "flake.lock",
+        "windows/winget/packages.json",
+        "windows/npm/packages.json",
+        "windows/pnpm/packages.json",
+        "scripts/python/update_darwin_packages.py",
+        ".github/workflows/ci-consistency.yml"
+      ],
+      "outputs": ["package_catalog"]
+    }
+  ]
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -324,6 +324,10 @@ Should -Invoke Invoke-Wsl -Times 1 -Exactly
 
 `ci-bootstrap.yml` は変更パスから Linux、Darwin、WSL、Windows の実行対象を個別に選択します。Docker Desktop、WSL2、nix-darwin switch の実機適用は nested virtualization と OS 制約のため CI では実行せず、one-command installer 末尾の local acceptance が判定します。
 
+言語・用途別のジョブは `ci/job-path-routing.json` で選択します。`.ps1` / `.psm1` / `.psd1` は PowerShell 検証、`.tmpl` はテンプレート検証、workflow YAML は actionlint、パッケージ定義は catalog 整合性検証に接続します。契約テストは別言語の設定も読むため、拡張子に加えて Taskfile、Nix、chezmoi、Docker の依存パスも判定します。変更が複数なら対象の和集合を実行し、削除・移動元のパスも検証対象に残します。
+
+各 workflow の既存チェック名を維持し、対象外ジョブは `if` でスキップします。変更検出失敗はチェック失敗として扱い、手動実行は全対象を検証します。`ci/bootstrap-path-routing.json` は説明用 README / docs の変更を OS 結合テストから除外しますが、配布される agent の Markdown 設定や未分類の runtime パスには保守的な判定を残します。GitHub の必須チェック設定を変更する必要はありません。
+
 Ubuntu、Debian、NixOS の hosted Linux job は 1 周目で clean bootstrap、2 周目で idempotency を検証し、各周回の後に runtime acceptance を実行します。pull request では hosted contract、declarative build、Linux runtime E2E の全checkが成功し、approval待ちやqueued jobがないことをmerge条件にします。
 
 ---

--- a/scripts/powershell/tests/CiWorkflow.Tests.ps1
+++ b/scripts/powershell/tests/CiWorkflow.Tests.ps1
@@ -1,6 +1,12 @@
 BeforeAll {
     $script:repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
 
+    function Get-CiJobPatterns {
+        param([string]$Output)
+        $manifest = Get-Content -LiteralPath (Join-Path $script:repoRoot 'ci/job-path-routing.json') -Raw | ConvertFrom-Json
+        $manifest.rules | Where-Object { $Output -in $_.outputs } | ForEach-Object { $_.patterns }
+    }
+
     function Assert-UniqueChezmoiPathOccurrence {
         param(
             [Parameter(Mandatory)]
@@ -220,7 +226,7 @@ Describe 'CI workflow configuration' {
     It 'should verify generated npm package catalog consistency' {
         $consistencyWorkflow = Get-Content -LiteralPath (Join-Path $script:repoRoot ".github/workflows/ci-consistency.yml") -Raw
 
-        $consistencyWorkflow | Should -Match '"windows/npm/packages\.json"'
+        (Get-CiJobPatterns -Output 'package_catalog') | Should -Contain 'windows/npm/packages.json'
         $consistencyWorkflow | Should -Match '/tmp/winget-export/npm/packages\.json'
         $consistencyWorkflow | Should -Match 'windows/npm/packages\.json'
     }
@@ -228,14 +234,17 @@ Describe 'CI workflow configuration' {
     It 'should trigger entrypoint tests when install.cmd or bootstrap tests change' {
         $powershellWorkflow = Get-Content -LiteralPath (Join-Path $script:repoRoot ".github/workflows/ci-powershell.yml") -Raw
 
-        $powershellWorkflow | Should -Match '"install\.cmd"'
-        $powershellWorkflow | Should -Match '"docker/hermes-agent/\*\*"'
+        $powershellWorkflow | Should -Match 'needs.changes.outputs.powershell_test'
+        (Get-CiJobPatterns -Output 'powershell_test') | Should -Contain '**/*.cmd'
+        (Get-CiJobPatterns -Output 'powershell_test') | Should -Contain 'docker/**'
     }
 
     It 'should assign every Bats file to exactly one CI owner' {
         $contractWorkflow = Get-Content -LiteralPath (Join-Path $script:repoRoot ".github/workflows/ci-contract.yml") -Raw
         $devcontainerWorkflow = Get-Content -LiteralPath (Join-Path $script:repoRoot ".github/workflows/ci-devcontainer.yml") -Raw
         $devcontainerBatsScript = Get-Content -LiteralPath (Join-Path $script:repoRoot ".devcontainer/ci/bats.sh") -Raw
+        $devcontainerPaths = Get-CiJobPatterns -Output 'devcontainer'
+        $devcontainerWorkflow | Should -Match 'needs.changes.outputs.devcontainer'
 
         $contractWorkflow | Should -Match '"tests/bash/\*\*"'
         $contractWorkflow | Should -Match 'shopt -s nullglob'
@@ -258,7 +267,7 @@ Describe 'CI workflow configuration' {
         }
         foreach ($batsFile in $allBats) {
             if ($batsFile -in $excludedBats) {
-                $devcontainerWorkflow | Should -Match "tests/bash/$([regex]::Escape($batsFile))"
+                $devcontainerPaths | Should -Contain "tests/bash/$batsFile"
             }
             else {
                 $contractWorkflow | Should -Match 'bats_files=\(tests/bash/\*\.bats\)'
@@ -266,9 +275,9 @@ Describe 'CI workflow configuration' {
         }
 
         $excludedBats.Count | Should -Be 2
-        $devcontainerWorkflow | Should -Match '"tests/bash/install_macos\.bats"'
-        $devcontainerWorkflow | Should -Match '"tests/bash/install_linux\.bats"'
-        $devcontainerWorkflow | Should -Not -Match '"tests/bash/\*\*"'
+        $devcontainerPaths | Should -Contain 'tests/bash/install_macos.bats'
+        $devcontainerPaths | Should -Contain 'tests/bash/install_linux.bats'
+        $devcontainerPaths | Should -Not -Contain 'tests/bash/**'
 
         $activeBatsInvocations = @(
             $devcontainerBatsScript -split '\r?\n' |
@@ -284,8 +293,8 @@ Describe 'CI workflow configuration' {
     It 'should trigger PowerShell CI when Plane GitHub sync config changes' {
         $powershellWorkflow = Get-Content -LiteralPath (Join-Path $script:repoRoot ".github/workflows/ci-powershell.yml") -Raw
 
-        $path = '- "chezmoi/dot_config/plane-github-sync/**"'
-        ([regex]::Matches($powershellWorkflow, [regex]::Escape($path))).Count | Should -Be 2
+        $powershellWorkflow | Should -Match 'needs.changes.outputs.powershell_test'
+        (Get-CiJobPatterns -Output 'powershell_test') | Should -Contain 'chezmoi/**'
     }
 
     It 'should trigger dcnvim platform tests when dcnvim implementations change' {
@@ -293,10 +302,12 @@ Describe 'CI workflow configuration' {
         $powershellWorkflow = Get-Content -LiteralPath (Join-Path $script:repoRoot ".github/workflows/ci-powershell.yml") -Raw
         $devcontainerWorkflow = Get-Content -LiteralPath (Join-Path $script:repoRoot ".github/workflows/ci-devcontainer.yml") -Raw
 
-        $chezmoiWorkflow | Should -Match '"chezmoi/\*\*"'
+        (Get-CiJobPatterns -Output 'chezmoi_lint') | Should -Contain 'chezmoi/**'
         $chezmoiWorkflow | Should -Match '\.\\tests\\Invoke-Tests\.ps1 -Path \.\\tests\\chezmoi'
-        $powershellWorkflow | Should -Match '"scripts/powershell/\*\*"'
-        $devcontainerWorkflow | Should -Match '"scripts/sh/dcnvim\.sh"'
+        $powershellWorkflow | Should -Match 'needs.changes.outputs.powershell_test'
+        (Get-CiJobPatterns -Output 'powershell_test') | Should -Contain '**/*.ps1'
+        $devcontainerWorkflow | Should -Match 'needs.changes.outputs.devcontainer'
+        (Get-CiJobPatterns -Output 'devcontainer') | Should -Contain 'scripts/sh/dcnvim.sh'
     }
 
     It 'should use a supported Intel macOS runner for devcontainer E2E' {

--- a/scripts/python/detect_ci_changes.py
+++ b/scripts/python/detect_ci_changes.py
@@ -11,7 +11,6 @@ from fnmatch import fnmatchcase
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-
 EXPECTED_OUTPUTS = frozenset(
     {
         "linux",
@@ -27,23 +26,45 @@ EXPECTED_OUTPUTS = frozenset(
     }
 )
 PLATFORM_OUTPUTS = frozenset({"linux", "darwin", "wsl", "windows"})
+JOB_OUTPUTS = frozenset(
+    {
+        "python",
+        "bash",
+        "actionlint",
+        "powershell_lint",
+        "powershell_test",
+        "chezmoi_lint",
+        "templates",
+        "fonts",
+    }
+)
 DEFAULT_MANIFEST_PATH = Path(__file__).resolve().parents[2] / "ci" / "path-routing.json"
 
 
 def route_paths(paths: Iterable[str], manifest_path: Path) -> dict[str, bool]:
     """Return the union of manifest outputs selected by repository-relative paths."""
-    outputs, rules, fallback_outputs = _load_manifest(manifest_path)
+    outputs, rules, fallback_outputs, ignored_patterns, fallback_patterns = (
+        _load_manifest(manifest_path)
+    )
     selected = {output: output == "contract" for output in outputs}
 
     for raw_path in paths:
         path = _validate_path(raw_path)
+        if any(_full_match(path, pattern) for pattern in ignored_patterns):
+            continue
         matched_platform = False
         for rule in rules:
-            if any(_full_match(path, pattern) for pattern in rule["patterns"]):
+            if any(
+                _full_match(path, pattern) for pattern in rule["patterns"]
+            ) and not any(
+                _full_match(path, pattern) for pattern in rule["exclude_patterns"]
+            ):
                 matched_platform |= bool(PLATFORM_OUTPUTS.intersection(rule["outputs"]))
                 for output in rule["outputs"]:
                     selected[output] = True
-        if not matched_platform:
+        if not matched_platform and any(
+            _full_match(path, pattern) for pattern in fallback_patterns
+        ):
             for output in fallback_outputs:
                 selected[output] = True
 
@@ -76,10 +97,14 @@ def _full_match(path: PurePosixPath, pattern: str) -> bool:
 
 def _load_manifest(
     manifest_path: Path,
-) -> tuple[list[str], list[dict[str, list[str]]], list[str]]:
+) -> tuple[list[str], list[dict[str, list[str]]], list[str], list[str], list[str]]:
     manifest: Any = json.loads(manifest_path.read_text(encoding="utf-8"))
     required_keys = {"version", "outputs", "rules"}
-    allowed_keys = required_keys | {"fallback_outputs"}
+    allowed_keys = required_keys | {
+        "fallback_outputs",
+        "ignored_patterns",
+        "fallback_patterns",
+    }
     if (
         not isinstance(manifest, dict)
         or not required_keys.issubset(manifest)
@@ -94,9 +119,10 @@ def _load_manifest(
     outputs = manifest.get("outputs")
     if (
         not isinstance(outputs, list)
-        or len(outputs) != len(EXPECTED_OUTPUTS)
+        or not outputs
         or not all(isinstance(output, str) for output in outputs)
-        or set(outputs) != EXPECTED_OUTPUTS
+        or len(outputs) != len(set(outputs))
+        or not set(outputs).issubset(EXPECTED_OUTPUTS | JOB_OUTPUTS)
     ):
         raise ValueError("routing manifest outputs must be strings")
 
@@ -104,9 +130,23 @@ def _load_manifest(
     if (
         not isinstance(fallback_outputs, list)
         or not all(isinstance(output, str) for output in fallback_outputs)
-        or not set(fallback_outputs).issubset(EXPECTED_OUTPUTS)
+        or not set(fallback_outputs).issubset(outputs)
     ):
         raise ValueError("routing manifest fallback outputs must be known strings")
+
+    ignored_patterns = manifest.get("ignored_patterns", [])
+    if not isinstance(ignored_patterns, list) or not all(
+        isinstance(pattern, str) for pattern in ignored_patterns
+    ):
+        raise ValueError("routing manifest ignored patterns must be strings")
+    ignored_patterns = [_validate_pattern(pattern) for pattern in ignored_patterns]
+
+    fallback_patterns = manifest.get("fallback_patterns", ["**"])
+    if not isinstance(fallback_patterns, list) or not all(
+        isinstance(pattern, str) for pattern in fallback_patterns
+    ):
+        raise ValueError("routing manifest fallback patterns must be strings")
+    fallback_patterns = [_validate_pattern(pattern) for pattern in fallback_patterns]
 
     rules = manifest.get("rules")
     if not isinstance(rules, list):
@@ -114,10 +154,15 @@ def _load_manifest(
 
     validated_rules: list[dict[str, list[str]]] = []
     for rule in rules:
-        if not isinstance(rule, dict) or set(rule) != {"patterns", "outputs"}:
+        if (
+            not isinstance(rule, dict)
+            or not {"patterns", "outputs"}.issubset(rule)
+            or not set(rule).issubset({"patterns", "outputs", "exclude_patterns"})
+        ):
             raise ValueError("routing manifest rule keys are invalid")
         patterns = rule.get("patterns")
         rule_outputs = rule.get("outputs")
+        exclude_patterns = rule.get("exclude_patterns", [])
         if (
             not isinstance(patterns, list)
             or not patterns
@@ -125,17 +170,30 @@ def _load_manifest(
             or not isinstance(rule_outputs, list)
             or not rule_outputs
             or not all(isinstance(output, str) for output in rule_outputs)
-            or not set(rule_outputs).issubset(EXPECTED_OUTPUTS)
+            or not set(rule_outputs).issubset(outputs)
+            or not isinstance(exclude_patterns, list)
+            or not all(isinstance(pattern, str) for pattern in exclude_patterns)
         ):
-            raise ValueError("routing manifest rule contains invalid patterns or outputs")
+            raise ValueError(
+                "routing manifest rule contains invalid patterns or outputs"
+            )
         validated_rules.append(
             {
                 "patterns": [_validate_pattern(pattern) for pattern in patterns],
                 "outputs": rule_outputs,
+                "exclude_patterns": [
+                    _validate_pattern(pattern) for pattern in exclude_patterns
+                ],
             }
         )
 
-    return outputs, validated_rules, fallback_outputs
+    return (
+        outputs,
+        validated_rules,
+        fallback_outputs,
+        ignored_patterns,
+        fallback_patterns,
+    )
 
 
 def _validate_path(raw_path: str) -> PurePosixPath:
@@ -150,11 +208,15 @@ def _validate_path(raw_path: str) -> PurePosixPath:
 
 def _validate_pattern(pattern: str) -> str:
     if not pattern or "\\" in pattern:
-        raise ValueError(f"routing pattern must be a nonempty POSIX-relative path: {pattern}")
+        raise ValueError(
+            f"routing pattern must be a nonempty POSIX-relative path: {pattern}"
+        )
 
     path = PurePosixPath(pattern)
     if path.is_absolute() or ".." in path.parts:
-        raise ValueError(f"routing pattern must be a nonempty POSIX-relative path: {pattern}")
+        raise ValueError(
+            f"routing pattern must be a nonempty POSIX-relative path: {pattern}"
+        )
     return pattern
 
 
@@ -190,7 +252,7 @@ def main(arguments: list[str] | None = None) -> int:
     args = parser.parse_args(arguments)
     try:
         if args.all:
-            outputs, _, _ = _load_manifest(args.manifest)
+            outputs, _, _, _, _ = _load_manifest(args.manifest)
             result = dict.fromkeys(outputs, True)
         else:
             result = route_paths(_read_paths(args.paths_file), args.manifest)

--- a/tests/bash/bootstrap_acceptance.bats
+++ b/tests/bash/bootstrap_acceptance.bats
@@ -257,6 +257,10 @@ EOF
 	workflow="$REPO_ROOT/.github/workflows/ci-hermes-bootstrap.yml"
 	pre_commit="$REPO_ROOT/.pre-commit-config.yaml"
 
-	[ "$(grep -c -- '- \"taskfiles/hermes/taskfile.yml\"' "$workflow")" -eq 2 ]
+	grep -Fq 'manifest: ci/job-path-routing.json' "$workflow"
+	run python3 "$REPO_ROOT/scripts/python/detect_ci_changes.py" \
+		--manifest "$REPO_ROOT/ci/job-path-routing.json" --paths-file - <<<"taskfiles/hermes/taskfile.yml"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'"hermes": true'* ]]
 	grep -Eq 'taskfiles/hermes/taskfile\\.yml' "$pre_commit"
 }

--- a/tests/bash/ci_routing.bats
+++ b/tests/bash/ci_routing.bats
@@ -123,10 +123,10 @@ assert_bootstrap_routing() {
 		'{"chezmoi": false, "contract": true, "darwin": true, "devcontainer": false, "hermes": false, "linux": false, "nix": true, "package_catalog": false, "windows": false, "wsl": false}'
 }
 
-@test "bootstrap Home Manager layout documentation enables every Unix check" {
+@test "bootstrap Home Manager layout documentation skips runtime checks" {
 	assert_bootstrap_routing \
 		"nix/home/README.md" \
-		'{"chezmoi": false, "contract": true, "darwin": true, "devcontainer": false, "hermes": false, "linux": true, "nix": true, "package_catalog": false, "windows": false, "wsl": true}'
+		'{"chezmoi": false, "contract": true, "darwin": false, "devcontainer": false, "hermes": false, "linux": false, "nix": false, "package_catalog": false, "windows": false, "wsl": false}'
 }
 
 @test "bootstrap shared paths enable every platform" {

--- a/tests/bash/macos_config.bats
+++ b/tests/bash/macos_config.bats
@@ -47,10 +47,12 @@ setup() {
 }
 
 @test "devcontainer CI watches macOS installer files" {
-	run grep -F '"install.sh"' "$REPO_ROOT/.github/workflows/ci-devcontainer.yml"
-	[ "$status" -eq 0 ]
-	run grep -F '"scripts/sh/install-macos.sh"' "$REPO_ROOT/.github/workflows/ci-devcontainer.yml"
-	[ "$status" -eq 0 ]
+	for path in install.sh scripts/sh/install-macos.sh; do
+		run python3 "$REPO_ROOT/scripts/python/detect_ci_changes.py" \
+			--manifest "$REPO_ROOT/ci/job-path-routing.json" --paths-file - <<<"$path"
+		[ "$status" -eq 0 ]
+		[[ "$output" == *'"devcontainer": true'* ]]
+	done
 }
 
 @test "macOS devcontainer CI allows the cold start and full test suite to finish" {

--- a/tests/python/test_ci_job_routing.py
+++ b/tests/python/test_ci_job_routing.py
@@ -1,0 +1,257 @@
+"""Behavioral tests for extension-aware jobs and required-check completion."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.python.test_detect_ci_changes import load_detector
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "ci/job-path-routing.json"
+BOOTSTRAP = ROOT / "ci/bootstrap-path-routing.json"
+JOBS = {
+    "ci-chezmoi.yml": {
+        "lint": "chezmoi_lint",
+        "fmt": "templates",
+        "font-install": "fonts",
+        "op-guard": "templates",
+    },
+    "ci-powershell.yml": {
+        "lint": "powershell_lint",
+        "test": "powershell_test",
+        "test-windows-powershell": "powershell_test",
+    },
+    "ci-consistency.yml": {"check": "package_catalog"},
+    "ci-devcontainer.yml": {
+        "linux-nix": "devcontainer",
+        "macos": "devcontainer",
+        "windows": "devcontainer",
+    },
+    "ci-hermes-bootstrap.yml": {"hermes-bootstrap-tests": "hermes"},
+}
+
+
+class CiJobRoutingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.detector = load_detector()
+
+    def selected(self, *paths: str, manifest: Path = MANIFEST) -> set[str]:
+        return {
+            key
+            for key, value in self.detector.route_paths(paths, manifest).items()
+            if value
+        }
+
+    def test_python_test_only_does_not_start_platform_or_template_jobs(self) -> None:
+        self.assertEqual(self.selected("tests/python/test_example.py"), {"python"})
+        self.assertEqual(
+            self.selected("tests/python/test_example.py", manifest=BOOTSTRAP),
+            {"contract"},
+        )
+
+    def test_bash_test_selects_contracts_without_container_builds(self) -> None:
+        self.assertEqual(self.selected("tests/bash/example.bats"), {"python", "bash"})
+
+    def test_powershell_extensions_select_lint_and_contracts(self) -> None:
+        for suffix in ("ps1", "psm1", "psd1"):
+            with self.subTest(suffix=suffix):
+                self.assertEqual(
+                    self.selected(f"scripts/powershell/example.{suffix}"),
+                    {"python", "bash", "powershell_lint", "powershell_test"},
+                )
+
+    def test_lua_does_not_select_template_or_font_jobs(self) -> None:
+        self.assertEqual(
+            self.selected("chezmoi/editors/nvim/init.lua"),
+            {"python", "bash", "powershell_test", "chezmoi_lint"},
+        )
+
+    def test_double_extension_template_and_font_installer_are_detected(self) -> None:
+        self.assertIn(
+            "templates", self.selected("chezmoi/dot_config/example.json.tmpl")
+        )
+        selected = self.selected(
+            "chezmoi/.chezmoiscripts/setup/fonts/run_onchange_before_00-install-udev-gothic.ps1.tmpl"
+        )
+        self.assertTrue({"fonts", "templates", "chezmoi_lint"}.issubset(selected))
+
+    def test_shared_template_data_and_extensionless_files_are_dependencies(
+        self,
+    ) -> None:
+        self.assertIn("templates", self.selected("chezmoi/.chezmoidata/packages.yaml"))
+        self.assertIn("templates", self.selected("chezmoi/.chezmoitemplates/shared"))
+        self.assertIn("hermes", self.selected("docker/hermes-agent/Dockerfile"))
+        self.assertIn("chezmoi_lint", self.selected("chezmoi/shells/bashrc"))
+
+    def test_nix_catalog_keeps_cross_language_contracts(self) -> None:
+        selected = self.selected("nix/packages/sets.nix")
+        self.assertTrue(
+            {"package_catalog", "powershell_test", "chezmoi_lint"}.issubset(selected)
+        )
+        self.assertNotIn("powershell_lint", selected)
+        self.assertNotIn("fonts", selected)
+
+    def test_workflow_yaml_is_linted_but_regular_yaml_is_not(self) -> None:
+        self.assertIn("actionlint", self.selected(".github/workflows/example.yaml"))
+        self.assertNotIn("actionlint", self.selected("docker/mlflow/compose.yml"))
+
+    def test_existing_workflow_dependencies_remain_selected(self) -> None:
+        for path, output in (
+            ("taskfiles/hermes/taskfile.yml", "hermes"),
+            (".pre-commit-config.yaml", "hermes"),
+            ("Taskfile.yml", "hermes"),
+            ("scripts/sh/install-macos.sh", "devcontainer"),
+            ("install.sh", "devcontainer"),
+            ("chezmoi/dot_config/plane-github-sync/config.json", "powershell_test"),
+            ("windows/npm/packages.json", "package_catalog"),
+        ):
+            with self.subTest(path=path):
+                self.assertIn(output, self.selected(path))
+
+    def test_mixed_changes_union_targets(self) -> None:
+        paths = [
+            "tests/python/test_example.py",
+            "scripts/powershell/example.ps1",
+            "chezmoi/dot_config/example.json.tmpl",
+        ]
+        self.assertEqual(
+            self.selected(*paths), set().union(*(self.selected(p) for p in paths))
+        )
+
+    def test_documentation_skips_expensive_jobs_but_runtime_markdown_is_kept(
+        self,
+    ) -> None:
+        for path in (
+            "README.md",
+            "nix/home/README.md",
+            "scripts/powershell/README.md",
+            "docker/hermes-agent/README.md",
+            "chezmoi/README.md",
+            "docs/mlflow/setup.md",
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(self.selected(path).issubset({"python", "bash"}))
+                self.assertEqual(self.selected(path, manifest=BOOTSTRAP), {"contract"})
+        self.assertIn(
+            "hermes", self.selected("docker/hermes-agent/profiles/example/SOUL.md")
+        )
+        self.assertIn("chezmoi_lint", self.selected("chezmoi/dot_codex/AGENTS.md"))
+
+    def test_unknown_bootstrap_runtime_path_keeps_conservative_fallback(self) -> None:
+        self.assertTrue(
+            {"linux", "darwin", "wsl", "windows"}.issubset(
+                self.selected("scripts/sh/new-installer.sh", manifest=BOOTSTRAP)
+            )
+        )
+
+    def test_routing_changes_and_manual_runs_cover_all_job_outputs(self) -> None:
+        manifest = json.loads(MANIFEST.read_text())
+        self.assertEqual(
+            self.selected("ci/job-path-routing.json"), set(manifest["outputs"])
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "scripts/python/detect_ci_changes.py"),
+                "--manifest",
+                str(MANIFEST),
+                "--all",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        self.assertTrue(all(json.loads(result.stdout).values()))
+
+    def test_invalid_exclusions_and_undeclared_outputs_fail_closed(self) -> None:
+        for mutate in (
+            lambda m: m.update(ignored_patterns=["../outside"]),
+            lambda m: m.update(fallback_patterns=["../outside"]),
+            lambda m: m["rules"][0].update(exclude_patterns=["/absolute"]),
+            lambda m: m["rules"][0].update(exclude_patterns="*.md"),
+            lambda m: m["outputs"].remove("python"),
+            lambda m: m["outputs"].append("python"),
+        ):
+            manifest = json.loads(MANIFEST.read_text())
+            mutate(manifest)
+            with tempfile.TemporaryDirectory() as directory:
+                path = Path(directory) / "routing.json"
+                path.write_text(json.dumps(manifest))
+                with self.assertRaises(ValueError):
+                    self.selected("README.md", manifest=path)
+
+    def test_workflows_keep_check_names_and_gate_jobs_after_detection(self) -> None:
+        for filename, jobs in JOBS.items():
+            workflow = (ROOT / ".github/workflows" / filename).read_text()
+            with self.subTest(workflow=filename):
+                triggers = workflow.split("\nconcurrency:")[0]
+                self.assertNotIn("    paths:", triggers)
+                self.assertIn("manifest: ci/job-path-routing.json", workflow)
+                self.assertIn("fetch-depth: 0", workflow)
+                self.assertIn("github.event_name == 'workflow_dispatch'", workflow)
+                for job, output in jobs.items():
+                    body = re.search(
+                        rf"(?ms)^  {job}:\n(.*?)(?=^  [\w-]+:\n|\Z)", workflow
+                    )[1]
+                    self.assertRegex(body, r"needs: (changes|\[changes, lint\])")
+                    self.assertIn(f"needs.changes.outputs.{output} == 'true'", body)
+                    self.assertIn(
+                        "always() && (needs.changes.result != 'success'", body
+                    )
+                    self.assertIn("name: Verify change detection", body)
+                    self.assertIn("run: exit 1", body)
+
+    def test_bootstrap_always_reports_on_pull_requests(self) -> None:
+        workflow = (ROOT / ".github/workflows/ci-bootstrap.yml").read_text()
+        trigger = workflow.split("  pull_request:\n", 1)[1].split("\nconcurrency:", 1)[
+            0
+        ]
+        self.assertIn("branches: [main]", trigger)
+        self.assertNotIn("paths:", trigger)
+
+    def test_bootstrap_aggregate_accepts_no_work_but_rejects_missing_required_jobs(
+        self,
+    ) -> None:
+        workflow = (ROOT / ".github/workflows/ci-bootstrap.yml").read_text()
+        aggregate = workflow.split("  complete:\n", 1)[1]
+        script = aggregate.split("        run: |\n", 1)[1]
+        script = "\n".join(line[10:] for line in script.splitlines())
+        variables = set(re.findall(r"\$\{([A-Z_]+)\}", script))
+        env = (
+            os.environ
+            | {
+                key: "skipped" if key.endswith("_RESULT") else "false"
+                for key in variables
+            }
+            | {"CHANGES_RESULT": "success"}
+        )
+        for changes, expected in (
+            ({}, 0),
+            ({"CHANGES_RESULT": "failure"}, 1),
+            ({"LINUX_REQUIRED": "true"}, 1),
+            ({"NIX_REQUIRED": "true"}, 1),
+            ({"DARWIN_RESULT": "success"}, 1),
+        ):
+            with self.subTest(changes=changes):
+                result = subprocess.run(
+                    ["bash", "-c", script],
+                    env=env | changes,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(
+                    result.returncode, expected, result.stdout + result.stderr
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_ci_workflow_routing.py
+++ b/tests/python/test_ci_workflow_routing.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import re
 import sys
 import unittest
 from pathlib import Path
-
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "ci-contract.yml"
@@ -59,6 +59,11 @@ class CiWorkflowRoutingContractTests(unittest.TestCase):
         )
         self.assertIsNotNone(match, f"missing {event} path filter")
         return match.group("paths") if match is not None else ""
+
+    def _job_patterns(self, output: str) -> list[str]:
+        manifest = json.loads((REPOSITORY_ROOT / "ci/job-path-routing.json").read_text())
+        return [pattern for rule in manifest["rules"] if output in rule["outputs"]
+                for pattern in rule["patterns"]]
 
     def test_pull_requests_to_main_always_run_ci_contract(self) -> None:
         workflow = self._workflow()
@@ -179,7 +184,7 @@ class CiWorkflowRoutingContractTests(unittest.TestCase):
 
     def test_bootstrap_workflow_watches_nix_validation_paths(self) -> None:
         workflow = self._named_workflow("ci-bootstrap.yml")
-        for event in ("push", "pull_request"):
+        for event in ("push",):
             paths = self._trigger_paths(workflow, event)
             self.assertIn('"scripts/sh/**"', paths)
             self.assertIn('".github/e2e/**"', paths)
@@ -228,7 +233,7 @@ class CiWorkflowRoutingContractTests(unittest.TestCase):
         self.assertIn("windows-installer", complete)
         self.assertIn("check_required_job", complete)
 
-        for event in ("push", "pull_request"):
+        for event in ("push",):
             paths = self._trigger_paths(workflow, event)
             self.assertIn('"scripts/powershell/handlers/**"', paths)
 
@@ -289,7 +294,6 @@ class CiWorkflowRoutingContractTests(unittest.TestCase):
         return json.loads(result.stdout)
 
     def test_devcontainer_ci_owns_only_the_two_excluded_bats_files(self) -> None:
-        workflow = self._named_workflow("ci-devcontainer.yml")
         contract_workflow = self._workflow()
         bats_script = DEVCONTAINER_BATS_PATH.read_text(encoding="utf-8")
 
@@ -333,12 +337,11 @@ class CiWorkflowRoutingContractTests(unittest.TestCase):
         for owned_path in devcontainer_paths:
             self.assertTrue((REPOSITORY_ROOT / owned_path).is_file(), owned_path)
 
-        for event in ("push", "pull_request"):
-            paths = self._trigger_paths(workflow, event)
-            self.assertIn("scripts/sh/dcnvim.sh", paths)
-            self.assertIn("tests/bash/install_macos.bats", paths)
-            self.assertIn("tests/bash/install_linux.bats", paths)
-            self.assertNotIn("tests/bash/**", paths)
+        paths = self._job_patterns("devcontainer")
+        self.assertIn("scripts/sh/dcnvim.sh", paths)
+        self.assertIn("tests/bash/install_macos.bats", paths)
+        self.assertIn("tests/bash/install_linux.bats", paths)
+        self.assertNotIn("tests/bash/**", paths)
 
         contract_push_paths = self._trigger_paths(contract_workflow, "push")
         for path in (
@@ -360,16 +363,15 @@ class CiWorkflowRoutingContractTests(unittest.TestCase):
             "docker/hermes-xapi-mcp/**",
             "docker/hindsight/**",
             "docker/local-ai-services/**",
-            "scripts/sh/hermes-agent.sh",
+            "scripts/sh/hermes-*.sh",
             "scripts/powershell/handlers/Handler.HermesAgent.ps1",
             "tests/python/test_xapi_image_contract.py",
             ".github/workflows/ci-hermes-provenance.yml",
         )
 
-        for event in ("push", "pull_request"):
-            paths = self._trigger_paths(workflow, event)
-            for required_path in required_paths:
-                self.assertIn(required_path, paths)
+        paths = self._job_patterns("hermes")
+        for required_path in required_paths:
+            self.assertIn(required_path, paths)
         self.assertIn(
             "python3 -m unittest tests/python/test_xapi_image_contract.py -v",
             workflow,
@@ -451,7 +453,7 @@ class CiWorkflowRoutingContractTests(unittest.TestCase):
     def test_unified_bootstrap_workflow_fails_closed_for_selected_platforms(self) -> None:
         workflow = self._named_workflow("ci-bootstrap.yml")
 
-        for event in ("push", "pull_request"):
+        for event in ("push",):
             paths = self._trigger_paths(workflow, event)
             self.assertIn('      - "Taskfile.yml"', paths)
             self.assertIn('      - "taskfiles/**"', paths)

--- a/tests/python/test_detect_ci_action_contract.py
+++ b/tests/python/test_detect_ci_action_contract.py
@@ -10,7 +10,6 @@ import tempfile
 import unittest
 from pathlib import Path
 
-
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 ACTION_PATH = REPOSITORY_ROOT / ".github" / "actions" / "detect-ci-changes" / "action.yml"
 DETECTOR_PATH = REPOSITORY_ROOT / "scripts" / "python" / "detect_ci_changes.py"
@@ -29,6 +28,10 @@ OUTPUTS = {
     "devcontainer",
     "package_catalog",
 }
+JOB_OUTPUTS = {
+    "python", "bash", "actionlint", "powershell_lint", "powershell_test",
+    "chezmoi_lint", "templates", "fonts",
+}
 
 
 class DetectCiActionContractTests(unittest.TestCase):
@@ -38,9 +41,9 @@ class DetectCiActionContractTests(unittest.TestCase):
     def test_action_declares_the_stable_interface(self) -> None:
         self.assertTrue(ACTION_PATH.is_file(), "composite action is missing")
         self.assertEqual(self._top_level_keys("inputs"), INPUTS)
-        self.assertEqual(self._top_level_keys("outputs"), OUTPUTS)
+        self.assertEqual(self._top_level_keys("outputs"), OUTPUTS | JOB_OUTPUTS)
 
-        for output in OUTPUTS:
+        for output in OUTPUTS | JOB_OUTPUTS:
             self.assertIn(
                 f"    value: ${{{{ steps.detect.outputs.{output} }}}}",
                 self._section("outputs"),
@@ -183,6 +186,27 @@ class DetectCiActionContractTests(unittest.TestCase):
                 "scripts/sh/install-linux.sh\n",
             )
 
+    def test_pull_request_ignores_changes_only_on_the_base_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository = self._make_test_repository(Path(temporary_directory))
+            self._git(repository, "branch", "pull-request")
+            (repository / "scripts/sh").mkdir()
+            (repository / "scripts/sh/install-macos.sh").write_text("#!/bin/sh\n")
+            self._git(repository, "add", ".")
+            self._git(repository, "commit", "-m", "advance base with macOS change")
+            base_sha = self._git(repository, "rev-parse", "HEAD")
+            self._git(repository, "switch", "pull-request")
+            head_sha = self._commit_linux_installer(repository)
+
+            completed, output_path, _ = self._run_action_script(
+                repository, base_sha=base_sha, head_sha=head_sha,
+                run_all=False, event_name="pull_request",
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertTrue(self._read_outputs(output_path)["linux"])
+            self.assertFalse(self._read_outputs(output_path)["darwin"])
+
     def _section(self, name: str) -> str:
         lines = self.action.splitlines()
         try:
@@ -250,6 +274,7 @@ class DetectCiActionContractTests(unittest.TestCase):
         base_sha: str,
         head_sha: str,
         run_all: bool,
+        event_name: str = "push",
     ) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
         temporary_directory = repository.parent
         runner_temp = temporary_directory / "runner-temp"
@@ -262,6 +287,7 @@ class DetectCiActionContractTests(unittest.TestCase):
         environment = os.environ.copy()
         environment.update(
             {
+                "GITHUB_EVENT_NAME": event_name,
                 "BASE_SHA": base_sha,
                 "HEAD_SHA": head_sha,
                 "RUN_ALL": "true" if run_all else "false",

--- a/tests/python/test_detect_ci_changes.py
+++ b/tests/python/test_detect_ci_changes.py
@@ -10,7 +10,6 @@ import tempfile
 import unittest
 from pathlib import Path
 
-
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 MANIFEST_PATH = REPOSITORY_ROOT / "ci" / "path-routing.json"
 BOOTSTRAP_MANIFEST_PATH = REPOSITORY_ROOT / "ci" / "bootstrap-path-routing.json"
@@ -160,7 +159,7 @@ BOOTSTRAP_CASES = {
     "nix/home/linux.nix": {"linux", "contract", "nix"},
     "nix/home/wsl.nix": {"wsl", "contract", "nix"},
     "nix/home/darwin.nix": {"darwin", "contract", "nix"},
-    "nix/home/README.md": {"linux", "darwin", "wsl", "contract", "nix"},
+    "nix/home/README.md": {"contract"},
     "scripts/powershell/handlers/Handler.NixOSWSL.ps1": {"wsl", "contract"},
     "scripts/powershell/lib/SetupHandler.ps1": {"wsl", "windows", "contract"},
     "chezmoi/shells/Microsoft.PowerShell_profile.ps1": {
@@ -201,13 +200,7 @@ BOOTSTRAP_CASES = {
         "windows",
         "contract",
     },
-    "docs/mlflow/local-ai-services.md": {
-        "linux",
-        "darwin",
-        "wsl",
-        "windows",
-        "contract",
-    },
+    "docs/mlflow/local-ai-services.md": {"contract"},
     "tests/python/test_mlflow_contract.py": {
         "linux",
         "darwin",


### PR DESCRIPTION
Closes #602

変更と無関係な Chezmoi 検証や Bootstrap の全 OS テストが実行されるため、拡張子と依存パスから必要な CI ジョブを選択するようにしました。

`ci/job-path-routing.json` に Python / Bash 契約、PowerShell 解析・テスト、テンプレート、フォント、Hermes、devcontainer、package catalog の判定を集約します。説明用 README / docs は重い OS テストから除外し、Taskfile・Nix・chezmoi・Docker の相互依存、拡張子のない設定、複合拡張子、配布する Markdown は検証対象に残します。

既存チェック名を維持して対象外ジョブをスキップし、変更検出の失敗と選択済みジョブの未完了は成功扱いしません。Bootstrap はすべての PR で結果を返し、PR の差分は merge-base から計算して base branch 側だけの変更による不要な実行を防ぎます。

ローカル検証:

- Python 契約テスト: 100 件成功
- 関連 Bats: 41 件成功
- CI workflow の Pester 契約: 30 件成功（macOS / PowerShell 7、Pester 5.9.1）
- actionlint: 成功
- `task commit`: 成功。整形、pre-commit 全ファイル検証、Hermes bootstrap コンテナ検証を含む。

main の必須チェックは `Lint (Pester chezmoi)`、`Format (.tmpl BOM check)`、`Render guard (op unauthenticated)` の 3 件であり、すべて同じチェック名を維持しています。Windows runner の実行、Nix build / OS E2E、必須チェックとの実際の統合は hosted CI で確認します。
