### PR TITLE
feat: add render-markdown preview keymap

### DIFF
--- a/chezmoi/dot_config/nvim/lua/config/keymaps.lua
+++ b/chezmoi/dot_config/nvim/lua/config/keymaps.lua
@@ -53,7 +53,7 @@ map("n", "-", "<cmd>Oil<cr>", { desc = "Open parent directory" })
 
 -- Marp preview
 require("config.marp").setup()
-map("n", "<leader>mp", "<cmd>MarpToggle<cr>", { desc = "Toggle Marp preview" })
+map("n", "<leader>marp", "<cmd>MarpToggle<cr>", { desc = "Toggle Marp preview" })
 
 -- Terminal mode
 map("t", "jk", "<C-\\><C-n>", { desc = "Exit terminal mode" })

--- a/chezmoi/dot_config/nvim/lua/plugins/markdown.lua
+++ b/chezmoi/dot_config/nvim/lua/plugins/markdown.lua
@@ -1,0 +1,17 @@
+return {
+    {
+        "MeanderingProgrammer/render-markdown.nvim",
+        ft = "markdown",
+        dependencies = { "nvim-tree/nvim-web-devicons" },
+        opts = {},
+        keys = {
+            {
+                "<leader>mp",
+                function()
+                    require("render-markdown").toggle()
+                end,
+                desc = "Toggle Markdown rendering",
+            },
+        },
+    },
+}

