### PR TITLE
docs(nix): classify retained package catalog Bats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 ## テスト責務
 
 - Nix expression、Home Manager option、flake output、Nix package 選択のテストは `nix/tests/` に Nix 式で記載し、`nix-unit` / `nix flake check` を authoritative check とする。
-- Bats は shell、installer、外部コマンド、runtime/integration 契約に限定する。Nix option を `nix eval` するだけの Bats テストは追加しない。
+- Bats は shell、installer、外部コマンド、runtime/integration 契約に限定する。Nix option を `nix eval` するだけの Bats テストは追加しない。ただし既存の `tests/bash/package_catalog.bats` は、`nix/tests/home/README.md` に完全分類した一時的な catalog/Nix/source-shape 例外であり、`tests/bash/nixos_wsl_postinstall.bats` の `nix eval` は、stubbed `nixos-rebuild` 境界内で選択 user と `--impure` 伝播を実 Nix eval で確認する runtime/integration assertion に限る。新しい例外は追加しない。
 
 ## 実行コマンド
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -25,6 +25,10 @@
 5. dotfile と秘密情報は `chezmoi/` と既存の secret 経路を使い、所有を重複させない。
 6. Nix 設定の変更は `nix flake check --all-systems --no-write-lock-file` と focused `nix-unit`
    build で検証する。Bats は installer、shell、外部プロセス、runtime 契約に限って実行する。
+   既存の `tests/bash/package_catalog.bats` だけは、`nix/tests/home/README.md` に完全分類した
+   一時的な catalog/Nix/source-shape 例外であり、`nixos_wsl_postinstall.bats` の `nix eval` は
+   stubbed `nixos-rebuild` 境界内で選択 user と `--impure` 伝播を実 Nix eval で確認する
+   runtime/integration assertion に限る。新しい例外は追加しない。
 
 ホストの標準レイアウトは `nix/hosts/<host>/default.nix` と
 `nix/hosts/<host>/configuration.nix` の組み合わせです。Darwin、native NixOS、NixOS-WSL

--- a/nix/home/README.md
+++ b/nix/home/README.md
@@ -35,7 +35,10 @@ flake 評価へ渡す。
 - Nix option、package、session variable のテストは `nix/tests/` に追加し、
   `nix flake check --all-systems --no-write-lock-file` と focused `nix-unit` build を実行する。
 - Bats は Home Manager option の値を検査する用途には使わず、installer、shell、外部プロセス、
-  runtime 契約に限る。
+  runtime 契約に限る。ただし既存の `tests/bash/package_catalog.bats` は、
+  `nix/tests/home/README.md` に完全分類した一時的な catalog/Nix/source-shape 例外であり、
+  `nixos_wsl_postinstall.bats` の `nix eval` は、stubbed `nixos-rebuild` 境界内で選択 user と
+  `--impure` 伝播を実 Nix eval で確認する runtime/integration assertion に限る。新しい例外は追加しない。
 
 ホストの system 設定は `nix/hosts/<host>/configuration.nix`、import の入口は同じディレクトリの
 `default.nix` が所有します。Home Manager の OS 差分は `nix/home/<os>.nix` に置き、host

--- a/nix/tests/home/README.md
+++ b/nix/tests/home/README.md
@@ -9,6 +9,9 @@ package、session variable も `nix-unit` で評価します。
 - Nix expression、Home Manager option、package 選択、session variable、flake output は `nix/tests/` に記載する。
 - `tests/bash/` は shell/installer の順序、外部コマンドの stub、runtime/integration 契約に限定する。
 - Nix 設定の値を `nix eval` で確認するだけの Bats テストは追加しない。既存の同種テストも対応する Nix test に移す。
