### PR TITLE
fix(install): update custom Darwin packages before activation

### DIFF
--- a/.devcontainer/ci/bats.sh
+++ b/.devcontainer/ci/bats.sh
@@ -13,4 +13,7 @@ for bats_file in "${owned_bats_files[@]}"; do
 done
 
 apt-get install -y -qq --no-install-recommends bats jq
-bats --print-output-on-failure tests/bash/install_linux.bats tests/bash/install_macos.bats
+# Installer contracts exercise the real Taskfile, even before Home Manager is applied.
+nix --extra-experimental-features 'nix-command flakes' shell \
+  --inputs-from . nixpkgs#go-task \
+  --command bats --print-output-on-failure "${owned_bats_files[@]}"

--- a/.devcontainer/ci/bats.sh
+++ b/.devcontainer/ci/bats.sh
@@ -12,8 +12,8 @@ for bats_file in "${owned_bats_files[@]}"; do
   fi
 done
 
-apt-get install -y -qq --no-install-recommends bats jq
+apt-get install -y -qq --no-install-recommends bats jq python3 git
 # Installer contracts exercise the real Taskfile, even before Home Manager is applied.
 nix --extra-experimental-features 'nix-command flakes' shell \
-  --inputs-from . nixpkgs#go-task \
+  --inputs-from path:. nixpkgs#go-task \
   --command bats --print-output-on-failure "${owned_bats_files[@]}"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ Home Manager、chezmoi と明示的に選択した optional profile を適用し
 Docker profile では最後に runtime acceptance も実行します。途中で失敗した場合も
 同じコマンドを再実行できます。
 
+更新も同じ入口を使います。macOS / Linux は `./install.sh`、Windows は
+`.\install.cmd` を再実行してください。既存の optional profile を更新する場合も、
+初回と同じ profile 引数を指定します。リポジトリ自体の pull / merge は自動では行いません。
+
+- macOS: flake inputs と Orca・Dia・Hammerspoon の独自 Nix 定義を更新してから、
+  nix-darwin / Home Manager と選択済み Homebrew パッケージを反映します。
+- Linux / NixOS: flake inputs を更新し、その OS の構成と Home Manager を反映します。
+- Windows: catalog 対象を既存の WinGet 等のハンドラーで install / upgrade します。
+  手動管理・非対応のアプリは追加しません。
+
+macOS の独自パッケージ更新は `version` / URL / hash をチェックアウト内で更新します。
+差分は `git diff` で確認できます。取得エラーがある場合は独自定義を書き換えず、
+システム反映前に停止します（先行する `flake.lock` の更新は残ります）。
+GitHub API の認証には、設定されていれば `GH_TOKEN`、次に `GITHUB_TOKEN` を使用します。
+レート制限時は認証設定を確認して再実行してください。固定版 / オフライン検証向けの
+`DOTFILES_SKIP_FLAKE_UPDATE=1` は、Unix の flake 更新と macOS の独自パッケージ更新を
+スキップします。必要な依存パッケージは事前にキャッシュされている必要があります。
+
 ### Windows
 
 PowerShell または Command Prompt で実行します。管理者処理は installer が必要に応じて分離します。

--- a/scripts/powershell/tests/CiWorkflow.Tests.ps1
+++ b/scripts/powershell/tests/CiWorkflow.Tests.ps1
@@ -281,13 +281,16 @@ Describe 'CI workflow configuration' {
 
         $activeBatsInvocations = @(
             $devcontainerBatsScript -split '\r?\n' |
-                Where-Object { $_ -match '^\s*bats\s+' }
+                Where-Object { $_ -match '^\s*--command bats\s+' }
         )
         $activeBatsInvocations.Count | Should -Be 1
-        $activeBatsInvocations[0] | Should -Match 'tests/bash/install_linux\.bats'
-        $activeBatsInvocations[0] | Should -Match 'tests/bash/install_macos\.bats'
-        $activeBatsInvocations[0] | Should -Not -Match 'bats\s+tests/bash/?(?:\s|$)'
-        $activeBatsInvocations[0] | Should -Not -Match '[*?]'
+        $activeBatsInvocations[0].Trim() | Should -Be '--command bats --print-output-on-failure "${owned_bats_files[@]}"'
+        $ownedArray = [regex]::Match($devcontainerBatsScript, '(?ms)^owned_bats_files=\((.*?)^\)')
+        $ownedArray.Success | Should -BeTrue
+        $declaredPaths = @($ownedArray.Groups[1].Value.Trim() -split '\s+')
+        $declaredPaths.Count | Should -Be 2
+        $declaredPaths | Should -Contain 'tests/bash/install_linux.bats'
+        $declaredPaths | Should -Contain 'tests/bash/install_macos.bats'
     }
 
     It 'should trigger PowerShell CI when Plane GitHub sync config changes' {

--- a/scripts/python/update_darwin_packages.py
+++ b/scripts/python/update_darwin_packages.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
 import tempfile
+import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
@@ -348,6 +350,24 @@ def _dia_release(payload: bytes) -> Release | None:
     return None
 
 
+def _orca_release(payload: bytes) -> Release | None:
+    """Match the DMG unpacker and architecture of our custom derivation."""
+    data = json.loads(payload.decode("utf-8"))
+    version = str(data.get("tag_name", "")).lstrip("v")
+    if not re.fullmatch(r"[0-9]+(?:\.[0-9]+)+", version):
+        return None
+    expected = (
+        f"https://github.com/stablyai/orca/releases/download/v{version}/"
+        "orca-macos-arm64.dmg"
+    )
+    if any(
+        asset.get("browser_download_url") == expected
+        for asset in data.get("assets", [])
+    ):
+        return Release(version, expected)
+    return None
+
+
 def _choose_release(version: str, urls: list[str], *, arm64: bool) -> Release | None:
     if not version:
         return None
@@ -376,7 +396,7 @@ PROFILES = {
         "orca-editor",
         "https://api.github.com/repos/stablyai/orca/releases/latest",
         DERIVATIONS["orca-editor"],
-        lambda payload: _json_release(payload, arm64=True),
+        _orca_release,
     ),
 }
 