--- a/docs/chezmoi/keybindings.md
+++ b/docs/chezmoi/keybindings.md
@@ -86,6 +86,8 @@ Window Manager 契約外の操作は維持する。WezTerm の `Ctrl+Command+矢
   - `Ctrl+.`: Sidekick focus、`Space+as/ad`: CLI 選択／close
   - `Space+at/af/av/ap`: Sidekick へ位置／ファイル／選択範囲送信／prompt 選択
   - `Space+du/dc/dd/dt`: Devcontainer up／コンテナ内 bash／down／toggle
+  - Markdown のインライン表示切り替え: `Space+mp`（`render-markdown.nvim`）
+  - Marp のブラウザプレビュー切り替え: `Space+marp`
   - 詳細・terminal prefix と補完の競合は [Neovim](./neovim.md) を参照
 - VS Code / Cursor
   - `Vim` 拡張は利用しない

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1787796349,
-        "narHash": "sha256-5s+MJAFyemD6lvrtL2c0jQ7P/XChdx1MPXzoCaQY+ic=",
+        "lastModified": 1788591592,
+        "narHash": "sha256-NbwVKwKLFl0oXub7oPjvmDaOygCtV2oboeKTu4xXFTk=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "3e3da86e4eaccd23f4ce43df9b0a31b16c707347",
+        "rev": "08e85c4e42f5d8f1ea17c36cb59cf61c2ccb26c3",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.20",
+        "ref": "6.0.22",
         "repo": "brew",
         "type": "github"
       }
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788651960,
-        "narHash": "sha256-v9wJd32eZ2bvhBzVOd7TIjLQd011P7nwOhjKtWlci5I=",
+        "lastModified": 1789099078,
+        "narHash": "sha256-zzHj2wl69724lzx7DLAVziWbL75wRIk+xJ3duD0Bgrc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2c0350c759688177331b8f5242311fae8877bdb3",
+        "rev": "f10b3f2ad4aae9259617a1ff518cc921e3394228",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1788778790,
-        "narHash": "sha256-SWJA3/xQhqjpQuBnmDHNWW4s0nW0exdMW/Itx5VEhVA=",
+        "lastModified": 1789098570,
+        "narHash": "sha256-0i3Gd0hjiXLeQGPrpvNx85iynzG/5/Q7523pTdt1kwA=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "c246aa6d43a378f24c2410d4c062b12f2e8ccee7",
+        "rev": "3a31e665ca59fc6e553610d96100cc08cbbc759f",
         "type": "github"
       },
       "original": {
@@ -276,11 +276,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1788444135,
-        "narHash": "sha256-ChwTDZPvTmEgZdS30dUfgdXlzAPtZAUWwEH/PfDXZmg=",
+        "lastModified": 1788981439,
+        "narHash": "sha256-fEaFq0XgpgWFPLfpq1UK4/8ylHd2T0+fo6O3hKz1LUM=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "ec8417a617de4d3c739aed40837e308ebd667165",
+        "rev": "09a921d0181146cf6163ec2cc1db7b6fd539a885",
         "type": "github"
       },
       "original": {
@@ -337,11 +337,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784642409,
-        "narHash": "sha256-hcbDqFuySAJawljt5r0sKBCJKYnbtGD0T/ZIozH1Dq0=",
+        "lastModified": 1789039320,
+        "narHash": "sha256-SBHeKJ6fyQIb8PaUc0iarznGhaGdnc+SXdDb5Z96Qn0=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "eaeb18da90024448a60eb1ec7132eafa4003404e",
+        "rev": "8c333e5b3abb693139e4df80988810ce44788b4e",
         "type": "github"
       },
       "original": {
@@ -352,11 +352,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788608636,
-        "narHash": "sha256-RqeFOwW329f4i1f5QlJgQYwgEZvxIHJsUYlzIBxsKsY=",
+        "lastModified": 1788982683,
+        "narHash": "sha256-PJCTsE4I20CrJJPcye9/z6brRFysG5+aygr/dZK097k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0af3d1402dec3fc7e93635e511d1f7428c89cebf",
+        "rev": "5052d7ccbcfb7e4ae1586cb2ecf95a2e3707dce9",
         "type": "github"
       },
       "original": {
@@ -383,11 +383,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1788614874,
-        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
+        "lastModified": 1789006805,
+        "narHash": "sha256-xB8mKMOx1IA9vTDNLmJZ6n4wCMq/cuWBBOzGCRnqxrU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
+        "rev": "8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe",
         "type": "github"
       },
       "original": {
@@ -451,11 +451,11 @@
         "userborn": "userborn"
       },
       "locked": {
-        "lastModified": 1788643028,
-        "narHash": "sha256-llyR4NuuJLDS49y8j9zbGi5pzjSuuc6CB8ipPJlXfIk=",
+        "lastModified": 1789068434,
+        "narHash": "sha256-w0qD6GyyY8rQZbMuXsonCXO4OPsLOo8prqN3eAdoiw8=",
         "owner": "numtide",
         "repo": "system-manager",
-        "rev": "41d9628959faa2d12f65057aeb6f566c4ccfbd3d",
+        "rev": "13c7006728ea6cf5f1de1e358809dab2b7f97f25",
         "type": "github"
       },
       "original": {
@@ -607,11 +607,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788725915,
-        "narHash": "sha256-QRjx4uXWYhH2yLGsOxj9NRwfIbRMC6zMKp+L72wwT90=",
+        "lastModified": 1789105554,
+        "narHash": "sha256-58YT4pad85tyQCyMJWiQtgIoAjH9zZzu7kvg7ZK7208=",
         "owner": "raine",
         "repo": "workmux",
-        "rev": "ac4289fceed31c77d81b6b674699ea4e12f4ceac",
+        "rev": "0c6bedc55ceac499997438cca57a72139f116047",
         "type": "github"
       },
       "original": {

--- a/nix/packages/dia-browser/default.nix
+++ b/nix/packages/dia-browser/default.nix
@@ -7,11 +7,11 @@
 
 stdenvNoCC.mkDerivation {
   pname = "dia-browser";
-  version = "1.45.2-85817";
+  version = "1.48.0-86796";
 
   src = fetchurl {
-    url = "https://releases.diabrowser.com/release/Dia-1.45.2-85817.zip";
-    hash = "sha256-xlbeV+uT2qS4mI6Of+1wHC9VEXqT0qssyaQ49nL/TBI=";
+    url = "https://releases.diabrowser.com/release/Dia-1.48.0-86796.zip";
+    hash = "sha256-6EhVLvviaeTKvlbKe5fpY6VVdqEGt01X+2F4Yzd5Fb0=";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/nix/packages/orca-editor/default.nix
+++ b/nix/packages/orca-editor/default.nix
@@ -7,11 +7,11 @@
 
 stdenvNoCC.mkDerivation {
   pname = "orca-editor";
-  version = "1.4.188";
+  version = "1.4.200";
 
   src = fetchurl {
-    url = "https://github.com/stablyai/orca/releases/download/v1.4.188/orca-macos-arm64.dmg";
-    hash = "sha256-rC7OdVj2/YkxNcUC6EshYfHGJD2KYuL7lL7G62s7JX4=";
+    url = "https://github.com/stablyai/orca/releases/download/v1.4.200/orca-macos-arm64.dmg";
+    hash = "sha256-Riwk46kMzsauTyQxrdsBqYrleaF36xiU7bRlbRJf2HI=";
   };
 
   nativeBuildInputs = [ undmg ];

--- a/nix/tests/neovim.nix
+++ b/nix/tests/neovim.nix
@@ -10,6 +10,7 @@ pkgs.runCommand "neovim-native-check" { nativeBuildInputs = [ neovim ]; } ''
   export XDG_CACHE_HOME="$TMPDIR/cache"
   cd ${../..}
   nvim --headless -u NONE -i NONE -l tests/lua/nvim_modern_test.lua
+  nvim --headless -u NONE -i NONE -l tests/lua/nvim_markdown_test.lua
   nvim --headless -u NONE -i NONE -l tests/lua/nvim_treesitter_test.lua
   nvim --headless -u NONE -i NONE -l tests/lua/nvim_treesitter_installer_test.lua
   DOTFILES_NVIM_LSPCONFIG=${pkgs.vimPlugins.nvim-lspconfig} \

--- a/tests/lua/nvim_markdown_test.lua
+++ b/tests/lua/nvim_markdown_test.lua
@@ -1,0 +1,26 @@
+-- Run with: nvim --headless -u NONE -i NONE -l tests/lua/nvim_markdown_test.lua
+local root = vim.fn.getcwd() .. "/chezmoi/dot_config/nvim"
+vim.opt.rtp:prepend(root)
+
+local specs = dofile(root .. "/lua/plugins/markdown.lua")
+assert(#specs == 1, "Markdown rendering must have one plugin specification")
+local spec = specs[1]
+assert(spec[1] == "MeanderingProgrammer/render-markdown.nvim", "render-markdown.nvim must be configured")
+assert(spec.ft == "markdown", "Markdown rendering must load only for Markdown buffers")
+assert(type(spec.opts) == "table", "render-markdown.nvim must use lazy.nvim opts")
+assert(
+    spec.dependencies and spec.dependencies[1] == "nvim-tree/nvim-web-devicons",
+    "Markdown icons dependency must be declared"
+)
+
+local markdown_key = spec.keys and spec.keys[1]
+assert(markdown_key and markdown_key[1] == "<leader>mp", "<leader>mp must toggle Markdown rendering")
+assert(type(markdown_key[2]) == "function", "Markdown toggle must lazy-load the plugin through a function mapping")
+
+vim.g.mapleader = " "
+dofile(root .. "/lua/config/keymaps.lua")
+local marp_key = vim.fn.maparg("<leader>marp", "n", false, true)
+assert(marp_key.desc == "Toggle Marp preview", "<leader>marp must remain the Marp preview mapping")
+assert(vim.fn.maparg("<leader>mp", "n") == "", "<leader>mp must not be claimed by Marp")
+
+print("Markdown rendering and Marp keymap checks passed")


### PR DESCRIPTION
## Description

- Add `MeanderingProgrammer/render-markdown.nvim` for in-buffer Markdown rendering.
- Bind Markdown rendering toggle to `<leader>mp`.
- Move Marp browser preview to `<leader>marp`.
- Add Neovim regression coverage and update keybinding documentation.
- Include the pre-existing Nix package and flake-lock updates present in the workspace.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally (the full PowerShell suite cannot run cleanly on macOS because it requires Windows-only drives and commands; Neovim tests and Nix `neovim-native` pass)

## Verification

- `task commit -- "feat: add render-markdown preview keymap"`
- `nvim --headless -u NONE -i NONE -l tests/lua/nvim_markdown_test.lua`
- `nvim --headless -u NONE -i NONE -l tests/lua/nvim_modern_test.lua`
- `nix build path:.#checks.aarch64-darwin.neovim-native --no-link`
- `git diff --check`