+  ただし既存の `tests/bash/package_catalog.bats` は下記の分類済み一時例外であり、
+  `nixos_wsl_postinstall.bats` の `nix eval` は、stubbed `nixos-rebuild` 境界内で選択 user と
+  `--impure` 伝播を実 Nix eval で確認する runtime/integration assertion に限る。
 - activation、実機のサービス起動、secret、network は Nix-unit の対象外とし、必要な runtime 契約だけを Bats または CI の実機ジョブで検査する。
 
 ## ファイル規則
@@ -34,3 +37,78 @@ nix build .#checks.$(nix eval --raw --impure --expr 'builtins.currentSystem').ni
 `--no-build` は flake graph の評価だけで、nix-unit assertion の実行結果を保証しません。
 変更時は focused build と `nix flake check` の両方を実行してください。Linux 専用 check を
 Darwin から直接 build せず、`x86_64-linux` / `aarch64-linux` の CI runner で実行します。
+
+## Bats の一時例外と完全分類
+
+`tests/bash/package_catalog.bats` の46ケースは、Nix の所有境界を曖昧にしないため、次のとおり
+全ケースを分類する。番号はファイル内の `@test` の出現順であり、Nix 側の所有チェックは
+`tests/bash/*.bats` を動的に列挙して `nix eval` を含むファイルを
+`["nixos_wsl_postinstall.bats" "package_catalog.bats"]` に固定する。
+
+### 正当な Bats runtime / artifact 契約（5件）
+
+以下は、実行時の stub、生成物、または署名済み artifact を検証するための Bats 所有です。
+
+| 番号 | テスト |
+| ---: | --- |
+| 17 | `pnpm v11 global installs skip packages present in the global manifest` |
+| 22 | `winget export reproduces committed Windows manifests byte-for-byte` |
+| 33 | `Darwin Raycast artifact has the declared identity and trusted signature` |
+| 34 | `Darwin Discord keeps staged modules outside its signed application bundle` |
+| 35 | `generated Windows manifest contains Discord` |
+
+### 一時的な catalog / Nix / source-shape 例外（41件）
+
+対象範囲は `1-16, 18-21, 23-32, 36-46` で、既存の package catalog、Nix provider、source shape の互換性を守るための
+分類済み例外である。これらを新しい Bats の所有境界として拡張せず、追加・変更時は対応する
+Nix-native test へ移行する。
+
+| 番号 | テスト |
+| ---: | --- |
+| 1 | `Claude and TablePlus are not managed by dotfiles` |
+| 2 | `catalog defines provider coverage outputs` |
+| 3 | `host package set includes GitHub CLI for Darwin and Linux` |
+| 4 | `catalog accepts an explicitly maintained Codex package` |
+| 5 | `Codex package input is available for supported Nix systems` |
+| 6 | `repository Codex output follows the maintained package input` |
+| 7 | `Codex support metadata records the external provider` |
+| 8 | `Hermes Desktop uses the official Homebrew cask only with the Hermes profile` |
+| 9 | `Hermes Desktop Docker launcher is a Darwin Hermes package` |
+| 10 | `Hermes Docker CLI is a Darwin Hermes package` |
+| 11 | `Hermes Desktop is absent from default package outputs` |
+| 12 | `catalog rejects incomplete metadata and invalid active Nix packages` |
+| 13 | `Node.js follows the current nixpkgs major` |
+| 14 | `DeepSeek Harness is managed as a cross-platform pnpm package` |
+| 15 | `DeepSeek Harness native builds are pre-approved for pnpm global installs` |
+| 16 | `DeepSeek Harness is reinstalled when the native build approval changes` |
+| 18 | `cross-platform applications are not classified as Windows-only` |
+| 19 | `Docker declares Homebrew cask Darwin and Linux system providers` |
+| 20 | `true Windows-only packages carry unsupported reasons` |
+| 21 | `support report derivation and CI gate are wired` |
+| 23 | `missing providers require an explicitly reviewed unsupported reason` |
+| 24 | `catalog Winget packages preserve ID-keyed metadata` |
+| 25 | `macOS desktop apps include Dia and Orca migration metadata` |
+| 26 | `Visual Studio Code uses the unmodified nixpkgs application with migration metadata` |
+| 27 | `Darwin routes Nix GUI apps to system packages and keeps commands in Home Manager` |
+| 28 | `Arc remains Windows-only and Dia remains macOS-only` |
+| 29 | `Discord preserves Windows and Linux providers while declaring a Nix Darwin GUI migration` |
+| 30 | `Google Chrome preserves its Windows provider while declaring a Nix Darwin GUI migration` |
+| 31 | `Raycast preserves reviewed Windows and Linux unsupported reasons while declaring a Nix Darwin GUI migration` |
+| 32 | `Tart preserves Apple Silicon-only unsupported reasons while declaring a Nix command migration` |
+| 36 | `WezTerm uses the Nix Darwin application and preserves nightly cask migration metadata` |
+| 37 | `Ollama uses the Nix Darwin service package with legacy cask migration metadata` |
+| 38 | `Darwin GUI promotions use custom products instead of same-named nixpkgs packages` |
+| 39 | `custom Darwin package derivations preserve vendor bundles` |
+| 40 | `Docker Desktop has no custom Darwin package or provider candidate` |
+| 41 | `ChatGPT uses the nixpkgs Darwin application with legacy cask migration metadata` |
+| 42 | `ChatGPT Linux package is wired as a reproducible Nix derivation` |
+| 43 | `ChatGPT Linux package supplies Qt runtimes and ignores optional musl modules` |
+| 44 | `ChatGPT Linux package uses the normal Nix output layout` |
+| 45 | `Warp is removed from the package catalog` |
+| 46 | `terminal keybinding helpers have platform-scoped providers` |
+
+必須検証は、Nix の authoritative check（`nix flake check --all-systems --no-write-lock-file` と
+focused `nix-unit` build）に加えて `task test:bash`、または変更対象に絞った `bats` 実行を行うこと。
+package catalog の変更時は focused exact command として `bats tests/bash/package_catalog.bats` も実行する。
+Nix または `jq` がないため Bats ケースが `skip` された場合、検証成功とは扱わない。必要なツールを
+用意して再実行するか、未検証として停止する。

