### PR TITLE
feat: make Obsidian available cross-platform

### DIFF
--- a/nix/packages/sets.nix
+++ b/nix/packages/sets.nix
@@ -359,6 +359,25 @@ let
           pkg = pkgs.obsidian;
           winget = "Obsidian.Obsidian";
           category = "editors";
+          support = {
+            darwin = {
+              provider = "nix";
+              source = "nixpkgs";
+              nixAttr = "obsidian";
+              identity = {
+                homepage = "https://obsidian.md/";
+                appName = "Obsidian.app";
+                bundleId = "md.obsidian";
+                executable = "Obsidian";
+              };
+            };
+            linux = {
+              provider = "nix";
+              source = "nixpkgs";
+              nixAttr = "obsidian";
+              identity = "obsidian";
+            };
+          };
         };
         vscode = {
           pkg = pkgs.vscode;

--- a/nix/tests/home/composition.nix
+++ b/nix/tests/home/composition.nix
@@ -54,6 +54,32 @@ let
       installFeatures = [ ];
     };
   };
+
+  darwinPackageSets =
+    let
+      system = "aarch64-darwin";
+      pkgs =
+        (import inputs.nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+        }).extend
+          (
+            _: _: {
+              workmux = inputs.workmux.packages.${system}.default;
+            }
+          );
+      sets = import ../../packages/sets.nix {
+        inherit pkgs;
+        lib = pkgs.lib;
+        codexPackage = pkgs.hello;
+      };
+      contains = package: packages: builtins.elem package packages;
+    in
+    {
+      inherit sets;
+      obsidian = pkgs.obsidian;
+      contains = contains;
+    };
 in
 {
   testCommonHomeModuleEvaluatesWithoutOSSpecialArgs = {
@@ -114,6 +140,53 @@ in
       onePassword = "true";
       homebrewPath = true;
       terminfo = true;
+    };
+  };
+
+  testObsidianDeclaresCrossPlatformProviders = {
+    expr = {
+      windows = darwinPackageSets.sets.supportReport.obsidian.windows;
+      darwin = darwinPackageSets.sets.supportReport.obsidian.darwin;
+      linux = darwinPackageSets.sets.supportReport.obsidian.linux;
+    };
+    expected = {
+      windows = {
+        provider = "winget";
+        source = "winget";
+        identity = "Obsidian.Obsidian";
+      };
+      darwin = {
+        provider = "nix";
+        source = "nixpkgs";
+        nixAttr = "obsidian";
+        identity = {
+          homepage = "https://obsidian.md/";
+          appName = "Obsidian.app";
+          bundleId = "md.obsidian";
+          executable = "Obsidian";
+        };
+      };
+      linux = {
+        provider = "nix";
+        source = "nixpkgs";
+        nixAttr = "obsidian";
+        identity = "obsidian";
+      };
+    };
+  };
+
+  testObsidianDarwinGuiUsesSystemPackage = {
+    expr = {
+      system = darwinPackageSets.contains darwinPackageSets.obsidian (
+        darwinPackageSets.sets.darwinSystemPackagesForInstallFeatures [ ]
+      );
+      home = darwinPackageSets.contains darwinPackageSets.obsidian (
+        darwinPackageSets.sets.darwinHomePackagesForInstallFeatures [ ]
+      );
+    };
+    expected = {
+      system = true;
+      home = false;
     };
   };
 }


### PR DESCRIPTION
## Summary
- add Obsidian to the Nix package catalog with explicit Darwin/Linux provider metadata
- install the macOS GUI through nix-darwin system packages and keep Linux/WSL on Nix
- retain the generated Windows winget package and add Nix-native composition tests

## Verification
- nix-unit: 43/43 successful
- bats tests/bash/package_catalog.bats: 46/46 successful
- nix build .#winget-export
- nix fmt -- --fail-on-change
- nix flake check --all-systems --no-write-lock-file
- nix build .#darwin-obsidian

Closes #610