@@ -402,9 +422,36 @@ IDENTITIES = {
 }
 
 
+class ReleaseRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Never forward GitHub credentials to another origin or plaintext HTTP."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        redirected = super().redirect_request(req, fp, code, msg, headers, newurl)
+        target = urllib.parse.urlsplit(newurl)
+        if redirected is not None and (target.scheme, target.netloc) != (
+            "https", "api.github.com"
+        ):
+            redirected.remove_header("Authorization")
+        return redirected
+
+
 def fetch(url: str) -> bytes:
-    request = urllib.request.Request(url, headers={"User-Agent": "dotfiles-darwin-updater"})
-    with urllib.request.urlopen(request, timeout=30) as response:
+    headers = {"User-Agent": "dotfiles-darwin-updater"}
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    target = urllib.parse.urlsplit(url)
+    if (target.scheme, target.netloc) == ("https", "api.github.com") and token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    opener = urllib.request.build_opener(ReleaseRedirectHandler())
+    with opener.open(request, timeout=30) as response:
         return response.read()
 
 
@@ -446,7 +493,14 @@ def collect_updates(
         except (OSError, ET.ParseError, json.JSONDecodeError) as error:
             updates.append({"package": package_id, "status": "error", "reason": str(error)})
             continue
-        if release is None or release.version == version:
+        if release is None:
+            updates.append({
+                "package": package_id,
+                "status": "error",
+                "reason": "No compatible release asset found",
+            })
+            continue
+        if release.version == version:
             continue
         try:
             hash_value = prefetch_hash(release.url)
@@ -502,7 +556,14 @@ def main(argv: list[str] | None = None) -> int:
 
     package_ids = args.packages or list(PROFILES)
     registry = load_candidate_registry()
+    if set(registry) != set(PROFILES):
+        raise ValueError("candidate registry and updater profiles differ")
     updates = collect_updates(package_ids)
+    if any(update.get("status") == "error" for update in updates):
+        report = {"updates": updates, "promotions": []}
+        write_report(args.output, report)
+        print(json.dumps(report, indent=2))
+        return 1
     promotion_results = (
         promote_candidates(
             registry,
@@ -540,10 +601,6 @@ def main(argv: list[str] | None = None) -> int:
             REGISTRY_PATH.write_text(registry_text, encoding="utf-8")
     write_report(args.output, report)
     print(json.dumps(report, indent=2))
-    # Loading the registry here makes an invalid or accidentally expanded
-    # registry fail before a scheduled job can create a pull request.
-    if set(registry) != set(PROFILES):
-        raise ValueError("candidate registry and updater profiles differ")
     return 0
 
 

--- a/scripts/sh/install-macos.sh
+++ b/scripts/sh/install-macos.sh
@@ -45,9 +45,9 @@ ZSHRC_PATH="${DOTFILES_ZSHRC_PATH:-/etc/zshrc}"
 USER_PROFILE_ROOT="${DOTFILES_USER_PROFILE_ROOT:-/etc/profiles/per-user}"
 HOMEBREW_BIN_DIR="${DOTFILES_HOMEBREW_BIN_DIR:-/usr/local/bin}"
 HOMEBREW_CLI_PLUGINS_DIR="${DOTFILES_HOMEBREW_CLI_PLUGINS_DIR:-/usr/local/cli-plugins}"
-DOTFILES_WITH_OLLAMA=0
-DOTFILES_WITH_DOCKER=0
-DOTFILES_WITH_HERMES=0
+DOTFILES_WITH_OLLAMA="${DOTFILES_WITH_OLLAMA:-0}"
+DOTFILES_WITH_DOCKER="${DOTFILES_WITH_DOCKER:-0}"
+DOTFILES_WITH_HERMES="${DOTFILES_WITH_HERMES:-0}"
 DOCKER_CASK_REPAIR_REQUIRED=0
 DOCKER_CASK_LINK_TRANSACTION_ACTIVE=0
 DOCKER_CASK_LINK_TRANSACTION_COUNT=0
@@ -71,6 +71,11 @@ EOF
 }
 
 resolve_install_profile() {
+  # The public entrypoint selects profiles only through explicit CLI flags.
+  # A sourced activation adapter retains the already-resolved environment.
+  DOTFILES_WITH_OLLAMA=0
+  DOTFILES_WITH_DOCKER=0
+  DOTFILES_WITH_HERMES=0
   while (($# > 0)); do
     case "$1" in
     --with-ollama) DOTFILES_WITH_OLLAMA=1 ;;
@@ -932,18 +937,12 @@ migrate_darwin_providers() {
   "$DARWIN_MIGRATION" "${migration_args[@]}"
 }
 
-update_darwin_packages() {
-  # The pinned/offline installer mode must not advance custom sources either.
-  if [[ ${DOTFILES_SKIP_FLAKE_UPDATE:-0} == 1 ]]; then
-    dotfiles_log "Skipping custom Darwin package updates (pinned install)."
-    return 0
-  fi
-  dotfiles_log "Updating custom Darwin packages before activation..."
+run_darwin_install_workflow() {
   # Bootstrap dependencies before Home Manager has installed Python and go-task.
   # Reuse the checkout's locked nixpkgs and the public update task.
   nix --extra-experimental-features 'nix-command flakes' shell \
     --inputs-from "$ROOT" nixpkgs#python3 nixpkgs#go-task \
-    --command task --dir "$ROOT" darwin:update
+    --command task --exit-code --dir "$ROOT" darwin:install
 }
 
 main() {
@@ -954,7 +953,11 @@ main() {
   ensure_nix
   dotfiles_link_checkout "$ROOT"
   dotfiles_update_flake "$ROOT"
-  update_darwin_packages
+  run_darwin_install_workflow
+}
+
+# Platform adapter invoked only after the Taskfile's update step succeeds.
+finish_macos_install() {
   preserve_shell_rc_for_nix_darwin
   if ((DOTFILES_WITH_DOCKER == 1)); then
     stop_existing_docker_desktop

--- a/scripts/sh/install-macos.sh
+++ b/scripts/sh/install-macos.sh
@@ -932,6 +932,20 @@ migrate_darwin_providers() {
   "$DARWIN_MIGRATION" "${migration_args[@]}"
 }
 
+update_darwin_packages() {
+  # The pinned/offline installer mode must not advance custom sources either.
+  if [[ ${DOTFILES_SKIP_FLAKE_UPDATE:-0} == 1 ]]; then
+    dotfiles_log "Skipping custom Darwin package updates (pinned install)."
+    return 0
+  fi
+  dotfiles_log "Updating custom Darwin packages before activation..."
+  # Bootstrap dependencies before Home Manager has installed Python and go-task.
+  # Reuse the checkout's locked nixpkgs and the public update task.
+  nix --extra-experimental-features 'nix-command flakes' shell \
+    --inputs-from "$ROOT" nixpkgs#python3 nixpkgs#go-task \
+    --command task --dir "$ROOT" darwin:update
+}
+
 main() {
   dotfiles_sanitize_incomplete_git_config_environment
   resolve_install_profile "$@"
@@ -940,6 +954,7 @@ main() {
   ensure_nix
   dotfiles_link_checkout "$ROOT"
   dotfiles_update_flake "$ROOT"
+  update_darwin_packages
   preserve_shell_rc_for_nix_darwin
   if ((DOTFILES_WITH_DOCKER == 1)); then
     stop_existing_docker_desktop

--- a/taskfiles/nix/taskfile.yml
+++ b/taskfiles/nix/taskfile.yml
@@ -1,6 +1,23 @@
 version: "3"
 
 tasks:
+  darwin:install:
+    desc: Update custom packages then run the macOS activation adapter
+    interactive: true
+    preconditions:
+      - sh: test -n "${DOTFILES_ROOT:-}" && test -n "${DOTFILES_WITH_OLLAMA:-}" && test -n "${DOTFILES_WITH_DOCKER:-}" && test -n "${DOTFILES_WITH_HERMES:-}"
+        msg: Run ./install.sh to initialize the macOS install profile
+    cmds:
+      - task: darwin:install:update
+      - bash -c 'source scripts/sh/install-macos.sh; finish_macos_install'
+
+  darwin:install:update:
+    internal: true
+    status:
+      - test "${DOTFILES_SKIP_FLAKE_UPDATE:-0}" = 1
+    cmds:
+      - task: darwin:update
+
   darwin:verify:
     cmds:
       - "bash scripts/sh/verify-darwin-package.sh {{.CLI_ARGS}}"

--- a/tests/bash/bootstrap_acceptance.bats
+++ b/tests/bash/bootstrap_acceptance.bats
@@ -6,6 +6,24 @@ setup() {
 	RUNNER="$FIXTURE_ROOT/run-bootstrap-acceptance.sh"
 }
 
+@test "devcontainer installer contracts provision go-task before running Bats" {
+	local stub_bin="$BATS_TEST_TMPDIR/bin"
+	export CONTRACT_COMMAND_LOG="$BATS_TEST_TMPDIR/commands"
+	mkdir -p "$stub_bin"
+	for command in apt-get nix bats; do
+		cat >"$stub_bin/$command" <<'EOF'
+#!/usr/bin/env bash
+printf '%s %s\n' "${0##*/}" "$*" >>"$CONTRACT_COMMAND_LOG"
+EOF
+		chmod +x "$stub_bin/$command"
+	done
+	cd "$REPO_ROOT"
+	run env PATH="$stub_bin:$PATH" bash .devcontainer/ci/bats.sh
+	[ "$status" -eq 0 ]
+	grep -Fxq 'nix --extra-experimental-features nix-command flakes shell --inputs-from . nixpkgs#go-task --command bats --print-output-on-failure tests/bash/install_linux.bats tests/bash/install_macos.bats' "$CONTRACT_COMMAND_LOG"
+	! grep -q '^bats ' "$CONTRACT_COMMAND_LOG"
+}
+
 @test "destructive Linux E2E routes installers through the acceptance fixture" {
 	workflow="$REPO_ROOT/.github/workflows/ci-bootstrap.yml"
 	nixos_test="$REPO_ROOT/nix/tests/bootstrap-nixos.nix"

--- a/tests/bash/bootstrap_acceptance.bats
+++ b/tests/bash/bootstrap_acceptance.bats
@@ -20,7 +20,8 @@ EOF
 	cd "$REPO_ROOT"
 	run env PATH="$stub_bin:$PATH" bash .devcontainer/ci/bats.sh
 	[ "$status" -eq 0 ]
-	grep -Fxq 'nix --extra-experimental-features nix-command flakes shell --inputs-from . nixpkgs#go-task --command bats --print-output-on-failure tests/bash/install_linux.bats tests/bash/install_macos.bats' "$CONTRACT_COMMAND_LOG"
+	grep -Fxq 'apt-get install -y -qq --no-install-recommends bats jq python3 git' "$CONTRACT_COMMAND_LOG"
+	grep -Fxq 'nix --extra-experimental-features nix-command flakes shell --inputs-from path:. nixpkgs#go-task --command bats --print-output-on-failure tests/bash/install_linux.bats tests/bash/install_macos.bats' "$CONTRACT_COMMAND_LOG"
 	! grep -q '^bats ' "$CONTRACT_COMMAND_LOG"
 }
 

--- a/tests/bash/helpers/macos_install_boundary.sh
+++ b/tests/bash/helpers/macos_install_boundary.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Host-only operations replaced at the macOS installer integration boundary.
+if [[ ${DOTFILES_TEST_HOMEBREW_UNAVAILABLE:-0} == 1 ]]; then
+  homebrew_command() {
+    [[ -f $FAKE_DOCKER_CASK_STATE ]] || return 1
+    printf '%s\n' "$DOTFILES_BREW_COMMAND"
+  }
+fi
+ensure_docker_desktop_md5_compatibility() {
+  :
+}
+homebrew_cask_link_parent_metadata() {
+  printf '%s\n' "$TEST_HOMEBREW_PARENT_METADATA"
+}
+homebrew_cask_link_parent_acl_state() {
+  printf '%s\n' "$TEST_HOMEBREW_PARENT_ACL_STATE"
+}
+homebrew_cask_link_parent_is_immutable_to_caller() {
+  [[ $TEST_HOMEBREW_PARENT_IMMUTABLE_TO_CALLER == 1 ]]
+}

--- a/tests/bash/hermes_agent.bats
+++ b/tests/bash/hermes_agent.bats
@@ -19,6 +19,7 @@ setup() {
 	COMPOSE_FILE="$BATS_TEST_TMPDIR/docker/hermes-service/compose file.yml"
 	REAL_JQ="$(command -v jq)"
 	REAL_PYTHON3="$(command -v python3)"
+	export REAL_INSTALL_TASK="$(command -v task)"
 	SECRET_MARKER="adapter-secret-marker"
 	mkdir -p "$TEST_HOME/.hermes" "$STUB_BIN"
 	: >"$COMMAND_LOG"
@@ -700,6 +701,8 @@ create_mocked_installer_fixture() {
 		"$MOCK_DOCKER_APP/Contents/Resources/bin"
 	MOCK_REPO="$(cd "$MOCK_REPO" && pwd -P)"
 	cp "$REPO_ROOT/install.sh" "$MOCK_REPO/install.sh"
+	cp "$REPO_ROOT/Taskfile.yml" "$MOCK_REPO/Taskfile.yml"
+	cp -R "$REPO_ROOT/taskfiles" "$MOCK_REPO/taskfiles"
 	cp "$REPO_ROOT/scripts/sh/install-common.sh" "$MOCK_REPO/scripts/sh/install-common.sh"
 	cat >"$MOCK_REPO/scripts/sh/migrate-darwin-provider.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -716,7 +719,7 @@ EOF
 set -euo pipefail
 
 export DOTFILES_TEST_SELECTED_INSTALLER="$0"
-. "$(dirname "$0")/install-macos-under-test.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/install-macos-under-test.sh"
 ensure_docker_desktop_md5_compatibility() {
   :
 }
@@ -729,7 +732,9 @@ homebrew_cask_link_parent_acl_state() {
 homebrew_cask_link_parent_is_immutable_to_caller() {
   return 0
 }
-main "$@"
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  main "$@"
+fi
 EOF
 	touch "$MOCK_REPO/flake.nix" \
 		"$MOCK_REPO/docker/hermes-service/compose.yml" \
@@ -783,6 +788,11 @@ esac
 '
 	write_fixture_stub nix '
 printf "nix %s\\n" "$*" >>"$COMMAND_LOG"
+if [[ ${1:-} == --extra-experimental-features ]]; then
+  while [[ ${1:-} != --command ]]; do shift; done
+  shift
+  exec "$@"
+fi
 if [[ $* == *"builtins.currentSystem"* ]]; then
   printf "x86_64-linux"
 fi
@@ -847,7 +857,19 @@ exit 97
 	write_fixture_stub launchctl 'printf "launchctl %s\\n" "$*" >>"$COMMAND_LOG"'
 	write_fixture_stub open 'printf "open %s\\n" "$*" >>"$COMMAND_LOG"'
 	write_fixture_stub docker 'printf "docker %s\\n" "$*" >>"$COMMAND_LOG"'
-	write_fixture_stub task 'printf "task %s\\n" "$*" >>"$COMMAND_LOG"'
+	write_fixture_stub task '
+printf "task %s\\n" "$*" >>"$COMMAND_LOG"
+case " $* " in
+  *" darwin:install "*) exec "$REAL_INSTALL_TASK" "$@" ;;
+esac
+'
+	write_fixture_stub python3 '
+if [[ ${1:-} == scripts/python/update_darwin_packages.py ]]; then
+  printf "python3 %s\\n" "$*" >>"$COMMAND_LOG"
+  exit 0
+fi
+exec "$REAL_PYTHON3" "$@"
+'
 
 	cat >"$MOCK_DOCKER_APP/Contents/MacOS/install" <<'EOF'
 #!/usr/bin/env bash

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -29,6 +29,9 @@ setup() {
 	FAKE_DOCKER_CASK_STATE="$BATS_TEST_TMPDIR/docker-cask-installed"
 	REAL_JQ="$(command -v jq)"
 	REAL_TIMEOUT="$(command -v timeout)"
+	REAL_TASK="$(command -v task)"
+	REAL_PYTHON="$(command -v python3)"
+	REAL_BASH="$(command -v bash)"
 	mkdir -p "$TEST_HOME" "$STUB_BIN" "$TEST_HOMEBREW_CASK_PARENT_DIR" "$TEST_HOMEBREW_LINK_TARGET"
 	chmod 0755 "$TEST_HOMEBREW_CASK_PARENT_DIR"
 	: >"$COMMAND_LOG"
@@ -41,6 +44,8 @@ setup() {
 	export DOTFILES_USER="test-user"
 	export PATH="$STUB_BIN:/usr/bin:/bin"
 	export COMMAND_LOG STUB_BIN PAYLOAD_CAPTURE REAL_JQ REAL_TIMEOUT INSTALLER REPO_ROOT
+	export REAL_TASK REAL_PYTHON REAL_BASH
+	export MACOS_TEST_BOUNDARY="$REPO_ROOT/tests/bash/helpers/macos_install_boundary.sh"
 	export DOTFILES_SKIP_HERDR_INSTALL=1
 	export FAKE_BASHRC FAKE_ZSHRC FAKE_DOCKER_APP FAKE_LEGACY_DOCKER_APP
 	export FAKE_HOMEBREW_BIN_DIR FAKE_HOMEBREW_CLI_PLUGINS_DIR
@@ -256,6 +261,7 @@ exit 97
 	write_stub task '
 printf "task %s\n" "$*" >>"$COMMAND_LOG"
 case " $* " in
+  *" darwin:install "*) exec "$REAL_TASK" "$@" ;;
   *" hermes:bootstrap "*)
     source "$REPO_ROOT/scripts/sh/install-common.sh"
     source "$REPO_ROOT/scripts/sh/hermes-agent.sh"
@@ -264,6 +270,19 @@ case " $* " in
 esac
 '
 	export DOTFILES_TASK_COMMAND="$STUB_BIN/task"
+	write_stub bash '
+if [[ ${1:-} == -c && ${2:-} == "source scripts/sh/install-macos.sh; finish_macos_install" ]]; then
+  exec "$REAL_BASH" -c '\''source scripts/sh/install-macos.sh; source "$MACOS_TEST_BOUNDARY"; finish_macos_install'\''
+fi
+exec "$REAL_BASH" "$@"
+'
+	write_stub python3 '
+if [[ ${1:-} == scripts/python/update_darwin_packages.py ]]; then
+  printf "python3 %s\n" "$*" >>"$COMMAND_LOG"
+  exit "${DARWIN_UPDATE_STATUS:-0}"
+fi
+exec "$REAL_PYTHON" "$@"
+'
 	write_stub op '
 printf "op %s\n" "$*" >>"$COMMAND_LOG"
 if [ "${3:-}" = "Hermes X API MCP" ]; then
@@ -279,8 +298,18 @@ fi
 write_stub() {
 	local name="$1"
 	local body="$2"
+	if [[ $name == nix ]]; then
+		body='
+if [[ ${1:-} == --extra-experimental-features ]]; then
+  printf "nix %s\n" "$*" >>"$COMMAND_LOG"
+  while [[ ${1:-} != --command ]]; do shift; done
+  shift
+  exec "$@"
+fi
+'"$body"
+	fi
 	cat >"$STUB_BIN/$name" <<EOF
-#!/usr/bin/env bash
+#!$REAL_BASH
 set -euo pipefail
 $body
 EOF
@@ -363,6 +392,11 @@ cat >"$STUB_BIN/nix" <<'"'"'NIX'"'"'
 #!/usr/bin/env bash
 set -euo pipefail
 printf "nix %s\n" "$*" >>"$COMMAND_LOG"
+if [[ ${1:-} == --extra-experimental-features ]]; then
+  while [[ ${1:-} != --command ]]; do shift; done
+  shift
+  exec "$@"
+fi
 if [ "${1:-}" = "run" ]; then
 	mkdir -p "$DOTFILES_DOCKER_APP_PATH/Contents/MacOS" "$DOTFILES_DOCKER_APP_PATH/Contents/Resources/bin"
 		cat >"$DOTFILES_DOCKER_APP_PATH/Contents/MacOS/install" <<'"'"'DOCKER_INSTALL'"'"'
@@ -488,24 +522,7 @@ run_macos_installer_for_host() {
 	run bash -c '
 set -euo pipefail
 . "$INSTALLER"
-if [[ ${DOTFILES_TEST_HOMEBREW_UNAVAILABLE:-0} == 1 ]]; then
-  homebrew_command() {
-    [[ -f $FAKE_DOCKER_CASK_STATE ]] || return 1
-    printf "%s\n" "$DOTFILES_BREW_COMMAND"
-  }
-fi
-ensure_docker_desktop_md5_compatibility() {
-  :
-}
-homebrew_cask_link_parent_metadata() {
-  printf "%s\n" "$TEST_HOMEBREW_PARENT_METADATA"
-}
-homebrew_cask_link_parent_acl_state() {
-  printf "%s\n" "$TEST_HOMEBREW_PARENT_ACL_STATE"
-}
-homebrew_cask_link_parent_is_immutable_to_caller() {
-  [[ $TEST_HOMEBREW_PARENT_IMMUTABLE_TO_CALLER == 1 ]]
-}
+. "$MACOS_TEST_BOUNDARY"
 main "$@"
 ' bash "$@"
 }
@@ -543,7 +560,7 @@ run_macos_installer() {
 	grep -Fq '<DOTFILES_WITH_OLLAMA=0> <DOTFILES_WITH_DOCKER=0> <DOTFILES_WITH_HERMES=0>' "$COMMAND_LOG"
 	assert_log_order \
 		"nix flake update --flake $REPO_ROOT" \
-		"nix --extra-experimental-features nix-command flakes shell --inputs-from $REPO_ROOT nixpkgs#python3 nixpkgs#go-task --command task --dir $REPO_ROOT darwin:update" \
+		"python3 scripts/python/update_darwin_packages.py --write --output darwin-package-update.json" \
 		"nix run .#darwin-rebuild -- switch --flake .#macos --impure" \
 		"migrate-darwin-provider --all" \
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
@@ -557,15 +574,20 @@ run_macos_installer() {
 
 @test "package update failure prevents macOS activation" {
 	write_installed_stubs
-	write_stub nix '
-printf "nix %s\n" "$*" >>"$COMMAND_LOG"
-case " $* " in
-  *" darwin:update "*) exit 42 ;;
-esac
-'
+	export DARWIN_UPDATE_STATUS=42
 	run_macos_installer
 	[ "$status" -eq 42 ]
+	grep -q 'python3 scripts/python/update_darwin_packages.py' "$COMMAND_LOG"
 	! grep -q 'nix run .#darwin-rebuild' "$COMMAND_LOG"
+}
+
+@test "public install ignores inherited optional profiles" {
+	write_installed_stubs
+	export DOTFILES_WITH_OLLAMA=1 DOTFILES_WITH_DOCKER=1 DOTFILES_WITH_HERMES=1
+	run_macos_installer
+	[ "$status" -eq 0 ]
+	grep -Fq '<DOTFILES_WITH_OLLAMA=0> <DOTFILES_WITH_DOCKER=0> <DOTFILES_WITH_HERMES=0>' "$COMMAND_LOG"
+	! grep -q '^docker ' "$COMMAND_LOG"
 }
 
 @test "pinned installer mode skips both flake and custom package updates" {
@@ -1692,6 +1714,8 @@ printf "%s\n" "$DOCKER_APP"
 	cp "$INSTALLER" "$HOME/.dotfiles/scripts/sh/install-macos.sh"
 	cp "$COMMON_INSTALLER" "$HOME/.dotfiles/scripts/sh/install-common.sh"
 	cp "$HERMES_INSTALLER" "$HOME/.dotfiles/scripts/sh/hermes-agent.sh"
+	cp "$REPO_ROOT/Taskfile.yml" "$HOME/.dotfiles/Taskfile.yml"
+	cp -R "$REPO_ROOT/taskfiles" "$HOME/.dotfiles/taskfiles"
 	touch \
 		"$HOME/.dotfiles/flake.nix" \
 		"$HOME/.dotfiles/docker/hermes-service/compose.yml"

--- a/tests/bash/install_macos.bats
+++ b/tests/bash/install_macos.bats
@@ -543,6 +543,7 @@ run_macos_installer() {
 	grep -Fq '<DOTFILES_WITH_OLLAMA=0> <DOTFILES_WITH_DOCKER=0> <DOTFILES_WITH_HERMES=0>' "$COMMAND_LOG"
 	assert_log_order \
 		"nix flake update --flake $REPO_ROOT" \
+		"nix --extra-experimental-features nix-command flakes shell --inputs-from $REPO_ROOT nixpkgs#python3 nixpkgs#go-task --command task --dir $REPO_ROOT darwin:update" \
 		"nix run .#darwin-rebuild -- switch --flake .#macos --impure" \
 		"migrate-darwin-provider --all" \
 		"chezmoi init --source $REPO_ROOT/chezmoi" \
@@ -552,6 +553,28 @@ run_macos_installer() {
 	! grep -q '/api/tags' "$COMMAND_LOG"
 	! grep -q '^docker ' "$COMMAND_LOG"
 	! grep -q '^task .*\(hindsight:up\|hermes:bootstrap\)' "$COMMAND_LOG"
+}
+
+@test "package update failure prevents macOS activation" {
+	write_installed_stubs
+	write_stub nix '
+printf "nix %s\n" "$*" >>"$COMMAND_LOG"
+case " $* " in
+  *" darwin:update "*) exit 42 ;;
+esac
+'
+	run_macos_installer
+	[ "$status" -eq 42 ]
+	! grep -q 'nix run .#darwin-rebuild' "$COMMAND_LOG"
+}
+
+@test "pinned installer mode skips both flake and custom package updates" {
+	write_installed_stubs
+	export DOTFILES_SKIP_FLAKE_UPDATE=1
+	run_macos_installer
+	[ "$status" -eq 0 ]
+	! grep -q 'nix flake update\|darwin:update' "$COMMAND_LOG"
+	grep -q 'nix run .#darwin-rebuild' "$COMMAND_LOG"
 }
 
 @test "macOS installer clears an incomplete inherited Git command config" {

--- a/tests/python/test_ci_workflow_routing.py
+++ b/tests/python/test_ci_workflow_routing.py
@@ -320,16 +320,18 @@ class CiWorkflowRoutingContractTests(unittest.TestCase):
         active_bats_lines = [
             line.strip()
             for line in bats_script.splitlines()
-            if line.strip().startswith("bats ")
+            if line.strip().startswith("--command bats ")
         ]
         self.assertEqual(len(active_bats_lines), 1)
-        runtime_paths = set(
-            re.findall(r"tests/bash/[^\s]+\.bats", active_bats_lines[0])
+        self.assertEqual(
+            active_bats_lines[0],
+            '--command bats --print-output-on-failure "${owned_bats_files[@]}"',
         )
-        self.assertEqual(runtime_paths, devcontainer_paths)
-        self.assertNotEqual(active_bats_lines[0], "bats tests/bash/")
-        for glob_marker in ("*", "?", "["):
-            self.assertNotIn(glob_marker, active_bats_lines[0])
+        owned_array = re.search(r"(?ms)^owned_bats_files=\((.*?)^\)", bats_script)
+        self.assertIsNotNone(owned_array)
+        declared_paths = owned_array.group(1).split() if owned_array is not None else []
+        self.assertEqual(set(declared_paths), devcontainer_paths)
+        self.assertEqual(len(declared_paths), len(devcontainer_paths))
 
         self.assertEqual(contract_excluded, devcontainer_paths)
         self.assertTrue(devcontainer_paths.isdisjoint(contract_owned))

--- a/tests/python/test_update_darwin_packages.py
+++ b/tests/python/test_update_darwin_packages.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import importlib.util
+import contextlib
+import io
 import json
+import os
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -96,6 +100,66 @@ class UpdateDarwinPackagesTests(unittest.TestCase):
             path.write_text(before, encoding="utf-8")
             self.updater.write_report(path, {"updates": [], "promotions": []})
             self.assertEqual(path.read_bytes(), before.encode())
+
+    def test_orca_uses_arm64_dmg_even_when_zip_is_first(self) -> None:
+        payload = json.dumps({"tag_name": "v1.4.198", "assets": [
+            {"browser_download_url": "https://github.com/stablyai/orca/releases/download/v1.4.198/Orca-1.4.198-arm64-mac.zip"},
+            {"browser_download_url": "https://github.com/stablyai/orca/releases/download/v1.4.198/orca-macos-x64.dmg"},
+            {"browser_download_url": "https://github.com/stablyai/orca/releases/download/v1.4.198/orca-macos-arm64.dmg"},
+        ]}).encode()
+        release = self.updater.PROFILES["orca-editor"].parse_release(payload)
+        self.assertEqual(release.version, "1.4.198")
+        self.assertEqual(release.url, "https://github.com/stablyai/orca/releases/download/v1.4.198/orca-macos-arm64.dmg")
+
+    def test_orca_missing_dmg_is_an_update_error_not_an_x64_fallback(self) -> None:
+        payload = json.dumps({"tag_name": "v9.0", "assets": [
+            {"browser_download_url": "https://github.com/stablyai/orca/releases/download/v9.0/orca-macos-x64.dmg"},
+        ]}).encode()
+        with patch.object(self.updater, "prefetch_hash", return_value="sha256-test"):
+            updates = self.updater.collect_updates(["orca-editor"], fetcher=lambda _: payload)
+        self.assertEqual(updates[0]["status"], "error")
+
+    def test_release_fetch_authenticates_only_github_api(self) -> None:
+        requests = []
+        def open_request(request, **kwargs):
+            requests.append(request)
+            return io.BytesIO(b"{}")
+        with patch.dict(os.environ, {"GH_TOKEN": "test-token", "GITHUB_TOKEN": "other-token"}), patch.object(self.updater.urllib.request.OpenerDirector, "open", side_effect=open_request):
+            self.updater.fetch("https://api.github.com/repos/stablyai/orca/releases/latest")
+            self.updater.fetch("https://releases.diabrowser.com/BoostBrowser-updates.xml")
+        self.assertEqual(requests[0].get_header("Authorization"), "Bearer test-token")
+        self.assertIsNone(requests[1].get_header("Authorization"))
+
+    def test_partial_update_error_fails_without_changing_derivations(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "default.nix"
+            original = 'version = "1";\nurl = "https://example.invalid/1.zip";\nhash = "sha256-old";\n'
+            target.write_text(original)
+            report = Path(directory) / "report.json"
+            updates = [
+                {"package": "dia-browser", "status": "update-available", "version": "2", "url": "https://example.invalid/2.zip", "hash": "sha256-new"},
+                {"package": "orca-editor", "status": "error", "reason": "HTTP 403"},
+            ]
+            with patch.object(self.updater, "collect_updates", return_value=updates), patch.dict(self.updater.DERIVATIONS, {"dia-browser": target}), contextlib.redirect_stdout(io.StringIO()):
+                status = self.updater.main(["--write", "--output", str(report)])
+            self.assertNotEqual(status, 0)
+            self.assertEqual(target.read_text(), original)
+            self.assertEqual(json.loads(report.read_text())["updates"][1]["status"], "error")
+
+    def test_fetch_does_not_forward_authentication_across_redirect_origins(self) -> None:
+        handler = self.updater.ReleaseRedirectHandler()
+        request = self.updater.urllib.request.Request(
+            "https://api.github.com/repos/old/repo/releases/latest",
+            headers={"Authorization": "Bearer test-token"},
+        )
+        for url, expected in (
+            ("https://api.github.com/repos/new/repo/releases/latest", "Bearer test-token"),
+            ("https://example.invalid/feed", None),
+            ("http://api.github.com/feed", None),
+        ):
+            with self.subTest(url=url):
+                redirected = handler.redirect_request(request, None, 302, "Found", {}, url)
+                self.assertEqual(redirected.get_header("Authorization"), expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Preserve install.sh for macOS/Linux and install.cmd for Windows; do not introduce a shared task install entrypoint.
- Update custom Darwin packages before activation through the existing Taskfile updater, bootstrapping Python/go-task from the checkout's locked nixpkgs.
- Select Orca's ARM64 DMG, authenticate GitHub API requests when credentials are supplied, strip credentials on cross-origin redirects, and fail before changing definitions if any update lookup/download fails.
- Preserve pinned/offline installer behavior and existing Windows/Linux update paths; document rerun/update semantics.

## Validation
- Python updater/CI routing: 31 tests passed.
- Unix installer/dispatcher regression tests: 92 passed.
- PowerShell WinGet handler: 58 passed, including upgrading already-installed packages.
- Full task commit formatting and pre-commit hooks passed, including Hermes container tests.
- Actual Nix shell / Taskfile update check succeeded, downloading and hashing Dia and Orca releases without applying them.
- Independent read-only review: no findings.

## Scope
No application/system activation was performed. Existing dirty flake.lock in the main checkout was preserved. Scheduled updater PR creation's pre-existing missing-chezmoi issue is outside this installer change.