--- a/nix/tests/home/README.md
+++ b/nix/tests/home/README.md
@@ -49,13 +49,13 @@ Darwin から直接 build せず、`x86_64-linux` / `aarch64-linux` の CI runne
 
 以下は、実行時の stub、生成物、または署名済み artifact を検証するための Bats 所有です。
 
-| 番号 | テスト |
-| ---: | --- |
-| 17 | `pnpm v11 global installs skip packages present in the global manifest` |
-| 22 | `winget export reproduces committed Windows manifests byte-for-byte` |
-| 33 | `Darwin Raycast artifact has the declared identity and trusted signature` |
-| 34 | `Darwin Discord keeps staged modules outside its signed application bundle` |
-| 35 | `generated Windows manifest contains Discord` |
+| 番号 | テスト                                                                      |
+| ---: | --------------------------------------------------------------------------- |
+|   17 | `pnpm v11 global installs skip packages present in the global manifest`     |
+|   22 | `winget export reproduces committed Windows manifests byte-for-byte`        |
+|   33 | `Darwin Raycast artifact has the declared identity and trusted signature`   |
+|   34 | `Darwin Discord keeps staged modules outside its signed application bundle` |
+|   35 | `generated Windows manifest contains Discord`                               |
 
 ### 一時的な catalog / Nix / source-shape 例外（41件）
 
@@ -63,49 +63,49 @@ Darwin から直接 build せず、`x86_64-linux` / `aarch64-linux` の CI runne
 分類済み例外である。これらを新しい Bats の所有境界として拡張せず、追加・変更時は対応する
 Nix-native test へ移行する。
 
-| 番号 | テスト |
-| ---: | --- |
-| 1 | `Claude and TablePlus are not managed by dotfiles` |
-| 2 | `catalog defines provider coverage outputs` |
-| 3 | `host package set includes GitHub CLI for Darwin and Linux` |
-| 4 | `catalog accepts an explicitly maintained Codex package` |
-| 5 | `Codex package input is available for supported Nix systems` |
-| 6 | `repository Codex output follows the maintained package input` |
-| 7 | `Codex support metadata records the external provider` |
-| 8 | `Hermes Desktop uses the official Homebrew cask only with the Hermes profile` |
-| 9 | `Hermes Desktop Docker launcher is a Darwin Hermes package` |
-| 10 | `Hermes Docker CLI is a Darwin Hermes package` |
-| 11 | `Hermes Desktop is absent from default package outputs` |
-| 12 | `catalog rejects incomplete metadata and invalid active Nix packages` |
-| 13 | `Node.js follows the current nixpkgs major` |
-| 14 | `DeepSeek Harness is managed as a cross-platform pnpm package` |
-| 15 | `DeepSeek Harness native builds are pre-approved for pnpm global installs` |
-| 16 | `DeepSeek Harness is reinstalled when the native build approval changes` |
-| 18 | `cross-platform applications are not classified as Windows-only` |
-| 19 | `Docker declares Homebrew cask Darwin and Linux system providers` |
-| 20 | `true Windows-only packages carry unsupported reasons` |
-| 21 | `support report derivation and CI gate are wired` |
-| 23 | `missing providers require an explicitly reviewed unsupported reason` |
-| 24 | `catalog Winget packages preserve ID-keyed metadata` |
-| 25 | `macOS desktop apps include Dia and Orca migration metadata` |
-| 26 | `Visual Studio Code uses the unmodified nixpkgs application with migration metadata` |
-| 27 | `Darwin routes Nix GUI apps to system packages and keeps commands in Home Manager` |
-| 28 | `Arc remains Windows-only and Dia remains macOS-only` |
-| 29 | `Discord preserves Windows and Linux providers while declaring a Nix Darwin GUI migration` |
-| 30 | `Google Chrome preserves its Windows provider while declaring a Nix Darwin GUI migration` |
-| 31 | `Raycast preserves reviewed Windows and Linux unsupported reasons while declaring a Nix Darwin GUI migration` |
-| 32 | `Tart preserves Apple Silicon-only unsupported reasons while declaring a Nix command migration` |
-| 36 | `WezTerm uses the Nix Darwin application and preserves nightly cask migration metadata` |
-| 37 | `Ollama uses the Nix Darwin service package with legacy cask migration metadata` |
-| 38 | `Darwin GUI promotions use custom products instead of same-named nixpkgs packages` |
-| 39 | `custom Darwin package derivations preserve vendor bundles` |
-| 40 | `Docker Desktop has no custom Darwin package or provider candidate` |
-| 41 | `ChatGPT uses the nixpkgs Darwin application with legacy cask migration metadata` |
-| 42 | `ChatGPT Linux package is wired as a reproducible Nix derivation` |
-| 43 | `ChatGPT Linux package supplies Qt runtimes and ignores optional musl modules` |
-| 44 | `ChatGPT Linux package uses the normal Nix output layout` |
-| 45 | `Warp is removed from the package catalog` |
-| 46 | `terminal keybinding helpers have platform-scoped providers` |
+| 番号 | テスト                                                                                                        |
+| ---: | ------------------------------------------------------------------------------------------------------------- |
+|    1 | `Claude and TablePlus are not managed by dotfiles`                                                            |
+|    2 | `catalog defines provider coverage outputs`                                                                   |
+|    3 | `host package set includes GitHub CLI for Darwin and Linux`                                                   |
+|    4 | `catalog accepts an explicitly maintained Codex package`                                                      |
+|    5 | `Codex package input is available for supported Nix systems`                                                  |
+|    6 | `repository Codex output follows the maintained package input`                                                |
+|    7 | `Codex support metadata records the external provider`                                                        |
+|    8 | `Hermes Desktop uses the official Homebrew cask only with the Hermes profile`                                 |
+|    9 | `Hermes Desktop Docker launcher is a Darwin Hermes package`                                                   |
+|   10 | `Hermes Docker CLI is a Darwin Hermes package`                                                                |
+|   11 | `Hermes Desktop is absent from default package outputs`                                                       |
+|   12 | `catalog rejects incomplete metadata and invalid active Nix packages`                                         |
+|   13 | `Node.js follows the current nixpkgs major`                                                                   |
+|   14 | `DeepSeek Harness is managed as a cross-platform pnpm package`                                                |
+|   15 | `DeepSeek Harness native builds are pre-approved for pnpm global installs`                                    |
+|   16 | `DeepSeek Harness is reinstalled when the native build approval changes`                                      |
+|   18 | `cross-platform applications are not classified as Windows-only`                                              |
+|   19 | `Docker declares Homebrew cask Darwin and Linux system providers`                                             |
+|   20 | `true Windows-only packages carry unsupported reasons`                                                        |
+|   21 | `support report derivation and CI gate are wired`                                                             |
+|   23 | `missing providers require an explicitly reviewed unsupported reason`                                         |
+|   24 | `catalog Winget packages preserve ID-keyed metadata`                                                          |
+|   25 | `macOS desktop apps include Dia and Orca migration metadata`                                                  |
+|   26 | `Visual Studio Code uses the unmodified nixpkgs application with migration metadata`                          |
+|   27 | `Darwin routes Nix GUI apps to system packages and keeps commands in Home Manager`                            |
+|   28 | `Arc remains Windows-only and Dia remains macOS-only`                                                         |
+|   29 | `Discord preserves Windows and Linux providers while declaring a Nix Darwin GUI migration`                    |
+|   30 | `Google Chrome preserves its Windows provider while declaring a Nix Darwin GUI migration`                     |
+|   31 | `Raycast preserves reviewed Windows and Linux unsupported reasons while declaring a Nix Darwin GUI migration` |
+|   32 | `Tart preserves Apple Silicon-only unsupported reasons while declaring a Nix command migration`               |
+|   36 | `WezTerm uses the Nix Darwin application and preserves nightly cask migration metadata`                       |
+|   37 | `Ollama uses the Nix Darwin service package with legacy cask migration metadata`                              |
+|   38 | `Darwin GUI promotions use custom products instead of same-named nixpkgs packages`                            |
+|   39 | `custom Darwin package derivations preserve vendor bundles`                                                   |
+|   40 | `Docker Desktop has no custom Darwin package or provider candidate`                                           |
+|   41 | `ChatGPT uses the nixpkgs Darwin application with legacy cask migration metadata`                             |
+|   42 | `ChatGPT Linux package is wired as a reproducible Nix derivation`                                             |
+|   43 | `ChatGPT Linux package supplies Qt runtimes and ignores optional musl modules`                                |
+|   44 | `ChatGPT Linux package uses the normal Nix output layout`                                                     |
+|   45 | `Warp is removed from the package catalog`                                                                    |
+|   46 | `terminal keybinding helpers have platform-scoped providers`                                                  |
 
 必須検証は、Nix の authoritative check（`nix flake check --all-systems --no-write-lock-file` と
 focused `nix-unit` build）に加えて `task test:bash`、または変更対象に絞った `bats` 実行を行うこと。

--- a/nix/tests/ownership.nix
+++ b/nix/tests/ownership.nix
@@ -14,7 +14,7 @@ let
       line
       != null
     || builtins.match
-      "^[[:space:]]*\"\\$[A-Za-z_][A-Za-z0-9_]*\"[[:space:]]+eval([[:space:]]|$).*"
+      "^[[:space:]]*\"?\\$(\\{[A-Za-z_][A-Za-z0-9_]*\\}|[A-Za-z_][A-Za-z0-9_]*)\"?[[:space:]]+eval([[:space:]]|$).*"
       line
       != null;
   hasNixEvalCommandIn = source:

--- a/nix/tests/ownership.nix
+++ b/nix/tests/ownership.nix
@@ -1,8 +1,66 @@
 let
   bashTests = ../../tests/bash;
+  bashEntries = builtins.readDir bashTests;
+  batsTests = builtins.sort builtins.lessThan (
+    builtins.filter
+      (name: bashEntries.${name} == "regular" && builtins.match ".*\\.bats" name != null)
+      (builtins.attrNames bashEntries)
+  );
+  linesOf = source: builtins.filter builtins.isString (builtins.split "\n" source);
+  # Match executable command forms, rather than comments or diagnostic strings.
+  hasNixEvalCommand = line:
+    builtins.match
+      "^[[:space:]]*(run[[:space:]]+[^#]*[[:space:]]+)?nix[[:space:]]+eval([[:space:]]|$).*"
+      line
+      != null
+    || builtins.match
+      "^[[:space:]]*\"\\$[A-Za-z_][A-Za-z0-9_]*\"[[:space:]]+eval([[:space:]]|$).*"
+      line
+      != null;
+  hasNixEvalCommandIn = source:
+    builtins.any hasNixEvalCommand (linesOf source);
+  nixEvalOwners = builtins.filter (
+    name: hasNixEvalCommandIn (builtins.readFile (bashTests + "/${name}"))
+  ) batsTests;
+  expectedNixEvalOwners = [
+    "nixos_wsl_postinstall.bats"
+    "package_catalog.bats"
+  ];
+  packageCatalog = builtins.readFile (bashTests + "/package_catalog.bats");
+  packageCatalogTests = builtins.filter
+    (line: builtins.match "^[[:space:]]*@test[[:space:]].*" line != null)
+    (linesOf packageCatalog);
+  packageCatalogTestNames = builtins.map
+    (line: builtins.head (builtins.match "^[[:space:]]*@test[[:space:]]+\"([^\"]+)\"[[:space:]]*[{].*" line))
+    packageCatalogTests;
+  homeReadme = builtins.readFile ./home/README.md;
+  classifiedTestNames = builtins.filter (name: name != null) (builtins.map
+    (line:
+      let
+        match = builtins.match "^[|][[:space:]]*[0-9]+[[:space:]]*[|][[:space:]]*`([^`]+)`[[:space:]]*[|][[:space:]]*$" line;
+      in
+      if match == null then null else builtins.head match)
+    (linesOf homeReadme));
+  sortedPackageCatalogTestNames = builtins.sort builtins.lessThan packageCatalogTestNames;
+  sortedClassifiedTestNames = builtins.sort builtins.lessThan classifiedTestNames;
   macosConfig = builtins.readFile (bashTests + "/macos_config.bats");
 in
 {
+  testNixEvalBatsHaveExplicitTemporaryOwnership = {
+    expr = nixEvalOwners;
+    expected = expectedNixEvalOwners;
+  };
+
+  testPackageCatalogHasClassifiedTestCount = {
+    expr = builtins.length packageCatalogTests;
+    expected = 46;
+  };
+
+  testPackageCatalogNamesMatchTheReadmeClassification = {
+    expr = sortedPackageCatalogTestNames == sortedClassifiedTestNames;
+    expected = true;
+  };
+
   testHomeManagerStructureIsNotOwnedByBats = {
     expr = builtins.map (name: builtins.pathExists (bashTests + "/${name}")) [
       "home_layout.bats"
@@ -15,7 +73,7 @@ in
   };
 
   testDarwinConfigBatsContainsOnlyRuntimeContracts = {
-    expr = builtins.match ".*nix eval.*" macosConfig == null;
+    expr = !hasNixEvalCommandIn macosConfig;
     expected = true;
   };
 }

--- a/nix/tests/ownership.nix
+++ b/nix/tests/ownership.nix
@@ -2,23 +2,20 @@ let
   bashTests = ../../tests/bash;
   bashEntries = builtins.readDir bashTests;
   batsTests = builtins.sort builtins.lessThan (
-    builtins.filter
-      (name: bashEntries.${name} == "regular" && builtins.match ".*\\.bats" name != null)
-      (builtins.attrNames bashEntries)
+    builtins.filter (
+      name: bashEntries.${name} == "regular" && builtins.match ".*\\.bats" name != null
+    ) (builtins.attrNames bashEntries)
   );
   linesOf = source: builtins.filter builtins.isString (builtins.split "\n" source);
   # Match executable command forms, rather than comments or diagnostic strings.
-  hasNixEvalCommand = line:
-    builtins.match
-      "^[[:space:]]*(run[[:space:]]+[^#]*[[:space:]]+)?nix[[:space:]]+eval([[:space:]]|$).*"
-      line
-      != null
-    || builtins.match
-      "^[[:space:]]*\"?\\$(\\{[A-Za-z_][A-Za-z0-9_]*\\}|[A-Za-z_][A-Za-z0-9_]*)\"?[[:space:]]+eval([[:space:]]|$).*"
-      line
+  hasNixEvalCommand =
+    line:
+    builtins.match "^[[:space:]]*(run[[:space:]]+[^#]*[[:space:]]+)?nix[[:space:]]+eval([[:space:]]|$).*" line
+    != null
+    ||
+      builtins.match "^[[:space:]]*\"?\\$([{][A-Za-z_][A-Za-z0-9_]*[}]|[A-Za-z_][A-Za-z0-9_]*)\"?[[:space:]]+eval([[:space:]]|$).*" line
       != null;
-  hasNixEvalCommandIn = source:
-    builtins.any hasNixEvalCommand (linesOf source);
+  hasNixEvalCommandIn = source: builtins.any hasNixEvalCommand (linesOf source);
   nixEvalOwners = builtins.filter (
     name: hasNixEvalCommandIn (builtins.readFile (bashTests + "/${name}"))
   ) batsTests;
@@ -27,20 +24,23 @@ let
     "package_catalog.bats"
   ];
   packageCatalog = builtins.readFile (bashTests + "/package_catalog.bats");
-  packageCatalogTests = builtins.filter
-    (line: builtins.match "^[[:space:]]*@test[[:space:]].*" line != null)
-    (linesOf packageCatalog);
-  packageCatalogTestNames = builtins.map
-    (line: builtins.head (builtins.match "^[[:space:]]*@test[[:space:]]+\"([^\"]+)\"[[:space:]]*[{].*" line))
-    packageCatalogTests;
+  packageCatalogTests = builtins.filter (
+    line: builtins.match "^[[:space:]]*@test[[:space:]].*" line != null
+  ) (linesOf packageCatalog);
+  packageCatalogTestNames = builtins.map (
+    line:
+    builtins.head (builtins.match "^[[:space:]]*@test[[:space:]]+\"([^\"]+)\"[[:space:]]*[{].*" line)
+  ) packageCatalogTests;
   homeReadme = builtins.readFile ./home/README.md;
-  classifiedTestNames = builtins.filter (name: name != null) (builtins.map
-    (line:
+  classifiedTestNames = builtins.filter (name: name != null) (
+    builtins.map (
+      line:
       let
         match = builtins.match "^[|][[:space:]]*[0-9]+[[:space:]]*[|][[:space:]]*`([^`]+)`[[:space:]]*[|][[:space:]]*$" line;
       in
-      if match == null then null else builtins.head match)
-    (linesOf homeReadme));
+      if match == null then null else builtins.head match
+    ) (linesOf homeReadme)
+  );
   sortedPackageCatalogTestNames = builtins.sort builtins.lessThan packageCatalogTestNames;
   sortedClassifiedTestNames = builtins.sort builtins.lessThan classifiedTestNames;
   macosConfig = builtins.readFile (bashTests + "/macos_config.bats");

--- a/taskfiles/test/taskfile.yml
+++ b/taskfiles/test/taskfile.yml
@@ -23,6 +23,6 @@ tasks:
       - pwsh -NoProfile -Command "& ./scripts/powershell/tests/Invoke-Tests.ps1 -IncludeIntegration -ShowCoverage"
 
   test:bash:
-    desc: Run retained Bats contracts for shell and runtime behavior
+    desc: Run classified Bats contracts (runtime/artifact plus documented package-catalog exception)
     cmds:
       - '{{if eq OS "darwin"}}sh -c ''export PATH=/opt/homebrew/bin:/opt/homebrew/sbin:$PATH; cd "$(cd {{.DOTFILES_PATH}} && pwd -P)" && bats tests/bash''{{else}}{{.WSL}}bash -lc "cd {{.DOTFILES_PATH}} && bats tests/bash"{{end}}'


### PR DESCRIPTION
Closes #604

## 調査結果

- `tests/bash/package_catalog.bats` には46件のテストがあり、Nix/package/provider/source-shape検証とruntime/artifact契約が同居していました。
- 既存のauthoritative Nix経路は `nix/tests/` のregistered suiteだけを実行し、retained Bats例外を暗黙には実行しません。
- 全37個のregular `tests/bash/*.bats` を調べると、実際のNix eval実行を所有するのは `package_catalog.bats` と `nixos_wsl_postinstall.bats` の2件です。

## 根本原因

READMEの所有ルールが理想状態だけを説明し、残存するpackage catalog Batsと、その必須実行経路を明示していませんでした。またownership testは3つの既知ファイルだけを個別確認し、全Batsを動的に走査していませんでした。

## 変更

- 46件をruntime/artifact 5件と一時的なcatalog/Nix/source-shape例外41件に完全分類。
- retained exception、focused command `bats tests/bash/package_catalog.bats`、Nix/Bats双方の必須検証、skipを成功扱いしない条件を文書化。
- 全Batsを動的列挙し、実Nix eval所有者を固定するnix-unit regression checkを追加。
- 直接 `nix eval`、`$VAR eval`、`${VAR} eval`（引用符あり/なし）を検出し、コメント・診断文字列を除外。
- Batsの46テスト名とREADME分類表の集合一致を機械的に検証。
- `task test:bash` の実行経路を維持し、説明を実態へ合わせました。

## 検証

- 変更前再現: ownership checkは `package_catalog.bats` を参照せず、READMEにもretained exception/必須Bats commandがありませんでした。
- 静的分類: 46/46 test名がREADME分類と完全一致、runtime 5件 + 一時例外41件。
- `nix build .#checks.x86_64-linux.nix-unit --no-link --no-write-lock-file`: 41/41成功。
- `bats --show-output-of-passing-tests tests/bash/package_catalog.bats`: 46/46成功（実Nix使用）。
- `bats tests/bash/nixos_wsl_postinstall.bats`: 3/3成功。
- CI routing Python tests: 60/60成功。
- `nix fmt -- --fail-on-change`: 成功、変更0件。
- `git diff --check`: 成功。
- `nix flake check --all-systems --no-write-lock-file`: 291 checkの評価を開始後、変更外のPowerShell formatterがPSGalleryを取得できず失敗。focused checkとGitHub Actionsで補完します。

## 影響範囲

文書、Nix ownership regression test、Taskの説明のみです。既存Bats本体、package selection、installer/runtimeロジックは変更していません。

## 残存リスク

現在のhead SHA `6e6003d13f6fe15fee25c05b36b01be196fa525a` に対する32 check（全7 workflow）はすべて成功・skipped/neutralで完了し、変更対象を通るBootstrapの全13 jobも成功しました。既知の未解決リスクはありません。